### PR TITLE
Interrupt Support, DPC fixes and additional EmuX86 instructions

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -1527,7 +1527,7 @@ struct _KDPC;
 // ******************************************************************
 // * PKDEFERRED_ROUTINE
 // ******************************************************************
-typedef VOID (*PKDEFERRED_ROUTINE)
+typedef VOID (__stdcall *PKDEFERRED_ROUTINE)
 (
     IN struct _KDPC *Dpc,
     IN PVOID         DeferredContext,

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -382,7 +382,7 @@ static unsigned int WINAPI CxbxKrnlInterruptThread(PVOID param)
 
 	while (true) {
 		for (int i = 0; i < MAX_BUS_INTERRUPT_LEVEL; i++) {
-			// If the interrupt is pending, pending and connected, process it
+			// If the interrupt is pending and connected, process it
 			if (HalSystemInterrupts[i].IsPending() && EmuInterruptList[i]->Connected) {
 				HalSystemInterrupts[i].Trigger(EmuInterruptList[i]);
 			}

--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -193,7 +193,7 @@ XBSYSAPI EXPORTNUM(264) xboxkrnl::VOID NTAPI xboxkrnl::RtlAssert
 		LOG_FUNC_ARG(Message)
 		LOG_FUNC_END;
 
-	CxbxKrnlCleanup("RtlAssert() raised by emulated program - consult Debug log");
+	CxbxPopupMessage("RtlAssert() raised by emulated program - consult Debug log");
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -809,6 +809,37 @@ bool  EmuX86_Opcode_AND(LPEXCEPTION_POINTERS e, _DInst& info)
 	return true;
 }
 
+bool  EmuX86_Opcode_CMP(LPEXCEPTION_POINTERS e, _DInst& info)
+{
+	// Read value from Source and Destination
+	uint32_t src = 0;
+	if (!EmuX86_Operand_Read(e, info, 1, &src))
+		return false;
+
+	uint32_t dest = 0;
+	if (!EmuX86_Operand_Read(e, info, 0, &dest))
+		return false;
+
+	// SUB Destination with src (cmp internally is a discarded subtract)
+	uint32_t result = dest - src;
+
+	EmuX86_SetFlag(e, EMUX86_EFLAG_CF, (result >> 32) > 0);
+	EmuX86_SetFlag(e, EMUX86_EFLAG_OF, (result >> 31) != (dest >> 31));
+	// TODO: Figure out how to calculate this EmuX86_SetFlag(e, EMUX86_EFLAG_AF, 0);
+
+	EmuX86_SetFlag(e, EMUX86_EFLAG_SF, result >> 31);
+	EmuX86_SetFlag(e, EMUX86_EFLAG_ZF, result == 0 ? 1 : 0);
+	// Set Parity flag, based on "Compute parity in parallel" method from
+	// http://graphics.stanford.edu/~seander/bithacks.html#ParityParallel
+	uint32_t v = 255 & dest;
+	v ^= v >> 4;
+	v &= 0xf;
+	EmuX86_SetFlag(e, EMUX86_EFLAG_PF, (0x6996 >> v) & 1);
+
+	return true;
+}
+
+
 bool  EmuX86_Opcode_CMPXCHG(LPEXCEPTION_POINTERS e, _DInst& info)
 {
 	// Read value from Source and Destination
@@ -1084,6 +1115,10 @@ bool EmuX86_DecodeException(LPEXCEPTION_POINTERS e)
 			goto unimplemented_opcode;
 		case I_AND:
 			if (EmuX86_Opcode_AND(e, info))
+				break;
+			goto unimplemented_opcode;
+		case I_CMP:
+			if (EmuX86_Opcode_CMP(e, info))
 				break;
 			goto unimplemented_opcode;
 		case I_CMPXCHG:

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -970,6 +970,36 @@ void  EmuX86_Opcode_CPUID(LPEXCEPTION_POINTERS e, _DInst& info)
 	}
 }
 
+bool EmuX86_Opcode_IN(LPEXCEPTION_POINTERS e, _DInst& info)
+{
+	uint32_t value = 0;
+	uint32_t addr;
+
+	if (!EmuX86_Operand_Read(e, info, 1, &addr))
+		return false;
+	
+	switch (info.ops[0].size) {
+		case 8:
+			value = EmuX86_IORead8(addr);
+			break;
+		case 16:
+			value = EmuX86_IORead16(addr);
+			break;
+		case 32: 
+			value = EmuX86_IORead32(addr);
+			break;
+		default:
+			return false;
+	}
+
+	if (!EmuX86_Operand_Write(e, info, 0, value)) {
+		return false;
+	}
+
+	return true;
+}
+
+
 bool  EmuX86_Opcode_OUT(LPEXCEPTION_POINTERS e, _DInst& info)
 {
 	// OUT will address the first operand :
@@ -1063,6 +1093,11 @@ bool EmuX86_DecodeException(LPEXCEPTION_POINTERS e)
 		case I_CPUID:
 			EmuX86_Opcode_CPUID(e, info);
 			break;
+		case I_IN:
+			if (EmuX86_Opcode_IN(e, info))
+				break;
+
+			goto unimplemented_opcode;
 		case I_INVD: // Flush internal caches; initiate flushing of external caches.
 			 // We can safely ignore this
 			break;

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -60,19 +60,31 @@
 
 uint32_t EmuX86_IORead32(xbaddr addr)
 {
-	EmuWarning("EmuX86_IORead32(0x%08X) Not Implemented", addr);
+	switch (addr) {
+	case 0x8008:	// TIMER
+		// HACK: This is very wrong.
+		// This timer should count at a specific frequency (3579.545 ticks per ms)
+		// But this is enough to keep NXDK from hanging for now.
+		LARGE_INTEGER performanceCount;
+		QueryPerformanceCounter(&performanceCount);
+		return performanceCount.QuadPart;
+		break;
+		
+	}
+
+	EmuWarning("EmuX86_IORead32(0x%08X) [Unknown address]", addr);
 	return 0;
 }
 
 uint16_t EmuX86_IORead16(xbaddr addr)
 {
-	EmuWarning("EmuX86_IORead16(0x%08X) Not Implemented", addr);
+	EmuWarning("EmuX86_IORead16(0x%08X) [Unknown address]", addr);
 	return 0;
 }
 
 uint8_t EmuX86_IORead8(xbaddr addr)
 {
-	EmuWarning("EmuX86_IORead8(0x%08X) Not Implemented", addr);
+	EmuWarning("EmuX86_IORead8(0x%08X) [Unknown address]", addr);
 	return 0;
 }
 


### PR DESCRIPTION
Fix some bugs in DPC handling:
  - DPC Routines are xbox code, but were being called under the windows thread context, without the Xbox thread handling code being used
 - DPC routines were using the wrong calling convention

Implement more X86 Instructions:
 - CMP
 - IN

Implement support for interrupts:
 - Interrupts use a processing thread on the same thread affinity as xbox cores, this prevents other xbox code running at the same time as an interrupt is being processed
 - As interrupts run in their own thread, the execution of ISR routines may be delayed: It cannot execute until Windows causes a context switch to that thread, this is the best we can do without either full CPU emulation, or at least simulating xbox context switching, neither of which as possible with the current design of Cxbx-Reloaded.

Prevented RtlAssert from aborting emulation, still shows a warning.

- Implemented IO port 0x8008. This implementation is not correct, but good enough to please NXDK.
 