### PR TITLE
Fix for issue #674 (Show loaded XBE logo in user interface)

### DIFF
--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -313,15 +313,6 @@ Xbe::Xbe(const char *x_szFilename)
 
         printf("OK\n");
     }
-	printf("-------\n");															// * FIXME remove this block (it is here only for debug purpose)
-	void* bitmapData;																// *************************************************************
-	int width;																		// *************************************************************
-	int height;																		// *************************************************************
-	bool res = ExportGameLogoBitmap(bitmapData, &width, &height);					// *************************************************************
-	printf("Result is: %d\n", res);													// *************************************************************
-	printf("Widht: %d and height: %d of game logo after export\n", width, height);	// *************************************************************
-	//free(bitmapData);																// *************************************************************
-	printf("-------\n");															// *************************************************************
 
 cleanup:
 
@@ -1081,8 +1072,13 @@ bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data
 bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap)
 {
 	printf("ReadS3TCFormatIntoBitmap\n");
+	printf("data[0]=0x%08X\n", data[0]);
+	printf("data[1]=0x%08X\n", data[1]);
+	printf("data[2]=0x%08X\n", data[2]);
+	printf("data[3]=0x%08X\n", data[3]);
 	uint08 color[3];
 	TRGB32 color32b[4];
+	//TRGB32 color32b[1024 * sizeof(TRGB32)];
 	uint32 r, g, b, r1, g1, b1, pixelmap, j;
 	int k, p, x, y;
 
@@ -1107,39 +1103,39 @@ bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 da
 			// Read 5+6+5 bit color channels and convert them to 8+8+8 bit :
 			r = ((color[0] >> 11) & 31) * 255 / 31;
 			g = ((color[0] >>  5) & 63) * 255 / 63;
-			b = ((color[0]) & 31) * 255 / 31;
+			b = ((color[0]		) & 31) * 255 / 31;
 
 			r1 = ((color[1] >> 11) & 31) * 255 / 31;
 			g1 = ((color[1] >>  5) & 63) * 255 / 63;
-			b1 = ((color[1]) & 31) * 255 / 31;
+			b1 = ((color[1]		 ) & 31) * 255 / 31;
 
 			// Build first half of RGB32 color map :
-			color32b[0].R = r;
-			color32b[0].G = g;
-			color32b[0].B = b;
+			color32b[0].R = (unsigned char)r;
+			color32b[0].G = (unsigned char)g;
+			color32b[0].B = (unsigned char)b;
 
-			color32b[1].R = r1;
-			color32b[1].G = g1;
-			color32b[1].B = b1;
+			color32b[1].R = (unsigned char)r1;
+			color32b[1].G = (unsigned char)g1;
+			color32b[1].B = (unsigned char)b1;
 
 			// Build second half of RGB32 color map :
 			if (color[0] > color[1])
 			{
 				// Make up 2 new colors, 1/3 A + 2/3 B and 2/3 A + 1/3 B :
-				color32b[2].R = (r + r + r1 + 2) / 3;
-				color32b[2].G = (g + g + g1 + 2) / 3;
-				color32b[2].B = (b + b + b1 + 2) / 3;
+				color32b[2].R = (unsigned char)((r + r + r1 + 2) / 3);
+				color32b[2].G = (unsigned char)((g + g + g1 + 2) / 3);
+				color32b[2].B = (unsigned char)((b + b + b1 + 2) / 3);
 
-				color32b[3].R = (r + r1 + r1 + 2) / 3;
-				color32b[3].G = (g + g1 + g1 + 2) / 3;
-				color32b[3].B = (b + b1 + b1 + 2) / 3;
+				color32b[3].R = (unsigned char)((r + r1 + r1 + 2) / 3);
+				color32b[3].G = (unsigned char)((g + g1 + g1 + 2) / 3);
+				color32b[3].B = (unsigned char)((b + b1 + b1 + 2) / 3);
 			}
 			else 
 			{
 				// Make up one new color : 1/2 A + 1/2 B :
-				color32b[2].R = (r + r1) / 2;
-				color32b[2].G = (g + g1) / 2;
-				color32b[2].B = (b + b1) / 2;
+				color32b[2].R = (unsigned char)((r + r1) / 2);
+				color32b[2].G = (unsigned char)((g + g1) / 2);
+				color32b[2].B = (unsigned char)((b + b1) / 2);
 
 				color32b[3].R = 0;
 				color32b[3].G = 0;
@@ -1161,15 +1157,15 @@ bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 da
 			for (p = 0; p < 16 - 1; p++)
 			{
 				((TRGB32*)bitmap)[x + (p & 3) + pitch * (y + (p >> 2))] = color32b[pixelmap & 3];
-				pixelmap = pixelmap >> 2;
+				pixelmap >>= 2;
 			};
 			
 			j = j + 8;
 			k = k + 8;
 		}
-		catch (int e)
+		catch (const char* msg)
 		{
-			printf("Exception in ReadS3TCFormatIntoBitmap: %d\n",e);
+			printf("Exception in ReadS3TCFormatIntoBitmap: %s\n",msg);
 			return false;
 		}
 	}

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -317,7 +317,7 @@ Xbe::Xbe(const char *x_szFilename)
 	void* bitmapData;																// *************************************************************
 	int width;																		// *************************************************************
 	int height;																		// *************************************************************
