### PR TITLE
Fix for registry folder keys

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -41,8 +41,6 @@
 #include "CxbxKrnl/EmuShared.h"
 #include "ResCxbx.h"
 #include "CxbxVersion.h"
-// I am not sure if this is already included in the other includes. If it is, remove it
-#include "Shlwapi.h"
 
 #include <io.h>
 
@@ -148,18 +146,6 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 
             dwType = REG_SZ; dwSize = MAX_PATH;
             RegQueryValueEx(hKey, "KrnlDebugFilename", NULL, &dwType, (PBYTE)m_KrnlDebugFilename, &dwSize);
-
-            // Prevent using an incorrect path from the registry if the debug folders have been moved
-
-            if(PathFileExists((LPCSTR)m_CxbxDebugFilename) == FALSE)
-            {
-                m_CxbxDebugFilename = "";
-            }
-
-            if(PathFileExists((LPCSTR)m_KrnlDebugFilename) == FALSE)
-            {
-                m_KrnlDebugFilename = "";
-            }
 
             int v=0;
 

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -41,6 +41,7 @@
 #include "CxbxKrnl/EmuShared.h"
 #include "ResCxbx.h"
 #include "CxbxVersion.h"
+#include "Shlwapi.h"
 
 #include <io.h>
 
@@ -141,11 +142,43 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
             dwType = REG_DWORD; dwSize = sizeof(DWORD);
             RegQueryValueEx(hKey, "RecentXbe", NULL, &dwType, (PBYTE)&m_dwRecentXbe, &dwSize);
 
-            dwType = REG_SZ; dwSize = MAX_PATH;
-            RegQueryValueEx(hKey, "CxbxDebugFilename", NULL, &dwType, (PBYTE)m_CxbxDebugFilename, &dwSize);
+            dwType = REG_SZ; dwSize = MAX_PATH; LONG lErrCodeCxbxDebugFilename;
+			lErrCodeCxbxDebugFilename = RegQueryValueEx(hKey, "CxbxDebugFilename", NULL, &dwType, (PBYTE)m_CxbxDebugFilename, &dwSize);
 
-            dwType = REG_SZ; dwSize = MAX_PATH;
-            RegQueryValueEx(hKey, "KrnlDebugFilename", NULL, &dwType, (PBYTE)m_KrnlDebugFilename, &dwSize);
+			dwType = REG_SZ; dwSize = MAX_PATH; LONG lErrCodeKrnlDebugFilename;
+			lErrCodeKrnlDebugFilename = RegQueryValueEx(hKey, "KrnlDebugFilename", NULL, &dwType, (PBYTE)m_KrnlDebugFilename, &dwSize);
+
+			// Prevent using an incorrect path from the registry if the debug folders have been moved
+
+			{
+				if(lErrCodeCxbxDebugFilename != ERROR_FILE_NOT_FOUND && strlen(m_CxbxDebugFilename) > strlen("\\CxbxDebug.txt"))
+				{
+					char *m_CxbxDebugPath = (char*)calloc(1, MAX_PATH);
+
+					strncpy(m_CxbxDebugPath, m_CxbxDebugFilename, strlen(m_CxbxDebugFilename) - strlen("\\CxbxDebug.txt"));
+
+					if(PathFileExists((LPCSTR)m_CxbxDebugPath) == FALSE)
+					{
+						memset((char*)m_CxbxDebugFilename, '\0', MAX_PATH);
+					}
+
+					free(m_CxbxDebugPath);
+				}
+				
+				if(lErrCodeKrnlDebugFilename != ERROR_FILE_NOT_FOUND && strlen(m_KrnlDebugFilename) > strlen("\\KrnlDebug.txt"))
+				{
+					char *m_KrnlDebugPath = (char*)calloc(1, MAX_PATH);
+
+					strncpy(m_KrnlDebugPath, m_KrnlDebugFilename, strlen(m_KrnlDebugFilename) - strlen("\\KrnlDebug.txt"));
+
+					if(PathFileExists((LPCSTR)m_KrnlDebugPath) == FALSE)
+					{
+						memset((char*)m_KrnlDebugFilename, '\0', MAX_PATH);
+					}
+
+					free(m_KrnlDebugPath);
+				}
+			}
 
             int v=0;
 


### PR DESCRIPTION
New fix for issue #515. Tested by building cxbx in VS 2017 with it.