### PR TITLE
Index buffer fixes

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -754,6 +754,9 @@ void CxbxKrnlInit
 	// initialize grapchics
 	DbgPrintf("EmuMain: Initializing render window.\n");
 	XTL::CxbxInitWindow(pXbeHeader, dwXbeHeaderSize);
+
+	EmuHLEIntercept(pXbeHeader);
+
 	if (bLLE_GPU)
 	{
 		DbgPrintf("EmuMain: Initializing OpenGL.\n");
@@ -765,7 +768,6 @@ void CxbxKrnlInit
 		XTL::EmuD3DInit();
 	}
 
-	EmuHLEIntercept(pXbeHeader);
 	// Apply Media Patches to bypass Anti-Piracy checks
 	// Required until we perfect emulation of X2 DVD Authentication
 	// See: https://multimedia.cx/eggs/xbox-sphinx-protocol/

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1532,7 +1532,7 @@ void CxbxUpdateActiveIndexBuffer
 
 	// If the size has changed, free the buffer so it will be re-created
 	if (g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer != nullptr && 
-		g_ConvertedIndexBuffers[pIndexData].IndexCount != IndexCount) {
+		g_ConvertedIndexBuffers[pIndexData].IndexCount < IndexCount) {
 		g_ConvertedIndexBuffers[pIndexData].Hash = 0;
 		g_ConvertedIndexBuffers[pIndexData].IndexCount = 0;
 		g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer->Release();
@@ -1550,7 +1550,7 @@ void CxbxUpdateActiveIndexBuffer
 			&g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer);
 
 		if (FAILED(hRet)) {
-			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: IndexBuffer Create Failed!");
+			CxbxKrnlCleanup("CxbxUpdateActiveIndexBuffer: IndexBuffer Create Failed!");
 		}
 	}
 
@@ -1563,11 +1563,13 @@ void CxbxUpdateActiveIndexBuffer
 
 		g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer->Lock(0, 0, &pData, 0);
 		if (pData == nullptr) {
-			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: Could not lock index buffer!");
+			CxbxKrnlCleanup("CxbxUpdateActiveIndexBuffer: Could not lock index buffer!");
 		}
 
-		DbgPrintf("DxbxUpdateActiveIndexBuffer: Copying %d indices (D3DFMT_INDEX16)\n", IndexCount);
+		printf("CxbxUpdateActiveIndexBuffer: Copying %d indices (D3DFMT_INDEX16)\n", IndexCount);
 		memcpy(pData, pIndexData, IndexCount * 2); 
+
+		g_ConvertedIndexBuffers[pIndexData].Hash = XXHash32::hash(pIndexData, IndexCount * 2, 0);
 
 		g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer->Unlock();
 	}
@@ -1579,7 +1581,7 @@ void CxbxUpdateActiveIndexBuffer
 	// Activate the new native index buffer :
 	HRESULT hRet = g_pD3DDevice8->SetIndices(g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer, index);
 	if (FAILED(hRet)) {
-		CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: SetIndices Failed!");
+		CxbxKrnlCleanup("CxbxUpdateActiveIndexBuffer: SetIndices Failed!");
 	}
 
 	// Make sure the caller knows what StartIndex it has to use to point to the indicated index start pointer :

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3552,6 +3552,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateCubeTexture)
     return hRet;
 }
 
+#if 0
 // ******************************************************************
 // * patch: D3DDevice_CreateIndexBuffer
 // ******************************************************************
@@ -3629,8 +3630,10 @@ XTL::X_D3DIndexBuffer * WINAPI XTL::EMUPATCH(D3DDevice_CreateIndexBuffer2)(UINT 
     return pIndexBuffer;
 }
 
+#endif
 BOOL g_bBadIndexData = FALSE;
 
+#if 0
 // ******************************************************************
 // * patch: D3DDevice_SetIndices
 // ******************************************************************
@@ -3649,53 +3652,15 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_SetIndices)
            ");\n",
            pIndexData, BaseVertexIndex);
 
-    /*
-    fflush(stdout);
-    if(pIndexData != 0)
-    {
-        static int chk = 0;
-        if(chk++ == 0)
-        {
-            _asm int 3
-        }
-    }
-    //*/
-
     HRESULT hRet = D3D_OK;
 
-//#if 0
-	if(pIndexData != NULL)
-	{
-		DbgPrintf("EmuD3DDevice_SetIndices(): pIndexData->EmuIndexBuffer8:= 0x%.08X\n", pIndexData->EmuIndexBuffer8 );
-		DbgPrintf("EmuD3DDevice_SetIndices(): pIndexData->Lock:= 0x%.08X\n", pIndexData->Lock );
-	}
-
     g_dwBaseVertexIndex = BaseVertexIndex;
-
-    if(pIndexData != NULL)
-    {
-        g_pIndexBuffer = pIndexData;
-
-        EmuVerifyResourceIsRegistered(pIndexData);
-		
-        IDirect3DIndexBuffer8 *pIndexBuffer = pIndexData->EmuIndexBuffer8;
-
-		if (pIndexData->Lock == X_D3DRESOURCE_LOCK_FLAG_NOSIZE)
-			; // this should have been prevented by EmuVerifyResourceIsRegistered
-		else
-            hRet = g_pD3DDevice8->SetIndices(pIndexBuffer, BaseVertexIndex);
-    }
-    else
-    {
-        g_pIndexBuffer = nullptr;
-
-        hRet = g_pD3DDevice8->SetIndices(nullptr, BaseVertexIndex);
-    }
-//#endif
-    
+	g_pIndexBuffer = pIndexData;
 
     return hRet;
 }
+
+#endif
 
 // ******************************************************************
 // * patch: D3DDevice_SetTexture
@@ -4611,53 +4576,6 @@ HRESULT WINAPI XTL::EMUPATCH(D3DResource_Register)
         }
         break;
 
