### PR TITLE
Avoid including version.h everywhere. Use multiprocessor build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 #Documentation output
 doc/doxygen/html
 
+#Export
+export
+
 #Visual Studio files
 *.[Oo]bj
 *.user

--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -77,13 +77,13 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\src\Common;..\..\src;..\..\src\Common\Win32;..\..\import\stb;%(AdditionalIncludeDirectories);..\..\import\OpenXDK\include;..\..\import\distorm\include;..\..\import\glew-2.0.0\include;..\..\src;..\..\src\Common;..\..\src\Common\Win32</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -145,6 +145,7 @@ $(SOLUTIONDIR)Export.bat</Command>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -279,6 +280,7 @@ $(SOLUTIONDIR)Export.bat</Command>
     <ClInclude Include="..\..\src\CxbxKrnl\OOVPA.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\ReservedMemory.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\ResourceTracker.h" />
+    <ClInclude Include="..\..\src\CxbxVersion.h" />
     <ClInclude Include="..\..\src\Cxbx\DlgControllerConfig.h" />
     <ClInclude Include="..\..\src\Cxbx\DlgVideoConfig.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\Emu.h" />

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -525,6 +525,9 @@
     <ClInclude Include="..\..\src\Common\EmuEEPROM.h">
       <Filter>Shared</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\CxbxVersion.h">
+      <Filter>Shared</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\About.jpg">

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -34,6 +34,7 @@
 // *
 // ******************************************************************
 #include "Xbe.h"
+#include "CxbxVersion.h"
 #include "CxbxUtil.h"
 
 #include <memory.h>

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -75,14 +75,6 @@ typedef signed long    sint32;
 /*! define this to dump textures that are registered */
 //#define _DEBUG_DUMP_TEXTURE_REGISTER   "D:\\cxbx\\_textures\\"
 
-#include "Version.h"
-
-/*! version string dependent on trace flag */
-#ifndef _DEBUG_TRACE
-#define _CXBX_VERSION _GIT_VERSION " (" __DATE__  ")"
-#else
-#define _CXBX_VERSION _GIT_VERSION "-Trace (" __DATE__  ")"
-#endif
 
 /*! debug mode choices */
 enum DebugMode { DM_NONE, DM_CONSOLE, DM_FILE };

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -39,6 +39,7 @@
 #include "DlgVideoConfig.h"
 #include "CxbxKrnl/EmuShared.h"
 #include "ResCxbx.h"
+#include "CxbxVersion.h"
 
 #include <io.h>
 

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -44,6 +44,7 @@ namespace xboxkrnl
 };
 
 #include "CxbxKrnl.h"
+#include "CxbxVersion.h"
 #include "Emu.h"
 #include "EmuX86.h"
 #include "EmuFile.h"

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -43,6 +43,7 @@ namespace xboxkrnl
 };
 
 #include "CxbxUtil.h"
+#include "CxbxVersion.h"
 #include "CxbxKrnl.h"
 #include "Emu.h"
 #include "EmuFS.h"

--- a/src/CxbxVersion.h
+++ b/src/CxbxVersion.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Version.h"
+
+/*! version string dependent on trace flag */
+#ifndef _DEBUG_TRACE
+#define _CXBX_VERSION _GIT_VERSION " (" __DATE__  ")"
+#else
+#define _CXBX_VERSION _GIT_VERSION "-Trace (" __DATE__  ")"
+#endif


### PR DESCRIPTION
Version.h was included everywhere through Cxbx.h, and it's updated every build. This leads to every file being recompiled on every build which got to kill your workflow.

So moved that to CxbxVersion.h, which is now included only in four files. This does not make things perfect, but way, way faster at least.