### PR TITLE
Revert "Temporarily disable vertex buffer caching."

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -291,7 +291,6 @@ bool XTL::VertexPatcher::ApplyCachedStream(VertexPatchDesc *pPatchDesc,
                 }
             }
 
-			/*
             // Use the cached stream length (which is a must for the UP stream)
             uint32_t uiHash = XXHash32::hash((void *)pCalculateData, pCachedStream->uiLength, HASH_SEED);
             if(uiHash == pCachedStream->uiHash)
@@ -303,7 +302,7 @@ bool XTL::VertexPatcher::ApplyCachedStream(VertexPatchDesc *pPatchDesc,
                 }
                 pCachedStream->uiCount = 0;
             }
-            else */
+            else
             {
                 // TODO: Do something about this
                 if(pCachedStream->bIsUP)


### PR DESCRIPTION
This reverts commit d5b67a8f7b8163ab1ae132fae0e63b1917c8a4ba.

The speed impact, although almost non-existent for myself was
significant enough to hinder other users, and even other devs. We need
to figure out how to fix this properly.