### PR TITLE
Remove scanning D3DX8 library HACK

### DIFF
--- a/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.1.0.4627.inl
@@ -55,7 +55,7 @@ OOVPA_NO_XREF(Direct3D_CreateDevice, 4627, 8)
 OOVPA_END;
 
 // ******************************************************************
-// * D3D_CreateDeviceX (From D3D8X)
+// * D3D_CreateDeviceX (Direct3D_CreateDevice from D3D8LTCG)
 // ******************************************************************
 OOVPA_NO_XREF(D3D_CreateDeviceX, 4627, 8)
 
@@ -2702,7 +2702,7 @@ OOVPA_END;
 OOVPATable D3D8_4627[] = {
 
 	REGISTER_OOVPA(Direct3D_CreateDevice, 4627, PATCH),
-	REGISTER_OOVPA(D3D_CreateDeviceX, 4627, XREF), // If hitting a Breakpoint, redirect to Direct3D_CreateDevice.
+	REGISTER_OOVPA(D3D_CreateDeviceX, 4627, DISABLED),
 	REGISTER_OOVPA(D3D_CheckDeviceFormat, 4134, DISABLED),
 	REGISTER_OOVPA(D3DDevice_BeginVisibilityTest, 4627, PATCH),
 	REGISTER_OOVPA(D3DDevice_GetCreationParameters, 4034, PATCH),

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -267,8 +267,6 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
         uint32 LastUnResolvedXRefs = UnResolvedXRefs+1;
         uint32 OrigUnResolvedXRefs = UnResolvedXRefs;
 
-		bool bFoundD3D = false;
-
 		bXRefFirstPass = true; // Set to false for search speed optimization
 
 		// Mark all Xrefs initially as undetermined
@@ -306,12 +304,6 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
                 if(BuildVersion == 5933) { BuildVersion = 5849; }   // These XDK versions are pretty much the same
                 
 				std::string LibraryName(pLibraryVersion[v].szName, pLibraryVersion[v].szName + 8);
-				
-				// TODO: HACK: D3DX8 is packed into D3D8 database
-				if (strcmp(LibraryName.c_str(), Lib_D3DX8) == 0)
-				{
-					LibraryName = Lib_D3D8;
-				}
 
 				if (strcmp(LibraryName.c_str(), Lib_D3D8LTCG) == 0)
 				{
@@ -329,14 +321,6 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 					// Skip scanning for D3D8 symbols when LLE GPU is selected
 					if (bLLE_GPU)
 						continue;
-
-					// Prevent scanning D3D8 again (since D3D8X is packed into it above)
-					if (bFoundD3D)
-					{
-						continue;
-					}
-
-					bFoundD3D = true;
 
 					// Some 3911 titles have different D3D8 builds
 					if (BuildVersion <= 3948)


### PR DESCRIPTION
We get the appropriate error message run the LTCG titles.
![message](https://user-images.githubusercontent.com/20138367/28994738-47e54ec0-7a10-11e7-8067-9dba2538526d.png)
