### PR TITLE
Fixed errors when compiling with the LLVM toolset

### DIFF
--- a/src/Common/Error.h
+++ b/src/Common/Error.h
@@ -61,8 +61,8 @@ class Error
 
     private:
         // current error information
-        bool  m_bFatal;
         char *m_szError;
+        bool  m_bFatal;
 };
 
 #endif

--- a/src/Common/Win32/XBController.cpp
+++ b/src/Common/Win32/XBController.cpp
@@ -365,7 +365,7 @@ bool XBController::ConfigPoll(char *szStatus)
             // ******************************************************************
             if(dwHow != -1)
             {
-                char *szDirection = (dwFlags & DEVICE_FLAG_AXIS) ? (dwFlags & DEVICE_FLAG_POSITIVE) ? "Positive " : "Negative " : "";
+                const char *szDirection = (dwFlags & DEVICE_FLAG_AXIS) ? (dwFlags & DEVICE_FLAG_POSITIVE) ? "Positive " : "Negative " : "";
 
                 m_InputDevice[v].m_Device->GetDeviceInfo(&DeviceInstance);
 
@@ -510,8 +510,8 @@ bool XBController::ConfigPoll(char *szStatus)
                 // ******************************************************************
                 if(dwHow != -1)
                 {
-                    char *szDirection = (dwFlags & DEVICE_FLAG_POSITIVE) ? "Positive" : "Negative";
-                    char *szObjName = "Unknown";
+                    const char *szDirection = (dwFlags & DEVICE_FLAG_POSITIVE) ? "Positive" : "Negative";
+                    const char *szObjName = "Unknown";
 
                     ObjectInstance.dwSize = sizeof(ObjectInstance);
 
@@ -920,6 +920,7 @@ void XBController::DInputInit(HWND hwnd)
             return;
         }
     }
+
 
     // ******************************************************************
     // * Create all the devices available (well...most of them)

--- a/src/Common/Win32/XBVideo.cpp
+++ b/src/Common/Win32/XBVideo.cpp
@@ -66,24 +66,22 @@ void XBVideo::Load(const char *szRegistryKey)
 
         if(RegCreateKeyEx(HKEY_CURRENT_USER, szRegistryKey, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_QUERY_VALUE, NULL, &hKey, &dwDisposition) == ERROR_SUCCESS)
         {
-            int v=0;
-
-            dwType = REG_SZ; dwSize = 100;
+            dwType = REG_SZ; dwSize = sizeof(m_szVideoResolution);
             RegQueryValueEx(hKey, "VideoResolution", NULL, &dwType, (PBYTE)m_szVideoResolution, &dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_dwDisplayAdapter);
             RegQueryValueEx(hKey, "DisplayAdapter", NULL, &dwType, (PBYTE)&m_dwDisplayAdapter, &dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_dwDirect3DDevice);
             RegQueryValueEx(hKey, "Direct3DDevice", NULL, &dwType, (PBYTE)&m_dwDirect3DDevice, &dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_bFullscreen);
             RegQueryValueEx(hKey, "Fullscreen", NULL, &dwType, (PBYTE)&m_bFullscreen, &dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_bVSync);
             RegQueryValueEx(hKey, "VSync", NULL, &dwType, (PBYTE)&m_bVSync, &dwSize);
 
-			dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_bHardwareYUV);
             RegQueryValueEx(hKey, "HardwareYUV", NULL, &dwType, (PBYTE)&m_bHardwareYUV, &dwSize);
 
             RegCloseKey(hKey);
@@ -105,24 +103,22 @@ void XBVideo::Save(const char *szRegistryKey)
 
         if(RegCreateKeyEx(HKEY_CURRENT_USER, szRegistryKey, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_SET_VALUE, NULL, &hKey, &dwDisposition) == ERROR_SUCCESS)
         {
-            int v=0;
-
-            dwType = REG_SZ; dwSize = 100;
+            dwType = REG_SZ; dwSize = sizeof(m_szVideoResolution);
             RegSetValueEx(hKey, "VideoResolution", 0, dwType, (PBYTE)m_szVideoResolution, dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_dwDisplayAdapter);
             RegSetValueEx(hKey, "DisplayAdapter", 0, dwType, (PBYTE)&m_dwDisplayAdapter, dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_dwDirect3DDevice);
             RegSetValueEx(hKey, "Direct3DDevice", 0, dwType, (PBYTE)&m_dwDirect3DDevice, dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_bFullscreen);
             RegSetValueEx(hKey, "Fullscreen", 0, dwType, (PBYTE)&m_bFullscreen, dwSize);
 
-            dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_bVSync);
             RegSetValueEx(hKey, "VSync", 0, dwType, (PBYTE)&m_bVSync, dwSize);
 
