### PR TITLE
Remove unnecessary breakpoint, the EmuWarning should be sufficient

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -265,10 +265,8 @@ XTL::IDirect3DResource8 *GetHostResource(XTL::X_D3DResource *pXboxResource)
 		return nullptr;
 
 	XTL::IDirect3DResource8 *result = (XTL::IDirect3DResource8 *)pXboxResource->Lock;
-	if (result == nullptr)
-	{
-		__asm int 3;
-		//EmuWarning("EmuResource is not a valid pointer!");
+	if (result == nullptr) {
+		EmuWarning("EmuResource is not a valid pointer!");
 	}
 
 	return result;


### PR DESCRIPTION
This should reduce the number of new breakpoint exceptions that are being encountered.

Note: The root cause is that Release is being called on resources that may not have a host resource associated with them. This is a situation that will happen more and more as we remove patches, so I feel like removing this breakpoint is an acceptable solution