### PR TITLE
Fixed a bug in EmuIDirectSoundBuffer_SetNotificationPositions.

### DIFF
--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -3692,7 +3692,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetNotificationPositions)
 	{
 		if( pThis->EmuDirectSoundBuffer8 )
 		{
-			hr = pThis->EmuDirectSoundBuffer8->QueryInterface( IID_IDirectSoundNotify, (LPVOID*) pNotify );
+			hr = pThis->EmuDirectSoundBuffer8->QueryInterface( IID_IDirectSoundNotify, (LPVOID*) &pNotify );
 			if( SUCCEEDED( hr ) && pNotify != nullptr )
 			{
 				hr = pNotify->SetNotificationPositions( dwNotifyCount, paNotifies );


### PR DESCRIPTION
The QueryInterface was called with *ppvObject instead of **ppvObject.

This makes the call to SetNotificationPositions actually succeed, so for example the XBOX Dashboard logs are now completely free of "EmuWarn: Could not create notification interface!"