### PR TITLE
Various Bug Fixes

### DIFF
--- a/src/Common/EmuEEPROM.cpp
+++ b/src/Common/EmuEEPROM.cpp
@@ -130,7 +130,7 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 		EEPROM->UserSettings.ParentalControlGames = 0; // = XC_PC_ESRB_ALL
 		EEPROM->UserSettings.ParentalControlMovies = 0; // = XC_PC_ESRB_ALL
 		EEPROM->UserSettings.MiscFlags = 0;  // No automatic power down
-		EEPROM->FactorySettings.AVRegion = 0x01; // = NTSC_M
+		EEPROM->FactorySettings.AVRegion = 0x0100; // = NTSC_M
 
 		XboxFactoryGameRegion = 1; // = North America - TODO : This should be derived from EncryptedSection somehow
 

--- a/src/CxbxKrnl/EmuFile.h
+++ b/src/CxbxKrnl/EmuFile.h
@@ -166,6 +166,7 @@ struct NativeObjectAttributes {
 };
 
 NTSTATUS CxbxObjectAttributesToNT(xboxkrnl::POBJECT_ATTRIBUTES ObjectAttributes, NativeObjectAttributes& nativeObjectAttributes, std::string aFileAPIName = "");
+NTSTATUS CxbxConvertFilePath(std::string RelativeXboxPath, OUT std::wstring &RelativeHostPath, OUT NtDll::HANDLE *RootDirectory, std::string aFileAPIName = "");
 
 // ******************************************************************
 // * Wrapper of a handle object

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -435,10 +435,10 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 		{
 			// Save the launch data page to disk for later.
 			// (Note : XWriteTitleInfoNoReboot does this too)
-			MmPersistContiguousMemory((PVOID)xboxkrnl::LaunchDataPage, sizeof(LAUNCH_DATA_PAGE), TRUE);
+			// Commented out because XLaunchNewImage is disabled!
+			// MmPersistContiguousMemory((PVOID)xboxkrnl::LaunchDataPage, sizeof(LAUNCH_DATA_PAGE), TRUE);
 
 			std::string TitlePath = xboxkrnl::LaunchDataPage->Header.szLaunchPath;
-			char szXbePath[MAX_PATH];
 			char szWorkingDirectoy[MAX_PATH];
 
 			// If the title path starts with a semicolon, remove it

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -977,7 +977,7 @@ DWORD WINAPI XTL::EMUPATCH(XLaunchNewImageA)
 	PLAUNCH_DATA	pLaunchData
 )
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	// Note : This can be tested using "Innocent tears",
 	// which relaunches different xbes between scenes;


### PR DESCRIPTION
Fix an issue where EEPROM.bin was generated with an invalid Factory AV Region.
NOTE: This requires users to delete their EEPROM.BIN, then a clean one will be created, an option to detect/fix invalid values could be added in the future.

Finally fix HalReturnToFirmware. Multiple XBE executables now work without patches, and rebooting to the dashboard or game from update.xbe also works as intended.