### PR TITLE
Fixed #197 Silent Hill 4 regression

### DIFF
--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.5849.inl
@@ -1489,6 +1489,8 @@ OOVPATable D3D8_5849[] = {
 	REGISTER_OOVPA(D3D_SetFence, 5849, XREF),
 	REGISTER_OOVPA(D3DDevice_GetViewportOffsetAndScale, 5849, PATCH),
 	REGISTER_OOVPA(D3DDevice_CreateStateBlock, 5849, PATCH),
+	REGISTER_OOVPA(D3DDevice_CreateIndexBuffer2, 5558, PATCH),
+	REGISTER_OOVPA(D3DDevice_CreatePalette2, 5558, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5849.inl
@@ -761,14 +761,15 @@ OOVPA_END;
 // Xbe Explorer generated pattern, derived from address $00439F47 in "SpiderMan 2" :
 // 56E8........833DD4........0FB6F0741685F6740B68E03B4400FF15...... 00 0000 005F ? SetRolloffFactor@CDirectSound@DirectSound@@QAGJMK@Z ^ 0002R ? DirectSoundEnterCriticalSection@@YGHXZ ^0009D _g_fDirectSoundInFinalRelease ^ 001DD __imp__RtlLeaveCriticalSection@4 ^ 0046R ? CommitDeferredSettings@CDirectSound@DirectSound@@QAGJXZ ^ 0055D __imp__RtlLeaveCriticalSection@4
 // ******************************************************************
-OOVPA_XREF(DirectSound_CDirectSound_SetRolloffFactor, 5849, 22,
+OOVPA_XREF(DirectSound_CDirectSound_SetRolloffFactor, 5849, 20,
+
     XREF_SETROLLOFFFACTORA,
     XRefZero)
+
         { 0x00, 0x56 },
         { 0x01, 0xE8 },
         { 0x06, 0x83 },
         { 0x07, 0x3D },
-        { 0x08, 0xD4 },
         { 0x0D, 0x0F },
         { 0x0E, 0xB6 },
 		{ 0x0F, 0xF0 },
@@ -779,12 +780,11 @@ OOVPA_XREF(DirectSound_CDirectSound_SetRolloffFactor, 5849, 22,
 		{ 0x14, 0x74 },
 		{ 0x15, 0x0B },
 		{ 0x16, 0x68 },
-		{ 0x17, 0xE0 },
-		{ 0x18, 0x3B },
-		{ 0x19, 0x44 },
 		{ 0x1A, 0x00 },
 		{ 0x1B, 0xFF },
 		{ 0x1C, 0x15 },
+		{ 0x35, 0x6C },
+		{ 0x3C, 0x10 },
 		{ 0x5C, 0xC2 },
 OOVPA_END;
 
@@ -1702,6 +1702,7 @@ OOVPATable DSound_5849[] = {
 
 	REGISTER_OOVPA(DirectSoundCreate, 4361, PATCH),
 	REGISTER_OOVPA(DirectSound_CDirectSound_CreateSoundBuffer, 4627, XREF),
+	REGISTER_OOVPA(DirectSound_CDirectSoundBuffer_SetPlayRegion, 5558, XREF),
 	REGISTER_OOVPA(IDirectSoundBuffer_SetPlayRegion, 4361, PATCH),
 	REGISTER_OOVPA(CMcpxBuffer_SetBufferData, 5849, XREF),
 	REGISTER_OOVPA(DirectSound_CDirectSoundBuffer_SetBufferData, 4361, XREF),
@@ -1767,7 +1768,7 @@ OOVPATable DSound_5849[] = {
 	REGISTER_OOVPA(IDirectSoundBuffer_StopEx, 5849, ALIAS, DirectSound_CDirectSoundBuffer_StopEx),
 	REGISTER_OOVPA(DirectSound_CDirectSound_SetRolloffFactor, 5849, XREF),
 	REGISTER_OOVPA(IDirectSound_SetRolloffFactor, 4627, PATCH),
-	REGISTER_OOVPA(DirectSound_CDirectSound_SetRolloffFactor, 5344, XREF),
+	REGISTER_OOVPA(DirectSound_CDirectSound_SetRolloffFactor, 5344, DISABLED),
 	REGISTER_OOVPA(DirectSound_CDirectSound_SetDopplerFactor, 5849, XREF),
 	REGISTER_OOVPA(IDirectSound_SetDopplerFactor, 4627, PATCH),
 	REGISTER_OOVPA(DirectSound_CDirectSoundVoice_SetPitch, 5849, XREF),


### PR DESCRIPTION
Again showed Konami logo. However, the color of the logo is incorrect.