-        case X_D3DCOMMON_TYPE_INDEXBUFFER:
-        {
-            DbgPrintf("EmuIDirect3DResource8_Register :-> IndexBuffer...\n");
-
-            X_D3DIndexBuffer *pIndexBuffer = (X_D3DIndexBuffer*)pResource;
-
-            // create index buffer
-            {
-                DWORD dwSize = g_MemoryManager.QueryAllocationSize(pBase);
-
-                if(dwSize == -1 || dwSize == 0)
-                {
-                    // TODO: once this is known to be working, remove the warning
-                    EmuWarning("Index buffer allocation size unknown");
-
-                    pIndexBuffer->Lock = X_D3DRESOURCE_LOCK_FLAG_NOSIZE;
-
-                    break;
-                    // Halo dwSize = 0x336;
-                }
-
-                HRESULT hRet = g_pD3DDevice8->CreateIndexBuffer
-                (
-                    dwSize, /*Usage=*/0, D3DFMT_INDEX16, D3DPOOL_MANAGED,
-                    &pIndexBuffer->EmuIndexBuffer8
-                );
-                if(FAILED(hRet))
-					CxbxKrnlCleanup("CreateIndexBuffer Failed!\n\nError: \nDesc: \nSize: %d",
-								/*DXGetErrorString8A(hRet), *//*DXGetErrorDescription8A(hRet),*/ dwSize);
-
-                BYTE *pNativeData = nullptr;
-
-                hRet = pResource->EmuIndexBuffer8->Lock(/*OffsetToLock=*/0, dwSize, &pNativeData, /*Flags*/0);
-                if(FAILED(hRet))
-                    CxbxKrnlCleanup("IndexBuffer Lock Failed!\n\nError: %s\nDesc: "/*,
-						DXGetErrorString8A(hRet)*//*, DXGetErrorDescription8A(hRet)*/);
-
-                memcpy(pNativeData, (void*)pBase, dwSize);
-                pResource->EmuIndexBuffer8->Unlock();
-
-                pResource->Data = (DWORD)pNativeData; // For now, give the native buffer memory to Xbox. TODO : Use pBase
-            }
-
-            DbgPrintf("EmuIDirect3DResource8_Register : Successfully Created IndexBuffer (0x%.08X)\n", pResource->EmuIndexBuffer8);
-        }
-        break;
-
         case X_D3DCOMMON_TYPE_PUSHBUFFER:
         {
             DbgPrintf("EmuIDirect3DResource8_Register :-> PushBuffer...\n");
@@ -5265,24 +5183,28 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_AddRef)
 		return 0;
     }
 
-	EmuVerifyResourceIsRegistered(pThis);
-
 	// Initially, increment the Xbox refcount and return that
 	ULONG uRet = (++(pThis->Common)) & X_D3DCOMMON_REFCOUNT_MASK;
 
-	// If this is the first reference on a surface
-	if (uRet == 1)
-		if (pThis->Common & X_D3DCOMMON_TYPE_SURFACE)
-			// Try to AddRef the parent too
-			if (((X_D3DSurface *)pThis)->Parent != NULL)
-				((X_D3DSurface *)pThis)->Parent->Common++;
+	// Index buffers don't have a native resource assigned
+	if (!(pThis->Common & X_D3DCOMMON_TYPE_INDEXBUFFER)) {
+		EmuVerifyResourceIsRegistered(pThis);
 
-	// Try to retrieve the host resource behind this resource
-	IDirect3DResource8 *pResource8 = GetHostResource(pThis);
-	if (pResource8 != 0)
-		// if there's a host resource, AddRef it too and return that
-		uRet = pResource8->AddRef();
+		// If this is the first reference on a surface
+		if (uRet == 1)
+			if (pThis->Common & X_D3DCOMMON_TYPE_SURFACE)
+				// Try to AddRef the parent too
+				if (((X_D3DSurface *)pThis)->Parent != NULL)
+					((X_D3DSurface *)pThis)->Parent->Common++;
 
+		// Try to retrieve the host resource behind this resource
+		IDirect3DResource8 *pResource8 = GetHostResource(pThis);
+		if (pResource8 != 0)
+			// if there's a host resource, AddRef it too and return that
+			uRet = pResource8->AddRef();
+	}
+
+	
     return uRet;
 }
 
@@ -7939,102 +7861,128 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVerticesUP)
     return;
 }
 
