### PR TITLE
HLE verification

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -357,6 +357,8 @@ extern "C" CXBXKRNL_API void CxbxKrnlInit
 #endif
 	}
 
+	VerifyHLEData();
+
 	{
 		// Create a fake kernel header for XapiRestrictCodeSelectorLimit
 		// Thanks advancingdragon / DirtBox

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -357,7 +357,9 @@ extern "C" CXBXKRNL_API void CxbxKrnlInit
 #endif
 	}
 
+#ifdef _DEBUG_TRACE
 	VerifyHLEDataBase();
+#endif
 
 	{
 		// Create a fake kernel header for XapiRestrictCodeSelectorLimit

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -357,7 +357,7 @@ extern "C" CXBXKRNL_API void CxbxKrnlInit
 #endif
 	}
 
-	VerifyHLEData();
+	VerifyHLEDataBase();
 
 	{
 		// Create a fake kernel header for XapiRestrictCodeSelectorLimit

--- a/src/CxbxKrnl/EmuKrnlEx.cpp
+++ b/src/CxbxKrnl/EmuKrnlEx.cpp
@@ -290,6 +290,7 @@ DWORD EEPROM_XboxLanguage = 0x01;  // = English
 DWORD EEPROM_XboxVideo = 0x10;  // = Letterbox
 DWORD EEPROM_XboxAudio = 0;  // = Stereo, no AC3, no DTS
 DWORD EEPROM_ParentalControlGames = 0; // = XC_PC_ESRB_ALL
+DWORD EEPROM_ParentalControlMovies = 0; // = XC_PC_ESRB_ALL
 DWORD EEPROM_XboxMisc = 0;  // No automatic power down
 DWORD EEPROM_XboxFactoryAvRegion = 0x01; // = NTSC_M
 DWORD EEPROM_XboxFactoryGameRegion = 1; // = North America
@@ -308,6 +309,7 @@ static const EEPROMInfo EEPROMInfos[] = {
 	{ xboxkrnl::XC_VIDEO,               &EEPROM_XboxVideo,             REG_DWORD, sizeof(DWORD) },
 	{ xboxkrnl::XC_AUDIO,               &EEPROM_XboxAudio,             REG_DWORD, sizeof(DWORD) },
 	{ xboxkrnl::XC_P_CONTROL_GAMES,     &EEPROM_ParentalControlGames,  REG_DWORD, sizeof(DWORD) }, // Zapper queries this. TODO : Should this be REG_NONE?
+	{ xboxkrnl::XC_P_CONTROL_MOVIES,    &EEPROM_ParentalControlMovies, REG_DWORD, sizeof(DWORD) }, // Xbox Dashboard queries this.
 	{ xboxkrnl::XC_MISC,                &EEPROM_XboxMisc,              REG_DWORD, sizeof(DWORD) },
 	{ xboxkrnl::XC_FACTORY_AV_REGION,   &EEPROM_XboxFactoryAvRegion,   REG_DWORD, sizeof(DWORD) },
 	{ xboxkrnl::XC_FACTORY_GAME_REGION, &EEPROM_XboxFactoryGameRegion, REG_DWORD, sizeof(DWORD) },

--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4034.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4034.inl
@@ -1096,8 +1096,6 @@ OOVPATable D3D8_1_0_4034[] = {
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_Clear_1_0_4034, XTL::EmuIDirect3DDevice8_Clear),
 	// IDirect3DResource8::Register
 	OOVPA_TABLE_PATCH(IDirect3DResource8_Register_1_0_3925, XTL::EmuIDirect3DResource8_Register),
-	// IDirect3DDevice8::CreatePalette
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_CreatePalette_1_0_3925, XTL::EmuIDirect3DDevice8_CreatePalette),
 	// ********************** BEG WARNING UNTESTED!!! *******************
 
 #if 0
@@ -1316,8 +1314,6 @@ OOVPATable D3D8_1_0_4034[] = {
 	OOVPA_TABLE_PATCH(Direct3D_SetPushBufferSize_1_0_4034, XTL::EmuIDirect3D8_SetPushBufferSize),
 	// Get2DSurfacDesc
 	OOVPA_TABLE_PATCH(Get2DSurfaceDesc_1_0_4034, XTL::EmuGet2DSurfaceDesc),
-	// IDirect3DTexture8::GetSurfaceLevel (* unchanged since 3925 *)
-	OOVPA_TABLE_PATCH(IDirect3DTexture8_GetSurfaceLevel_1_0_3925, XTL::EmuIDirect3DTexture8_GetSurfaceLevel),
 	// D3DDevice_SetRenderState_ZEnable
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_ZEnable_1_0_4034, XTL::EmuIDirect3DDevice8_SetRenderState_ZEnable),
 	// D3DDevice_LightEnable
@@ -1328,8 +1324,6 @@ OOVPATable D3D8_1_0_4034[] = {
 	OOVPA_TABLE_PATCH(Direct3D_GetAdapterIdentifier_1_0_3925, XTL::EmuIDirect3D8_GetAdapterIdentifier),
 	// IDirect3DSurface8::GetDesc (* unchanged since 3925 *)
 	OOVPA_TABLE_PATCH(D3DSurface_GetDesc_1_0_3925, XTL::EmuIDirect3DSurface8_GetDesc),
-	// Get2DSurfacDesc
-	OOVPA_TABLE_PATCH(Get2DSurfaceDesc_1_0_4034, XTL::EmuGet2DSurfaceDesc),
 	// IDirect3DDevice8::SetLight
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetLight_1_0_4034, XTL::EmuIDirect3DDevice8_SetLight),
 	// IDirect3DVertexBuffer8::Lock

--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4134.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4134.inl
@@ -2035,8 +2035,6 @@ OOVPATable D3D8_1_0_4134[] = {
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_FrontFace_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_FrontFace),
 	// IDirect3DDevice8::SetRenderState_LogicOp
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_LogicOp_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_LogicOp),
-	// IDirect3DDevice8::SetRenderState_StencilFail
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_StencilFail_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_StencilFail),
 	// IDirect3DDevice8::SetRenderState_OcclusionCullEnable
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_OcclusionCullEnable_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_OcclusionCullEnable),
 	// IDirect3DDevice8::SetRenderState_StencilCullEnable

