### PR TITLE
Xbe title fallback

### DIFF
--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -135,6 +135,30 @@ Xbe::Xbe(const char *x_szFilename)
         printf("OK\n");
 
         printf("Xbe::Xbe: Title identified as %s\n", m_szAsciiTitle);
+
+		// Detect empty title :
+		int len = strlen(m_szAsciiTitle);
+		while (len > 0 && m_szAsciiTitle[len-1] <= ' ')
+			len--;
+		if (len <= 0) {
+			// Try to fix empty title; first, try the executable name:
+			char Dir[_MAX_DIR];
+			char Filename[_MAX_FNAME];
+			_splitpath(x_szFilename, nullptr, Dir, Filename, nullptr);
+			if (stricmp(Filename, "default") != 0) {
+				strcpy(m_szAsciiTitle, Filename);
+			}
+			else {
+				// If executable is named "default.xbe", try the parent folder name:
+				len = strlen(Dir);
+				if (len > 0) {
+					Dir[len - 1] = '\0';
+					_splitpath(Dir, nullptr, nullptr, m_szAsciiTitle, nullptr);
+				}
+			}
+
+			printf("Xbe::Xbe: Replaced empty title with fallback : %s\n", m_szAsciiTitle);
+		}
     }
 
     // read Xbe section headers


### PR DESCRIPTION
In cases when a TitleName is empty (which can happen sometimes), this code tries a few fallbacks, so there's still a nice name to show in logs and the window caption.