### PR TITLE
Log all configuration settings during start of emulation (FIX issue #668)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ jarupxx
 phire
 x1mixmzeng
 RadWolfie
+Luca D'Amico (Luca1991/Luca91)
 
 Supporters:
 Cisco	Martinez

--- a/src/Common/Win32/XBAudio.h
+++ b/src/Common/Win32/XBAudio.h
@@ -59,7 +59,7 @@ class XBAudio : public Error
         // ******************************************************************
         // * SetAudioAdapter
         // ******************************************************************
-        void  SetAudioAdapter(GUID binAudioAdapter) { m_binAudioAdapter = binAudioAdapter; }
+        void SetAudioAdapter(GUID binAudioAdapter) { m_binAudioAdapter = binAudioAdapter; }
         GUID GetAudioAdapter() const { return m_binAudioAdapter; }
 
         // ******************************************************************

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -71,6 +71,8 @@ typedef signed long    sint32;
 #define _DEBUG_WARNINGS
 /*! define this to trace vertex shader constants */
 #define _DEBUG_TRACK_VS_CONST
+/*! define this to print current configuration at kernel startup */
+#define _DEBUG_PRINT_CURRENT_CONF
 
 /*! define this to dump textures that have been set */
 //#define _DEBUG_DUMP_TEXTURE_SETTEXTURE "D:\\xbox\\_textures\\"

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -367,6 +367,8 @@ void PrintCurrentConfigurationLog() {
 		printf("[0x%X] EmuMain: Unknown Codec is %s\n", GetCurrentThreadId(), XBAudioConf.GetUnknownCodec() ? "enabled" : "disabled");
 	}
 
+	printf("------------------------- END OF CONFIG LOG ------------------------\n");
+
 }
 
 void CxbxKrnlMain(int argc, char* argv[])


### PR DESCRIPTION
I've written a function that write the current configuration at kernel start time.
It can be disabled by removing the #define in Cxbx.h

PS: I've added myself to the contributors list. If this ins't ok for you, feel free to remove me!