### PR TITLE
Re-enable patch for XgIsSwizzledFormat.

### DIFF
--- a/src/CxbxKrnl/EmuXG.cpp
+++ b/src/CxbxKrnl/EmuXG.cpp
@@ -53,7 +53,6 @@ namespace NtDll
 
 #include "EmuXTL.h"
 
-#if 0 // patch disabled
 // ******************************************************************
 // * patch: XGIsSwizzledFormat
 // ******************************************************************
@@ -66,7 +65,6 @@ PVOID WINAPI XTL::EMUPATCH(XGIsSwizzledFormat)
 
 	RETURN(FALSE);
 }
-#endif
 
 /* Leave unpatched
 // ******************************************************************

--- a/src/CxbxKrnl/EmuXG.h
+++ b/src/CxbxKrnl/EmuXG.h
@@ -42,7 +42,7 @@ typedef struct _XGPOINT3D
 }
 XGPOINT3D;
 
-#if 0 // patch disabled
+// patch disabled
 // ******************************************************************
 // * patch: XGIsSwizzledFormat
 // ******************************************************************
@@ -50,7 +50,6 @@ PVOID WINAPI EMUPATCH(XGIsSwizzledFormat)
 (
     X_D3DFORMAT     Format
 );
-#endif
 
 /* Leave unpatched
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.3911.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.3911.inl
@@ -126,7 +126,7 @@ OOVPA_END;
 // ******************************************************************
 OOVPATable XG_3911[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 3911, PATCH), // Leave unpatched
 	// REGISTER_OOVPA(XGUnswizzleRect, 3911, PATCH), // Leave unpatched
 	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4034.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4034.inl
@@ -114,7 +114,7 @@ OOVPA_END;
 // ******************************************************************
 OOVPATable XG_4034[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 3911, PATCH), // Leave unpatched
     // REGISTER_OOVPA(XGUnswizzleRect, 3911, PATCH),
 	REGISTER_OOVPA(XGSwizzleBox, 3911, DISABLED),

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4361.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4361.inl
@@ -151,7 +151,7 @@ OOVPA_END;
 // ******************************************************************
 OOVPATable XG_4361[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 4361, PATCH), // Leave unpatched
 	// REGISTER_OOVPA(XGUnswizzleRect, 4361, PATCH), // Leave unpatched
 	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4432.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4432.inl
@@ -39,7 +39,7 @@
 // ******************************************************************
 OOVPATable XG_4432[1] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 4361, PATCH), // Leave unpatched
 };
 

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4627.inl
@@ -92,7 +92,7 @@ OOVPA_END;
 // ******************************************************************
 OOVPATable XG_4627[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 4361, PATCH), // Leave unpatched
 	// REGISTER_OOVPA(XGUnswizzleRect, 4627, PATCH), // Leave unpatched
 	REGISTER_OOVPA(XGSwizzleBox, 4627, PATCH),

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5028.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5028.inl
@@ -37,7 +37,7 @@
 // ******************************************************************
 OOVPATable XG_5028[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 4361, PATCH), // Leave unpatched
 	// REGISTER_OOVPA(XGUnswizzleRect, 4627, PATCH), // Leave unpatched
 	REGISTER_OOVPA(XGSwizzleBox, 4627, PATCH),

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5233.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5233.inl
@@ -37,7 +37,7 @@
 // ******************************************************************
 OOVPATable XG_5233[1] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 4361, PATCH), // Leave unpatched
 };
 

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5344.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5344.inl
@@ -37,7 +37,7 @@
 // ******************************************************************
 OOVPATable XG_5344[1] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 4361, PATCH), // Leave unpatched
 };
 

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5558.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5558.inl
@@ -123,7 +123,7 @@ OOVPA_END;
 // ******************************************************************
 OOVPATable XG_5558[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
     
 	// REGISTER_OOVPA(XGSwizzleRect, 5558, PATCH), // Leave unpatched
 	REGISTER_OOVPA(XGSwizzleBox, 5558, PATCH), // (* UNTESTED *)

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5849.inl
@@ -76,7 +76,7 @@ OOVPA_END;
 // ******************************************************************
 OOVPATable XG_5849[1] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, DISABLED),
+	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
     // REGISTER_OOVPA(XGSwizzleRect, 5558, PATCH), // Leave unpatched
 	// REGISTER_OOVPA(XGUnswizzleRect, 5558, PATCH), // Leave unpatched
 	// REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 5849, PATCH),


### PR DESCRIPTION
This fixes texture corruption in X-Marbles, ZSNESBOX and potentially
others.