### PR TITLE
XAPI: Patch OutputDebugStringA

### DIFF
--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -1253,3 +1253,15 @@ DWORD WINAPI XTL::EMUPATCH(XMountMURootA)
 
 	RETURN(ERROR_SUCCESS);
 }
+
+// ******************************************************************
+// * patch: OutputDebugStringA
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(OutputDebugStringA)
+(
+	IN LPCSTR lpOutputString
+)
+{
+	LOG_FUNC_ONE_ARG(lpOutputString);
+	printf("OutputDebugStringA: %s\n", lpOutputString);
+}

--- a/src/CxbxKrnl/EmuXapi.h
+++ b/src/CxbxKrnl/EmuXapi.h
@@ -750,6 +750,14 @@ BOOL WINAPI EMUPATCH(WriteFileEx)
 	LPOVERLAPPED_COMPLETION_ROUTINE lpCompletionRoutine // completion routine
 );
 
+// ******************************************************************
+// * patch: OutputDebugStringA
+// ******************************************************************
+VOID WINAPI EMUPATCH(OutputDebugStringA)
+(
+	IN LPCSTR lpOutputString
+);
+
 // s+
 /* not necessary?
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.3911.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.3911.inl
@@ -156,6 +156,44 @@ OOVPA_NO_XREF(SetThreadPriority, 3911, 10)
 OOVPA_END;
 
 // ******************************************************************
+// * OutputDebugStringA
+// ******************************************************************
+OOVPA_NO_XREF(OutputDebugStringA, 3911, 32)
+		{ 0x00, 0x55 },
+		{ 0x01, 0x8B },
+		{ 0x02, 0xEC },
+		{ 0x03, 0x51 },
+		{ 0x04, 0x51 },
+		{ 0x05, 0x8B },
+		{ 0x06, 0x45 },
+		{ 0x07, 0x08 },
+		{ 0x08, 0x89 },
+		{ 0x09, 0x45 },
+		{ 0x0A, 0xFC },
+		{ 0x0B, 0x8D },
+		{ 0x0C, 0x48 },
+		{ 0x0D, 0x01 },
+		{ 0x0E, 0x8A },
+		{ 0x0F, 0x10 },
+		{ 0x10, 0x40 },
+		{ 0x11, 0x84 },
+		{ 0x12, 0xD2 },
+		{ 0x13, 0x75 },
+		{ 0x14, 0xF9 },
+		{ 0x15, 0x2B },
+		{ 0x16, 0xC1 },
+		{ 0x17, 0x66 },
+		{ 0x18, 0x89 },
+		{ 0x19, 0x45 },
+		{ 0x1A, 0xF8 },
+		{ 0x1B, 0x8B },
+		{ 0x1C, 0x45 },
+		{ 0x1D, 0xF8 },
+		{ 0x1E, 0x40 },
+		{ 0x1F, 0x66 },
+OOVPA_END;
+
+// ******************************************************************
 // * XapiInitProcess
 // ******************************************************************
 OOVPA_NO_XREF(XapiInitProcess, 3911, 7)
@@ -1031,13 +1069,13 @@ OOVPA_END;
 OOVPATable XAPI_3911[] = {
 
 	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
-	REGISTER_OOVPA(XInitDevices, 3911, PATCH), 
-    // REGISTER_OOVPA(CreateMutex, 3911, PATCH), // Too High Level
-    // REGISTER_OOVPA(CreateThread, 3911, PATCH), // Too High Level
+	REGISTER_OOVPA(XInitDevices, 3911, PATCH),
+	// REGISTER_OOVPA(CreateMutex, 3911, PATCH), // Too High Level
+	// REGISTER_OOVPA(CreateThread, 3911, PATCH), // Too High Level
 	REGISTER_OOVPA(SetThreadPriority, 3911, PATCH), //*/
 	REGISTER_OOVPA(GetTimeZoneInformation, 3911, DISABLED),
 	REGISTER_OOVPA(XRegisterThreadNotifyRoutine, 3911, PATCH),