--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4432.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4432.inl
@@ -748,8 +748,6 @@ OOVPATable D3D8_1_0_4432[]  {
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_GetCreationParameters_1_0_4034, XTL::EmuIDirect3DDevice8_GetCreationParameters),
 	// IDirect3DDevice8::GetVisibilityTestResult (* unchanged since 3925 *)
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_GetVisibilityTestResult_1_0_3925, XTL::EmuIDirect3DDevice8_GetVisibilityTestResult),
-	// IDirect3DDevice8::SetTextureState_BumpEnv (* unchanged since 4361 *)
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetTextureState_BumpEnv_1_0_4361, XTL::EmuIDirect3DDevice8_SetTextureState_BumpEnv),
 	// IDirect3DDevice8::SetRenderState_EdgeAntiAlias (* unchanged since 4361 *)
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_EdgeAntiAlias_1_0_4361, XTL::EmuIDirect3DDevice8_SetRenderState_EdgeAntiAlias),
 	// IDirect3DDevice8::SetRenderState_FillMode (* unchanged since 4361 *)

--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
@@ -3479,8 +3479,6 @@ OOVPATable D3D8_1_0_4627[] = {
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_RopZRead_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_RopZRead),
 	// IDirect3DDevice8::SetRenderState_DoNotCullUncompressed (* unchanged since 4134 *)
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_DoNotCullUncompressed_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_DoNotCullUncompressed),
-	// IDirect3DDevice8::DeletePixelShader (* unchanged since 4134 *)
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_DeletePixelShader_1_0_4134, XTL::EmuIDirect3DDevice8_DeletePixelShader),
 	// D3DDevice_PersistDisplay
 	OOVPA_TABLE_PATCH(D3DDevice_PersistDisplay_1_0_4627, XTL::EmuIDirect3DDevice8_PersistDisplay),
 	// D3DDevice_PersistDisplay

