### PR TITLE
Use IRQL value in the emulated KPCR structure rather than overwriting the Windows TIB structure

### DIFF
--- a/src/CxbxKrnl/EmuKrnl.cpp
+++ b/src/CxbxKrnl/EmuKrnl.cpp
@@ -56,6 +56,12 @@ namespace NtDll
 };
 
 // ******************************************************************
+// * Declaring this in a header causes errors with xboxkrnl
+// * namespace, so we must declare it within any file that uses it
+// ******************************************************************
+xboxkrnl::KPCR* KeGetPcr();
+
+// ******************************************************************
 // * 0x0033 - InterlockedCompareExchange()
 // ******************************************************************
 // Source:ReactOS
@@ -200,15 +206,8 @@ XBSYSAPI EXPORTNUM(160) xboxkrnl::UCHAR FASTCALL xboxkrnl::KfRaiseIrql
 	LOG_FUNC_ONE_ARG(NewIrql);
 
 	UCHAR OldIrql;
-	KPCR* Pcr = nullptr;
 
-	// Fetch KPCR data structure
-	__asm {
-		push eax
-		mov eax, fs:[0x14]
-		mov Pcr, eax
-		pop eax
-	}
+	KPCR* Pcr = KeGetPcr();
 
 	if (NewIrql < Pcr->Irql)	{
 		// TODO: Enable this after KeBugCheck is implemented

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -222,12 +222,17 @@ XBSYSAPI EXPORTNUM(103) xboxkrnl::KIRQL NTAPI xboxkrnl::KeGetCurrentIrql(void)
 
 	KIRQL Irql;
 
-	// TODO : Untested :
-	__asm
-	{
-		mov al, byte ptr fs : [24h]
-		mov Irql, al
+	KPCR* Pcr = nullptr;
+
+	// Fetch KPCR data structure
+	__asm {
+		push eax
+		mov eax, fs:[0x14]
+		mov Pcr, eax
+		pop eax
 	}
+
+	Irql = Pcr->Irql;
 
 	RETURN(Irql);
 }
@@ -439,13 +444,19 @@ XBSYSAPI EXPORTNUM(129) xboxkrnl::UCHAR NTAPI xboxkrnl::KeRaiseIrqlToDpcLevel()
 		CxbxKrnlCleanup("Bugcheck: Caller of KeRaiseIrqlToDpcLevel is higher than DISPATCH_LEVEL!");
 
 	KIRQL kRet = NULL;
-	__asm
-	{
-		mov al, byte ptr fs:[24h]
-		mov kRet, al
-		mov al, DISPATCH_LEVEL
-		mov byte ptr fs:[24h], al
+
+
+	KPCR* Pcr = nullptr;
+
+	// Fetch KPCR data structure
+	__asm {
+		push eax
+		mov eax, fs:[0x14]
+		mov Pcr, eax
+		pop eax
 	}
+
+	Pcr->Irql = DISPATCH_LEVEL;
 
 #ifdef _DEBUG_TRACE
 	DbgPrintf("Raised IRQL to DISPATCH_LEVEL (2).\n");


### PR DESCRIPTION
Note: The entire KPCR is currently per thread, this is not correct as the KPCR should be per processor.
The issue here is that the first part of the KPCR, NT_TIB should be per thread.

I haven't figured out a good way to keep that portion per-thread while keeping the rest of the structure global, that said, it will function fine if only one thread calls the IRQL functions.