-			dwType = REG_DWORD; dwSize = sizeof(DWORD);
+            dwType = REG_DWORD; dwSize = sizeof(m_bHardwareYUV);
             RegSetValueEx(hKey, "HardwareYUV", 0, dwType, (PBYTE)&m_bHardwareYUV, dwSize);
 
             RegCloseKey(hKey);

--- a/src/Common/Win32/XBVideo.h
+++ b/src/Common/Win32/XBVideo.h
@@ -60,13 +60,13 @@ class XBVideo : public Error
         // * SetDirect3DDevice
         // ******************************************************************
         void  SetDirect3DDevice(DWORD dwDirect3DDevice) { m_dwDirect3DDevice = dwDirect3DDevice; }
-        DWORD GetDirect3DDevice() { return m_dwDirect3DDevice; }
+        DWORD GetDirect3DDevice() const { return m_dwDirect3DDevice; }
 
         // ******************************************************************
         // * SetDisplayAdapter
         // ******************************************************************
         void  SetDisplayAdapter(DWORD dwDisplayAdapter) { m_dwDisplayAdapter = dwDisplayAdapter; }
-        DWORD GetDisplayAdapter() { return m_dwDisplayAdapter; }
+        DWORD GetDisplayAdapter() const { return m_dwDisplayAdapter; }
 
         // ******************************************************************
         // * SetVideoResolution
@@ -78,19 +78,19 @@ class XBVideo : public Error
         // * Fullscreen Toggling
         // ******************************************************************
         void SetFullscreen(BOOL bFullscreen) { m_bFullscreen = bFullscreen; }
-        BOOL GetFullscreen() { return m_bFullscreen; }
+        BOOL GetFullscreen() const { return m_bFullscreen; }
 
         // ******************************************************************
         // * VSync Toggling
         // ******************************************************************
         void SetVSync(BOOL bVSync) { m_bVSync = bVSync; }
-        BOOL GetVSync() { return m_bVSync; }
+        BOOL GetVSync() const { return m_bVSync; }
 
 		// ******************************************************************
 		// * Hardware YUV Toggling
 		// ******************************************************************
 		void SetHardwareYUV(BOOL bHardwareYUV) { m_bHardwareYUV = bHardwareYUV; }
-		BOOL GetHardwareYUV() { return m_bHardwareYUV; }
+		BOOL GetHardwareYUV() const { return m_bHardwareYUV; }
 
     private:
         // ******************************************************************
@@ -99,9 +99,9 @@ class XBVideo : public Error
         char  m_szVideoResolution[100];
         DWORD m_dwDisplayAdapter;
         DWORD m_dwDirect3DDevice;
-        BOOL  m_bFullscreen;
         BOOL  m_bVSync;
-		BOOL  m_bHardwareYUV;
+        BOOL  m_bFullscreen;
+        BOOL  m_bHardwareYUV;
 };
 
 #endif

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -86,9 +86,9 @@ typedef signed long    sint32;
 
 /*! version string dependent on trace flag */
 #ifndef _DEBUG_TRACE
-#define _CXBX_VERSION _GIT_VERSION " ("__DATE__ ")"
+#define _CXBX_VERSION _GIT_VERSION " (" __DATE__  ")"
 #else
-#define _CXBX_VERSION _GIT_VERSION "-Trace ("__DATE__ ")"
+#define _CXBX_VERSION _GIT_VERSION "-Trace (" __DATE__  ")"
 #endif
 
 /*! debug mode choices */
@@ -112,4 +112,4 @@ extern volatile bool g_bPrintfOn;
 	#define DbgPrintf null_func
 #endif
 
-#endif CXBX_H
+#endif

--- a/src/Cxbx/DlgVideoConfig.cpp
+++ b/src/Cxbx/DlgVideoConfig.cpp
@@ -324,7 +324,7 @@ VOID RefreshDirect3DDevice()
             /*! enumerate through available adapter modes */
             for(uint32 v=0;v<dwAdapterModeCount;v++)
             {
-                char *szFormat = 0;
+                const char *szFormat = "<unknown>";
 
                 XTL::D3DDISPLAYMODE displayMode;
 


### PR DESCRIPTION
Fixes a few errors from clang:

- Initialization order
- Const-correctness for texts
- Invalid pragma syntax with `#endif`
- Concatenating the date macro