### PR TITLE
Fix a crash when a titles calls Resource_Release on a palette.

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5162,7 +5162,7 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
 
         if(pThis->Lock == X_D3DRESOURCE_LOCK_PALETTE)
         {
-            delete[] (PVOID)pThis->Data;
+            g_MemoryManager.Free((void*)pThis->Data);
             uRet = --pThis->Lock;
         }
         else if(pResource8 != nullptr)


### PR DESCRIPTION
Gauntlet now shows a splash screen rather than crashing instantly