-	bool res = ExportGameLogoBitmap(&bitmapData, &width, &height);					// *************************************************************
+	bool res = ExportGameLogoBitmap(bitmapData, &width, &height);					// *************************************************************
 	printf("Result is: %d\n", res);													// *************************************************************
 	printf("Widht: %d and height: %d of game logo after export\n", width, height);	// *************************************************************
 	//free(bitmapData);																// *************************************************************
@@ -978,7 +978,7 @@ uint08 *Xbe::GetLogoBitmap(uint32 x_dwSize)
     return 0;
 }
 
-bool Xbe::ExportGameLogoBitmap(void* bitmapData, int *width, int *height)
+bool Xbe::ExportGameLogoBitmap(void*& bitmapData, int *width, int *height)
 {
 	bool result = false;
 	uint32 dwOffs = 0;
@@ -1024,7 +1024,7 @@ bool Xbe::ExportGameLogoBitmap(void* bitmapData, int *width, int *height)
 			*width,
 			*height,
 			pitch,
-			&bitmapData);
+			bitmapData);
 	}
 	else {
 		printf("Game Logo is 32bit\n");
@@ -1035,14 +1035,14 @@ bool Xbe::ExportGameLogoBitmap(void* bitmapData, int *width, int *height)
 			*width,
 			*height,
 			pitch,
-			&bitmapData);
+			bitmapData);
 	}
 
 	return result;
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap)
+bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap)
 {
 	printf("ReadD3DTextureFormatIntoBitmap\n");
 	switch (format)
@@ -1063,7 +1063,7 @@ bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uin
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap)
+bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap)
 {
 	printf("ReadD3D16bitTextureFormatIntoBitmap\n");
 	switch (format)
@@ -1078,7 +1078,7 @@ bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap)
+bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap)
 {
 	printf("ReadS3TCFormatIntoBitmap\n");
 	uint08 color[3];
@@ -1169,7 +1169,7 @@ bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 da
 		}
 		catch (int e)
 		{
-			printf("Exception in ReadS3TCFormatIntoBitmap\n");
+			printf("Exception in ReadS3TCFormatIntoBitmap: %d\n",e);
 			return false;
 		}
 	}