--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
@@ -1013,6 +1013,10 @@ OOVPA_END;
 // ******************************************************************
 OOVPA_NO_XREF(IDirect3DDevice8_Begin_1_0_4627, 14)
 
+        // IDirect3DDevice8_Begin+0x19 : shl edx, 6
+        { 0x19, 0xD1 }, // (Offset,Value)-Pair #7
+        { 0x1A, 0xE8 }, // (Offset,Value)-Pair #8
+
         // IDirect3DDevice8_Begin+0x25 : mov dword ptr [eax], 0x417FC
         { 0x25, 0xC7 }, // (Offset,Value)-Pair #1
         { 0x26, 0x00 }, // (Offset,Value)-Pair #2
@@ -1020,10 +1024,6 @@ OOVPA_NO_XREF(IDirect3DDevice8_Begin_1_0_4627, 14)
         { 0x28, 0x17 }, // (Offset,Value)-Pair #4
         { 0x29, 0x04 }, // (Offset,Value)-Pair #5
         { 0x2A, 0x00 }, // (Offset,Value)-Pair #6
-
-        // IDirect3DDevice8_Begin+0x19 : shl edx, 6
-        { 0x19, 0xD1 }, // (Offset,Value)-Pair #7
-        { 0x1A, 0xE8 }, // (Offset,Value)-Pair #8
 
         // IDirect3DDevice8_Begin+0x33 : or dword ptr [esi+8], 0x800
         { 0x33, 0x81 }, // (Offset,Value)-Pair #9

--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.5849.inl
@@ -1478,8 +1478,6 @@ OOVPATable D3D8_1_0_5849[] = {
 	OOVPA_TABLE_PATCH(D3DDevice_SetRenderState_StencilFail_1_0_5849, XTL::EmuIDirect3DDevice8_SetRenderState_StencilFail),
 	// D3DDevice_SetRenderState_VertexBlend
 	OOVPA_TABLE_PATCH(D3DDevice_SetRenderState_VertexBlend_1_0_5849, XTL::EmuIDirect3DDevice8_SetRenderState_VertexBlend),
-	// D3DDevice_SetRenderState_VertexBlend
-	OOVPA_TABLE_PATCH(D3DDevice_SetRenderState_VertexBlend_1_0_5849, XTL::EmuIDirect3DDevice8_SetRenderState_VertexBlend),
 	// IDirect3DDevice8::Reset (* unchanged since 4134 *)
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_Reset_1_0_4134, XTL::EmuIDirect3DDevice8_Reset),
 	// IDirect3DDevice::Release
@@ -1580,14 +1578,8 @@ OOVPATable D3D8_1_0_5849[] = {
 	OOVPA_TABLE_PATCH(D3DDevice_DeleteStateBlock_1_0_5849, XTL::EmuIDirect3DDevice8_DeleteStateBlock),
 	// IDirect3DDevice8::SetRenderState_StencilCullEnable (* unchanged since 4134 *)
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_StencilCullEnable_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_StencilCullEnable),
-	// IDirect3DDevice8::SetRenderState_OcclusionCullEnable (* unchanged since 4134 *)
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_OcclusionCullEnable_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_OcclusionCullEnable),
 	// IDirect3DDevice8::SetRenderState_RopZCmpAlwaysRead
 	OOVPA_TABLE_PATCH(D3DDevice_SetRenderState_RopZCmpAlwaysRead_1_0_5849, XTL::EmuIDirect3DDevice8_SetRenderState_RopZCmpAlwaysRead),
-	// IDirect3DDevice8::SetRenderState_RopZRead (* unchanged since 4134 *)
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_RopZRead_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_RopZRead),
-	// IDirect3DDevice8::SetRenderState_DoNotCullUncompressed (* unchanged since 4134 *)
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetRenderState_DoNotCullUncompressed_1_0_4134, XTL::EmuIDirect3DDevice8_SetRenderState_DoNotCullUncompressed),
 	// D3DDevice_GetTexture2
 	OOVPA_TABLE_PATCH(D3DDevice_GetTexture2_1_0_5849, XTL::EmuIDirect3DDevice8_GetTexture2),
 	// IDirect3DDevice8::SetRenderTargetFast (* unchanged since 5344 *)

