### PR TITLE
Unpatched GetOverlappedResult

### DIFF
--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -939,6 +939,7 @@ DWORD WINAPI XTL::EMUPATCH(QueueUserAPC)
 	RETURN(dwRet);
 }
 
+#if 0 // Handled by WaitForSingleObject
 // ******************************************************************
 // * patch: GetOverlappedResult
 // ******************************************************************
@@ -966,6 +967,7 @@ BOOL WINAPI XTL::EMUPATCH(GetOverlappedResult)
 
 	RETURN(bRet);
 }
+#endif
 
 // ******************************************************************
 // * patch: XLaunchNewImageA

--- a/src/CxbxKrnl/EmuXapi.h
+++ b/src/CxbxKrnl/EmuXapi.h
@@ -606,6 +606,7 @@ DWORD WINAPI EMUPATCH(QueueUserAPC)
 	DWORD   	dwData
 );
 
+#if 0 // Handled by WaitForSingleObject
 // ******************************************************************
 // * patch: GetOverlappedResult
 // ******************************************************************
@@ -616,6 +617,7 @@ BOOL WINAPI EMUPATCH(GetOverlappedResult)
 	LPDWORD			lpNumberOfBytesTransferred,
 	BOOL			bWait
 );
+#endif
 
 // ******************************************************************
 // * patch: XLaunchNewImageA


### PR DESCRIPTION
Not a need GetOverlappedResult just calls WaitForSingleObject internally https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/700#issuecomment-326549092.
ZSNES is work again.