@@ -1177,11 +1177,12 @@ bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 da
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap)
+bool Xbe::ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap)
 {
 	printf("ReadSwizzledFormatIntoBitmap\n");
 	uint32* xSwizzle;
-	uint32	x, y, sy;
+	int x, y;
+	uint32	sy;
 	PRGB32Array* yscanline;
 
 	if (format != X_D3DFMT_A8R8G8B8 && format != X_D3DFMT_X8R8G8B8)
@@ -1218,11 +1219,12 @@ bool Xbe::ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint3
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap)
+bool Xbe::ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap)
 {
 	printf("ReadSwizzled16bitFormatIntoBitmap\n");
 	uint32* xSwizzle;
-	uint32	x, y, sy;
+	int x, y;
+	uint32	sy;
 	PRGB16Array* yscanline;
 
 	if (format != X_D3DFMT_R5G6B5)

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -1012,6 +1012,8 @@ bool Xbe::ExportLogoBitmap()
 			(m_xprImage->xprImageHeader.d3dTexture.Format & X_D3DFORMAT_FORMAT_MASK) >> X_D3DFORMAT_FORMAT_SHIFT,
 			m_xprImage->pBits[0],
 			m_xprImage->xprImageHeader.xprHeader.dwXprTotalSize - m_xprImage->xprImageHeader.xprHeader.dwXprHeaderSize,
+			width,
+			height,
 			bitmap);
 	}
 	else {
@@ -1020,26 +1022,27 @@ bool Xbe::ExportLogoBitmap()
 			(m_xprImage->xprImageHeader.d3dTexture.Format & X_D3DFORMAT_FORMAT_MASK) >> X_D3DFORMAT_FORMAT_SHIFT,
 			m_xprImage->pBits[0],
 			m_xprImage->xprImageHeader.xprHeader.dwXprTotalSize - m_xprImage->xprImageHeader.xprHeader.dwXprHeaderSize,
+			width,
+			height,
 			bitmap);
 	}
-	
-	
+		
 	return result;
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap)
+bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap)
 {
 	switch (format)
 	{
 	case X_D3DFMT_DXT1:
 	case X_D3DFMT_DXT3:
 	case X_D3DFMT_DXT5:
-		return ReadS3TCFormatIntoBitmap(format, data, dataSize, bitmap);
+		return ReadS3TCFormatIntoBitmap(format, data, dataSize, width, height, bitmap);
 		break;
 	case X_D3DFMT_A8R8G8B8:
 	case X_D3DFMT_X8R8G8B8:
-		return ReadSwizzledFormatIntoBitmap(format, data, dataSize, bitmap);
+		return ReadSwizzledFormatIntoBitmap(format, data, dataSize, width, height, bitmap);
 		break;
 	default:
 		return false;
@@ -1048,12 +1051,12 @@ bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char &data, uin
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap)
+bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap)
 {
 	switch (format)
 	{
 	case X_D3DFMT_R5G6B5:
-		return ReadSwizzled16bitFormatIntoBitmap(format, data, dataSize, bitmap);
+		return ReadSwizzled16bitFormatIntoBitmap(format, data, dataSize, width, height, bitmap);
 		break;
 	default:
 		return false;
@@ -1062,19 +1065,47 @@ bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char &data
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap)
+bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap)
+{
+	uint08 color[3];
+	uint32 color32b[4];
+	uint32 r, g, b, r1, g1, b1, pixelmap;
+	int j, k, p, x, y;
+
+	r = g = b = r1 = g1 = b1 = pixelmap = 0;
+	j = k = p = x = y = 0;
+
+	if (format != X_D3DFMT_DXT1 || format != X_D3DFMT_DXT3 || format != X_D3DFMT_DXT5)
+		return false;
+	if (!(width > 0) || !(height > 0))
+		return false;
+
+	while (j < dataSize) {
+		try
+		{
+			if (format != X_D3DFMT_DXT1) // Skip X_D3DFMT_DXT3 and X_D3DFMT_DXT5 alpha data (ported from Dxbx)
+				j += 8;
+
+			color[0] = (data[j + 0] << 0) + (data[j + 1] << 8);
+
+			// FIXME - This function is incomplete
+		}
+		catch (int e)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+// FIXME: this function should be moved elsewhere
+bool Xbe::ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap)
 {
 	// FIXME - STUB
 }
 
 // FIXME: this function should be moved elsewhere
-bool Xbe::ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap)
-{
-	// FIXME - STUB
-}
-
-// FIXME: this function should be moved elsewhere
-bool Xbe::ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap)
+bool Xbe::ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap)
 {
 	// FIXME - STUB
 }

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -314,7 +314,7 @@ Xbe::Xbe(const char *x_szFilename)
         printf("OK\n");
     }
 	printf("-------\n");
-	ExportLogoBitmap(); // FIXME move this line elsewhere
+	ExportGameLogoBitmap(); // FIXME move this line elsewhere
 	printf("-------\n");
 
 cleanup:
@@ -972,7 +972,7 @@ uint08 *Xbe::GetLogoBitmap(uint32 x_dwSize)
     return 0;
 }
 
-bool Xbe::ExportLogoBitmap()
+bool Xbe::ExportGameLogoBitmap()
 {
 	bool result = false;
 	uint32 dwOffs = 0;
@@ -984,6 +984,7 @@ bool Xbe::ExportLogoBitmap()
 			dwOffs = m_SectionHeader[v].dwVirtualAddr;
 			dwLength = m_SectionHeader[v].dwVirtualSize;
 			index = v;
+			break;
 		}
 	}
 	if (dwOffs == 0 || dwLength == 0)
@@ -1004,7 +1005,7 @@ bool Xbe::ExportLogoBitmap()
 	printf("Game Logo Height: %X\n", height);
 
 	int pitch = width * sizeof(uint32);
-	void* bitmap = (void*)malloc(sizeof(uint32) * pitch * height);
+	void* bitmap = (void*)malloc(pitch * height);
 
 	if ((m_xprImage->xprImageHeader.xprHeader.dwXprTotalSize - m_xprImage->xprImageHeader.xprHeader.dwXprHeaderSize) / width / height == 2) {
 		printf("Game Logo is 16bit\n");

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -261,6 +261,55 @@ class Xbe : public Error
             }
             m_Sixteen;
         };
+
+		// Export Game Logo - FIXME this function isn't complete yet 
+		bool ExportLogoBitmap();
+
+		struct X_D3DResourceLoc
+		{
+			uint32 Common;
+			uint32 Data;
+			uint32 Lock;
+			uint32 Format;
+			uint32 Size;
+		};
+
+		#include "AlignPrefix1.h"
+		struct XprHeader
+		{
+			uint32 dwXprMagic;
+			uint32 dwXprTotalSize;
+			uint32 dwXprHeaderSize;
+		}
+		#include "AlignPosfix1.h"
+		*m_xprHeader;
+
+		#include "AlignPrefix1.h"
+		struct XprImageHeader
+		{
+			XprHeader xprHeader;
+			X_D3DResourceLoc d3dTexture;
+			uint32 dwEndOfHeader;
+		}
+		#include "AlignPosfix1.h"
+		*m_xprImageHeader;
+
+		#include "AlignPrefix1.h"
+		struct XprImage
+		{
+			XprImageHeader xprImageHeader;
+			char strPad[2048 - sizeof(XprImageHeader) - 1];
+			unsigned char pBits[(128 * 128) / 2];
+		}
+		#include "AlignPosfix1.h"
+		*m_xprImage;
+
+		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
+		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
+
+		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
+		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
+		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
 };
 
 // debug/retail XOR keys

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -304,12 +304,20 @@ class Xbe : public Error
 		#include "AlignPosfix1.h"
 		*m_xprImage;
 
-		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
-		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
+		struct TRGB32 // FIXME move this elsewhere - this struct might be also need a rename
+		{
+			unsigned char B;
+			unsigned char G;
+			unsigned char R;
+			unsigned char A;
+		};
 
-		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
-		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
-		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
+		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
+		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
+
+		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
+		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
+		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
 };
 
 // debug/retail XOR keys

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -304,12 +304,12 @@ class Xbe : public Error
 		#include "AlignPosfix1.h"
 		*m_xprImage;
 
-		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
-		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
+		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
+		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
 
-		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
-		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
-		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char &data, uint32 dataSize, void* bitmap); // FIXME move this elsewhere
+		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
+		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
+		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, void* bitmap); // FIXME move this elsewhere
 };
 
 // debug/retail XOR keys

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -42,6 +42,9 @@
 //#include <windef.h> // For MAX_PATH
 // The above leads to 55 compile errors, so until we've sorted out why that happens, declare MAX_PATH ourselves for now :
 #define MAX_PATH 260
+#define XPR_IMAGE_WH 128
+#define XPR_IMAGE_DATA_SIZE (XPR_IMAGE_WH * XPR_IMAGE_WH) / 2
+#define XPR_IMAGE_HDR_SIZE 2048
 
 // Xbe (Xbox Executable) file object
 class Xbe : public Error
