### PR TITLE
Fix Controller Issues in some titles & Removed unnecessary breakpoints

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2715,10 +2715,10 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
     }
 
     LPD3DXBUFFER pRecompiledBuffer = NULL;
-    DWORD        *pRecompiledDeclaration;
+    DWORD        *pRecompiledDeclaration = NULL;
     DWORD        *pRecompiledFunction = NULL;
     DWORD        VertexShaderSize = 0;
-    DWORD        DeclarationSize;
+    DWORD        DeclarationSize = 0;
     DWORD        Handle = 0;
 
     HRESULT hRet = XTL::EmuRecompileVshDeclaration((DWORD*)pDeclaration,
@@ -9588,8 +9588,8 @@ HRESULT WINAPI XTL::EMUPATCH(D3D_MakeRequestedSpace)( DWORD Unknown1, DWORD Unkn
 	// create an XRef...
 	LOG_UNIMPLEMENTED();
 
-	__asm int 3;
-	CxbxKrnlCleanup("D3D::MakeRequestedSpace not implemented (tell blueshogun)");
+	//__asm int 3;
+	//CxbxKrnlCleanup("D3D::MakeRequestedSpace not implemented (tell blueshogun)");
 
 
 	return S_OK;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -9639,7 +9639,7 @@ void WINAPI XTL::EMUPATCH(D3D_BlockOnTime)( DWORD Unknown1, int Unknown2 )
 	// create an XRef...
 
 	//__asm int 3;
-	CxbxKrnlCleanup("D3D::BlockOnTime not implemented (tell blueshogun)");
+	EmuWarning("D3D::BlockOnTime not implemented (tell blueshogun)");
 
 	LOG_UNIMPLEMENTED();
 }

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -9588,10 +9588,6 @@ HRESULT WINAPI XTL::EMUPATCH(D3D_MakeRequestedSpace)( DWORD Unknown1, DWORD Unkn
 	// create an XRef...
 	LOG_UNIMPLEMENTED();
 
-	//__asm int 3;
-	//CxbxKrnlCleanup("D3D::MakeRequestedSpace not implemented (tell blueshogun)");
-
-
 	return S_OK;
 }
 
@@ -9607,10 +9603,6 @@ void WINAPI XTL::EMUPATCH(D3DDevice_MakeSpace)()
 	// NOTE: Like the above function, this should not be emulated.  The intended
 	// usage is the same as above.
 	LOG_UNIMPLEMENTED();
-
-	__asm int 3;
-	CxbxKrnlCleanup("D3DDevice::MakeSpace not implemented (tell blueshogun)");
-
 		
 }
 
@@ -9911,9 +9903,6 @@ void WINAPI XTL::EMUPATCH(D3D_LazySetPointParams)( void* Device )
 	LOG_FUNC_ONE_ARG(Device);
 
 	LOG_UNIMPLEMENTED();
-
-	// Don't emulate this! Just look at the stack trace and go from there!
-//	__asm int 3;
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -182,7 +182,6 @@ DWORD WINAPI XTL::EMUPATCH(XGetDevices)
 	RETURN(ret);
 }
 
-#if 0 // patch disabled
 // ******************************************************************
 // * patch: XGetDeviceChanges
 // ******************************************************************
@@ -228,7 +227,6 @@ BOOL WINAPI XTL::EMUPATCH(XGetDeviceChanges)
 
 	RETURN(TRUE); // TODO : RETURN(bRet);
 }
-#endif
 
 // ******************************************************************
 // * patch: XInputOpen

--- a/src/CxbxKrnl/EmuXapi.h
+++ b/src/CxbxKrnl/EmuXapi.h
@@ -380,7 +380,6 @@ DWORD WINAPI EMUPATCH(XGetDevices)
     XPP_DEVICE_TYPE *DeviceType
 );
 
-#if 0 // patch disabled
 // ******************************************************************
 // * patch: XGetDeviceChanges
 // ******************************************************************
@@ -390,7 +389,6 @@ BOOL WINAPI EMUPATCH(XGetDeviceChanges)
     PDWORD           pdwInsertions,
     PDWORD           pdwRemovals
 );
-#endif
 
 // ******************************************************************
 // * patch: XInputOpen


### PR DESCRIPTION
This has improved Lego Star Wars: It is now accepts controller input.

It still crashes due to an unpatched D3D function that was inlined in the .text section, I'm still trying to identify what the function is so we can fix that. 

I'll make another pull-request when it progresses even further.