### PR TITLE
All XGRAPHC REGISTER_OOVPA to reviewed

### DIFF
--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.3911.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.3911.inl
@@ -96,15 +96,31 @@ OOVPA_END;
 // ******************************************************************
 // * XGWriteSurfaceOrTextureToXPR
 // ******************************************************************
-OOVPA_NO_XREF(XGWriteSurfaceOrTextureToXPR, 3911, 7)
+OOVPA_NO_XREF(XGWriteSurfaceOrTextureToXPR, 3911, 12)
 
+        { 0x0C, 0x08 },
+        { 0x1E, 0x3D },
+
+        { 0x21, 0x05 },
+        { 0x22, 0x00 },
+        { 0x23, 0x74 },
+        { 0x24, 0x0A },
+        { 0x25, 0xB8 },
+        { 0x26, 0x05 },
+        { 0x27, 0x40 },
+        { 0x28, 0x00 },
+
+        { 0x2E, 0x00 },
+        { 0x47, 0x03 },
+
+/*
         { 0x1E, 0x3D },
         { 0x3E, 0xE0 },
         { 0x5E, 0x75 },
         { 0x7E, 0x33 },
         { 0x9E, 0xC2 },
-        { 0xBE, 0xF0 },
-        { 0xDE, 0xFC },
+        { 0xAE, 0x4D },
+        { 0xBE, 0xF0 },*/
 OOVPA_END;
 
 // ******************************************************************
@@ -122,6 +138,80 @@ OOVPA_NO_XREF(XGSetTextureHeader, 3911, 7)
 OOVPA_END;
 
 // ******************************************************************