@@ -65,8 +68,8 @@ class Xbe : public Error
         // export logo bitmap to raw monochrome data
         void ExportLogoBitmap(uint08 x_Gray[100*17]);
 
-		// Export Game Logo bitmap
-		bool ExportGameLogoBitmap(void*& bitmapData, int *width, int *height);
+		// Export Game Logo bitmap (XTIMAG or XSIMAG)
+		bool ExportGameLogoBitmap(void*& bitmapData, int *width, int *height, int *bit);
 
         // Xbe header
         #include "AlignPrefix1.h"
@@ -298,12 +301,13 @@ class Xbe : public Error
 		#include "AlignPosfix1.h"
 		*m_xprImageHeader;
 
+
 		#include "AlignPrefix1.h"
 		struct XprImage
 		{
 			XprImageHeader xprImageHeader;
-			char strPad[2048 - sizeof(XprImageHeader)];
-			unsigned char pBits[((128 * 128) / 2)];
+			char strPad[XPR_IMAGE_HDR_SIZE - sizeof(XprImageHeader)];
+			unsigned char pBits[XPR_IMAGE_DATA_SIZE];
 		}
 		#include "AlignPosfix1.h"
 		*m_xprImage;
@@ -328,9 +332,7 @@ class Xbe : public Error
 
 		uint32 Swizzle(uint32 value, uint32 max, uint32 shift); // FIXME move this elsewhere
 
-		typedef TRGB32 PRGB32Array[INT_MAX / sizeof(TRGB32)]; // FIXME move this elsewhere - this typedef might also need a rename
 		typedef uint16 TRGB16; // FIXME move this elsewhere - this typedef might also need a rename
-		typedef TRGB16 PRGB16Array[INT_MAX / sizeof(TRGB16)]; // FIXME move this elsewhere - this typedef might also need a rename
 
 };
 

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -263,7 +263,7 @@ class Xbe : public Error
         };
 
 		// Export Game Logo - FIXME this function isn't complete yet 
-		bool ExportLogoBitmap();
+		bool ExportGameLogoBitmap();
 
 		struct X_D3DResourceLoc
 		{

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -266,6 +266,7 @@ class Xbe : public Error
         };
 
 		// used to decode game logo bitmap data
+		#include "AlignPrefix1.h"
 		struct X_D3DResourceLoc
 		{
 			uint32 Common;
@@ -273,7 +274,9 @@ class Xbe : public Error
 			uint32 Lock;
 			uint32 Format;
 			uint32 Size;
-		};
+		}
+		#include "AlignPosfix1.h"
+		;
 
 		#include "AlignPrefix1.h"
 		struct XprHeader
@@ -299,8 +302,8 @@ class Xbe : public Error
 		struct XprImage
 		{
 			XprImageHeader xprImageHeader;
-			char strPad[2048 - sizeof(XprImageHeader) - 1];
-			unsigned char pBits[(128 * 128) / 2];
+			char strPad[2048 - sizeof(XprImageHeader)];
+			unsigned char pBits[((128 * 128) / 2)];
 		}
 		#include "AlignPosfix1.h"
 		*m_xprImage;
@@ -322,7 +325,7 @@ class Xbe : public Error
 
 		uint32 Swizzle(uint32 value, uint32 max, uint32 shift); // FIXME move this elsewhere
 
-		typedef TRGB32 PRGB32Array[INT_MAX / sizeof(TRGB32) - 1]; // FIXME move this elsewhere - this typedef might also need a rename
+		typedef TRGB32 PRGB32Array[INT_MAX / sizeof(TRGB32)]; // FIXME move this elsewhere - this typedef might also need a rename
 		typedef uint16 TRGB16; // FIXME move this elsewhere - this typedef might also need a rename
 		typedef TRGB16 PRGB16Array[INT_MAX / sizeof(TRGB16)]; // FIXME move this elsewhere - this typedef might also need a rename
 

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -66,7 +66,7 @@ class Xbe : public Error
         void ExportLogoBitmap(uint08 x_Gray[100*17]);
 
 		// Export Game Logo bitmap
-		bool ExportGameLogoBitmap(void* bitmapData, int *width, int *height);
+		bool ExportGameLogoBitmap(void*& bitmapData, int *width, int *height);
 
         // Xbe header
         #include "AlignPrefix1.h"
