### PR TITLE
All Xapi REGISTER_OOVPA to reviewed

### DIFF
--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.3911.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.3911.inl
@@ -546,7 +546,7 @@ OOVPA_END;
 // ******************************************************************
 // * SetThreadPriorityBoost
 // ******************************************************************
-OOVPA_NO_XREF(SetThreadPriorityBoost, 3911, 10)
+OOVPA_NO_XREF(SetThreadPriorityBoost, 3911, 10) // generic version
 
         // SetThreadPriorityBoost+0x0D : push [ebp+0x08]
         { 0x0D, 0xFF }, // (Offset,Value)-Pair #1
@@ -778,7 +778,7 @@ OOVPA_END;
 // ******************************************************************
 // * SignalObjectAndWait
 // ******************************************************************
-OOVPA_NO_XREF(SignalObjectAndWait, 3911, 8)
+OOVPA_NO_XREF(SignalObjectAndWait, 3911, 8) // generic version
 
         { 0x07, 0x75 },
         { 0x12, 0x8B },
@@ -793,7 +793,7 @@ OOVPA_END;
 // ******************************************************************
 // * QueueUserAPC
 // ******************************************************************
-OOVPA_NO_XREF(QueueUserAPC, 3911, 7)
+OOVPA_NO_XREF(QueueUserAPC, 3911, 7) // generic version
 
         { 0x03, 0x74 },
         { 0x08, 0x24 },
@@ -822,6 +822,30 @@ OOVPA_END;
 // ******************************************************************
 // * XMountAlternateTitleA
 // ******************************************************************
+OOVPA_NO_XREF(XMountAlternateTitleA, 3911, 13)
+
+        { 0x04, 0xEC },
+
+        { 0x0F, 0x18 },
+        { 0x10, 0x01 },
+        { 0x11, 0x01 },
+        { 0x12, 0x00 },
+        { 0x13, 0x53 },
+        { 0x14, 0x8A },
+
+        { 0x30, 0x39 },
+        { 0x31, 0x55 },
+        { 0x32, 0x0C },
+        { 0x33, 0x74 },
+        { 0x34, 0x09 },
+
+        { 0x3D, 0xEC },
+OOVPA_END;
+
+#if 0 // No longer used, replaced by generic 3911 version
+// ******************************************************************
+// * XMountAlternateTitleA
+// ******************************************************************
 OOVPA_NO_XREF(XMountAlternateTitleA, 3911, 7)
 
         { 0x1E, 0x0F },
@@ -832,6 +856,7 @@ OOVPA_NO_XREF(XMountAlternateTitleA, 3911, 7)
         { 0xBE, 0x66 },
         { 0xDE, 0xF0 },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * XUnmountAlternateTitleA
@@ -850,7 +875,7 @@ OOVPA_END;
 // ******************************************************************
 // * XMountMUA
 // ******************************************************************
-OOVPA_NO_XREF(XMountMUA, 3911, 7)
+OOVPA_NO_XREF(XMountMUA, 3911, 7) // generic version
 
         { 0x1E, 0x0C },
         { 0x3E, 0x66 },
@@ -1008,7 +1033,7 @@ OOVPA_END;
 // ******************************************************************
 // * XMountMURootA
 // ******************************************************************
-OOVPA_NO_XREF(XMountMURootA, 3911, 7)
+OOVPA_NO_XREF(XMountMURootA, 3911, 7) // generic version
 
         { 0x1E, 0x0C },
         { 0x3E, 0x00 },
@@ -1064,6 +1089,128 @@ OOVPA_NO_XREF(WriteFileEx, 3911, 8)
 OOVPA_END;
 
 // ******************************************************************
