### PR TITLE
Add partial implementation of KeLowerIrql

### DIFF
--- a/src/CxbxKrnl/EmuKrnl.cpp
+++ b/src/CxbxKrnl/EmuKrnl.cpp
@@ -320,7 +320,20 @@ XBSYSAPI EXPORTNUM(161) xboxkrnl::VOID FASTCALL xboxkrnl::KfLowerIrql
 {
 	LOG_FUNC_ONE_ARG(NewIrql);
 
-	LOG_UNIMPLEMENTED();
+	KPCR* Pcr = KeGetPcr();
+
+	if (NewIrql > Pcr->Irql) {
+		// TODO: Enable this after KeBugCheck is implemented
+		//KeBugCheck(IRQL_NOT_LESS_OR_EQUAL);
+		// for (;;);
+
+		CxbxKrnlCleanup("IRQL_NOT_LESS_OR_EQUAL");
+	}
+
+	Pcr->Irql = NewIrql;
+
+	// TODO: Dispatch pending interrupts
+	LOG_INCOMPLETE();
 }
 
 // ******************************************************************


### PR DESCRIPTION
There should be much less occurrences of KeBugCheck being called now!

Verified with various pieces of homebrew + XOnline Dashboard