### PR TITLE
Audio hot patch

### DIFF
--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -959,7 +959,12 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
 		LOG_FUNC_ARG(dwBufferBytes)
 		LOG_FUNC_END;
 
-    ResizeIDirectSoundBuffer(pThis->EmuDirectSoundBuffer8, pThis->EmuBufferDesc, pThis->EmuPlayFlags, dwBufferBytes, pThis->EmuDirectSound3DBuffer8);
+    //TODO: Current workaround method since dwBufferBytes do set to zero. Otherwise it will produce lock error message.
+    if (dwBufferBytes == 0) {
+        leaveCriticalSection;
+        return DS_OK;
+    }
+	ResizeIDirectSoundBuffer(pThis->EmuDirectSoundBuffer8, pThis->EmuBufferDesc, pThis->EmuPlayFlags, dwBufferBytes, pThis->EmuDirectSound3DBuffer8);
 
     XTL::EMUPATCH(IDirectSoundBuffer_Lock)(pThis, 0, dwBufferBytes, &pThis->EmuLockPtr1, &pThis->EmuLockBytes1, NULL, NULL, pThis->EmuLockFlags);
 

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -207,6 +207,7 @@ inline void GeneratePCMFormat(
     DWORD          &dwEmuFlags)
 {
     bool bIsSpecial = false;
+    DWORD checkAvgBps;
 
     // convert from Xbox to PC DSound
     {
@@ -239,6 +240,13 @@ inline void GeneratePCMFormat(
             switch (pDSBufferDesc->lpwfxFormat->wFormatTag) {
                 case WAVE_FORMAT_PCM:
                     dwEmuFlags |= DSB_FLAG_PCM;
+
+                    //TODO: Phantasy Star Online Episode I & II made an attempt to use avg byte/second below sample/second requirement.
+                    //In other word, this is a workaround to fix title mistake...
+                    checkAvgBps = lpwfxFormat->nSamplesPerSec * lpwfxFormat->nBlockAlign;
+                    if (lpwfxFormat->nAvgBytesPerSec < checkAvgBps) {
+                        pDSBufferDesc->lpwfxFormat->nAvgBytesPerSec = checkAvgBps;
+                    }
                     break;
                 case WAVE_FORMAT_XBOX_ADPCM:
                     dwEmuFlags |= DSB_FLAG_XADPCM;


### PR DESCRIPTION
Reference of #274 Fixed CreateSoundBuffer creation failure with a workaround method to force nAvgBytesPerSec to be higher than nSamplesPerSeconds per PC's DSound requirement.

Several titles has issue with SetBufferData getting zero byte value since Lock function doesn't like zero byte value input.