+typedef struct {
+	DWORD IndexData;
+	DWORD IndexEnd;
+	XTL::IDirect3DIndexBuffer8* pHostIndexBuffer;
+} ConvertedIndexBuffer;
+
+std::vector<ConvertedIndexBuffer> g_ConvertedIndexBuffers;
+
 void CxbxUpdateActiveIndexBuffer
 (
-	CONST PWORD         pIndexData,
-	UINT                VertexCount,
-	UINT				&uiStartIndex,
-	UINT				&uiNumVertices,
-	bool				&bActiveIB,
-	XTL::IDirect3DIndexBuffer8 *&pIndexBuffer
+	PWORD         pIndexData,
+	UINT          IndexCount,
+	UINT       	  &uiStartIndex
 )
 {
-	//#if 0
-	// update index buffer, if necessary
-	if (g_pIndexBuffer != 0 && g_pIndexBuffer->Lock == X_D3DRESOURCE_LOCK_FLAG_NOSIZE)
-	{
-		DWORD dwSize = VertexCount * 2;   // 16-bit indices
+	PWORD pwInitialStart = pIndexData; // Remember this to calculate StartIndex later!
+	PWORD pwIndexEnd = pIndexData + IndexCount;
+	bool MustCopy = false;
 
-		HRESULT hRet = g_pD3DDevice8->CreateIndexBuffer
-		(
-			dwSize, 0, XTL::D3DFMT_INDEX16, XTL::D3DPOOL_MANAGED,
-			&g_pIndexBuffer->EmuIndexBuffer8
-		);
+	// Note : We assume that all outdated index buffer(s) are already removed,
+	// so that we'll never merge with buffers already destroyed on the Xbox side!
 
-		if (FAILED(hRet))
-			CxbxKrnlCleanup("CreateIndexBuffer Failed!");
+	// Now, see if we already have a (partial) index buffer for this range :
+	ConvertedIndexBuffer* pConvertedIndexBuffer = nullptr;
 
-		BYTE *pData = 0;
+	for(auto it = g_ConvertedIndexBuffers.begin(); it != g_ConvertedIndexBuffers.end(); ++it) {
+		// Check if the given index range overlaps with this buffer :
+		if ((DWORD)pIndexData > (DWORD)it->IndexEnd) {
+			// new buffer starts beyond current (so no overlap)
+		}
+		else if ((DWORD)pwIndexEnd < (DWORD)it->IndexData) {
+			// new buffer end before current (so no overlap)
+		}
+		else {
+			// The new and current buffer overlap - we found a merge candidate!
+			break;
+		}
 
-		hRet = g_pIndexBuffer->EmuIndexBuffer8->Lock(0, dwSize, &pData, 0);
-
-		if (FAILED(hRet))
-			CxbxKrnlCleanup("IndexBuffer Lock Failed!");
-
-		memcpy(pData, (void*)g_pIndexBuffer->Data, dwSize);
-
-		g_pIndexBuffer->EmuIndexBuffer8->Unlock();
-
-		g_pIndexBuffer->Data = (ULONG)pData;
-
-		hRet = g_pD3DDevice8->SetIndices(g_pIndexBuffer->EmuIndexBuffer8, g_dwBaseVertexIndex);
-
-		if (FAILED(hRet))
-			CxbxKrnlCleanup("SetIndices Failed!");
+		pConvertedIndexBuffer = &(*it);
 	}
 
-#ifdef _DEBUG_TRACK_VB
-	if (!g_bVBSkipStream)
-	{
-#endif
-		// check if there is an active index buffer
-		{
-			UINT BaseIndex = 0; // ignored
+	// Did we find a merge candidate?
+	if (pConvertedIndexBuffer == nullptr) {
+		DbgPrintf("DxbxUpdateActiveIndexBuffer: Creating new buffer for 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
 
-			g_pD3DDevice8->GetIndices(&pIndexBuffer, &BaseIndex);
+		// No merge, so add a new converted index buffer to the chain :
+		ConvertedIndexBuffer buffer;
+		g_ConvertedIndexBuffers.push_back(buffer);
 
-			if (pIndexBuffer != 0)
-			{
-				bActiveIB = true;
-				pIndexBuffer->Release();
-			}
+		pConvertedIndexBuffer = &g_ConvertedIndexBuffers.back();
+		MustCopy = true;
+	} else {
+		// We found an existing index buffer, see if we must extend it's bounds :
+		if ((DWORD)pIndexData < pConvertedIndexBuffer->IndexData) {
+			MustCopy = true; // The merge has a new start pointer
+		} else {
+			pIndexData = (PWORD)pConvertedIndexBuffer->IndexData; // The merge keeps the old start pointer
 		}
 
-		// TODO: caching (if it becomes noticably slow to recreate the buffer each time)
-		if (!bActiveIB)
-		{
-			if (FAILED(g_pD3DDevice8->CreateIndexBuffer(VertexCount * 2, D3DUSAGE_WRITEONLY, XTL::D3DFMT_INDEX16, XTL::D3DPOOL_MANAGED, &pIndexBuffer)))
-				CxbxKrnlCleanup("Cound not create index buffer! (%d bytes)", VertexCount * 2);
-
-			if (pIndexBuffer == 0)
-				CxbxKrnlCleanup("Could not create index buffer! (%d bytes)", VertexCount * 2);
-
-			BYTE *pbData = 0;
-
-			pIndexBuffer->Lock(0, 0, &pbData, 0);
-
-			if (pbData == 0)
-				CxbxKrnlCleanup("Could not lock index buffer!");
-
-			if (pIndexData)
-				memcpy(pbData, pIndexData, VertexCount * 2);
-
-			pIndexBuffer->Unlock();
-
-			g_pD3DDevice8->SetIndices(pIndexBuffer, g_dwBaseVertexIndex);
-
-			uiNumVertices = VertexCount;
-			uiStartIndex = 0;
-		}
-		else
-		{
-			uiNumVertices = ((DWORD)pIndexData) / 2 + VertexCount;
-			uiStartIndex = ((DWORD)pIndexData) / 2;
+		if ((DWORD)pwIndexEnd > pConvertedIndexBuffer->IndexEnd) {
+			MustCopy = true; // The merge has a new end pointer
+		} else {
+			pwIndexEnd = (PWORD)pConvertedIndexBuffer->IndexEnd; // The merge keeps the old end pointer
 		}
 
-#ifdef _DEBUG_TRACK_VB
+		// TODO : What if this grow causes two (or more) existing ranges to overlap - we should merge them all...
+		// TOOD : What if the index buffer exceeds D3DCaps.MaxVertexIndex ?
+
+		// TODO : If not MustCopy, Add a CRC check on the contents (forcing MustCopy) ?
+
+		if (MustCopy) {
+			DbgPrintf("DxbxUpdateActiveIndexBuffer: Enlarging buffer to 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
+
+			// Remove previous native buffer (this might leave one stale reference,
+			// but this one will be released automatically in the next SetIndices call) :
+			pConvertedIndexBuffer->pHostIndexBuffer->Release();
+			pConvertedIndexBuffer->pHostIndexBuffer = nullptr;
+		}
 	}
-#endif
+
+	HRESULT hRet;
+
+	if (MustCopy) {
+		// Remember the (new) buffer bounds :
+		pConvertedIndexBuffer->IndexData = (DWORD)pIndexData;
+		pConvertedIndexBuffer->IndexEnd = (DWORD)pwIndexEnd;
+		IndexCount = pwIndexEnd - pIndexData; // Calculate the number of WORD's between start & end
+
+		// Create a new native index buffer of the above determined size :
+		hRet = g_pD3DDevice8->CreateIndexBuffer(
+			IndexCount * 2,
+			D3DUSAGE_WRITEONLY,
+			XTL::D3DFMT_INDEX16,
+			XTL::D3DPOOL_MANAGED,
+			&pConvertedIndexBuffer->pHostIndexBuffer);
+		  
+		if (FAILED(hRet)) {
+			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: IndexBuffer Create Failed!");
+		}
+
+		// Copy the xbox indexes into this native buffer :
+		BYTE* pData = nullptr;
+		
+		pConvertedIndexBuffer->pHostIndexBuffer->Lock(0, 0, &pData, 0);
+		if (pData == nullptr) {
+			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: Could not lock index buffer!");
+		}
+
+		DbgPrintf("DxbxUpdateActiveIndexBuffer: Copying %d indices (D3DFMT_INDEX16)\n", IndexCount);
+		memcpy(pData, pIndexData, IndexCount * 2); // TODO : Why does this crash at the 4th copy in Cartoon sample?
+
+		pConvertedIndexBuffer->pHostIndexBuffer->Unlock();
+	}
+
+	// Activate the new native index buffer :
+	hRet = g_pD3DDevice8->SetIndices(pConvertedIndexBuffer->pHostIndexBuffer, 0);
+	if (FAILED(hRet)) {
+		CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: SetIndices Failed!");
+	}
+
+	// Make sure the caller knows what StartIndex it has to use to point to the indicated index start pointer :
+	uiStartIndex = (UINT)pwInitialStart - (UINT)pConvertedIndexBuffer->IndexData;
 }
 
 #define VERTICES_PER_QUAD 4
@@ -8066,11 +8014,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 
 	UINT uiStartIndex = 0;
 	UINT uiNumVertices = 0;
-	bool bActiveIB = false;
-	XTL::IDirect3DIndexBuffer8 *pIndexBuffer = nullptr;
 
-	CxbxUpdateActiveIndexBuffer(pIndexData, VertexCount, /*OUT*/uiStartIndex,
-		/*OUT*/uiNumVertices, /*OUT*/bActiveIB, /*OUT*/pIndexBuffer);
+	CxbxUpdateActiveIndexBuffer(pIndexData, VertexCount, uiStartIndex);
 
     VertexPatchDesc VPDesc;
 
@@ -8083,7 +8028,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 
     VertexPatcher VertPatch;
 	bool FatalError = false;
-    bool bPatched = VertPatch.Apply(&VPDesc, &FatalError);
+    VertPatch.Apply(&VPDesc, &FatalError);
 
     if(IsValidCurrentShader() && !FatalError)
     {
@@ -8136,12 +8081,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 		}
 
 		g_dwPrimPerFrame += VPDesc.dwPrimitiveCount;
-    }
-
-    if(!bActiveIB)
-    {
-        g_pD3DDevice8->SetIndices(0, 0);
-        pIndexBuffer->Release();
     }
 
     VertPatch.Restore();

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1498,6 +1498,154 @@ static void EmuUnswizzleTextureStages()
 	}
 }
 
+typedef struct {
+	DWORD IndexData;
+	DWORD IndexEnd;
+	XTL::IDirect3DIndexBuffer8* pHostIndexBuffer;
+} ConvertedIndexBuffer;
+
+std::vector<ConvertedIndexBuffer> g_ConvertedIndexBuffers;
+	
+void CxbxRemoveIndexBuffer(PWORD pData)
+{
+	// Now, see if we already have a (partial) index buffer for this range :
+	ConvertedIndexBuffer* pConvertedIndexBuffer = nullptr;
+
+	auto it = g_ConvertedIndexBuffers.begin();
+	for (; it != g_ConvertedIndexBuffers.end(); ++it) {
+		// Check if we found an index buffer containing this pointer
+		if ((DWORD)it->IndexData <= (DWORD)pData && (DWORD)pData < (DWORD)it->IndexEnd) {
+			pConvertedIndexBuffer = &(*it);
+			break;
+		}
+	}
+
+	if (pConvertedIndexBuffer != nullptr) {
+		DbgPrintf("DxbxRemoveIndexBuffer: Removing buffer for 0x%08x-0x%08x", pConvertedIndexBuffer->IndexData, pConvertedIndexBuffer->IndexEnd);
+		pConvertedIndexBuffer->pHostIndexBuffer->Release();
+		g_ConvertedIndexBuffers.erase(it);
+	}
+}
+
+void CxbxUpdateActiveIndexBuffer
+(
+	PWORD         pIndexData,
+	UINT          IndexCount,
+	UINT       	  &uiStartIndex
+)
+{
+	PWORD pwInitialStart = pIndexData; // Remember this to calculate StartIndex later!
+	PWORD pwIndexEnd = pIndexData + IndexCount;
+	bool MustCopy = false;
+
+	// Note : We assume that all outdated index buffer(s) are already removed,
+	// so that we'll never merge with buffers already destroyed on the Xbox side!
+
+	// Now, see if we already have a (partial) index buffer for this range :
+	ConvertedIndexBuffer* pConvertedIndexBuffer = nullptr;
+
+	for (auto it = g_ConvertedIndexBuffers.begin(); it != g_ConvertedIndexBuffers.end(); ++it) {
+		// Check if the given index range overlaps with this buffer :
+		if ((DWORD)pIndexData > (DWORD)it->IndexEnd) {
+			// new buffer starts beyond current (so no overlap)
+		}
+		else if ((DWORD)pwIndexEnd < (DWORD)it->IndexData) {
+			// new buffer end before current (so no overlap)
+		}
+		else {
+			// The new and current buffer overlap - we found a merge candidate!
+			break;
+		}
+
+		pConvertedIndexBuffer = &(*it);
+	}
+
+	// Did we find a merge candidate?
+	if (pConvertedIndexBuffer == nullptr) {
+		DbgPrintf("DxbxUpdateActiveIndexBuffer: Creating new buffer for 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
+
+		// No merge, so add a new converted index buffer to the chain :
+		ConvertedIndexBuffer buffer;
+		g_ConvertedIndexBuffers.push_back(buffer);
+
+		pConvertedIndexBuffer = &g_ConvertedIndexBuffers.back();
+		MustCopy = true;
+	}
+	else {
+		// We found an existing index buffer, see if we must extend it's bounds :
+		if ((DWORD)pIndexData < pConvertedIndexBuffer->IndexData) {
+			MustCopy = true; // The merge has a new start pointer
+		}
+		else {
+			pIndexData = (PWORD)pConvertedIndexBuffer->IndexData; // The merge keeps the old start pointer
+		}
+
+		if ((DWORD)pwIndexEnd > pConvertedIndexBuffer->IndexEnd) {
+			MustCopy = true; // The merge has a new end pointer
+		}
+		else {
+			pwIndexEnd = (PWORD)pConvertedIndexBuffer->IndexEnd; // The merge keeps the old end pointer
+		}
+
+		// TODO : What if this grow causes two (or more) existing ranges to overlap - we should merge them all...
+		// TOOD : What if the index buffer exceeds D3DCaps.MaxVertexIndex ?
+
+		// TODO : If not MustCopy, Add a CRC check on the contents (forcing MustCopy) ?
+
+		if (MustCopy) {
+			DbgPrintf("DxbxUpdateActiveIndexBuffer: Enlarging buffer to 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
+
+			// Remove previous native buffer (this might leave one stale reference,
+			// but this one will be released automatically in the next SetIndices call) :
+			pConvertedIndexBuffer->pHostIndexBuffer->Release();
+			pConvertedIndexBuffer->pHostIndexBuffer = nullptr;
+		}
+	}
+
+	HRESULT hRet;
+
+	if (MustCopy) {
+		// Remember the (new) buffer bounds :
+		pConvertedIndexBuffer->IndexData = (DWORD)pIndexData;
+		pConvertedIndexBuffer->IndexEnd = (DWORD)pwIndexEnd;
+		IndexCount = pwIndexEnd - pIndexData; // Calculate the number of WORD's between start & end
+
+											  // Create a new native index buffer of the above determined size :
+		hRet = g_pD3DDevice8->CreateIndexBuffer(
+			IndexCount * 2,
+			D3DUSAGE_WRITEONLY,
+			XTL::D3DFMT_INDEX16,
+			XTL::D3DPOOL_MANAGED,
+			&pConvertedIndexBuffer->pHostIndexBuffer);
+
+		if (FAILED(hRet)) {
+			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: IndexBuffer Create Failed!");
+		}
+
+		// Copy the xbox indexes into this native buffer :
+		BYTE* pData = nullptr;
+
+		pConvertedIndexBuffer->pHostIndexBuffer->Lock(0, 0, &pData, 0);
+		if (pData == nullptr) {
+			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: Could not lock index buffer!");
+		}
+
+		DbgPrintf("DxbxUpdateActiveIndexBuffer: Copying %d indices (D3DFMT_INDEX16)\n", IndexCount);
+		memcpy(pData, pIndexData, IndexCount * 2); // TODO : Why does this crash at the 4th copy in Cartoon sample?
+
+		pConvertedIndexBuffer->pHostIndexBuffer->Unlock();
+	}
+
+	// Activate the new native index buffer :
+	hRet = g_pD3DDevice8->SetIndices(pConvertedIndexBuffer->pHostIndexBuffer, 0);
+	if (FAILED(hRet)) {
+		CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: SetIndices Failed!");
+	}
+
+	// Make sure the caller knows what StartIndex it has to use to point to the indicated index start pointer :
+	uiStartIndex = (UINT)pwInitialStart - (UINT)pConvertedIndexBuffer->IndexData;
+}
+
 // ******************************************************************
 // * patch: Direct3D_CreateDevice
 // ******************************************************************
@@ -5247,9 +5395,13 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
         }
         
 		EMUPATCH(D3DDevice_EnableOverlay)(FALSE);
-    }
-    else
-    {
+    } else if (pThis->Common & X_D3DCOMMON_TYPE_INDEXBUFFER)  {
+		if ((pThis->Common & X_D3DCOMMON_REFCOUNT_MASK) == 1) {
+			CxbxRemoveIndexBuffer((PWORD)GetDataFromXboxResource(pThis));
+		}
+
+		uRet = pThis->Common--; // Release
+    } else {
         IDirect3DResource8 *pResource8 = pThis->EmuResource8;
 
         if(pThis->Lock == X_D3DRESOURCE_LOCK_PALETTE)
@@ -7859,130 +8011,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVerticesUP)
     
 
     return;
-}
-
-typedef struct {
-	DWORD IndexData;
-	DWORD IndexEnd;
-	XTL::IDirect3DIndexBuffer8* pHostIndexBuffer;
-} ConvertedIndexBuffer;
-
-std::vector<ConvertedIndexBuffer> g_ConvertedIndexBuffers;
-
-void CxbxUpdateActiveIndexBuffer
-(
-	PWORD         pIndexData,
-	UINT          IndexCount,
-	UINT       	  &uiStartIndex
-)
-{
-	PWORD pwInitialStart = pIndexData; // Remember this to calculate StartIndex later!
-	PWORD pwIndexEnd = pIndexData + IndexCount;
-	bool MustCopy = false;
-
-	// Note : We assume that all outdated index buffer(s) are already removed,
-	// so that we'll never merge with buffers already destroyed on the Xbox side!
-
-	// Now, see if we already have a (partial) index buffer for this range :
-	ConvertedIndexBuffer* pConvertedIndexBuffer = nullptr;
-
-	for(auto it = g_ConvertedIndexBuffers.begin(); it != g_ConvertedIndexBuffers.end(); ++it) {
-		// Check if the given index range overlaps with this buffer :
-		if ((DWORD)pIndexData > (DWORD)it->IndexEnd) {
-			// new buffer starts beyond current (so no overlap)
-		}
-		else if ((DWORD)pwIndexEnd < (DWORD)it->IndexData) {
-			// new buffer end before current (so no overlap)
-		}
-		else {
-			// The new and current buffer overlap - we found a merge candidate!
-			break;
-		}
-
-		pConvertedIndexBuffer = &(*it);
-	}
-
-	// Did we find a merge candidate?
-	if (pConvertedIndexBuffer == nullptr) {
-		DbgPrintf("DxbxUpdateActiveIndexBuffer: Creating new buffer for 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
-
-		// No merge, so add a new converted index buffer to the chain :
-		ConvertedIndexBuffer buffer;
-		g_ConvertedIndexBuffers.push_back(buffer);
-
-		pConvertedIndexBuffer = &g_ConvertedIndexBuffers.back();
-		MustCopy = true;
-	} else {
-		// We found an existing index buffer, see if we must extend it's bounds :
-		if ((DWORD)pIndexData < pConvertedIndexBuffer->IndexData) {
-			MustCopy = true; // The merge has a new start pointer
-		} else {
-			pIndexData = (PWORD)pConvertedIndexBuffer->IndexData; // The merge keeps the old start pointer
-		}
-
-		if ((DWORD)pwIndexEnd > pConvertedIndexBuffer->IndexEnd) {
-			MustCopy = true; // The merge has a new end pointer
-		} else {
-			pwIndexEnd = (PWORD)pConvertedIndexBuffer->IndexEnd; // The merge keeps the old end pointer
-		}
-
-		// TODO : What if this grow causes two (or more) existing ranges to overlap - we should merge them all...
-		// TOOD : What if the index buffer exceeds D3DCaps.MaxVertexIndex ?
-
-		// TODO : If not MustCopy, Add a CRC check on the contents (forcing MustCopy) ?
-
-		if (MustCopy) {
-			DbgPrintf("DxbxUpdateActiveIndexBuffer: Enlarging buffer to 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
-
-			// Remove previous native buffer (this might leave one stale reference,
-			// but this one will be released automatically in the next SetIndices call) :
-			pConvertedIndexBuffer->pHostIndexBuffer->Release();
-			pConvertedIndexBuffer->pHostIndexBuffer = nullptr;
-		}
-	}
-
-	HRESULT hRet;
-
-	if (MustCopy) {
-		// Remember the (new) buffer bounds :
-		pConvertedIndexBuffer->IndexData = (DWORD)pIndexData;
-		pConvertedIndexBuffer->IndexEnd = (DWORD)pwIndexEnd;
-		IndexCount = pwIndexEnd - pIndexData; // Calculate the number of WORD's between start & end
-
-		// Create a new native index buffer of the above determined size :
-		hRet = g_pD3DDevice8->CreateIndexBuffer(
-			IndexCount * 2,
-			D3DUSAGE_WRITEONLY,
-			XTL::D3DFMT_INDEX16,
-			XTL::D3DPOOL_MANAGED,
-			&pConvertedIndexBuffer->pHostIndexBuffer);
-		  
-		if (FAILED(hRet)) {
-			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: IndexBuffer Create Failed!");
-		}
-
-		// Copy the xbox indexes into this native buffer :
-		BYTE* pData = nullptr;
-		
-		pConvertedIndexBuffer->pHostIndexBuffer->Lock(0, 0, &pData, 0);
-		if (pData == nullptr) {
-			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: Could not lock index buffer!");
-		}
-
-		DbgPrintf("DxbxUpdateActiveIndexBuffer: Copying %d indices (D3DFMT_INDEX16)\n", IndexCount);
-		memcpy(pData, pIndexData, IndexCount * 2); // TODO : Why does this crash at the 4th copy in Cartoon sample?
-
-		pConvertedIndexBuffer->pHostIndexBuffer->Unlock();
-	}
-
-	// Activate the new native index buffer :
-	hRet = g_pD3DDevice8->SetIndices(pConvertedIndexBuffer->pHostIndexBuffer, 0);
-	if (FAILED(hRet)) {
-		CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: SetIndices Failed!");
-	}
-
-	// Make sure the caller knows what StartIndex it has to use to point to the indicated index start pointer :
-	uiStartIndex = (UINT)pwInitialStart - (UINT)pConvertedIndexBuffer->IndexData;
 }
 
 #define VERTICES_PER_QUAD 4

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -35,6 +35,7 @@
 // ******************************************************************
 #define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
+#include "xxhash32.h"
 
 // prevent name collisions
 namespace xboxkrnl
@@ -53,6 +54,7 @@ namespace xboxkrnl
 #include "EmuAlloc.h"
 #include "MemoryManager.h"
 #include "EmuXTL.h"
+#include "HLEDatabase.h"
 
 #include <assert.h>
 #include <process.h>
@@ -171,6 +173,9 @@ struct EmuD3D8CreateDeviceProxyData
     };
 }
 g_EmuCDPD = {0};
+
+// TODO: This should be a D3DDevice structure
+BYTE g_XboxD3DDevice[ONE_MB] = { 0 };
 
 VOID XTL::CxbxInitWindow(Xbe::Header *XbeHeader, uint32 XbeHeaderSize)
 {
@@ -1499,32 +1504,17 @@ static void EmuUnswizzleTextureStages()
 }
 
 typedef struct {
-	DWORD IndexData;
-	DWORD IndexEnd;
-	XTL::IDirect3DIndexBuffer8* pHostIndexBuffer;
+	DWORD Hash = 0;
+	DWORD IndexCount = 0;;
+	XTL::IDirect3DIndexBuffer8* pHostIndexBuffer = nullptr;
 } ConvertedIndexBuffer;
 
-std::vector<ConvertedIndexBuffer> g_ConvertedIndexBuffers;
+std::map<PWORD, ConvertedIndexBuffer> g_ConvertedIndexBuffers;
 	
 void CxbxRemoveIndexBuffer(PWORD pData)
 {
-	// Now, see if we already have a (partial) index buffer for this range :
-	ConvertedIndexBuffer* pConvertedIndexBuffer = nullptr;
-
-	auto it = g_ConvertedIndexBuffers.begin();
-	for (; it != g_ConvertedIndexBuffers.end(); ++it) {
-		// Check if we found an index buffer containing this pointer
-		if ((DWORD)it->IndexData <= (DWORD)pData && (DWORD)pData < (DWORD)it->IndexEnd) {
-			pConvertedIndexBuffer = &(*it);
-			break;
-		}
-	}
-
-	if (pConvertedIndexBuffer != nullptr) {
-		DbgPrintf("DxbxRemoveIndexBuffer: Removing buffer for 0x%08x-0x%08x", pConvertedIndexBuffer->IndexData, pConvertedIndexBuffer->IndexEnd);
-		pConvertedIndexBuffer->pHostIndexBuffer->Release();
-		g_ConvertedIndexBuffers.erase(it);
-	}
+	// HACK: Never Free
+	return;
 }
 
 void CxbxUpdateActiveIndexBuffer
@@ -1534,116 +1524,66 @@ void CxbxUpdateActiveIndexBuffer
 	UINT       	  &uiStartIndex
 )
 {
-	PWORD pwInitialStart = pIndexData; // Remember this to calculate StartIndex later!
-	PWORD pwIndexEnd = pIndexData + IndexCount;
-	bool MustCopy = false;
-
-	// Note : We assume that all outdated index buffer(s) are already removed,
-	// so that we'll never merge with buffers already destroyed on the Xbox side!
-
-	// Now, see if we already have a (partial) index buffer for this range :
-	ConvertedIndexBuffer* pConvertedIndexBuffer = nullptr;
-
-	for (auto it = g_ConvertedIndexBuffers.begin(); it != g_ConvertedIndexBuffers.end(); ++it) {
-		// Check if the given index range overlaps with this buffer :
-		if ((DWORD)pIndexData > (DWORD)it->IndexEnd) {
-			// new buffer starts beyond current (so no overlap)
-		}
-		else if ((DWORD)pwIndexEnd < (DWORD)it->IndexData) {
-			// new buffer end before current (so no overlap)
-		}
-		else {
-			// The new and current buffer overlap - we found a merge candidate!
-			break;
-		}
-
-		pConvertedIndexBuffer = &(*it);
-	}
-
-	// Did we find a merge candidate?
-	if (pConvertedIndexBuffer == nullptr) {
-		DbgPrintf("DxbxUpdateActiveIndexBuffer: Creating new buffer for 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
-
-		// No merge, so add a new converted index buffer to the chain :
+	// If the index buffer is not already in our data structure, add it
+	if(g_ConvertedIndexBuffers.find(pIndexData) == g_ConvertedIndexBuffers.end()) {
 		ConvertedIndexBuffer buffer;
-		g_ConvertedIndexBuffers.push_back(buffer);
+		g_ConvertedIndexBuffers[pIndexData] = buffer;
+	};
 
-		pConvertedIndexBuffer = &g_ConvertedIndexBuffers.back();
-		MustCopy = true;
-	}
-	else {
-		// We found an existing index buffer, see if we must extend it's bounds :
-		if ((DWORD)pIndexData < pConvertedIndexBuffer->IndexData) {
-			MustCopy = true; // The merge has a new start pointer
-		}
-		else {
-			pIndexData = (PWORD)pConvertedIndexBuffer->IndexData; // The merge keeps the old start pointer
-		}
-
-		if ((DWORD)pwIndexEnd > pConvertedIndexBuffer->IndexEnd) {
-			MustCopy = true; // The merge has a new end pointer
-		}
-		else {
-			pwIndexEnd = (PWORD)pConvertedIndexBuffer->IndexEnd; // The merge keeps the old end pointer
-		}
-
-		// TODO : What if this grow causes two (or more) existing ranges to overlap - we should merge them all...
-		// TOOD : What if the index buffer exceeds D3DCaps.MaxVertexIndex ?
-
-		// TODO : If not MustCopy, Add a CRC check on the contents (forcing MustCopy) ?
-
-		if (MustCopy) {
-			DbgPrintf("DxbxUpdateActiveIndexBuffer: Enlarging buffer to 0x%08x-0x%08x (%d indices)\n", pIndexData, pwIndexEnd, pwIndexEnd - pIndexData);
-
-			// Remove previous native buffer (this might leave one stale reference,
-			// but this one will be released automatically in the next SetIndices call) :
-			pConvertedIndexBuffer->pHostIndexBuffer->Release();
-			pConvertedIndexBuffer->pHostIndexBuffer = nullptr;
-		}
+	// If the size has changed, free the buffer so it will be re-created
+	if (g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer != nullptr && 
+		g_ConvertedIndexBuffers[pIndexData].IndexCount != IndexCount) {
+		g_ConvertedIndexBuffers[pIndexData].Hash = 0;
+		g_ConvertedIndexBuffers[pIndexData].IndexCount = 0;
+		g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer->Release();
+		g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer = nullptr;
 	}
 
-	HRESULT hRet;
-
-	if (MustCopy) {
-		// Remember the (new) buffer bounds :
-		pConvertedIndexBuffer->IndexData = (DWORD)pIndexData;
-		pConvertedIndexBuffer->IndexEnd = (DWORD)pwIndexEnd;
-		IndexCount = pwIndexEnd - pIndexData; // Calculate the number of WORD's between start & end
-
-											  // Create a new native index buffer of the above determined size :
-		hRet = g_pD3DDevice8->CreateIndexBuffer(
+	// If we need to create an index buffer, do so.
+	if (g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer == nullptr) {
+		// Create a new native index buffer of the above determined size :
+		HRESULT hRet = g_pD3DDevice8->CreateIndexBuffer(
 			IndexCount * 2,
 			D3DUSAGE_WRITEONLY,
 			XTL::D3DFMT_INDEX16,
 			XTL::D3DPOOL_MANAGED,
-			&pConvertedIndexBuffer->pHostIndexBuffer);
+			&g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer);
 
 		if (FAILED(hRet)) {
 			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: IndexBuffer Create Failed!");
 		}
+	}
 
-		// Copy the xbox indexes into this native buffer :
+	// If the data needs updating, do so
+	uint32_t uiHash = XXHash32::hash(pIndexData, IndexCount * 2, 0);
+	if (uiHash != g_ConvertedIndexBuffers[pIndexData].Hash)	{
+		g_ConvertedIndexBuffers[pIndexData].IndexCount = IndexCount;
+
 		BYTE* pData = nullptr;
 
-		pConvertedIndexBuffer->pHostIndexBuffer->Lock(0, 0, &pData, 0);
+		g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer->Lock(0, 0, &pData, 0);
 		if (pData == nullptr) {
 			CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: Could not lock index buffer!");
 		}
 
 		DbgPrintf("DxbxUpdateActiveIndexBuffer: Copying %d indices (D3DFMT_INDEX16)\n", IndexCount);
-		memcpy(pData, pIndexData, IndexCount * 2); // TODO : Why does this crash at the 4th copy in Cartoon sample?
+		memcpy(pData, pIndexData, IndexCount * 2); 
 
-		pConvertedIndexBuffer->pHostIndexBuffer->Unlock();
+		g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer->Unlock();
 	}
 
+	DWORD index = 0;
+	// Determine the vertex index from D3D
+	index = *(DWORD*)(g_XboxD3DDevice + 0x1C);
+
 	// Activate the new native index buffer :
-	hRet = g_pD3DDevice8->SetIndices(pConvertedIndexBuffer->pHostIndexBuffer, 0);
+	HRESULT hRet = g_pD3DDevice8->SetIndices(g_ConvertedIndexBuffers[pIndexData].pHostIndexBuffer, index);
 	if (FAILED(hRet)) {
 		CxbxKrnlCleanup("DxbxUpdateActiveIndexBuffer: SetIndices Failed!");
 	}
 
 	// Make sure the caller knows what StartIndex it has to use to point to the indicated index start pointer :
-	uiStartIndex = (UINT)pwInitialStart - (UINT)pConvertedIndexBuffer->IndexData;
+	uiStartIndex = 0;
 }
 
 // ******************************************************************
@@ -1705,8 +1645,9 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice)
     // Wait until proxy is completed
     while(g_EmuCDPD.bReady)
         Sleep(10);
-
-    
+	
+	// Set the Xbox g_pD3DDevice pointer to our D3D Device object
+	*((DWORD*)XRefDataBase[XREF_D3DDEVICE]) = (DWORD)g_XboxD3DDevice;
 
     return g_EmuCDPD.hRet;
 }
@@ -5335,7 +5276,7 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_AddRef)
 	ULONG uRet = (++(pThis->Common)) & X_D3DCOMMON_REFCOUNT_MASK;
 
 	// Index buffers don't have a native resource assigned
-	if (!(pThis->Common & X_D3DCOMMON_TYPE_INDEXBUFFER)) {
+	if (pThis->Common & X_D3DCOMMON_TYPE_MASK != X_D3DCOMMON_TYPE_INDEXBUFFER) {
 		EmuVerifyResourceIsRegistered(pThis);
 
 		// If this is the first reference on a surface
@@ -5395,7 +5336,7 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
         }
         
 		EMUPATCH(D3DDevice_EnableOverlay)(FALSE);
-    } else if (pThis->Common & X_D3DCOMMON_TYPE_INDEXBUFFER)  {
+    } else if ((pThis->Common & X_D3DCOMMON_TYPE_MASK) == X_D3DCOMMON_TYPE_INDEXBUFFER)  {
 		if ((pThis->Common & X_D3DCOMMON_REFCOUNT_MASK) == 1) {
 			CxbxRemoveIndexBuffer((PWORD)GetDataFromXboxResource(pThis));
 		}
@@ -5420,8 +5361,10 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
             D3DRESOURCETYPE Type = pResource8->GetType();
             #endif
 
-            uRet = pResource8->Release();
-            if(uRet == 0)
+			/*
+			 * Temporarily disable this until we figure out correct reference counting!
+			uRet = pResource8->Release();
+            if(uRet == 0 && pThis->Common)
             {
                 DbgPrintf("EmuIDirect3DResource8_Release : Cleaned up a Resource!\n");
 
@@ -5434,7 +5377,7 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
                 #endif
 
                 //delete pThis;
-            }
+            } */
         }
 
         pThis->Common--; // Release
@@ -7705,7 +7648,6 @@ XTL::X_D3DVertexBuffer* WINAPI XTL::EMUPATCH(D3DDevice_GetStreamSource2)
     X_D3DVertexBuffer* pVertexBuffer = EmuNewD3DVertexBuffer();
     g_pD3DDevice8->GetStreamSource(StreamNumber, &pVertexBuffer->EmuVertexBuffer8, pStride);
 
-    
     return pVertexBuffer;
 }
 
