### PR TITLE
Verified the LoadVertexShaderProgram (4627-5344)

### DIFF
--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
@@ -1747,7 +1747,7 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_LoadVertexShaderProgram
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 4627, 9)
+OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 4627, 8)
 
         { 0x0B, 0x2D },
         { 0x18, 0x10 },
@@ -1757,7 +1757,6 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 4627, 9)
         { 0x1C, 0x8D },
         { 0x25, 0xE0 },
         { 0x32, 0x5F },
-        { 0x61, 0xC2 },
 OOVPA_END;
 
 // ******************************************************************


### PR DESCRIPTION
I changed it with commit 108228e75a7c2b73654ad392581ed4aa4a6fb11d, but length was different between 5344 and 4627, so retn 8 was removed.
Source: Terminator - Dawn of Fate