@@ -313,12 +313,12 @@ class Xbe : public Error
 			unsigned char A;
 		};
 				
-		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
-		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
+		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
+		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
 
-		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
-		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
-		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
+		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
+		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
+		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
 
 		uint32 Swizzle(uint32 value, uint32 max, uint32 shift); // FIXME move this elsewhere
 

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -308,13 +308,16 @@ class Xbe : public Error
 		#include "AlignPosfix1.h"
 		*m_xprImage;
 
+		#include "AlignPrefix1.h"
 		struct TRGB32 // FIXME move this elsewhere - this struct might also need a rename
 		{
 			unsigned char B;
 			unsigned char G;
 			unsigned char R;
 			unsigned char A;
-		};
+		}
+		#include "AlignPosfix1.h"
+		;
 				
 		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
 		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -307,13 +307,13 @@ class Xbe : public Error
 		{
 			XprImageHeader xprImageHeader;
 			char strPad[XPR_IMAGE_HDR_SIZE - sizeof(XprImageHeader)];
-			unsigned char pBits[XPR_IMAGE_DATA_SIZE];
+			unsigned char pBits;
 		}
 		#include "AlignPosfix1.h"
 		*m_xprImage;
 
 		#include "AlignPrefix1.h"
-		struct TRGB32 // FIXME move this elsewhere - this struct might also need a rename
+		struct TRGB32
 		{
 			unsigned char B;
 			unsigned char G;
@@ -322,18 +322,17 @@ class Xbe : public Error
 		}
 		#include "AlignPosfix1.h"
 		;
-				
-		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
-		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
 
-		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
-		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
-		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap); // FIXME move this elsewhere
+		typedef uint16 TRGB16;
 
-		uint32 Swizzle(uint32 value, uint32 max, uint32 shift); // FIXME move this elsewhere
+		bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
+		bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
 
-		typedef uint16 TRGB16; // FIXME move this elsewhere - this typedef might also need a rename
+		bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
+		bool Xbe::ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
+		bool Xbe::ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
 
+		uint32 Xbe::Swizzle(uint32 value, uint32 max, uint32 shift); // Generic swizzle function, usable for both x and y dimensions.
 };
 
 // debug/retail XOR keys

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -65,6 +65,9 @@ class Xbe : public Error
         // export logo bitmap to raw monochrome data
         void ExportLogoBitmap(uint08 x_Gray[100*17]);
 
+		// Export Game Logo bitmap
+		bool ExportGameLogoBitmap(void* bitmapData, int *width, int *height);
+
         // Xbe header
         #include "AlignPrefix1.h"
         struct Header
@@ -262,9 +265,7 @@ class Xbe : public Error
             m_Sixteen;
         };
 
-		// Export Game Logo - FIXME this function isn't complete yet 
-		bool ExportGameLogoBitmap();
-
+		// used to decode game logo bitmap data
 		struct X_D3DResourceLoc
 		{
 			uint32 Common;
@@ -304,20 +305,27 @@ class Xbe : public Error
 		#include "AlignPosfix1.h"
 		*m_xprImage;
 
-		struct TRGB32 // FIXME move this elsewhere - this struct might be also need a rename
+		struct TRGB32 // FIXME move this elsewhere - this struct might also need a rename
 		{
 			unsigned char B;
 			unsigned char G;
 			unsigned char R;
 			unsigned char A;
 		};
-
+				
 		bool ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
 		bool ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
 
 		bool ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
 		bool ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
 		bool ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void* bitmap); // FIXME move this elsewhere
+
+		uint32 Swizzle(uint32 value, uint32 max, uint32 shift); // FIXME move this elsewhere
+
+		typedef TRGB32 PRGB32Array[INT_MAX / sizeof(TRGB32) - 1]; // FIXME move this elsewhere - this typedef might also need a rename
+		typedef uint16 TRGB16; // FIXME move this elsewhere - this typedef might also need a rename
+		typedef TRGB16 PRGB16Array[INT_MAX / sizeof(TRGB16)]; // FIXME move this elsewhere - this typedef might also need a rename
+
 };
 
 // debug/retail XOR keys

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -389,7 +389,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 
                 m_BackDC   = CreateCompatibleDC(hDC);
                 m_LogoDC   = CreateCompatibleDC(hDC);