+// * XGUnswizzleBox
+// ******************************************************************
+OOVPA_NO_XREF(XGUnswizzleBox, 3911, 8)
+
+        { 0x1E, 0x26 },
+        { 0x3E, 0x55 },
+        { 0x5E, 0x58 },
+        { 0x7E, 0x89 },
+        { 0xA0, 0xFF },
+        { 0xBE, 0x2C },
+        { 0xDE, 0x24 },
+        { 0xFE, 0x20 },
+OOVPA_END;
+
+// ******************************************************************
+// * XGCompressRect
+// ******************************************************************
+OOVPA_NO_XREF(XGCompressRect, 3911, 8)
+
+        { 0x01, 0x8D },
+        { 0x1E, 0x00 },
+        { 0x32, 0x0F },
+        { 0x5E, 0x85 },
+        { 0x80, 0x85 },
+        { 0x9E, 0x07 },
+        { 0xBE, 0x80 },
+        { 0xDA, 0xAF },
+OOVPA_END;
+
+// ******************************************************************
+// * XGSetIndexBufferHeader
+// ******************************************************************
+OOVPA_NO_XREF(XGSetIndexBufferHeader, 3911, 13)
+
+        { 0x01, 0x44 },
+        { 0x04, 0x8B },
+
+        { 0x06, 0x24 },
+        { 0x07, 0x18 },
+        { 0x08, 0xC7 },
+        { 0x09, 0x00 },
+        { 0x0A, 0x01 },
+        { 0x0B, 0x00 },
+        { 0x0C, 0x01 },
+        { 0x0D, 0x00 },
+
+        { 0x10, 0x04 },
+        { 0x11, 0xC2 },
+        { 0x12, 0x18 },
+OOVPA_END;
+
+// ******************************************************************
+// * XGSetVertexBufferHeader
+// ******************************************************************
+OOVPA_NO_XREF(XGSetVertexBufferHeader, 3911, 13)
+
+        { 0x01, 0x44 },
+        { 0x04, 0x8B },
+
+        { 0x07, 0x18 },
+        { 0x08, 0xC7 },
+        { 0x09, 0x00 },
+        { 0x0A, 0x01 },
+        { 0x0B, 0x00 },
+        { 0x0C, 0x00 },
+        { 0x0D, 0x00 },
+        { 0x0E, 0x89 },
+
+        { 0x10, 0x04 },
+        { 0x11, 0xC2 },
+        { 0x12, 0x18 },
+OOVPA_END;
+
+// ******************************************************************
 // * XG_3911
 // ******************************************************************
 OOVPATable XG_3911[] = {
@@ -132,6 +222,10 @@ OOVPATable XG_3911[] = {
 	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
 	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
 	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 3911, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 3911, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4034.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4034.inl
@@ -39,12 +39,17 @@ OOVPATable XG_4034[] = {
 
 	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
-    // REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
+	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
 	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
-	// REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, DISABLED),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 3911, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 3911, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
 };
 
 // ******************************************************************
-// * XG_3911_SIZE
+// * XG_4034_SIZE
 // ******************************************************************
 uint32 XG_4034_SIZE = sizeof(XG_4034);

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4361.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4361.inl
@@ -32,6 +32,7 @@
 // *
 // ******************************************************************
 
+#if 0 // No longer used, replaced by generic 3911 version
 // ******************************************************************
 // * XGIsSwizzledFormat
 // ******************************************************************
@@ -59,7 +60,8 @@ OOVPA_NO_XREF(XGIsSwizzledFormat, 4361, 12)
         { 0x42, 0xEB }, // (Offset,Value)-Pair #11
         { 0x43, 0xE4 }, // (Offset,Value)-Pair #12
 OOVPA_END;
-
+#endif
+#if 0 // No longer used, replaced by generic 3911 version
 // ******************************************************************
 // * XGSwizzleRect
 // ******************************************************************
@@ -83,11 +85,11 @@ OOVPA_NO_XREF(XGSwizzleRect, 4361, 10)
         { 0xEC, 0xEB }, // (Offset,Value)-Pair #9
         { 0xED, 0x0B }, // (Offset,Value)-Pair #10
 OOVPA_END;
-
+#endif
 // ******************************************************************
 // * XGSetVertexBufferHeader
 // ******************************************************************
-OOVPA_NO_XREF(XGSetVertexBufferHeader, 4361, 8)
+OOVPA_NO_XREF(XGSetVertexBufferHeader, 4361, 8) // 4134
 
         { 0x01, 0x44 },
         { 0x04, 0x8B },
@@ -98,7 +100,7 @@ OOVPA_NO_XREF(XGSetVertexBufferHeader, 4361, 8)
         { 0x13, 0x48 },
         { 0x16, 0x18 },
 OOVPA_END;
-
+#if 0 // Moved to 3911
 // ******************************************************************
 // * XGCompressRect
 // ******************************************************************
@@ -113,20 +115,43 @@ OOVPA_NO_XREF(XGCompressRect, 4361, 8)
         { 0xDE, 0x74 },
         { 0xFE, 0x8B },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * XGSetIndexBufferHeader
 // ******************************************************************
-OOVPA_NO_XREF(XGSetIndexBufferHeader, 4361, 8)
+OOVPA_NO_XREF(XGSetIndexBufferHeader, 4361, 13)
 
         { 0x01, 0x44 },
         { 0x04, 0x8B },
         { 0x07, 0x18 },
         { 0x0A, 0x08 },
+
+        { 0x0C, 0xC7 },
         { 0x0D, 0x00 },
+        { 0x0E, 0x01 },
+        { 0x0F, 0x00 },
         { 0x10, 0x01 },
+        { 0x11, 0x00 },
+        { 0x12, 0x89 },
         { 0x13, 0x48 },
+
         { 0x16, 0x18 },
+OOVPA_END;
+
+// ******************************************************************
+// * XFONT_OpenBitmapFontFromMemory
+// ******************************************************************
+OOVPA_NO_XREF(XFONT_OpenBitmapFontFromMemory, 4361, 8)
+
+        { 0x0B, 0x75 },
+        { 0x1A, 0x8B },
+        { 0x28, 0x8B },
+        { 0x32, 0x08 },
+        { 0x3F, 0x8B },
+        { 0x4C, 0x8B },
+        { 0x59, 0x45 },
+        { 0x66, 0x0C },
 OOVPA_END;
 
 // ******************************************************************
@@ -134,13 +159,17 @@ OOVPA_END;
 // ******************************************************************
 OOVPATable XG_4361[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-	// REGISTER_OOVPA(XGSwizzleRect, 4361, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
 	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
 	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
 	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
 	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
-	REGISTER_OOVPA(XGCompressRect, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4432.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4432.inl
@@ -37,10 +37,25 @@
 // ******************************************************************
 // * XG_4432
 // ******************************************************************
-OOVPATable XG_4432[1] = {
+OOVPATable XG_4432[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-	// REGISTER_OOVPA(XGSwizzleRect, 4361, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
+	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+
+	// ******************************************************************
+	// Provisional registration functions in XDK 4432
+	// TODO: Need test cases
+	// ******************************************************************
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
+	// ******************************************************************
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.4627.inl
@@ -32,6 +32,7 @@
 // *
 // ******************************************************************
 
+#if 0 // No longer used, replaced by generic 3911 version
 // ******************************************************************
 // * XGSwizzleBox
 // ******************************************************************
@@ -55,7 +56,8 @@ OOVPA_NO_XREF(XGSwizzleBox, 4627, 10)
         { 0xE2, 0x85 }, // (Offset,Value)-Pair #9
         { 0xE3, 0xDB }, // (Offset,Value)-Pair #10
 OOVPA_END;
-
+#endif
+#if 0 // No longer used, replaced by generic 3911 version
 // ******************************************************************
 // * XGWriteSurfaceOrTextureToXPR
 // ******************************************************************
@@ -69,17 +71,23 @@ OOVPA_NO_XREF(XGWriteSurfaceOrTextureToXPR, 4627, 7)
         { 0xBE, 0xF0 },
         { 0xE2, 0x8B },
 OOVPA_END;
-
+#endif
 // ******************************************************************
 // * XG_4627
 // ******************************************************************
 OOVPATable XG_4627[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-	// REGISTER_OOVPA(XGSwizzleRect, 4361, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
 	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
-	REGISTER_OOVPA(XGSwizzleBox, 4627, PATCH),
-	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 4627, PATCH),
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5028.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5028.inl
@@ -37,13 +37,24 @@
 // ******************************************************************
 OOVPATable XG_5028[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-	// REGISTER_OOVPA(XGSwizzleRect, 4361, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
 	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
-	REGISTER_OOVPA(XGSwizzleBox, 4627, PATCH),
-	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 4627, PATCH),
-};
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 
+	// ******************************************************************
+	// Provisional registration functions in XDK 5028
+	// TODO: Need test cases
+	// ******************************************************************
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	// ******************************************************************
+};
 // ******************************************************************
 // * XG_5028_SIZE
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5233.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5233.inl
@@ -35,10 +35,19 @@
 // ******************************************************************
 // * XG_5233
 // ******************************************************************
-OOVPATable XG_5233[1] = {
+OOVPATable XG_5233[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-	// REGISTER_OOVPA(XGSwizzleRect, 4361, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
+	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5344.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5344.inl
@@ -35,10 +35,19 @@
 // ******************************************************************
 // * XG_5344
 // ******************************************************************
-OOVPATable XG_5344[1] = {
+OOVPATable XG_5344[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-	// REGISTER_OOVPA(XGSwizzleRect, 4361, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
+	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5558.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5558.inl
@@ -46,7 +46,7 @@
 //        { 0xDE, 0xAF },
 //        { 0xFE, 0x45 },
 //OOVPA_END;
-
+#if 0 // Moved to 3911
 // ******************************************************************
 // * XGUnswizzleBox
 // ******************************************************************
@@ -61,18 +61,23 @@ OOVPA_NO_XREF(XGUnswizzleBox, 5558, 8)
         { 0xDE, 0x24 },
         { 0xFE, 0x20 },
 OOVPA_END;
-
+#endif
 // ******************************************************************
 // * XG_5558
 // ******************************************************************
 OOVPATable XG_5558[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-    
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
 	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
-	REGISTER_OOVPA(XGSwizzleBox, 4627, PATCH), // (* UNTESTED *)
 	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
-	// REGISTER_OOVPA(XGUnswizzleBox, 5558, PATCH), //  (* UNTESTED *)
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5788.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5788.inl
@@ -32,6 +32,7 @@
 // *
 // ******************************************************************
 
+#if 0 // Moved to 4361
 // ******************************************************************
 // * XFONT_OpenBitmapFontFromMemory
 // ******************************************************************
@@ -46,16 +47,24 @@ OOVPA_NO_XREF(XFONT_OpenBitmapFontFromMemory, 5788, 8)
         { 0x59, 0x45 },
         { 0x66, 0x0C },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * XG_5788
 // ******************************************************************
 OOVPATable XG_5788[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-    // REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
 	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
-	// REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 5788, PATCH),
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/XG.1.0.5849.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.1.0.5849.inl
@@ -35,12 +35,19 @@
 // ******************************************************************
 // * XG_5849
 // ******************************************************************
-OOVPATable XG_5849[1] = {
+OOVPATable XG_5849[] = {
 
-	REGISTER_OOVPA(XGIsSwizzledFormat, 4361, PATCH),
-    // REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
+	REGISTER_OOVPA(XGIsSwizzledFormat, 3911, PATCH),
+	// REGISTER_OOVPA(XGSwizzleRect, 3911, DISABLED), // TODO : Uncomment
 	// REGISTER_OOVPA(XGUnswizzleRect, 3911, DISABLED), // TODO : Uncomment
-	// REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 5788, PATCH),
+	REGISTER_OOVPA(XGSwizzleBox, 3911, PATCH),
+	REGISTER_OOVPA(XGWriteSurfaceOrTextureToXPR, 3911, PATCH),
+	REGISTER_OOVPA(XGSetTextureHeader, 3911, PATCH),
+	REGISTER_OOVPA(XGSetVertexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGSetIndexBufferHeader, 4361, XREF),
+	REGISTER_OOVPA(XGCompressRect, 3911, XREF),
+	REGISTER_OOVPA(XGUnswizzleBox, 3911, DISABLED),
+	REGISTER_OOVPA(XFONT_OpenBitmapFontFromMemory, 4361, XREF),
 };
 
 // ******************************************************************


### PR DESCRIPTION
also registered missing OOVPA for each version.

Provisional registration in XDK 4432, 5028
- XFONT_OpenBitmapFontFromMemory 4432
- XGWriteSurfaceOrTextureToXPR 5028
- XGCompressRect 5028