@@ -8112,6 +8054,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
     }
 
     VertPatch.Restore();
+
+	g_pD3DDevice8->SetIndices(NULL, 0);
 
 	// Execute callback procedure
 	if( g_CallbackType == X_D3DCALLBACK_WRITE )

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -138,8 +138,13 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 				CxbxKrnlCleanup("EmuD3DDeferredTextureState was not found!");
 			}
 
+			if (g_HLECache.find("D3DDEVICE") == g_HLECache.end()) {
+				CxbxKrnlCleanup("D3DDEVICE was not found!");
+			}
+
 			XTL::EmuD3DDeferredRenderState = (DWORD*)g_HLECache["D3DDeferredRenderState"];
 			XTL::EmuD3DDeferredTextureState = (DWORD*)g_HLECache["D3DDeferredTextureState"];
+			XRefDataBase[XREF_D3DDEVICE] = g_HLECache["D3DDEVICE"];
 
 			// TODO: Move this into a function rather than duplicating from HLE scanning code
 			for (int v = 0; v<44; v++) {
@@ -150,6 +155,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 				for (int v = 0; v<32; v++)
 					XTL::EmuD3DDeferredTextureState[v + s * 32] = X_D3DTSS_UNK;
 			}
+
 			g_HLECacheUsed = true;
 		}
 