+// * XInputPoll
+// ******************************************************************
+OOVPA_NO_XREF(XInputPoll, 3911, 14)
+
+        { 0x00, 0x53 },
+        { 0x01, 0x56 },
+        { 0x02, 0x33 },
+        { 0x03, 0xF6 },
+        { 0x04, 0xFF },
+        { 0x05, 0x15 },
+
+        { 0x18, 0x04 },
+        { 0x19, 0x02 },
+        { 0x1A, 0x75 },
+        { 0x1B, 0x29 },
+        { 0x1C, 0xF6 },
+        { 0x1D, 0x80 },
+        { 0x1E, 0xA2 },
+        { 0x1F, 0x00 },
+OOVPA_END;
+
+#if 0 // No longer used, replaced by generic 3911 version
+// ******************************************************************
+// * XInputPoll
+// ******************************************************************
+OOVPA_NO_XREF(XInputPoll, 3911, 10)
+
+        { 0x16, 0xF6 }, // (Offset,Value)-Pair #1
+        { 0x17, 0x41 }, // (Offset,Value)-Pair #2
+        { 0x18, 0x04 }, // (Offset,Value)-Pair #3
+        { 0x19, 0x02 }, // (Offset,Value)-Pair #4
+
+        { 0x25, 0x39 }, // (Offset,Value)-Pair #5
+        { 0x26, 0x70 }, // (Offset,Value)-Pair #6
+        { 0x27, 0x04 }, // (Offset,Value)-Pair #7
+
+        { 0x3A, 0x83 }, // (Offset,Value)-Pair #8
+        { 0x3B, 0xC0 }, // (Offset,Value)-Pair #9
+        { 0x3C, 0x52 }, // (Offset,Value)-Pair #10
+OOVPA_END;
+#endif
+
+// ******************************************************************
+// * timeSetEvent
+// ******************************************************************
+OOVPA_NO_XREF(timeSetEvent, 3911, 7) // generic version
+
+        { 0x1E, 0x8D },
+        { 0x3E, 0x89 },
+        { 0x5E, 0x15 },
+        { 0x7E, 0x3F },
+        { 0x9E, 0x03 },
+        { 0xBE, 0x32 },
+        { 0xDE, 0x89 },
+OOVPA_END;
+
+// ******************************************************************
+// * timeKillEvent
+// ******************************************************************
+OOVPA_NO_XREF(timeKillEvent, 3911, 12)
+
+        { 0x02, 0xBF },
+        { 0x13, 0x0D },
+
+        { 0x18, 0x0F },
+        { 0x19, 0xB7 },
+        { 0x1A, 0xC2 },
+        { 0x1B, 0x48 },
+        { 0x1C, 0x85 },
+        { 0x1D, 0xC9 },
+        { 0x1E, 0x74 },
+        { 0x1F, 0x3E },
+
+        { 0x4A, 0x6A },
+        { 0x55, 0x15 },
+OOVPA_END;
+
+#if 0 // No longer used, replaced by generic 3911 version
+// ******************************************************************
+// * timeKillEvent
+// ******************************************************************
+OOVPA_NO_XREF(timeKillEvent, 3911, 8)
+
+        { 0x0E, 0x8B },
+        { 0x1A, 0xC2 },
+        { 0x28, 0x8D },
+        { 0x36, 0x56 },
+        { 0x44, 0x00 },
+        { 0x52, 0x00 },
+        { 0x60, 0x5E },
+        { 0x6E, 0x00 },
+OOVPA_END;
+#endif
+// ******************************************************************
+// * GetOverlappedResult
+// ******************************************************************
+OOVPA_NO_XREF(GetOverlappedResult, 3911, 7)
+
+        { 0x0B, 0x75 },
+        { 0x18, 0xC0 },
+        { 0x27, 0xEB },
+        { 0x32, 0x00 },
+        { 0x3F, 0xEB },
+        { 0x4C, 0x89 },
+        { 0x59, 0x56 },
+OOVPA_END;
+
+// ******************************************************************
+// * RaiseException
+// ******************************************************************
+OOVPA_NO_XREF(RaiseException, 3911, 7)
+
+        { 0x09, 0x83 },
+        { 0x14, 0x8B },
+        { 0x1F, 0xC7 },
+        { 0x2A, 0x10 },
+        { 0x35, 0x89 },
+        { 0x40, 0x5F },
+        { 0x4B, 0xFF },
+OOVPA_END;
+
+// ******************************************************************
 // * XAPI_3911
 // ******************************************************************
 OOVPATable XAPI_3911[] = {
@@ -1102,6 +1249,11 @@ OOVPATable XAPI_3911[] = {
 	REGISTER_OOVPA(XMountMURootA, 3911, PATCH),
 	REGISTER_OOVPA(XMountUtilityDrive, 3911, PATCH),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 	// REGISTER_OOVPA(ReadFileEx, 3911, PATCH),
 	// REGISTER_OOVPA(WriteFileEx, 3911, PATCH),
 	// REGISTER_OOVPA(CloseHandle, 3911, PATCH),

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4034.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4034.inl
@@ -165,11 +165,6 @@ OOVPATable XAPI_4034[] = {
 
 	REGISTER_OOVPA(XInitDevices, 3911, PATCH),
 	REGISTER_OOVPA(XGetDevices, 3911, PATCH),
-/* These functions havent been rev'd yet (may be same as new/old)
-	REGISTER_OOVPA(XInputOpen, 4034, PATCH),
-	REGISTER_OOVPA(XInputGetCapabilities, 4361, PATCH),
-	REGISTER_OOVPA(XInputGetState, 4361, PATCH),
-*/
 	// REGISTER_OOVPA(CreateThread, 3911, PATCH), // Too High Level
 	// REGISTER_OOVPA(CloseHandle, (???, PATCH)),
 	REGISTER_OOVPA(CreateFiber, 3911, DISABLED),
@@ -178,7 +173,6 @@ OOVPATable XAPI_4034[] = {
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(GetTimeZoneInformation, 3911, DISABLED),
 	REGISTER_OOVPA(SetThreadPriority, 3911, PATCH),
-	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
 	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
 	REGISTER_OOVPA(XInputSetState, 3911, PATCH),
 	REGISTER_OOVPA(XRegisterThreadNotifyRoutine, 3911, PATCH),
@@ -190,6 +184,26 @@ OOVPATable XAPI_4034[] = {
 	REGISTER_OOVPA(XInputOpen, 3911, PATCH),
 	REGISTER_OOVPA(XInputGetState, 3911, PATCH),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
+	REGISTER_OOVPA(SetThreadPriorityBoost, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMUA, 3911, PATCH),
+	REGISTER_OOVPA(XLaunchNewImageA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 3911, PATCH),
+	REGISTER_OOVPA(XMountUtilityDrive, 3911, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
+
+	// ******************************************************************
+	// Provisional registration functions in XDK 4034
+	// TODO: Need test cases
+	// ******************************************************************
+	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
+	// ******************************************************************
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4134.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4134.inl
@@ -111,7 +111,7 @@ OOVPA_NO_XREF(XMountUtilityDrive, 4134, 10)
         { 0xAB, 0x45 }, // (Offset,Value)-Pair #9
         { 0xAC, 0xF0 }, // (Offset,Value)-Pair #10
 OOVPA_END;
-
+#if 0 // Moved to 3911
 // ******************************************************************
 // * XInputPoll
 // ******************************************************************
@@ -130,7 +130,8 @@ OOVPA_NO_XREF(XInputPoll, 4134, 10)
         { 0x3B, 0xC0 }, // (Offset,Value)-Pair #9
         { 0x3C, 0x52 }, // (Offset,Value)-Pair #10
 OOVPA_END;
-
+#endif
+#if 0 // version 4361, Not 4134
 // ******************************************************************
 // * XMountMUA
 // ******************************************************************
@@ -145,7 +146,8 @@ OOVPA_NO_XREF(XMountMUA, 4134, 8)
         { 0xDE, 0x8D },
         { 0xFE, 0x09 },
 OOVPA_END;
-
+#endif
+#if 0 // Moved to 3911
 // ******************************************************************
 // * timeSetEvent
 // ******************************************************************
@@ -159,7 +161,8 @@ OOVPA_NO_XREF(timeSetEvent, 4134, 7)
         { 0xBE, 0x32 },
         { 0xDE, 0x89 },
 OOVPA_END;
-
+#endif
+#if 0 // Moved to 3911
 // ******************************************************************
 // * timeKillEvent
 // ******************************************************************
@@ -173,6 +176,21 @@ OOVPA_NO_XREF(timeKillEvent, 4134, 8)
         { 0x52, 0x00 },
         { 0x60, 0x5E },
         { 0x6E, 0x00 },
+OOVPA_END;
+#endif
+
+// ******************************************************************
+// * XSetProcessQuantumLength
+// ******************************************************************
+OOVPA_NO_XREF(XSetProcessQuantumLength, 4134, 7)
+
+        { 0x01, 0xA1 },
+        { 0x04, 0x00 },
+        { 0x07, 0x4C },
+        { 0x0A, 0x8B },
+        { 0x0D, 0x8D },
+        { 0x10, 0x89 },
+        { 0x13, 0xC2 },
 OOVPA_END;
 
 // ******************************************************************
@@ -199,15 +217,21 @@ OOVPATable XAPI_4134[] = {
 	REGISTER_OOVPA(XInputClose, 3911, PATCH),
 	REGISTER_OOVPA(XInputGetCapabilities, 3911, PATCH),
 	REGISTER_OOVPA(GetThreadPriority, 3911, PATCH),
-	REGISTER_OOVPA(XInputPoll, 4134, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
 	REGISTER_OOVPA(SetThreadPriorityBoost, 3911, PATCH),
 	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
 	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
-	REGISTER_OOVPA(XMountMUA, 4134, PATCH),
-	REGISTER_OOVPA(timeSetEvent, 4134, PATCH),
-	REGISTER_OOVPA(timeKillEvent, 4134, PATCH),
+	REGISTER_OOVPA(XMountMUA, 3911, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
 	REGISTER_OOVPA(XLaunchNewImageA, 3911, PATCH),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 3911, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4361.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4361.inl
@@ -322,7 +322,7 @@ OOVPA_END;
 // ******************************************************************
 // * XMountMUA
 // ******************************************************************
-OOVPA_NO_XREF(XMountMUA, 4361, 8)
+OOVPA_NO_XREF(XMountMUA, 4361, 8) // generic version
 
         { 0x22, 0x8A },
         { 0x3E, 0x89 },
@@ -332,6 +332,48 @@ OOVPA_NO_XREF(XMountMUA, 4361, 8)
         { 0xBE, 0xF8 },
         { 0xDE, 0x8D },
         { 0xFE, 0x09 },
+OOVPA_END;
+
+// ******************************************************************
+// * XFormatUtilityDrive
+// ******************************************************************
+OOVPA_NO_XREF(XFormatUtilityDrive, 4361, 12)
+
+        { 0x02, 0xEC },
+        { 0x10, 0x50 },
+        { 0x1E, 0xEC },
+
+        { 0x40, 0xF8 },
+        { 0x41, 0x8D },
+        { 0x42, 0x45 },
+        { 0x43, 0xE4 },
+        { 0x44, 0x50 },
+        { 0x45, 0x8D },
+        { 0x46, 0x45 },
+        { 0x47, 0xF4 },
+
+        { 0x6D, 0x33 },
+OOVPA_END;
+
+// ******************************************************************
+// * XMountMURootA
+// ******************************************************************
+OOVPA_NO_XREF(XMountMURootA, 4361, 12)
+
+        { 0x16, 0xBF },
+        { 0x22, 0x8A },
+        { 0x39, 0x05 },
+
+        { 0x50, 0x55 },
+        { 0x51, 0x58 },
+        { 0x52, 0xE9 },
+        { 0x53, 0x0E },
+        { 0x54, 0x01 },
+        { 0x55, 0x00 },
+        { 0x56, 0x00 },
+        { 0x57, 0x66 },
+
+        { 0x72, 0xE8 },
 OOVPA_END;
 
 // ******************************************************************
@@ -361,9 +403,20 @@ OOVPATable XAPI_4361[] = {
 	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
 	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
 	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
-	REGISTER_OOVPA(timeSetEvent, 4134, PATCH),
-	REGISTER_OOVPA(timeKillEvent, 4134, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
+	REGISTER_OOVPA(XRegisterThreadNotifyRoutine, 3911, PATCH),
+	REGISTER_OOVPA(GetThreadPriority, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XLaunchNewImageA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4432.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4432.inl
@@ -58,6 +58,7 @@ OOVPA_END;
 // * XAPI_4432
 // ******************************************************************
 OOVPATable XAPI_4432[] = {
+
 	REGISTER_OOVPA(XMountUtilityDrive, 4432, PATCH),
 	REGISTER_OOVPA(XInitDevices, 3911, PATCH),
 	REGISTER_OOVPA(XGetDevices, 3911, PATCH),
@@ -78,10 +79,22 @@ OOVPATable XAPI_4432[] = {
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
-	REGISTER_OOVPA(timeSetEvent, 4134, PATCH),
-	REGISTER_OOVPA(timeKillEvent, 4134, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
 	REGISTER_OOVPA(XLaunchNewImageA, 3911, PATCH),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(XRegisterThreadNotifyRoutine, 3911, PATCH),
+	REGISTER_OOVPA(SetThreadPriorityBoost, 3911, PATCH),
+	REGISTER_OOVPA(GetThreadPriority, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4627.inl
@@ -32,6 +32,7 @@
 // *
 // ******************************************************************
 
+#if 0 // No longer used, replaced by generic 4361 version
 // ******************************************************************
 // * XFormatUtilityDrive
 // ******************************************************************
@@ -45,6 +46,7 @@ OOVPA_NO_XREF(XFormatUtilityDrive, 4627, 7)
         { 0x6D, 0x33 },
         { 0x7C, 0x40 },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * XID_fCloseDevice
@@ -127,6 +129,7 @@ OOVPA_NO_XREF(XInputGetCapabilities, 4831, 10)
         { 0x9A, 0xD0 },
 OOVPA_END;
 
+#if 0 // Moved to 3911
 // ******************************************************************
 // * GetOverlappedResult
 // ******************************************************************
@@ -140,7 +143,35 @@ OOVPA_NO_XREF(GetOverlappedResult, 4627, 7)
         { 0x4C, 0x89 },
         { 0x59, 0x56 },
 OOVPA_END;
+#endif
 
+
+// ******************************************************************
+// * XLaunchNewImageA
+// ******************************************************************
+OOVPA_NO_XREF(XLaunchNewImageA, 4721, 15)
+
+        { 0x03, 0x81 },
+        { 0x04, 0xEC },
+        { 0x05, 0x84 },
+        { 0x06, 0x03 },
+        { 0x07, 0x00 },
+        { 0x08, 0x00 },
+
+        { 0x33, 0x3C },
+        { 0x34, 0x44 },
+
+        { 0xA0, 0x3B },
+        { 0xA1, 0xC3 },
+        { 0xA2, 0x7C },
+        { 0xA3, 0x5A },
+        { 0xA4, 0x57 },
+        { 0xA5, 0x8D },
+
+        { 0xC1, 0x15 },
+OOVPA_END;
+
+#if 0 // No longer used, replaced by generic 4721 version
 // ******************************************************************
 // * XLaunchNewImageA
 // ******************************************************************
@@ -162,7 +193,8 @@ OOVPA_NO_XREF(XLaunchNewImageA, 4928, 12)
 		{ 0x43, 0x02 },
 		{ 0x44, 0x5C },
 OOVPA_END;
-
+#endif
+#if 0 // Moved to 4134
 // ******************************************************************
 // * XSetProcessQuantumLength
 // ******************************************************************
@@ -176,7 +208,8 @@ OOVPA_NO_XREF(XSetProcessQuantumLength, 4627, 7)
         { 0x10, 0x89 },
         { 0x13, 0xC2 },
 OOVPA_END;
-
+#endif
+#if 0 // No longer used, replaced by generic 3911 version
 // ******************************************************************
 // * timeSetEvent
 // ******************************************************************
@@ -190,7 +223,8 @@ OOVPA_NO_XREF(timeSetEvent, 4627, 7)
         { 0xBE, 0x32 },
         { 0xDE, 0x89 },
 OOVPA_END;
-
+#endif
+#if 0 // No longer used, replaced by generic 3911 version
 // ******************************************************************
 // * timeKillEvent
 // ******************************************************************
@@ -205,7 +239,8 @@ OOVPA_NO_XREF(timeKillEvent, 4627, 8)
         { 0x60, 0x5E },
         { 0x6E, 0x00 },
 OOVPA_END;
-
+#endif
+#if 0 // Moved to 3911
 // ******************************************************************
 // * RaiseException
 // ******************************************************************
@@ -219,7 +254,9 @@ OOVPA_NO_XREF(RaiseException, 4627, 7)
         { 0x40, 0x5F },
         { 0x4B, 0xFF },
 OOVPA_END;
+#endif
 
+#if 0 // No longer used, replaced by generic 3911 version
 // ******************************************************************
 // * XMountAlternateTitleA
 // ******************************************************************
@@ -233,7 +270,7 @@ OOVPA_NO_XREF(XMountAlternateTitleA, 4928, 7)
         { 0xBE, 0x01 },
         { 0xDE, 0x45 },
 OOVPA_END;
-
+#endif
 // ******************************************************************
 // * MoveFileA
 // ******************************************************************
@@ -247,7 +284,7 @@ OOVPA_NO_XREF(MoveFileA, 4627, 7)
         { 0x74, 0xFF },
         { 0x83, 0x33 },
 OOVPA_END;
-
+#if 0 // No longer used, this was _XInputGetCapabilities@8
 // ******************************************************************
 // * XInputGetDeviceDescription
 // ******************************************************************
@@ -263,13 +300,37 @@ OOVPA_NO_XREF(XInputGetDeviceDescription, 4831, 9)
 		{ 0x34, 0x6A },
 		{ 0x35, 0x06 },
 OOVPA_END;
+#endif
+
+// ******************************************************************
+// * XGetDeviceEnumerationStatus
+// ******************************************************************
+OOVPA_NO_XREF(XGetDeviceEnumerationStatus, 4831, 14)
+
+        { 0x04, 0x15 },
+        { 0x0A, 0x35 },
+        { 0x10, 0x09 },
+
+        { 0x17, 0x00 },
+        { 0x18, 0x74 },
+        { 0x19, 0x03 },
+        { 0x1A, 0x33 },
+        { 0x1B, 0xF6 },
+        { 0x1C, 0x46 },
+        { 0x1D, 0x8A },
+        { 0x1E, 0xC8 },
+        { 0x1F, 0xFF },
+
+        { 0x25, 0x8B },
+        { 0x28, 0xC3 },
+OOVPA_END;
 
 // ******************************************************************
 // * XAPI_4627
 // ******************************************************************
 OOVPATable XAPI_4627[] = {
 
-	REGISTER_OOVPA(XFormatUtilityDrive, 4627, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
 	REGISTER_OOVPA(SetThreadPriorityBoost, 3911, PATCH),
 	REGISTER_OOVPA(SetThreadPriority, 3911, PATCH),
 	REGISTER_OOVPA(GetThreadPriority, 3911, PATCH),
@@ -278,7 +339,7 @@ OOVPATable XAPI_4627[] = {
 	REGISTER_OOVPA(XInitDevices, 3911, PATCH),
 	REGISTER_OOVPA(XGetDevices, 3911, PATCH),
 	REGISTER_OOVPA(XInputOpen, 4361, PATCH),
-	REGISTER_OOVPA(XInputPoll, 4134, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
 	REGISTER_OOVPA(XID_fCloseDevice, 4627, XREF),
 	REGISTER_OOVPA(XID_fCloseDevice, 4928, XREF),
 	REGISTER_OOVPA(XInputClose, 3911, PATCH),
@@ -300,22 +361,24 @@ OOVPATable XAPI_4627[] = {
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(GetTimeZoneInformation, 3911, DISABLED),
 	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
-	REGISTER_OOVPA(GetOverlappedResult, 4627, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
 	REGISTER_OOVPA(XLaunchNewImageA, 3911, PATCH),
-	REGISTER_OOVPA(XLaunchNewImageA, 4928, PATCH),
+	REGISTER_OOVPA(XLaunchNewImageA, 4721, PATCH),
 	REGISTER_OOVPA(XGetLaunchInfo, 3911, DISABLED),
-	REGISTER_OOVPA(XSetProcessQuantumLength, 4627, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
 	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
-	REGISTER_OOVPA(timeSetEvent, 4627, PATCH),
-	REGISTER_OOVPA(timeKillEvent, 4627, PATCH),
-	REGISTER_OOVPA(RaiseException, 4627, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
 	REGISTER_OOVPA(XMountAlternateTitleA, 3911, PATCH),
-	REGISTER_OOVPA(XMountAlternateTitleA, 4928, PATCH),
 	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
-	REGISTER_OOVPA(XInputGetDeviceDescription, 4831, PATCH),
+	//REGISTER_OOVPA(XInputGetDeviceDescription, 4831, PATCH), // NOT XInputGetDeviceDescription
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 	// REGISTER_OOVPA(MoveFileA, 4627, PATCH),
+	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 4831, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4721.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.4721.inl
@@ -36,11 +36,12 @@
 // * XAPI_4721
 // ******************************************************************
 OOVPATable XAPI_4721[] = {
-    // REGISTER_OOVPA(RtlCreateHeap, 3911, PATCH), // obsolete, (* unchanged since 1.0.4361 *) (* OR FARTHER *)
-    // REGISTER_OOVPA(RtlAllocateHeap, 3911, PATCH), // obsolete (* unchanged since 1.0.4361 *) (* OR FARTHER *)
-    // REGISTER_OOVPA(RtlReAllocateHeap, 4627, PATCH), // obsolete 
-    // REGISTER_OOVPA(RtlFreeHeap, 4627, PATCH), // obsolete 
-    // REGISTER_OOVPA(RtlSizeHeap, 4627, PATCH), // obsolete 
+
+	// REGISTER_OOVPA(RtlCreateHeap, 3911, PATCH), // obsolete, (* unchanged since 1.0.4361 *) (* OR FARTHER *)
+	// REGISTER_OOVPA(RtlAllocateHeap, 3911, PATCH), // obsolete (* unchanged since 1.0.4361 *) (* OR FARTHER *)
+	// REGISTER_OOVPA(RtlReAllocateHeap, 4627, PATCH), // obsolete 
+	// REGISTER_OOVPA(RtlFreeHeap, 4627, PATCH), // obsolete 
+	// REGISTER_OOVPA(RtlSizeHeap, 4627, PATCH), // obsolete 
 	// REGISTER_OOVPA(RtlDestroyHeap, 4627, PATCH), // obsolete 
 	REGISTER_OOVPA(XMountUtilityDrive, 4432, PATCH),
 	REGISTER_OOVPA(XInitDevices, 3911, PATCH),
@@ -51,16 +52,34 @@ OOVPATable XAPI_4721[] = {
 	REGISTER_OOVPA(XInputSetState, 4361, PATCH),
 	REGISTER_OOVPA(XID_fCloseDevice, 4361, XREF),
 	REGISTER_OOVPA(XInputClose, 3911, PATCH),
-	// REGISTER_OOVPA(XInputClose, 4361, PATCH),
 	REGISTER_OOVPA(XGetDeviceChanges, 3911, PATCH),
 	// REGISTER_OOVPA(XapiThreadStartup, 4361, PATCH), // obsolete 
 	// REGISTER_OOVPA(XapiInitProcess, 4361, PATCH), // obsolete, Too High Level
-    // REGISTER_OOVPA(XapiBootDash, 3911, PATCH), // obsolete 
+	// REGISTER_OOVPA(XapiBootDash, 3911, PATCH), // obsolete 
 	REGISTER_OOVPA(CreateFiber, 3911, DISABLED),
 	REGISTER_OOVPA(DeleteFiber, 3911, DISABLED),
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
+	REGISTER_OOVPA(SetThreadPriority, 3911, PATCH),
+	REGISTER_OOVPA(XRegisterThreadNotifyRoutine, 3911, PATCH),
+	REGISTER_OOVPA(SetThreadPriorityBoost, 3911, PATCH),
+	REGISTER_OOVPA(GetThreadPriority, 3911, PATCH),
+	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
+	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(XLaunchNewImageA, 4721, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5028.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5028.inl
@@ -33,11 +33,35 @@
 // ******************************************************************
 
 // ******************************************************************
+// * XMountAlternateTitleA
+// ******************************************************************
+OOVPA_NO_XREF(XMountAlternateTitleA, 5028, 14)
+
+        { 0x04, 0xEC },
+
+        { 0x0F, 0x01 },
+        { 0x10, 0x00 },
+        { 0x11, 0x53 },
+        { 0x12, 0x8A },
+        { 0x13, 0x19 },
+        { 0x14, 0x88 },
+
+        { 0x82, 0x83 },
+        { 0x83, 0xC4 },
+        { 0x84, 0x0C },
+        { 0x85, 0x8D },
+        { 0x86, 0x85 },
+        { 0x91, 0x15 },
+
+        { 0x96, 0x8D },
+OOVPA_END;
+
+// ******************************************************************
 // * XAPI_5028
 // ******************************************************************
 OOVPATable XAPI_5028[] = {
 
-	REGISTER_OOVPA(XFormatUtilityDrive, 4627, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
 	REGISTER_OOVPA(SetThreadPriorityBoost, 3911, PATCH),
 	REGISTER_OOVPA(SetThreadPriority, 3911, PATCH),
 	REGISTER_OOVPA(GetThreadPriority, 3911, PATCH),
@@ -46,15 +70,11 @@ OOVPATable XAPI_5028[] = {
 	REGISTER_OOVPA(XInitDevices, 3911, PATCH),
 	REGISTER_OOVPA(XGetDevices, 3911, PATCH),
 	REGISTER_OOVPA(XInputOpen, 4361, PATCH),
-	REGISTER_OOVPA(XInputPoll, 4134, PATCH),
-	REGISTER_OOVPA(XID_fCloseDevice, 4627, XREF),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
 	REGISTER_OOVPA(XID_fCloseDevice, 4928, XREF),
 	REGISTER_OOVPA(XInputClose, 3911, PATCH),
-	REGISTER_OOVPA(XInputGetCapabilities, 4361, PATCH),
-	REGISTER_OOVPA(XInputGetState, 4361, PATCH),
 	REGISTER_OOVPA(XInputGetState, 4928, PATCH),
 	REGISTER_OOVPA(XInputGetCapabilities, 4831, PATCH),
-	REGISTER_OOVPA(XInputSetState, 4361, PATCH),
 	REGISTER_OOVPA(XInputSetState, 4928, PATCH),
 	REGISTER_OOVPA(XGetDeviceChanges, 3911, PATCH),
 	// REGISTER_OOVPA(XapiThreadStartup, 4361, PATCH), // obsolete?
@@ -68,22 +88,29 @@ OOVPATable XAPI_5028[] = {
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(GetTimeZoneInformation, 3911, DISABLED),
 	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
-	REGISTER_OOVPA(GetOverlappedResult, 4627, PATCH),
-	REGISTER_OOVPA(XLaunchNewImageA, 3911, PATCH),
-	REGISTER_OOVPA(XLaunchNewImageA, 4928, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XLaunchNewImageA, 4721, PATCH),
 	REGISTER_OOVPA(XGetLaunchInfo, 3911, DISABLED),
-	REGISTER_OOVPA(XSetProcessQuantumLength, 4627, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
 	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
-	REGISTER_OOVPA(timeSetEvent, 4627, PATCH),
-	REGISTER_OOVPA(timeKillEvent, 4627, PATCH),
-	REGISTER_OOVPA(RaiseException, 4627, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 	REGISTER_OOVPA(QueueUserAPC, 3911, PATCH),
-	REGISTER_OOVPA(XMountAlternateTitleA, 3911, PATCH),
-	REGISTER_OOVPA(XMountAlternateTitleA, 4928, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 5028, PATCH),
 	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
-	REGISTER_OOVPA(XInputGetDeviceDescription, 4831, PATCH),
+	// REGISTER_OOVPA(XInputGetDeviceDescription, 4831, PATCH), // Was NOT XInputGetDeviceDescription
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
 	// REGISTER_OOVPA(MoveFileA, 4627, PATCH),
+	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 4831, PATCH),
+
+	// ******************************************************************
+	// Provisional registration functions in XDK 5028
+	// TODO: Need test cases
+	// ******************************************************************
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	// ******************************************************************
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5233.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5233.inl
@@ -119,6 +119,27 @@ OOVPATable XAPI_5233[] = {
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
+	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 5028, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(XLaunchNewImageA, 4721, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
+	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 4831, PATCH),
+
+	// ******************************************************************
+	// Provisional registration functions in XDK 5233
+	// TODO: Need test cases
+	// ******************************************************************
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	// ******************************************************************
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5344.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5344.inl
@@ -33,6 +33,50 @@
 // ******************************************************************
 
 // ******************************************************************
+// * XInputGetDeviceDescription
+// ******************************************************************
+OOVPA_NO_XREF(XInputGetDeviceDescription, 5344, 15)
+
+        { 0x04, 0xEC },
+        { 0x0B, 0x15 },
+
+        { 0x13, 0x45 },
+        { 0x14, 0x08 },
+        { 0x15, 0x8B },
+        { 0x16, 0x30 },
+        { 0x17, 0x3B },
+        { 0x18, 0xF3 },
+        { 0x19, 0x88 },
+        { 0x1A, 0x4D },
+        { 0x1B, 0xFF },
+        { 0x1C, 0x0F },
+        { 0x1D, 0x84 },
+
+        { 0x30, 0x45 },
+        { 0x31, 0xF8 },
+OOVPA_END;
+
+// ******************************************************************
+// * XLaunchNewImageA
+// ******************************************************************
+OOVPA_NO_XREF(XLaunchNewImageA, 5344, 11)
+
+        { 0x00, 0xB8 },
+
+        { 0x18, 0x75 },
+        { 0x19, 0x19 },
+        { 0x1A, 0x83 },
+        { 0x1B, 0xC1 },
+        { 0x1C, 0x04 },
+        { 0x1D, 0x3B },
+        { 0x1E, 0xC8 },
+        { 0x1F, 0x72 },
+
+        { 0x30, 0xC2 },
+        { 0x41, 0xEE },
+OOVPA_END;
+
+// ******************************************************************
 // * XAPI_5344
 // ******************************************************************
 OOVPATable XAPI_5344[] = {
@@ -58,6 +102,22 @@ OOVPATable XAPI_5344[] = {
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
+	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 5028, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(XLaunchNewImageA, 5344, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
+	REGISTER_OOVPA(XInputGetDeviceDescription, 5344, PATCH),
+	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 4831, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5558.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5558.inl
@@ -157,6 +157,26 @@ OOVPA_XREF(XInputClose, 5558, 9,
 OOVPA_END;
 
 // ******************************************************************
+// * XMountAlternateTitleA
+// ******************************************************************
+OOVPA_NO_XREF(XMountAlternateTitleA, 5558, 11)
+
+        { 0x0B, 0x08 },
+
+        { 0x18, 0x0B },
+        { 0x19, 0x57 },
+        { 0x1A, 0x33 },
+        { 0x1B, 0xFF },
+        { 0x1C, 0x80 },
+        { 0x1D, 0xE3 },
+        { 0x1E, 0xDF },
+        { 0x1F, 0x80 },
+
+        { 0xC1, 0x83 },
+        { 0xD0, 0x15 },
+OOVPA_END;
+
+// ******************************************************************
 // * XAPI_5558
 // ******************************************************************
 OOVPATable XAPI_5558[] = {
@@ -187,6 +207,20 @@ OOVPATable XAPI_5558[] = {
 	REGISTER_OOVPA(XID_fCloseDevice, 5558, XREF),
 	REGISTER_OOVPA(XInputClose, 5558, PATCH),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
+	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 5558, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
+	REGISTER_OOVPA(XInputGetDeviceDescription, 5344, PATCH),
+	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 4831, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5788.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5788.inl
@@ -87,6 +87,7 @@ OOVPA_NO_XREF(XGetSectionSize, 5788, 5)
         { 0x08, 0x04 },
 OOVPA_END;
 
+#if 0 // No longer used, replaced by generic 4831 version
 // ******************************************************************
 // * XGetDeviceEnumerationStatus
 // ******************************************************************
@@ -100,6 +101,7 @@ OOVPA_NO_XREF(XGetDeviceEnumerationStatus, 5788, 7)
         { 0x25, 0x8B },
         { 0x28, 0xC3 },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * SwitchToThread
@@ -136,18 +138,30 @@ OOVPATable XAPI_5788[] = {
 	// REGISTER_OOVPA(GetThreadPriorityBoost, 5788, PATCH),
 	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
 	REGISTER_OOVPA(GetTimeZoneInformation, 3911, DISABLED),
-	REGISTER_OOVPA(RaiseException, 4627, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 	REGISTER_OOVPA(XLaunchNewImageA, 5558, PATCH),
 	REGISTER_OOVPA(XInputSetState, 5233, PATCH),
-	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 5788, PATCH),
+	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 4831, PATCH),
 	// REGISTER_OOVPA(SwitchToThread, 5788, PATCH),
-	REGISTER_OOVPA(XFormatUtilityDrive, 4627, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
 	REGISTER_OOVPA(CreateFiber, 3911, DISABLED),
 	REGISTER_OOVPA(DeleteFiber, 3911, DISABLED),
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(XID_fCloseDevice, 5558, XREF),
 	REGISTER_OOVPA(XInputClose, 5558, PATCH),
+	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
+	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 5558, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(timeSetEvent, 3911, PATCH),
+	REGISTER_OOVPA(timeKillEvent, 3911, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(XInputGetDeviceDescription, 5344, PATCH),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.1.0.5849.inl
@@ -60,7 +60,7 @@ OOVPA_NO_XREF(timeKillEvent, 5849, 10)
 	{ 0x18, 0x0F },
 	{ 0x1F, 0x3E }
 OOVPA_END;
-
+#if 0 // No longer used, replaced by generic 4831 version
 // ******************************************************************
 // * XGetDeviceEnumerationStatus
 // ******************************************************************
@@ -74,7 +74,7 @@ OOVPA_NO_XREF(XGetDeviceEnumerationStatus, 5849, 7)
         { 0x25, 0x8B },
         { 0x28, 0xC3 },
 OOVPA_END;
-
+#endif
 // ******************************************************************
 // * SwitchToThread
 // ******************************************************************
@@ -110,17 +110,28 @@ OOVPATable XAPI_5849[] = {
 	// REGISTER_OOVPA(GetThreadPriorityBoost, 5849, PATCH),
 	REGISTER_OOVPA(timeSetEvent, 5849, PATCH),
 	REGISTER_OOVPA(timeKillEvent, 5849, PATCH),
-	REGISTER_OOVPA(RaiseException, 4627, PATCH),
+	REGISTER_OOVPA(RaiseException, 3911, PATCH),
 	REGISTER_OOVPA(XLaunchNewImageA, 5558, PATCH),
 	REGISTER_OOVPA(XInputSetState, 5233, PATCH),
-	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 5849, PATCH),
+	REGISTER_OOVPA(XGetDeviceEnumerationStatus, 4831, PATCH),
 	// REGISTER_OOVPA(SwitchToThread, 5849, PATCH),
-	REGISTER_OOVPA(XFormatUtilityDrive, 4627, PATCH),
+	REGISTER_OOVPA(XFormatUtilityDrive, 4361, PATCH),
 	REGISTER_OOVPA(CreateFiber, 3911, DISABLED),
 	REGISTER_OOVPA(DeleteFiber, 3911, DISABLED),
 	REGISTER_OOVPA(SwitchToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(ConvertThreadToFiber, 3911, DISABLED),
 	REGISTER_OOVPA(OutputDebugStringA, 3911, PATCH),
+	REGISTER_OOVPA(GetExitCodeThread, 3911, PATCH),
+	REGISTER_OOVPA(XRegisterThreadNotifyRoutine, 3911, PATCH),
+	REGISTER_OOVPA(SignalObjectAndWait, 3911, PATCH),
+	REGISTER_OOVPA(XMountAlternateTitleA, 5558, PATCH),
+	REGISTER_OOVPA(XUnmountAlternateTitleA, 3911, PATCH),
+	REGISTER_OOVPA(XMountMUA, 4361, PATCH),
+	REGISTER_OOVPA(XMountMURootA, 4361, PATCH),
+	REGISTER_OOVPA(XInputPoll, 3911, PATCH),
+	REGISTER_OOVPA(GetOverlappedResult, 3911, PATCH),
+	REGISTER_OOVPA(XSetProcessQuantumLength, 4134, PATCH),
+	REGISTER_OOVPA(XInputGetDeviceDescription, 5344, PATCH),
 };
 
 // ******************************************************************


### PR DESCRIPTION
also registered missing OOVPA for each version.

Provisional registration in XDK 4034, 5028, 5233
- SignalObjectAndWait 4034
- XMountMURootA for 5028, 5233
- timeSetEvent for 5233
- timeKillEvent for 5028, 5233