### PR TITLE
Revert "Fixed Controller binding keys."

### DIFF
--- a/src/Common/Win32/XBController.h
+++ b/src/Common/Win32/XBController.h
@@ -63,12 +63,12 @@ enum XBCtrlObject
     // ******************************************************************
     // * Analog Buttons
     // ******************************************************************
-    XBCTRL_OBJECT_X,
-    XBCTRL_OBJECT_Y,
     XBCTRL_OBJECT_A,
     XBCTRL_OBJECT_B,
-    XBCTRL_OBJECT_WHITE,
+    XBCTRL_OBJECT_X,
+    XBCTRL_OBJECT_Y,
     XBCTRL_OBJECT_BLACK,
+    XBCTRL_OBJECT_WHITE,
     XBCTRL_OBJECT_LTRIGGER,
     XBCTRL_OBJECT_RTRIGGER,
     // ******************************************************************


### PR DESCRIPTION
Reverts Cxbx-Reloaded/Cxbx-Reloaded#186 - instead of changing the enum, just fix the real bug, in m_DeviceNameLookup