@@ -384,6 +390,8 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 
 									XRefDataBase[XREF_D3DDEVICE] = DerivedAddr_D3DDevice;
 								}
+
+								g_HLECache["D3DDEVICE"] = DerivedAddr_D3DDevice;
 
 								// Temporary verification - is XREF_D3DRS_CULLMODE derived correctly?
 								if (XRefDataBase[XREF_D3DRS_CULLMODE] != DerivedAddr_D3DRS_CULLMODE)

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -944,31 +944,7 @@ void VerifyHLEOOVPA(HLEVerifyContext *context, OOVPA *oovpa)
 
 void VerifyHLEDataEntry(HLEVerifyContext *context, const OOVPATable *table, uint32 index, uint32 count)
 {
-	if (context->against == nullptr) {
-		context->main_index = index;
-		// does this entry specify a redirection (patch)?
-		void * entry_redirect = table[index].emuPatch;
-		if (entry_redirect != nullptr) {
-			if (table[index].Oovpa == nullptr) {
-				HLEError(context, "Patch without an OOVPA at index %d",
-					index);
-			} else
-				// check no patch occurs twice in this table
-				for (uint32 t = index + 1; t < count; t++) {
-					if (entry_redirect == table[t].emuPatch) {
-						if (table[index].Oovpa == table[t].Oovpa) {
-							HLEError(context, "Patch registered again (with same OOVPA) at index %d",
-								t);
-						} else {
-							HLEError(context, "Patch also used for another OOVPA at index %d",
-								t);
-						}
-					}
-				}
-		}
-	}
-	else
-		context->against_index = index;
+	context->against_index = index;
 
 	// verify the OOVPA of this entry
 	if (table[index].Oovpa != nullptr)

--- a/src/CxbxKrnl/OOVPA.h
+++ b/src/CxbxKrnl/OOVPA.h
@@ -36,23 +36,6 @@
 
 #include "Cxbx.h"
 
-// ******************************************************************
-// * Take THIS C++ !!
-// ******************************************************************
-template <class BaseClass, typename MFT> inline void *MFPtoFP(MFT pMemFunc)
-{
-	union
-	{
-		MFT pMemFunc;
-		void(*pFunc)();
-	}
-	ThisConv;
-
-	ThisConv.pMemFunc = pMemFunc;
-
-	return ThisConv.pFunc;
-}
-
 #pragma pack(1)
 
 // ******************************************************************
@@ -150,7 +133,6 @@ OOVPA_XREF(Name, Version, Count, XRefNoSaveIndex, XRefZero)
 struct OOVPATable
 {
 	OOVPA *Oovpa;
-	void  *emuPatch;
 	char  *szFuncName;
 	uint16_t Version : 13; // 2^13 = 8192, enough to store lowest and higest possible Library Version number in
 	uint16_t Flags : 3;
@@ -160,8 +142,8 @@ const uint16_t Flag_DontScan = 1; // Indicates an entry that's currently disable
 const uint16_t Flag_XRef = 2;	  // Indicates that an entry is an X-Ref
 const uint16_t Flag_Reserved = 4; 
 
-#define OOVPA_TABLE_ENTRY_FULL(Oovpa, Patch, DebugName, Version, Flags) \
-	{ & Oovpa ## _ ## Version.Header, Patch, DebugName, Version, Flags }
+#define OOVPA_TABLE_ENTRY_FULL(Oovpa, DebugName, Version, Flags) \
+	{ & Oovpa ## _ ## Version.Header, DebugName, Version, Flags }
 
 // REGISTER_OOVPA is the ONLY allowed macro for registrations.
 // Registrations MUST stay sorted to prevent duplicates and maintain overview.
@@ -174,19 +156,19 @@ const uint16_t Flag_Reserved = 4;
 
 #define PATCH /* most common registration, Symbol indicates both an OOVPA and Patch */
 #define REGISTER_OOVPA_PATCH(Symbol, Version, ...) \
-	OOVPA_TABLE_ENTRY_FULL(Symbol, XTL::EMUPATCH(Symbol), #Symbol ##, Version, 0)
+	OOVPA_TABLE_ENTRY_FULL(Symbol, #Symbol ##, Version, 0)
 
 #define XREF /* registration of an XRef-only OOVPA, for which no Patch is present */
 #define REGISTER_OOVPA_XREF(Symbol, Version, ...) \
-	OOVPA_TABLE_ENTRY_FULL(Symbol, nullptr, #Symbol ##, Version, Flag_XRef)
+	OOVPA_TABLE_ENTRY_FULL(Symbol, #Symbol ##, Version, Flag_XRef)
 
 #define ALIAS /* registration of a Patch using an alternatively named OOVPA */
 #define REGISTER_OOVPA_ALIAS(Symbol, Version, AliasOovpa) \
-	OOVPA_TABLE_ENTRY_FULL(AliasOovpa, XTL::EMUPATCH(Symbol), #Symbol ##, Version, 0)
+	OOVPA_TABLE_ENTRY_FULL(AliasOovpa, #Symbol ##, Version, 0)
 
 #define DISABLED /* registration is (temporarily) disabled by a flag */
 #define REGISTER_OOVPA_DISABLED(Symbol, Version, ...) \
-	OOVPA_TABLE_ENTRY_FULL(Symbol, nullptr, #Symbol ##, Version, Flag_DontScan)
+	OOVPA_TABLE_ENTRY_FULL(Symbol, #Symbol ##, Version, Flag_DontScan)
 
 
 #pragma pack()


### PR DESCRIPTION
Significantly improves rendering of titles using DrawIndexedVertices.
Screenshots from GamePad sample, but Dashboard also shows improvements.

Before:
![image](https://cloud.githubusercontent.com/assets/740003/25558194/6609d554-2d19-11e7-864e-80b3ef45f7fc.png)
![image](https://cloud.githubusercontent.com/assets/740003/25558206/a9efed12-2d19-11e7-9254-bf8f5c1b0349.png)
![image](https://cloud.githubusercontent.com/assets/740003/25558211/c32c6710-2d19-11e7-85a5-1a26eb525b9c.png)

After:
![image](https://cloud.githubusercontent.com/assets/740003/25558170/d3e13fc8-2d18-11e7-94b1-b1956903842e.png)
![image](https://cloud.githubusercontent.com/assets/740003/25558239/67781aee-2d1a-11e7-87eb-bea83953bc50.png)
![image](https://cloud.githubusercontent.com/assets/740003/25558243/816b4a7a-2d1a-11e7-9178-cd0c9486320b.png)