--- a/src/CxbxKrnl/HLEDataBase/D3D8LTCG.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8LTCG.1.0.5849.inl
@@ -1033,10 +1033,6 @@ OOVPATable D3D8LTCG_1_0_5849[] = {
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetTextureState_ColorKeyColor_1_0_5849_LTCG, XTL::EmuIDirect3DDevice8_SetTextureState_ColorKeyColor),
 	// IDirect3DDevice8::Clear
 	OOVPA_TABLE_PATCH(IDirect3DDevice8_Clear_1_0_5849_LTCG, XTL::EmuIDirect3DDevice8_Clear),
-	// IDirect3DVertexBuffer8::Lock2
-	OOVPA_TABLE_PATCH(IDirect3DVertexBuffer8_Lock2_1_0_5849_LTCG, XTL::EmuIDirect3DVertexBuffer8_Lock2),
-	// IDirect3DDevice8::SetVertexShader
-	OOVPA_TABLE_PATCH(IDirect3DDevice8_SetVertexShader_1_0_5849_LTCG, XTL::EmuIDirect3DDevice8_SetVertexShader),
 };
 
 uint32 D3D8LTCG_1_0_5849_SIZE = sizeof(D3D8LTCG_1_0_5849);

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.3936.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.3936.inl
@@ -1763,6 +1763,11 @@ OOVPA_XREF(CDirectSoundStream_SetVelocityC_1_0_3936, 12,
     XREF_DSSTREAMSETVELOCITY1C,
     XRefZero)
 
+        // CDirectSoundStream_SetVelocityC+0x09 : movsd; movsd; movsd
+        { 0x09, 0xA5 }, // (Offset,Value)-Pair #8
+        { 0x0A, 0xA5 }, // (Offset,Value)-Pair #9
+        { 0x0B, 0xA5 }, // (Offset,Value)-Pair #10
+
         // CDirectSoundStream_SetVelocityC+0x0C : or byte ptr [ecx+0x80], 0x40
         { 0x0C, 0x83 }, // (Offset,Value)-Pair #1
         { 0x0D, 0x89 }, // (Offset,Value)-Pair #2
