### PR TITLE
Missing Patch To Improve Colin McRae Rally 2005

### DIFF
--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5344.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5344.inl
@@ -984,6 +984,8 @@ OOVPATable DSound_5344[] = {
 	REGISTER_OOVPA(CDirectSoundBuffer_SetConeOrientation, 4134, XREF),
 	REGISTER_OOVPA(IDirectSoundBuffer_SetConeOrientation, 4134, PATCH),
 	REGISTER_OOVPA(CDirectSoundStream_SetConeOrientation, 4134, PATCH),
+	REGISTER_OOVPA(CDirectSoundBuffer_SetNotificationPositions, 4627, XREF),
+	REGISTER_OOVPA(IDirectSoundBuffer_SetNotificationPositions, 4627, PATCH)
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5558.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5558.inl
@@ -1827,6 +1827,8 @@ OOVPATable DSound_5558[] = {
 	REGISTER_OOVPA(CDirectSoundBuffer_Use3DVoiceData, 5558, XREF),
 	REGISTER_OOVPA(IDirectSoundBuffer_Use3DVoiceData, 5558, PATCH),
 	REGISTER_OOVPA(CDirectSoundStream_Use3DVoiceData, 5558, XREF),
+	REGISTER_OOVPA(CDirectSoundBuffer_SetNotificationPositions, 4627, XREF),
+	REGISTER_OOVPA(IDirectSoundBuffer_SetNotificationPositions, 4627, PATCH)
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5788.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5788.inl
@@ -749,6 +749,8 @@ OOVPATable DSound_5788[] = {
 	REGISTER_OOVPA(CDirectSoundBuffer_Use3DVoiceData, 5558, XREF),
 	REGISTER_OOVPA(IDirectSoundBuffer_Use3DVoiceData, 5558, PATCH),
 	REGISTER_OOVPA(CDirectSoundStream_Use3DVoiceData, 5558, XREF),
+	REGISTER_OOVPA(CDirectSoundBuffer_SetNotificationPositions, 4627, XREF),
+	REGISTER_OOVPA(IDirectSoundBuffer_SetNotificationPositions, 4627, PATCH)
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5849.inl
@@ -304,6 +304,8 @@ OOVPATable DSound_5849[] = {
 	REGISTER_OOVPA(CDirectSoundBuffer_Use3DVoiceData, 5558, XREF),
 	REGISTER_OOVPA(IDirectSoundBuffer_Use3DVoiceData, 5558, PATCH),
 	REGISTER_OOVPA(CDirectSoundStream_Use3DVoiceData, 5558, XREF),
+	REGISTER_OOVPA(CDirectSoundBuffer_SetNotificationPositions, 4627, XREF),
+	REGISTER_OOVPA(IDirectSoundBuffer_SetNotificationPositions, 4627, PATCH)
 };
 
 // ******************************************************************


### PR DESCRIPTION
Add missing both SetNotificationPositions patches with existing OOVPA signature from 4627 HLE
database.

ref #535 - This fixed and made Colin McRae Rally 2005 go a bit further,
yet still crash after 2 black intro screens.

It does not affect Lego Star Wars, Lego Star Wars 2, and Star Wars KotoR 2 since all 3 return no detection for both SetNotificationPositions OOPVAs.