-
+				
                 m_OrigBmp  = (HBITMAP)SelectObject(m_BackDC, m_BackBmp);
                 m_OrigLogo = (HBITMAP)SelectObject(m_LogoDC, m_LogoBmp);
 
@@ -1268,6 +1268,8 @@ void WndMain::XbeLoaded()
 {
     LoadLogo();
 
+	LoadGameLogo();
+
     RefreshMenus();
 
     InvalidateRgn(m_hwnd, NULL, TRUE);
@@ -1306,6 +1308,13 @@ void WndMain::LoadLogo()
 
     RedrawWindow(m_hwnd, NULL, NULL, RDW_INVALIDATE);
 }
+
+// load logo bitmap - FIXME this is only a stub
+void WndMain::LoadGameLogo()
+{
+/*m_GameLogoBMP*/
+}
+
 
 // refresh menu items
 void WndMain::RefreshMenus()

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -484,7 +484,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 
                 BitBlt(hDC, 0, 0, m_w, m_h, m_BackDC, 0, 0, SRCCOPY);
 
-				BitBlt(hDC, m_w - gameLogoWidth, m_h - nLogoBmpH - 8 - gameLogoHeight, gameLogoWidth, gameLogoHeight, m_GameLogoDC, 0, 0, SRCCOPY);
+				BitBlt(hDC, m_w - gameLogoWidth - 3, m_h - nLogoBmpH - 12 - gameLogoHeight, gameLogoWidth, gameLogoHeight, m_GameLogoDC, 0, 0, SRCCOPY);
 
                 BitBlt(hDC, m_w-nLogoBmpW-4, m_h-nLogoBmpH-4, nLogoBmpW, nLogoBmpH, m_LogoDC, 0, 0, SRCCOPY);
 
@@ -1319,17 +1319,16 @@ void WndMain::LoadLogo()
     RedrawWindow(m_hwnd, NULL, NULL, RDW_INVALIDATE);
 }
 
-// load logo bitmap - FIXME this is only a stub
+// load game logo bitmap
 void WndMain::LoadGameLogo()
 {
-
-	void* bitmapData;																
+	void* bitmapData;
+	int bit;
 	gameLogoWidth = 0;
 	gameLogoHeight = 0;	
-	bool res = m_Xbe->ExportGameLogoBitmap(bitmapData, &gameLogoWidth, &gameLogoHeight);
-	printf("Result is: %d\n", res); // FIXME - check result
-
-	if (!res)
+	bool result = m_Xbe->ExportGameLogoBitmap(bitmapData, &gameLogoWidth, &gameLogoHeight, &bit);
+	
+	if (!result) // no game logo found
 		return;
 
 	HDC hDC = GetDC(m_hwnd);
@@ -1343,7 +1342,7 @@ void WndMain::LoadGameLogo()
 		BmpInfo.bmiHeader.biWidth = gameLogoWidth;
 		BmpInfo.bmiHeader.biHeight = 0 - (long)gameLogoHeight;
 		BmpInfo.bmiHeader.biPlanes = 1;
-		BmpInfo.bmiHeader.biBitCount = 32;
+		BmpInfo.bmiHeader.biBitCount = bit;
 		BmpInfo.bmiHeader.biCompression = BI_RGB;
 		BmpInfo.bmiHeader.biSizeImage = 0;
 		BmpInfo.bmiHeader.biXPelsPerMeter = 0;
@@ -1354,28 +1353,15 @@ void WndMain::LoadGameLogo()
 		SetDIBits(hDC, m_GameLogoBMP, 0, gameLogoHeight, bitmapData, &BmpInfo, DIB_RGB_COLORS);
 	}
 
-
 	m_GameLogoDC = CreateCompatibleDC(hDC);
 	m_OrigGameLogo = (HBITMAP)SelectObject(m_GameLogoDC, m_GameLogoBMP);
 
