### PR TITLE
Clear HLE Cache when LLE options are toggled

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -51,6 +51,34 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
+void ClearHLECache()
+{
+	std::string cacheDir = std::string(XTL::szFolder_CxbxReloadedData) + "\\HLECache\\";
+	std::string fullpath = cacheDir + "*.ini";
+
+	WIN32_FIND_DATA data;
+	HANDLE hFind = FindFirstFile(fullpath.c_str(), &data);
+
+	if (hFind != INVALID_HANDLE_VALUE) {
+		BOOL bContinue = TRUE;
+		do {
+			if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+				fullpath = cacheDir + data.cFileName;
+
+				if (!DeleteFile(fullpath.c_str())) {
+					break;
+				}
+			}
+
+			bContinue = FindNextFile(hFind, &data);
+		} while (bContinue);
+
+		FindClose(hFind);
+	}
+
+	printf("Cleared HLE Cache\n");
+}
+
 WndMain::WndMain(HINSTANCE x_hInstance) : 
 	Wnd(x_hInstance), 
 	m_bCreated(false), 
@@ -872,29 +900,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 
 				case ID_CACHE_CLEARHLECACHE_ALL:
 				{
-					std::string cacheDir = std::string(XTL::szFolder_CxbxReloadedData) + "\\HLECache\\";
-					std::string fullpath = cacheDir + "*.ini";
-
-					WIN32_FIND_DATA data;
-					HANDLE hFind = FindFirstFile(fullpath.c_str(), &data);
-
-					if (hFind != INVALID_HANDLE_VALUE) {
-						BOOL bContinue = TRUE;	
-						do	{
-							if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-								fullpath = cacheDir + data.cFileName;
-
-								if (!DeleteFile(fullpath.c_str())) {
-									break;
-								}
-							}
-
-							bContinue = FindNextFile(hFind, &data);
-						} while (bContinue);
-
-						FindClose(hFind);
-					}
-
+					ClearHLECache();
 					MessageBox(m_hwnd, "The entire HLE Cache has been cleared.", "Cxbx-Reloaded", MB_OK);
 				}
 				break;
@@ -1033,7 +1039,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				case ID_EMULATION_LLE_JIT:
 				{
 					m_FlagsLLE = m_FlagsLLE ^ LLE_JIT;
-					
+					ClearHLECache();
 					RefreshMenus();
 				}
 				break;
@@ -1041,7 +1047,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				case ID_EMULATION_LLE_APU:
 				{
 					m_FlagsLLE = m_FlagsLLE ^ LLE_APU;
-
+					ClearHLECache();
 					RefreshMenus();
 				}
 				break;
@@ -1049,7 +1055,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				case ID_EMULATION_LLE_GPU:
 				{
 					m_FlagsLLE = m_FlagsLLE ^ LLE_GPU;
-
+					ClearHLECache();
 					RefreshMenus();
 				}
 				break;


### PR DESCRIPTION
This is required because enabling/disabling LLE options alters which OOVPA Databases are used.