### PR TITLE
Cleanup of Certificate usage

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -772,7 +772,7 @@ void CxbxKrnlInit
 	std::string xbeDirectory(szBuffer);
 	CxbxBasePathHandle = CreateFile(CxbxBasePath.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
 	memset(szBuffer, 0, MAX_PATH);
-	sprintf(szBuffer, "%08X", ((Xbe::Certificate*)pXbeHeader->dwCertificateAddr)->dwTitleId);
+	sprintf(szBuffer, "%08X", g_pCertificate->dwTitleId);
 	std::string titleId(szBuffer);
 	// Games may assume they are running from CdRom :
 	CxbxDefaultXbeDriveIndex = CxbxRegisterDeviceHostPath(DeviceCdrom0, xbeDirectory);

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1083,8 +1083,6 @@ static BOOL WINAPI EmuEnumDisplayDevices(GUID FAR *lpGUID, LPSTR lpDriverDescrip
 // window message processing thread
 static DWORD WINAPI EmuRenderWindow(LPVOID lpVoid)
 {
-    char AsciiTitle[MAX_PATH];
-
     // register window class
     {
         LOGBRUSH logBrush = {BS_SOLID, RGB(0,0,0)};
@@ -1105,27 +1103,6 @@ static DWORD WINAPI EmuRenderWindow(LPVOID lpVoid)
         };
 
         RegisterClassEx(&wc);
-    }
-
-    // retrieve Xbe title (if possible)
-    {
-        char tAsciiTitle[40] = "Unknown";
-
-        uint32 CertAddr = g_XbeHeader->dwCertificateAddr - g_XbeHeader->dwBaseAddr;
-
-#define CertTitleNameLength 40
-
-		// Does the title fall entirely inside the read XbeHeader?
-        if(CertAddr + offsetof(Xbe::Certificate, wszTitleName) + CertTitleNameLength < g_XbeHeaderSize)
-        {
-            Xbe::Certificate *XbeCert = (Xbe::Certificate*)((uint32)g_XbeHeader + CertAddr);
-
-            setlocale( LC_ALL, "English" );
-
-            wcstombs(tAsciiTitle, XbeCert->wszTitleName, CertTitleNameLength);
-        }
-
-		sprintf(AsciiTitle, "Cxbx-Reloaded %s : Emulating %s", _CXBX_VERSION, tAsciiTitle);
     }
 
     // create the window
@@ -1158,7 +1135,7 @@ static DWORD WINAPI EmuRenderWindow(LPVOID lpVoid)
 
         g_hEmuWindow = CreateWindow
         (
-            "CxbxRender", AsciiTitle,
+            "CxbxRender", "Cxbx-Reloaded",
             dwStyle, x, y, nWidth, nHeight,
             hwndParent, NULL, GetModuleHandle(NULL), NULL
         );


### PR DESCRIPTION
This PR fixes two remaining issues regarding Certificates;
One occurence where the global certificate can already be used, and
one useless certificate title readout, which will be overwritten anyway.