-    // REGISTER_OOVPA(XCalculateSignatureBegin, 3911, PATCH),
+	// REGISTER_OOVPA(XCalculateSignatureBegin, 3911, PATCH),
 	REGISTER_OOVPA(XGetDevices, 3911, PATCH),
 	REGISTER_OOVPA(XGetDeviceChanges, 3911, PATCH),
 	REGISTER_OOVPA(XInputOpen, 3911, PATCH),
@@ -1063,6 +1101,7 @@ OOVPATable XAPI_3911[] = {
 	REGISTER_OOVPA(XAutoPowerDownResetTimer, 3911, PATCH),
 	REGISTER_OOVPA(XMountMURootA, 3911, PATCH),
 	REGISTER_OOVPA(XMountUtilityDrive, 3911, PATCH),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 	// REGISTER_OOVPA(ReadFileEx, 3911, PATCH),
 	// REGISTER_OOVPA(WriteFileEx, 3911, PATCH),
 	// REGISTER_OOVPA(CloseHandle, 3911, PATCH),

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4034.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4034.inl
@@ -189,6 +189,7 @@ OOVPATable XAPI_4034[] = {
 	REGISTER_OOVPA(GetThreadPriority, 3911, PATCH),
 	REGISTER_OOVPA(XInputOpen, 3911, PATCH),
 	REGISTER_OOVPA(XInputGetState, 3911, PATCH),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4134.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4134.inl
@@ -237,6 +237,7 @@ OOVPATable XAPI_4134[] = {
 	REGISTER_OOVPA(timeSetEvent, 4134, PATCH),
 	REGISTER_OOVPA(timeKillEvent, 4134, PATCH),
 	REGISTER_OOVPA(XLaunchNewImage, 3911, ALIAS, XLaunchNewImageA),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4361.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4361.inl
@@ -361,6 +361,7 @@ OOVPATable XAPI_4361[] = {
 	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
 	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
 	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4432.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4432.inl
@@ -80,6 +80,7 @@ OOVPATable XAPI_4432[] = {
 	REGISTER_OOVPA(timeSetEvent, 4134, PATCH),
 	REGISTER_OOVPA(timeKillEvent, 4134, PATCH),
 	REGISTER_OOVPA(XLaunchNewImage, 3911, ALIAS, XLaunchNewImageA),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4627.inl
@@ -692,6 +692,7 @@ OOVPATable XAPI_4627[] = {
 	REGISTER_OOVPA(XMountAlternateTitle, 4928, ALIAS, XMountAlternateTitleA),
 	REGISTER_OOVPA(XUnmountAlternateTitle, 4627, ALIAS, XUnmountAlternateTitleA),
 	REGISTER_OOVPA(XInputGetDeviceDescription, 4831, PATCH),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 	// REGISTER_OOVPA(MoveFileA, 4627, PATCH),
 };
 

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4721.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4721.inl
@@ -59,6 +59,7 @@ OOVPATable XAPI_4721[] = {
 	REGISTER_OOVPA(DeleteFiber, 3911, DISABLED),
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5233.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5233.inl
@@ -118,6 +118,7 @@ OOVPATable XAPI_5233[] = {
 	REGISTER_OOVPA(DeleteFiber, 3911, DISABLED),
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5344.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5344.inl
@@ -57,6 +57,7 @@ OOVPATable XAPI_5344[] = {
 	REGISTER_OOVPA(DeleteFiber, 3911, DISABLED),
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5558.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5558.inl
@@ -215,6 +215,7 @@ OOVPATable XAPI_5558[] = {
 	// REGISTER_OOVPA(XapiFiberStartup, 5558, PATCH),
 	REGISTER_OOVPA(XID_fCloseDevice, 5558, XREF),
 	REGISTER_OOVPA(XInputClose, 5558, PATCH),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5849.inl
@@ -202,6 +202,7 @@ OOVPATable XAPI_5849[] = {
 	REGISTER_OOVPA(DeleteFiber, 3911, DISABLED),
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 };
 
 // ******************************************************************


### PR DESCRIPTION
4x4 Evolution 2 now boots to Intros.
Many other titles are likely affected.

This is required to be patched as the Xbox implementation calls int 2Dh
and int 3, which on the Xbox causes the Kernel to trigger debug output.

On Windows, int 2Dh is skipped over, and we just end up with an
unexpected breakpoint.