### PR TITLE
UI improvements

### DIFF
--- a/src/Cxbx/WndMain.h
+++ b/src/Cxbx/WndMain.h
@@ -61,6 +61,7 @@ class WndMain : public Wnd
         // ******************************************************************
         void OpenXbe(const char *x_filename);
         void CloseXbe();
+        void OpenMRU(int mru);
         void SaveXbe(const char *x_filename);
         void SaveXbeAs();
 
@@ -142,7 +143,7 @@ class WndMain : public Wnd
         // * changes remembered for internal purposes
         // ******************************************************************
         bool        m_bXbeChanged;
-        bool        m_bCanStart;
+        bool        m_bIsStarted;
 
         // ******************************************************************
         // * cached filenames


### PR DESCRIPTION
Fixed drag-and-drop
F5 now loads the most recently used Xbe if none is loaded yet
Extracted OpenMRU() into a separate function
Simplified OpenXbe()
Compare m_Xbe to nullptr instead of 0
Less usage of m_hwndChild