### PR TITLE
Implement alternate Anti-Piracy patching

### DIFF
--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -137,7 +137,11 @@ class Xbe : public Error
             uint32  dwVersion;                            // 0x00AC - version
             uint08  bzLanKey[16];                         // 0x00B0 - lan key
             uint08  bzSignatureKey[16];                   // 0x00C0 - signature key
+            // NOT ALL XBEs have these fields!
             uint08  bzTitleAlternateSignatureKey[16][16]; // 0x00D0 - alternate signature keys
+            uint32  dwOriginalCertificateSize;			  // 0x01D0 - Original Certificate Size?
+            uint32  dwOnlineService;					  // 0x01D4 - Online Service ID
+            uint32  dwSecurityFlags;					  // 0x01D8 - Extra Security Flags
         }
         #include "AlignPosfix1.h"
         m_Certificate;

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -120,48 +120,25 @@ void ApplyMediaPatches()
 	Xbe::Certificate *pCertificate = (Xbe::Certificate*)CxbxKrnl_XbeHeader->dwCertificateAddr;
 
 	// Patch the XBE Header to allow running from all media types
-	pCertificate->dwAllowedMedia = XBEIMAGE_MEDIA_TYPE_HARD_DISK | XBEIMAGE_MEDIA_TYPE_DVD_CD | XBEIMAGE_MEDIA_TYPE_MEDIA_BOARD;
+	pCertificate->dwAllowedMedia |= XBEIMAGE_MEDIA_TYPE_HARD_DISK |
+		XBEIMAGE_MEDIA_TYPE_DVD_X2 | XBEIMAGE_MEDIA_TYPE_DVD_CD |
+		XBEIMAGE_MEDIA_TYPE_CD | XBEIMAGE_MEDIA_TYPE_DVD_5_RO |
+		XBEIMAGE_MEDIA_TYPE_DVD_9_RO | XBEIMAGE_MEDIA_TYPE_DVD_5_RW |
+		XBEIMAGE_MEDIA_TYPE_DVD_5_RW;
 
 	// Patch the XBE Header to allow running on all regions
-	pCertificate->dwGameRegion = XBEIMAGE_GAME_REGION_MANUFACTURING | XBEIMAGE_GAME_REGION_NA | XBEIMAGE_GAME_REGION_JAPAN | XBEIMAGE_GAME_REGION_RESTOFWORLD;
+	pCertificate->dwGameRegion = XBEIMAGE_GAME_REGION_MANUFACTURING |
+		XBEIMAGE_GAME_REGION_NA |	XBEIMAGE_GAME_REGION_JAPAN |
+		XBEIMAGE_GAME_REGION_RESTOFWORLD;
 
-	// Generic Media Check Patches (From DVD2XBOX)
-	typedef struct
-	{
-		std::string name;
-		std::vector<uint8_t> data;
-		std::vector<uint8_t> patch;
-	} hexpatch_t;
-	
-	std::vector<hexpatch_t> mediaPatches;
-	mediaPatches.push_back({ "Media Patch 1", 
-		{ 0x74, 0x4B, 0xE8, 0xCA, 0xFD, 0xFF, 0xFF, 0x85, 0xC0, 0x7D, 0x06, 0x33, 0xC0, 0x50, 0x50, 0xEB, 0x44, 0xF6, 0x05},
-		{ 0x74, 0x4B, 0xE8, 0xCA, 0xFD, 0xFF, 0xFF, 0x85, 0xC0, 0xEB, 0x06, 0x33, 0xC0, 0x50, 0x50, 0xEB, 0x44, 0xF6, 0x05 }
-	});
-
-	mediaPatches.push_back({ "Media Patch 2", 
-		{ 0xE8, 0xCA, 0xFD, 0xFF, 0xFF, 0x85, 0xC0, 0x7D }, 
-		{ 0xE8, 0xCA, 0xFD, 0xFF, 0xFF, 0x85, 0xC0, 0xEB } 
-	});
-
-	mediaPatches.push_back({ "FATX Patch",
-		{ 0x46, 0x41, 0x54, 0x58, 0x00, 0x00, 0x00, 0x00, 0x44, 0x3A, 0x5C },
-		{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } 
-	});
-
-	for (auto it = mediaPatches.begin(); it < mediaPatches.end(); ++it)	{
-		hexpatch_t patch = *it;
-		
-		// Iterate through the XBE until we find the patch
-		for (xbaddr addr = CxbxKrnl_XbeHeader->dwBaseAddr; addr < CxbxKrnl_XbeHeader->dwSizeofImage + CxbxKrnl_XbeHeader->dwBaseAddr; addr++) {
-			if (memcmp((void*)addr, &patch.data[0], patch.data.size()) == 0) {
-				printf("Applying %s\n", patch.name.c_str());
-				memcpy((void*)addr, &patch.patch[0], patch.patch.size());
-				addr += patch.data.size() - 1;
-			}
-		}
+	// Patch the XBE Security Flag
+	// This field is only present if the Xbe Size is >= than our Certificate Structure
+	// This works as our structure is large enough to fit the newer certificate size, 
+	// while dwSize is the actual size of the certificate in the Xbe.
+	// Source: Various Hacked Kernels
+	if (pCertificate->dwSize >= sizeof(Xbe::Certificate)) {
+		pCertificate->dwSecurityFlags &= ~1;
 	}
-
 }
 
 void SetupPerTitleKeys()


### PR DESCRIPTION
This eliminates the need to iterate through the Xbe contents to apply media patches.

This method is the same one used by various 'hacked' kernels to bypass security checks.