@@ -1771,11 +1776,6 @@ OOVPA_XREF(CDirectSoundStream_SetVelocityC_1_0_3936, 12,
         { 0x10, 0x00 }, // (Offset,Value)-Pair #5
         { 0x11, 0x00 }, // (Offset,Value)-Pair #6
         { 0x12, 0x40 }, // (Offset,Value)-Pair #7
-
-        // CDirectSoundStream_SetVelocityC+0x09 : movsd; movsd; movsd
-        { 0x09, 0xA5 }, // (Offset,Value)-Pair #8
-        { 0x0A, 0xA5 }, // (Offset,Value)-Pair #9
-        { 0x0B, 0xA5 }, // (Offset,Value)-Pair #10
 
         // CDirectSoundStream_SetVelocityC+0x25 : retn 0x08
         { 0x25, 0xC2 }, // (Offset,Value)-Pair #11

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5233.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5233.inl
@@ -937,8 +937,6 @@ OOVPATable DSound_1_0_5233[] = {
 	OOVPA_TABLE_XREF(CDirectSoundStream_FlushEx_1_0_5233),
 	// IDirectSoundBuffer8::StopEx
 	OOVPA_TABLE_PATCH(IDirectSoundBuffer8_StopEx_1_0_5233, XTL::EmuIDirectSoundBuffer8_StopEx),
-	// IDirectSound8::Release (* unchanged since 3936 *)
-	OOVPA_TABLE_PATCH(IDirectSound8_Release_1_0_3936, XTL::EmuIDirectSound8_Release),
     // DirectSound::CDirectSound::EnableHeadphones (XRef)
 	OOVPA_TABLE_XREF(CDirectSound_EnableHeadphones_1_0_5233),
 	// IDirectSound8::EnableHeadphones

--- a/src/CxbxKrnl/HLEDataBase/XOnline.1.0.5233.inl
+++ b/src/CxbxKrnl/HLEDataBase/XOnline.1.0.5233.inl
@@ -50,17 +50,7 @@ OOVPA_END;
 // ******************************************************************
 // * XNetGetEthernetLinkStatus
 // ******************************************************************
-OOVPA_NO_XREF(XNetGetEthernetLinkStatus_1_0_5344, 8)
-
-        { 0x08, 0x33 },
-        { 0x10, 0x8A },
-        { 0x19, 0x00 },
-        { 0x22, 0x56 },
-        { 0x2B, 0xFF },
-        { 0x34, 0xF0 },
-        { 0x3D, 0x24 },
-        { 0x46, 0x5B },
-OOVPA_END;
+#define XNetGetEthernetLinkStatus_1_0_5344 XNetGetEthernetLinkStatus_1_0_4627
 
 // ******************************************************************
 // * CXo::XOnlineLogon

--- a/src/CxbxKrnl/HLEDataBase/XOnline.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/XOnline.1.0.5849.inl
@@ -82,17 +82,7 @@ OOVPA_END;
 // ******************************************************************
 // * XNetGetEthernetLinkStatus
 // ******************************************************************
-OOVPA_NO_XREF(XNetGetEthernetLinkStatus_1_0_5849, 8)
-
-        { 0x08, 0x33 },
-        { 0x10, 0x8A },
-        { 0x19, 0x00 },
-        { 0x22, 0x56 },
-        { 0x2B, 0xFF },
-        { 0x34, 0xF0 },
-        { 0x3D, 0x24 },
-        { 0x46, 0x5B },
-OOVPA_END;
+#define XNetGetEthernetLinkStatus_1_0_5849 XNetGetEthernetLinkStatus_1_0_4627
 
 // ******************************************************************
 // * XOnline_1_0_5849

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.3911.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.3911.inl
@@ -1017,8 +1017,6 @@ OOVPATable XAPI_1_0_3911[] = {
 	OOVPA_TABLE_PATCH(SetThreadPriorityBoost_1_0_3911, XTL::EmuSetThreadPriorityBoost),
 	// GetThreadPriority
 	OOVPA_TABLE_PATCH(GetThreadPriority_1_0_3911, XTL::EmuGetThreadPriority),
-	// XGetDevices
-	OOVPA_TABLE_PATCH(XGetDevices_1_0_3911, XTL::EmuXGetDevices),
 	// CreateFiber
 	OOVPA_TABLE_PATCH(CreateFiber_1_0_3911, XTL::EmuCreateFiber),
 	// DeleteFiber
@@ -1027,8 +1025,6 @@ OOVPATable XAPI_1_0_3911[] = {
 	OOVPA_TABLE_PATCH(SwitchToFiber_1_0_3911, XTL::EmuSwitchToFiber),
 	// ConvertThreadToFiber
 	OOVPA_TABLE_PATCH(ConvertThreadToFiber_1_0_3911, XTL::EmuConvertThreadToFiber),
-	// XInputGetCapabilities
-	OOVPA_TABLE_PATCH(XInputGetCapabilities_1_0_3911, XTL::EmuXInputGetCapabilities),
 	// SignalObjectAndWait
 	OOVPA_TABLE_PATCH(SignalObjectAndWait_1_0_3911, XTL::EmuSignalObjectAndWait),
 	// QueueUserAPC

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5558.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5558.inl
@@ -282,8 +282,6 @@ OOVPATable XAPI_1_0_5558[] = {
 	OOVPA_TABLE_PATCH(GetThreadPriority_1_0_4627, XTL::EmuGetThreadPriority),
 	// GetTimeZoneInformation (* unchanged since 3911 *)
 	OOVPA_TABLE_PATCH(GetTimeZoneInformation_1_0_3911, XTL::EmuGetTimeZoneInformation),
-	// SetThreadPriority (* unchanged since 3911 *)
-	OOVPA_TABLE_PATCH(SetThreadPriority_1_0_3911, XTL::EmuSetThreadPriority),
 	// XMountMUA
 	OOVPA_TABLE_PATCH(XMountMUA_1_0_5558, XTL::EmuXMountMUA),
 	// CreateFiber

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -915,9 +915,13 @@ void VerifyHLEDataEntry(HLEVerifyContext *context, const OOVPATable *table, uint
 			// check no patch occurs twice in this table
 			for (uint32 t = index + 1; t < count; t++) {
 				if (entry_redirect == table[t].lpRedirect) {
-					HLEError(context, "Patch (0x%x) also occurs at index %d",
-						table[index].lpRedirect,
-						t);
+					if (table[index].Oovpa == table[t].Oovpa) {
+						HLEError(context, "Patch registered again (with same OOVPA) at index %d",
+							t);
+					} else {
+						HLEError(context, "Patch also used for another OOVPA at index %d",
+							t);
+					}
 				}
 			}
 		}

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -773,6 +773,7 @@ void VerifyOOVPA(OOVPA *against, std::string info, OOVPA *oovpa)
 			GetOovpaEntry(oovpa, p, curr_offset, dummy_value);
 			if (!(curr_offset > prev_offset)) {
 				printf("Error in %s OOVPA at index %d : offset %d must be larger then previous offset (%d)\n",
+					info.c_str(), p, curr_offset, prev_offset);
 			}
 		}
 
@@ -839,6 +840,7 @@ void VerifyOOVPA(OOVPA *against, std::string info, OOVPA *oovpa)
 	if (equal_offset_different_value == 0)
 		if (unique_offset_left < 3)
 			if (unique_offset_right < 3)
+				printf("%s Duplicate OOVPA found!\n", info.c_str());
 }
 
 void VerifyHLEDataEntry(OOVPA *against, std::string info, const OOVPATable *mainTable, uint32 e, uint32 count)

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -884,9 +884,10 @@ void VerifyHLEOOVPA(HLEVerifyContext *context, OOVPA *oovpa)
 	if (equal_offset_different_value == 0)
 		if (unique_offset_left < 3)
 			if (unique_offset_right < 3)
-				HLEError(context, "Duplicate OOVPA found (left +%d, right +%d)", 
-					unique_offset_left,
-					unique_offset_right);
+				if (equal_offset_value > 3)
+					HLEError(context, "Duplicate OOVPA found (left +%d, right +%d)",
+						unique_offset_left,
+						unique_offset_right);
 }
 
 void VerifyHLEDataEntry(HLEVerifyContext *context, const OOVPATable *table, uint32 index, uint32 count)

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -759,7 +759,7 @@ static void EmuXRefFailure()
     CxbxKrnlCleanup("XRef-only function body reached. Fatal Error.");
 }
 
-void VerifyOOVPA(OOVPA *against, OOVPA *oovpa)
+void VerifyOOVPA(OOVPA *against, std::string info, OOVPA *oovpa)
 {
 	if (against == nullptr) {
 		// TODO : verify XRefSaveIndex and XRef's (how?)
@@ -772,8 +772,7 @@ void VerifyOOVPA(OOVPA *against, OOVPA *oovpa)
 			uint32 curr_offset;
 			GetOovpaEntry(oovpa, p, curr_offset, dummy_value);
 			if (!(curr_offset > prev_offset)) {
-				printf("Error in OOVPA %s at index %d : offset %d must be larger then previous offset (%d)\n",
-					"todo", p, curr_offset, prev_offset);
+				printf("Error in %s OOVPA at index %d : offset %d must be larger then previous offset (%d)\n",
 			}
 		}
 
@@ -840,10 +839,9 @@ void VerifyOOVPA(OOVPA *against, OOVPA *oovpa)
 	if (equal_offset_different_value == 0)
 		if (unique_offset_left < 3)
 			if (unique_offset_right < 3)
-				printf("Duplicate OOVPA found!");
 }
 
-void VerifyHLEDataEntry(OOVPA *against, const OOVPATable *mainTable, uint32 e, uint32 count)
+void VerifyHLEDataEntry(OOVPA *against, std::string info, const OOVPATable *mainTable, uint32 e, uint32 count)
 {
 	if (against == nullptr) {
 		// does this entry specify a redirection (patch)?
@@ -853,7 +851,7 @@ void VerifyHLEDataEntry(OOVPA *against, const OOVPATable *mainTable, uint32 e, u
 			for (uint32 t = e + 1; t < count; t++) {
 				if (entry_redirect == mainTable[t].lpRedirect) {
 					printf("Error in OOVPA Table %s at index %d : patch 0x%x (%s) occurs also at index %d (%s)\n",
-						mainTable->szFuncName, 
+						info, 
 						e,
 						mainTable[e].lpRedirect,
 						mainTable[e].szFuncName,
@@ -865,15 +863,16 @@ void VerifyHLEDataEntry(OOVPA *against, const OOVPATable *mainTable, uint32 e, u
 	}
 
 	// verify the OOVPA of this entry
-	VerifyOOVPA(against, mainTable[e].Oovpa);
+	VerifyOOVPA(against, info, mainTable[e].Oovpa);
 }
 
 void VerifyHLEData(OOVPA *against, const HLEData *mainData)
 {
 	// verify each entry in this HLEData
+	std::string info = mainData->Library; // + mainData->BuildVersion
 	uint32 count = mainData->OovpaTableSize / sizeof(OOVPATable);
 	for (uint32 e = 0; e < count; e++)
-		VerifyHLEDataEntry(against, mainData->OovpaTable, e, count);
+		VerifyHLEDataEntry(against, info, mainData->OovpaTable, e, count);
 }
 
 void VerifyHLEDataBase(OOVPA *against)

--- a/src/CxbxKrnl/HLEIntercept.h
+++ b/src/CxbxKrnl/HLEIntercept.h
@@ -34,12 +34,14 @@
 #ifndef HLEINTERCEPT_H
 #define HLEINTERCEPT_H
 
+#include "OOVPA.h" // for OOVPA
+
 extern bool bLLE_APU; // Set this to true for experimental APU (sound) LLE
 extern bool bLLE_GPU; // Set this to true for experimental GPU (graphics) LLE
 extern bool bLLE_JIT; // Set this to true for experimental JIT
 
 void EmuHLEIntercept(Xbe::LibraryVersion *LibraryVersion, Xbe::Header *XbeHeader);
 
-void VerifyHLEData();
+void VerifyHLEDataBase(OOVPA *against = nullptr);
 
 #endif

--- a/src/CxbxKrnl/HLEIntercept.h
+++ b/src/CxbxKrnl/HLEIntercept.h
@@ -40,4 +40,6 @@ extern bool bLLE_JIT; // Set this to true for experimental JIT
 
 void EmuHLEIntercept(Xbe::LibraryVersion *LibraryVersion, Xbe::Header *XbeHeader);
 
+void VerifyHLEData();
+
 #endif

--- a/src/CxbxKrnl/HLEIntercept.h
+++ b/src/CxbxKrnl/HLEIntercept.h
@@ -34,14 +34,14 @@
 #ifndef HLEINTERCEPT_H
 #define HLEINTERCEPT_H
 
-#include "OOVPA.h" // for OOVPA
-
 extern bool bLLE_APU; // Set this to true for experimental APU (sound) LLE
 extern bool bLLE_GPU; // Set this to true for experimental GPU (graphics) LLE
 extern bool bLLE_JIT; // Set this to true for experimental JIT
 
 void EmuHLEIntercept(Xbe::LibraryVersion *LibraryVersion, Xbe::Header *XbeHeader);
 
-void VerifyHLEDataBase(OOVPA *against = nullptr);
-
+#ifdef _DEBUG_TRACE
+void VerifyHLEDataBase();
 #endif
+
+#endif // HLEINTERCEPT_H


### PR DESCRIPTION
This detects:
* multiple uses of the same patch in the same OOVPATable
* identical OOVPA's
* similar, but expanded OOVPA's
* non-incremental ordering of offsets 

Currently, this verification results in 1852 errors;
* 202 re-used patches
* 1176 identical OOVPA's
* 474 expanded OOVPA's

The last category (ordering of offsets) did trigger a few times, but are already fixed by this PR.