-	/*uint32 v = 0;
-	for (uint32 y = 0; y<17; y++)
-	{
-		for (uint32 x = 0; x<100; x++)
-		{
-			SetPixel(m_GameLogoDC, x, y, RGB(i_gray[v], i_gray[v], i_gray[v]));
-			v++;
-		}
-	}*/
-
 	RedrawWindow(m_hwnd, NULL, NULL, RDW_INVALIDATE);
-
 
 	if (hDC != NULL)
 		ReleaseDC(m_hwnd, hDC);
 
-	free(bitmapData);																// *************************************************************
-
+	free(bitmapData);
 }
 
 

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -1312,7 +1312,7 @@ void WndMain::LoadLogo()
 // load logo bitmap - FIXME this is only a stub
 void WndMain::LoadGameLogo()
 {
-/*m_GameLogoBMP*/
+	// FIXME this is only a stub
 }
 
 

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -1329,6 +1329,9 @@ void WndMain::LoadGameLogo()
 	bool res = m_Xbe->ExportGameLogoBitmap(bitmapData, &gameLogoWidth, &gameLogoHeight);
 	printf("Result is: %d\n", res); // FIXME - check result
 
+	if (!res)
+		return;
+
 	HDC hDC = GetDC(m_hwnd);
 	m_GameLogoBMP = CreateCompatibleBitmap(hDC, gameLogoWidth, gameLogoHeight);
 
@@ -1340,7 +1343,7 @@ void WndMain::LoadGameLogo()
 		BmpInfo.bmiHeader.biWidth = gameLogoWidth;
 		BmpInfo.bmiHeader.biHeight = 0 - (long)gameLogoHeight;
 		BmpInfo.bmiHeader.biPlanes = 1;
-		BmpInfo.bmiHeader.biBitCount = 24;
+		BmpInfo.bmiHeader.biBitCount = 32;
 		BmpInfo.bmiHeader.biCompression = BI_RGB;
 		BmpInfo.bmiHeader.biSizeImage = 0;
 		BmpInfo.bmiHeader.biXPelsPerMeter = 0;

--- a/src/Cxbx/WndMain.h
+++ b/src/Cxbx/WndMain.h
@@ -128,6 +128,7 @@ class WndMain : public Wnd
 		HDC         m_GameLogoDC;
         HBITMAP     m_OrigBmp;
         HBITMAP     m_OrigLogo;
+		HBITMAP     m_OrigGameLogo;
         HBITMAP     m_BackBmp;
         HBITMAP     m_LogoBmp;
 		HBITMAP		m_GameLogoBMP;

--- a/src/Cxbx/WndMain.h
+++ b/src/Cxbx/WndMain.h
@@ -95,6 +95,11 @@ class WndMain : public Wnd
         // ******************************************************************
         void LoadLogo();
 
+		// ******************************************************************
+		// * refresh the game logo in the main window
+		// ******************************************************************
+		void LoadGameLogo();
+
         // ******************************************************************
         // * refresh all menus (checks, enabled, disabled, etc)
         // ******************************************************************
@@ -120,10 +125,12 @@ class WndMain : public Wnd
         // ******************************************************************
         HDC         m_BackDC;
         HDC         m_LogoDC;
+		HDC         m_GameLogoDC;
         HBITMAP     m_OrigBmp;
         HBITMAP     m_OrigLogo;
         HBITMAP     m_BackBmp;
         HBITMAP     m_LogoBmp;
+		HBITMAP		m_GameLogoBMP;
 
         // ******************************************************************
         // * Xbe objects


### PR DESCRIPTION
Hello,
before to merge please read carefully:
The ReadSwizzled16bitFormatIntoBitmap function isn't tested yet, because I wasn't able to find any game/homebrew that use a 16bit logo. Probably, I'll have to write an ad-hoc xbe to test it.
Also, sorry for the amount of commits, I've learned the lesson (the hard way), and I'll work in a branch next time.
Many of these functions have been ported back from Dxbx, and many of them should be moved from the actual place when issue #706 will be fixed (the proper location should be Convert.cpp).

I'll be away from home tonight and tomorrow, so I'll not be able to reply to this PR in case of problems.


In case of problems PLEASE discard this PR and let me know what's wrong. I'll try my best to fix any possible issue.

Have a nice weekend,
Luca