### PR TITLE
Texture conversion

### DIFF
--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -994,22 +994,13 @@ uint08 *Xbe::GetLogoBitmap(uint32 x_dwSize)
 
 void *Xbe::FindSection(char *zsSectionName)
 {
-	uint32 dwOffs = 0;
-	uint32 dwLength = 0;
-	int sectionIndex = -1;
-
-	for (uint32 v = 0; v < m_Header.dwSections; v++)				
-	{
+	for (uint32 v = 0; v < m_Header.dwSections; v++) {
 		if (strcmp(m_szSectionName[v], zsSectionName) == 0) {
-			dwOffs = m_SectionHeader[v].dwVirtualAddr;
-			dwLength = m_SectionHeader[v].dwVirtualSize;
-			sectionIndex = v;
-			break;
+			if (m_SectionHeader[v].dwVirtualAddr > 0 && m_SectionHeader[v].dwVirtualSize > 0) {
+				return m_bzSection[v];
+			}
 		}
 	}
 
-	if (sectionIndex == -1 || dwOffs == 0 || dwLength == 0)
-		return NULL;
-
-	return m_bzSection[sectionIndex];
+	return NULL;
 }

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -56,6 +56,9 @@ class Xbe : public Error
         // deconstructor
        ~Xbe();
 
+	   // find an image by name
+	   void *FindSection(char *zsSectionName);
+
         // export to Xbe file
         void Export(const char *x_szXbeFilename);
 
@@ -67,9 +70,6 @@ class Xbe : public Error
 
         // export logo bitmap to raw monochrome data
         void ExportLogoBitmap(uint08 x_Gray[100*17]);
-
-		// Export Game Logo bitmap (XTIMAG or XSIMAG)
-		bool ExportGameLogoBitmap(void*& bitmapData, int *width, int *height, int *bit);
 
         // Xbe header
         #include "AlignPrefix1.h"
@@ -268,6 +268,7 @@ class Xbe : public Error
             m_Sixteen;
         };
 
+	public:
 		// used to decode game logo bitmap data
 		#include "AlignPrefix1.h"
 		struct X_D3DResourceLoc
@@ -282,9 +283,17 @@ class Xbe : public Error
 		;
 
 		#include "AlignPrefix1.h"
+		// XPR structures
+
+		// Purpose:
+		//   The XPR file format allows multiple graphics resources to be pre-defined
+		//   and bundled together into one file.  These resources can be copied into
+		//   memory and then immediately used in-place as D3D objects such as textures
+		//   and vertex buffers.  The structure below defines the XPR header and the
+		//   unique identifier for this file type.
 		struct XprHeader
 		{
-			uint32 dwXprMagic;
+			uint32 dwXprMagic; // 'XPR0' or 'XPR1'
 			uint32 dwXprTotalSize;
 			uint32 dwXprHeaderSize;
 		}
@@ -292,11 +301,15 @@ class Xbe : public Error
 		*m_xprHeader;
 
 		#include "AlignPrefix1.h"
+		// Layout of SaveImage.xbx saved game image file
+		//
+		// File is XPR0 format. Since the XPR will always contain only a single
+		// 256x256 DXT1 image, we know exactly what the header portion will look like
 		struct XprImageHeader
 		{
-			XprHeader xprHeader;
-			X_D3DResourceLoc d3dTexture;
-			uint32 dwEndOfHeader;
+			XprHeader xprHeader; // Standard XPR struct
+			X_D3DResourceLoc d3dTexture; // Standard D3D texture struct
+			uint32 dwEndOfHeader; // $FFFFFFFF
 		}
 		#include "AlignPosfix1.h"
 		*m_xprImageHeader;
@@ -311,28 +324,6 @@ class Xbe : public Error
 		}
 		#include "AlignPosfix1.h"
 		*m_xprImage;
-
-		#include "AlignPrefix1.h"
-		struct TRGB32
-		{
-			unsigned char B;
-			unsigned char G;
-			unsigned char R;
-			unsigned char A;
-		}
-		#include "AlignPosfix1.h"
-		;
-
-		typedef uint16 TRGB16;
-
-		bool Xbe::ReadD3DTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
-		bool Xbe::ReadD3D16bitTextureFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
-
-		bool Xbe::ReadS3TCFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
-		bool Xbe::ReadSwizzledFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
-		bool Xbe::ReadSwizzled16bitFormatIntoBitmap(uint32 format, unsigned char *data, uint32 dataSize, int width, int height, int pitch, void*& bitmap);
-
-		uint32 Xbe::Swizzle(uint32 value, uint32 max, uint32 shift); // Generic swizzle function, usable for both x and y dimensions.
 };
 
 // debug/retail XOR keys

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -40,9 +40,11 @@
 /*! \{ */
 typedef signed int     sint;
 typedef unsigned int   uint;
+typedef char           int8;
 typedef char           int08;
 typedef short          int16;
 typedef long           int32;
+typedef unsigned char  uint8;
 typedef unsigned char  uint08;
 typedef unsigned short uint16;
 typedef unsigned long  uint32;

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -1301,13 +1301,21 @@ void WndMain::LoadLogo()
 // load game logo bitmap
 void WndMain::LoadGameLogo()
 {
-	void* bitmapData;
-	int bit;
+	// Export Game Logo bitmap (XTIMAG or XSIMAG)
+	struct Xbe::XprImage *m_xprImage = (struct Xbe::XprImage*)m_Xbe->FindSection("$$XTIMAG"); // Check for XTIMAGE
+	if (!m_xprImage) {
+		m_xprImage = (struct Xbe::XprImage*)m_Xbe->FindSection("$$XSIMAG"); // if XTIMAGE isn't present, check for XSIMAGE (smaller)
+		if (!m_xprImage) {
+			return;
+		}
+	}
+
 	gameLogoWidth = 0;
 	gameLogoHeight = 0;	
-	bool result = m_Xbe->ExportGameLogoBitmap(bitmapData, &gameLogoWidth, &gameLogoHeight, &bit);
-	
-	if (!result) // no game logo found
+
+	XTL::X_D3DPixelContainer *pXboxPixelContainer = (XTL::X_D3DPixelContainer*)(&(m_xprImage->xprImageHeader.d3dTexture));
+	void *bitmapData = XTL::ConvertD3DTextureToARGB(pXboxPixelContainer, (uint8*)&m_xprImage->pBits, &gameLogoWidth, &gameLogoHeight);
+	if (!bitmapData) // no game logo found
 		return;
 
 	HDC hDC = GetDC(m_hwnd);
@@ -1321,7 +1329,7 @@ void WndMain::LoadGameLogo()
 		BmpInfo.bmiHeader.biWidth = gameLogoWidth;
 		BmpInfo.bmiHeader.biHeight = 0 - (long)gameLogoHeight;
 		BmpInfo.bmiHeader.biPlanes = 1;
-		BmpInfo.bmiHeader.biBitCount = bit;
+		BmpInfo.bmiHeader.biBitCount = 32;
 		BmpInfo.bmiHeader.biCompression = BI_RGB;
 		BmpInfo.bmiHeader.biSizeImage = 0;
 		BmpInfo.bmiHeader.biXPelsPerMeter = 0;

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -1327,7 +1327,7 @@ void WndMain::LoadGameLogo()
 
 		BmpInfo.bmiHeader.biSize = sizeof(BITMAPINFO) - sizeof(RGBQUAD);
 		BmpInfo.bmiHeader.biWidth = gameLogoWidth;
-		BmpInfo.bmiHeader.biHeight = 0 - (long)gameLogoHeight;
+		BmpInfo.bmiHeader.biHeight = 0 - (long)gameLogoHeight; //  If biHeight is negative, the bitmap is a top-down DIB and its origin is the upper-left corner.
 		BmpInfo.bmiHeader.biPlanes = 1;
 		BmpInfo.bmiHeader.biBitCount = 32;
 		BmpInfo.bmiHeader.biCompression = BI_RGB;

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -772,7 +772,7 @@ void CxbxKrnlInit
 	std::string xbeDirectory(szBuffer);
 	CxbxBasePathHandle = CreateFile(CxbxBasePath.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
 	memset(szBuffer, 0, MAX_PATH);
-	sprintf(szBuffer, "%08X", ((Xbe::Certificate*)pXbeHeader->dwCertificateAddr)->dwTitleId);
+	sprintf(szBuffer, "%08X", g_pCertificate->dwTitleId);
 	std::string titleId(szBuffer);
 	// Games may assume they are running from CdRom :
 	CxbxDefaultXbeDriveIndex = CxbxRegisterDeviceHostPath(DeviceCdrom0, xbeDirectory);

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1148,8 +1148,6 @@ static BOOL WINAPI EmuEnumDisplayDevices(GUID FAR *lpGUID, LPSTR lpDriverDescrip
 // window message processing thread
 static DWORD WINAPI EmuRenderWindow(LPVOID lpVoid)
 {
-    char AsciiTitle[MAX_PATH];
-
     // register window class
     {
         LOGBRUSH logBrush = {BS_SOLID, RGB(0,0,0)};
@@ -1170,27 +1168,6 @@ static DWORD WINAPI EmuRenderWindow(LPVOID lpVoid)
         };
 
         RegisterClassEx(&wc);
-    }
-
-    // retrieve Xbe title (if possible)
-    {
-        char tAsciiTitle[40] = "Unknown";
-
-        uint32 CertAddr = g_XbeHeader->dwCertificateAddr - g_XbeHeader->dwBaseAddr;
-
-#define CertTitleNameLength 40
-
-		// Does the title fall entirely inside the read XbeHeader?
-        if(CertAddr + offsetof(Xbe::Certificate, wszTitleName) + CertTitleNameLength < g_XbeHeaderSize)
-        {
-            Xbe::Certificate *XbeCert = (Xbe::Certificate*)((uint32)g_XbeHeader + CertAddr);
-
-            setlocale( LC_ALL, "English" );
-
-            wcstombs(tAsciiTitle, XbeCert->wszTitleName, CertTitleNameLength);
-        }
-
-		sprintf(AsciiTitle, "Cxbx-Reloaded %s : Emulating %s", _CXBX_VERSION, tAsciiTitle);
     }
 
     // create the window
@@ -1223,7 +1200,7 @@ static DWORD WINAPI EmuRenderWindow(LPVOID lpVoid)
 
         g_hEmuWindow = CreateWindow
         (
-            "CxbxRender", AsciiTitle,
+            "CxbxRender", "Cxbx-Reloaded",
             dwStyle, x, y, nWidth, nHeight,
             hwndParent, NULL, GetModuleHandle(NULL), NULL
         );

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -93,6 +93,7 @@ static void							UpdateCurrentMSpFAndFPS(); // Used for benchmarking/fps count
 static HMONITOR                     g_hMonitor      = NULL; // Handle to DirectDraw monitor
 static BOOL                         g_bSupportsYUY2 = FALSE;// Does device support YUY2 overlays?
 static BOOL                         g_bSupportsP8   = FALSE;// Does device support palette textures?
+static BOOL                         g_bDeviceSupportsFormat[XTL::D3DFMT_INDEX32 + 1] = { FALSE };// Does device support texture format?
 static XTL::LPDIRECTDRAW7           g_pDD7          = NULL; // DirectDraw7
 static XTL::DDCAPS                  g_DriverCaps          = { 0 };
 static DWORD                        g_dwOverlayW    = 640;  // Cached Overlay Width
@@ -1697,12 +1698,6 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 				// Dxbx addition : Prevent Direct3D from changing the FPU Control word :
 				g_EmuCDPD.BehaviorFlags |= D3DCREATE_FPU_PRESERVE;
 
-				// Does this device support paletized textures?
-				g_bSupportsP8 = g_pD3D8->CheckDeviceFormat(
-					g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
-					(XTL::D3DFORMAT)g_EmuCDPD.pPresentationParameters->BackBufferFormat, 0,
-					XTL::D3DRTYPE_TEXTURE, XTL::D3DFMT_P8) == D3D_OK;
-
 	            // Address debug DirectX runtime warning in _DEBUG builds
                 // Direct3D8: (WARN) :Device that was created without D3DCREATE_MULTITHREADED is being used by a thread other than the creation thread.
                 #ifdef _DEBUG
@@ -1723,6 +1718,18 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 
                 if(FAILED(g_EmuCDPD.hRet))
                     CxbxKrnlCleanup("IDirect3D8::CreateDevice failed");
+
+				// Determine which formats this device supports
+				for (int PCFormat = XTL::D3DFMT_UNKNOWN; PCFormat <= XTL::D3DFMT_INDEX32; PCFormat++) {
+					g_bDeviceSupportsFormat[PCFormat] = g_pD3D8->CheckDeviceFormat(
+						g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
+						(XTL::D3DFORMAT)g_EmuCDPD.pPresentationParameters->BackBufferFormat, 0,
+						XTL::D3DRTYPE_TEXTURE, (XTL::D3DFORMAT)PCFormat) == D3D_OK;
+				}
+
+				// TODO : Remove these :
+				g_bSupportsP8 = g_bDeviceSupportsFormat[XTL::D3DFMT_P8];
+				g_bSupportsYUY2 = g_bDeviceSupportsFormat[XTL::D3DFMT_YUY2];
 
                 // cache device pointer
                 g_pD3DDevice8 = *g_EmuCDPD.ppReturnedDeviceInterface;
@@ -1767,7 +1774,7 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
                     g_pDD7->GetFourCCCodes(&dwCodes, lpCodes);
                     lpCodes = (DWORD*)malloc(dwCodes*sizeof(DWORD));
                     g_pDD7->GetFourCCCodes(&dwCodes, lpCodes);
-                    g_bSupportsYUY2 = false;
+                    //g_bSupportsYUY2 = false;
                     for(DWORD v=0;v<dwCodes;v++)
                     {
                         if(lpCodes[v] == MAKEFOURCC('Y','U','Y','2'))

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -91,8 +91,7 @@ static void							UpdateCurrentMSpFAndFPS(); // Used for benchmarking/fps count
 
 // Static Variable(s)
 static HMONITOR                     g_hMonitor      = NULL; // Handle to DirectDraw monitor
-static BOOL                         g_bSupportsYUY2 = FALSE;// Does device support YUY2 overlays?
-static BOOL                         g_bSupportsP8   = FALSE;// Does device support palette textures?
+static BOOL                         g_bSupportsYUY2Overlay = FALSE; // Does device support YUY2 overlays?
 static bool                         g_bSupportsTextureFormat[XTL::X_D3DFMT_LIN_R8G8B8A8 + 1] = { false };// Does device support texture format?
 static XTL::LPDIRECTDRAW7           g_pDD7          = NULL; // DirectDraw7
 static XTL::DDCAPS                  g_DriverCaps          = { 0 };
@@ -1815,12 +1814,11 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 				}
 
 				// TODO : Remove these :
-				g_bSupportsP8 = g_bSupportsTextureFormat[XTL::X_D3DFMT_P8];
-				g_bSupportsYUY2 = g_bSupportsTextureFormat[XTL::X_D3DFMT_YUY2];
+				g_bSupportsYUY2Overlay = g_bSupportsTextureFormat[XTL::X_D3DFMT_YUY2];
 
 				// check for YUY2 overlay support TODO: accept other overlay types
 				{
-                    if(!g_bSupportsYUY2)
+                    if(!g_bSupportsYUY2Overlay)
                         EmuWarning("YUY2 overlays are not supported in hardware, could be slow!");
 					else
 					{
@@ -1829,14 +1827,14 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 							DbgPrintf("EmuD3D8: Hardware accelerated YUV surfaces Enabled...\n");
 						else
 						{
-							g_bSupportsYUY2 = false;
+							g_bSupportsYUY2Overlay = false;
 							DbgPrintf("EmuD3D8: Hardware accelerated YUV surfaces Disabled...\n");
 						}
 					}
                 }
 
                 // initialize primary surface
-                if(g_bSupportsYUY2)
+                if(g_bSupportsYUY2Overlay)
                 {
                     XTL::DDSURFACEDESC2 ddsd2;
 					HRESULT hRet;
@@ -1853,7 +1851,7 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 					{
 						CxbxKrnlCleanup("Could not create primary surface (0x%.08X)", hRet);
 						// TODO : Make up our mind: Either halt (above) or continue (below)
-						g_bSupportsYUY2 = false;
+						g_bSupportsYUY2Overlay = false;
 					}
                 }
 
@@ -3974,7 +3972,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateTexture)
 			PCFormat = D3DFMT_R5G6B5;
 		}
 		//*
-		else if(PCFormat == D3DFMT_P8 && !g_bSupportsP8)
+		else if(PCFormat == D3DFMT_P8 && !g_bSupportsTextureFormat[X_D3DFMT_P8])
 		{
 			EmuWarning("D3DFMT_P8 is an unsupported texture format!");
 			PCFormat = D3DFMT_L8;
@@ -4125,7 +4123,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVolumeTexture)
 			EmuWarning("D3DFMT_D16 is an unsupported texture format!");
 			PCFormat = D3DFMT_X8R8G8B8; // TODO : Use D3DFMT_R5G6B5 ?
 		}
-		else if (PCFormat == D3DFMT_P8 && !g_bSupportsP8)
+		else if (PCFormat == D3DFMT_P8 && !g_bSupportsTextureFormat[X_D3DFMT_P8])
 		{
 			EmuWarning("D3DFMT_P8 is an unsupported texture format!");
 			PCFormat = D3DFMT_L8;
@@ -4196,7 +4194,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateCubeTexture)
         EmuWarning("D3DFMT_D16 is an unsupported texture format!");
         PCFormat = D3DFMT_X8R8G8B8; // TODO : Use D3DFMT_R5G6B5?
     }
-    else if(PCFormat == D3DFMT_P8 && !g_bSupportsP8)
+    else if(PCFormat == D3DFMT_P8 && !g_bSupportsTextureFormat[X_D3DFMT_P8])
     {
         EmuWarning("D3DFMT_P8 is an unsupported texture format!");
         PCFormat = D3DFMT_L8;
@@ -5408,7 +5406,7 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
                     // Since most modern graphics cards does not support
                     // palette based textures we need to expand it to
                     // ARGB texture format
-					if ((PCFormat == D3DFMT_P8 && !g_bSupportsP8) || EmuXBFormatRequiresConversionToARGB(X_Format))
+					if ((PCFormat == D3DFMT_P8 && !g_bSupportsTextureFormat[X_D3DFMT_P8]) || EmuXBFormatRequiresConversionToARGB(X_Format))
                     {
 						if (PCFormat == D3DFMT_P8) //Palette
 							EmuWarning("D3DFMT_P8 -> D3DFMT_A8R8G8B8");
@@ -6595,7 +6593,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_EnableOverlay)
     else if(Enable == TRUE && (g_pDDSOverlay7 == nullptr))
     {
         // initialize overlay surface
-        if(g_bSupportsYUY2)
+        if(g_bSupportsYUY2Overlay)
         {
             XTL::DDSURFACEDESC2 ddsd2;
 
@@ -6670,7 +6668,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_UpdateOverlay)
 		}
 
 		// manually copy data over to overlay
-		if(g_bSupportsYUY2)
+		if(g_bSupportsYUY2Overlay)
 		{
 			// Make sure the overlay is allocated before using it
 			if (g_pDDSOverlay7 == nullptr) {
@@ -9101,7 +9099,7 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CheckDeviceMultiSampleType)
         EmuWarning("D3DFMT_D16 is an unsupported texture format!");
         PCSurfaceFormat = D3DFMT_X8R8G8B8;
     }
-    else if(PCSurfaceFormat == D3DFMT_P8 && !g_bSupportsP8)
+    else if(PCSurfaceFormat == D3DFMT_P8 && !g_bSupportsTextureFormat[X_D3DFMT_P8])
     {
         EmuWarning("D3DFMT_P8 is an unsupported texture format!");
         PCSurfaceFormat = D3DFMT_X8R8G8B8;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -93,7 +93,7 @@ static void							UpdateCurrentMSpFAndFPS(); // Used for benchmarking/fps count
 static HMONITOR                     g_hMonitor      = NULL; // Handle to DirectDraw monitor
 static BOOL                         g_bSupportsYUY2 = FALSE;// Does device support YUY2 overlays?
 static BOOL                         g_bSupportsP8   = FALSE;// Does device support palette textures?
-static BOOL                         g_bDeviceSupportsFormat[XTL::D3DFMT_INDEX32 + 1] = { FALSE };// Does device support texture format?
+static bool                         g_bSupportsTextureFormat[XTL::D3DFMT_INDEX32 + 1] = { false };// Does device support texture format?
 static XTL::LPDIRECTDRAW7           g_pDD7          = NULL; // DirectDraw7
 static XTL::DDCAPS                  g_DriverCaps          = { 0 };
 static DWORD                        g_dwOverlayW    = 640;  // Cached Overlay Width
@@ -1721,15 +1721,24 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 
 				// Determine which formats this device supports
 				for (int PCFormat = XTL::D3DFMT_UNKNOWN; PCFormat <= XTL::D3DFMT_INDEX32; PCFormat++) {
-					g_bDeviceSupportsFormat[PCFormat] = g_pD3D8->CheckDeviceFormat(
+					g_bSupportsTextureFormat[PCFormat] = g_pD3D8->CheckDeviceFormat(
 						g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 						(XTL::D3DFORMAT)g_EmuCDPD.pPresentationParameters->BackBufferFormat, 0,
 						XTL::D3DRTYPE_TEXTURE, (XTL::D3DFORMAT)PCFormat) == D3D_OK;
 				}
 
 				// TODO : Remove these :
-				g_bSupportsP8 = g_bDeviceSupportsFormat[XTL::D3DFMT_P8];
-				g_bSupportsYUY2 = g_bDeviceSupportsFormat[XTL::D3DFMT_YUY2];
+				g_bSupportsP8 = g_bSupportsTextureFormat[XTL::D3DFMT_P8];
+				g_bSupportsYUY2 = false; // g_bSupportsTextureFormat[XTL::D3DFMT_YUY2];
+/* TODO : The following Direct3D8 formats are too big to fit in a table - check if the Xbox counterparts (before XTL::EmuXB2PC_D3DFormat is called) could serve as an index instead
+				D3DFMT_UYVY = MAKEFOURCC('U', 'Y', 'V', 'Y'),
+				D3DFMT_YUY2 = MAKEFOURCC('Y', 'U', 'Y', '2'),
+				D3DFMT_DXT1 = MAKEFOURCC('D', 'X', 'T', '1'),
+				D3DFMT_DXT2 = MAKEFOURCC('D', 'X', 'T', '2'),
+				D3DFMT_DXT3 = MAKEFOURCC('D', 'X', 'T', '3'),
+				D3DFMT_DXT4 = MAKEFOURCC('D', 'X', 'T', '4'),
+				D3DFMT_DXT5 = MAKEFOURCC('D', 'X', 'T', '5'),
+*/
 
                 // cache device pointer
                 g_pD3DDevice8 = *g_EmuCDPD.ppReturnedDeviceInterface;
@@ -1774,13 +1783,11 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
                     g_pDD7->GetFourCCCodes(&dwCodes, lpCodes);
                     lpCodes = (DWORD*)malloc(dwCodes*sizeof(DWORD));
                     g_pDD7->GetFourCCCodes(&dwCodes, lpCodes);
-                    //g_bSupportsYUY2 = false;
                     for(DWORD v=0;v<dwCodes;v++)
                     {
-                        if(lpCodes[v] == MAKEFOURCC('Y','U','Y','2'))
-                        {
+						DbgPrintf("EmuD3D8: FourCC[%d] = %.4s\n", v, (char *)&(lpCodes[v]));
+						if(lpCodes[v] == MAKEFOURCC('Y','U','Y','2')) {
                             g_bSupportsYUY2 = true;
-                            break;
                         }
                     }
 

--- a/src/CxbxKrnl/EmuD3D8.h
+++ b/src/CxbxKrnl/EmuD3D8.h
@@ -57,6 +57,12 @@ extern VOID CxbxSetPixelContainerHeader
 	UINT				Pitch
 );
 
+extern uint8 *ConvertD3DTextureToARGB(
+	XTL::X_D3DPixelContainer *pXboxPixelContainer,
+	uint8 *pSrc,
+	int *pWidth, int *pHeight
+);
+
 // initialize direct3d
 extern VOID EmuD3DInit();
 

--- a/src/CxbxKrnl/EmuD3D8.h
+++ b/src/CxbxKrnl/EmuD3D8.h
@@ -51,8 +51,8 @@ extern VOID CxbxSetPixelContainerHeader
 	DWORD           	Common,
 	UINT				Width,
 	UINT				Height,
-	XTL::X_D3DFORMAT	Format,
 	UINT				Levels,
+	XTL::X_D3DFORMAT	Format,
 	UINT				Dimensions,
 	UINT				Pitch
 );

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -73,6 +73,7 @@ enum _ComponentEncoding {
 	____DXT1,
 	____DXT3,
 	____DXT5,
+	______P8,
 };
 
 #ifdef OLD_COLOR_CONVERSION
@@ -178,61 +179,61 @@ void X1R5G5B5ToARGBRow_C(const uint8* src_x1r5g5b5, uint8* dst_argb,
 }
 
 void A8R8G8B8ToARGBRow_C(const uint8* src_a8r8g8b8, uint8* dst_argb, int width) {
-	memcpy(dst_argb, src_a8r8g8b8, width * 4); // Cxbx pass-through
+	memcpy(dst_argb, src_a8r8g8b8, width * sizeof(XTL::D3DCOLOR)); // Cxbx pass-through
 }
 
-void X8R8G8B8ToARGBRow_C(const uint8* src_x8r8g8b8, uint8* dst_rgb, int width) {
+void X8R8G8B8ToARGBRow_C(const uint8* src_x8r8g8b8, uint8* dst_argb, int width) {
 	int x;
 	for (x = 0; x < width; ++x) {
 		uint8 b = src_x8r8g8b8[0];
 		uint8 g = src_x8r8g8b8[1];
 		uint8 r = src_x8r8g8b8[2];
-		dst_rgb[0] = b;
-		dst_rgb[1] = g;
-		dst_rgb[2] = r;
-		dst_rgb[3] = 255u;
-		dst_rgb += 4;
+		dst_argb[0] = b;
+		dst_argb[1] = g;
+		dst_argb[2] = r;
+		dst_argb[3] = 255u;
+		dst_argb += 4;
 		src_x8r8g8b8 += 4;
 	}
 }
 
-void ____R8B8ToARGBRow_C(const uint8* src_r8b8, uint8* dst_rgb, int width) {
+void ____R8B8ToARGBRow_C(const uint8* src_r8b8, uint8* dst_argb, int width) {
 	int x;
 	for (x = 0; x < width; ++x) {
 		uint8 b = src_r8b8[0];
 		uint8 r = src_r8b8[1];
-		dst_rgb[0] = b;
-		dst_rgb[1] = b;
-		dst_rgb[2] = r;
-		dst_rgb[3] = r;
-		dst_rgb += 4;
+		dst_argb[0] = b;
+		dst_argb[1] = b;
+		dst_argb[2] = r;
+		dst_argb[3] = r;
+		dst_argb += 4;
 		src_r8b8 += 2;
 	}
 }
 
-void ____G8B8ToARGBRow_C(const uint8* src_g8b8, uint8* dst_rgb, int width) {
+void ____G8B8ToARGBRow_C(const uint8* src_g8b8, uint8* dst_argb, int width) {
 	int x;
 	for (x = 0; x < width; ++x) {
 		uint8 b = src_g8b8[0];
 		uint8 g = src_g8b8[1];
-		dst_rgb[0] = b;
-		dst_rgb[1] = g;
-		dst_rgb[2] = b;
-		dst_rgb[3] = g;
-		dst_rgb += 4;
+		dst_argb[0] = b;
+		dst_argb[1] = g;
+		dst_argb[2] = b;
+		dst_argb[3] = g;
+		dst_argb += 4;
 		src_g8b8 += 2;
 	}
 }
 
-void ______A8ToARGBRow_C(const uint8* src_a8, uint8* dst_rgb, int width) {
+void ______A8ToARGBRow_C(const uint8* src_a8, uint8* dst_argb, int width) {
 	int x;
 	for (x = 0; x < width; ++x) {
 		uint8 a = src_a8[0];
-		dst_rgb[0] = 255u;
-		dst_rgb[1] = 255u;
-		dst_rgb[2] = 255u;
-		dst_rgb[3] = a;
-		dst_rgb += 4;
+		dst_argb[0] = 255u;
+		dst_argb[1] = 255u;
+		dst_argb[2] = 255u;
+		dst_argb[3] = a;
+		dst_argb += 4;
 		src_a8 += 1;
 	}
 }
@@ -284,50 +285,50 @@ void R4G4B4A4ToARGBRow_C(const uint8* src_r4g4b4a4, uint8* dst_argb, int width) 
 	}
 }
 
-void A8B8G8R8ToARGBRow_C(const uint8* src_a8b8g8r8, uint8* dst_rgb, int width) {
+void A8B8G8R8ToARGBRow_C(const uint8* src_a8b8g8r8, uint8* dst_argb, int width) {
 	int x;
 	for (x = 0; x < width; ++x) {
 		uint8 r = src_a8b8g8r8[0];
 		uint8 g = src_a8b8g8r8[1];
 		uint8 b = src_a8b8g8r8[3];
 		uint8 a = src_a8b8g8r8[4];
-		dst_rgb[0] = b;
-		dst_rgb[1] = g;
-		dst_rgb[2] = r;
-		dst_rgb[3] = a;
-		dst_rgb += 4;
+		dst_argb[0] = b;
+		dst_argb[1] = g;
+		dst_argb[2] = r;
+		dst_argb[3] = a;
+		dst_argb += 4;
 		src_a8b8g8r8 += 4;
 	}
 }
 
-void B8G8R8A8ToARGBRow_C(const uint8* src_b8g8r8a8, uint8* dst_rgb, int width) {
+void B8G8R8A8ToARGBRow_C(const uint8* src_b8g8r8a8, uint8* dst_argb, int width) {
 	int x;
 	for (x = 0; x < width; ++x) {
 		uint8 a = src_b8g8r8a8[0];
 		uint8 r = src_b8g8r8a8[1];
 		uint8 g = src_b8g8r8a8[3];
 		uint8 b = src_b8g8r8a8[4];
-		dst_rgb[0] = b;
-		dst_rgb[1] = g;
-		dst_rgb[2] = r;
-		dst_rgb[3] = a;
-		dst_rgb += 4;
+		dst_argb[0] = b;
+		dst_argb[1] = g;
+		dst_argb[2] = r;
+		dst_argb[3] = a;
+		dst_argb += 4;
 		src_b8g8r8a8 += 4;
 	}
 }
 
-void R8G8B8A8ToARGBRow_C(const uint8* src_r8g8b8a8, uint8* dst_rgb, int width) {
+void R8G8B8A8ToARGBRow_C(const uint8* src_r8g8b8a8, uint8* dst_argb, int width) {
 	int x;
 	for (x = 0; x < width; ++x) {
 		uint8 a = src_r8g8b8a8[0];
 		uint8 b = src_r8g8b8a8[1];
 		uint8 g = src_r8g8b8a8[3];
 		uint8 r = src_r8g8b8a8[4];
-		dst_rgb[0] = b;
-		dst_rgb[1] = g;
-		dst_rgb[2] = r;
-		dst_rgb[3] = a;
-		dst_rgb += 4;
+		dst_argb[0] = b;
+		dst_argb[1] = g;
+		dst_argb[2] = r;
+		dst_argb[3] = a;
+		dst_argb += 4;
 		src_r8g8b8a8 += 4;
 	}
 }
@@ -710,6 +711,16 @@ void ____DXT5ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 	}
 }
 
+void ______P8ToARGBRow_C(const uint8* src_p8, uint8* dst_argb, int width) {
+	TRGB32 *pTexturePalette = *(TRGB32 **)dst_argb; // dirty hack to avoid another argument
+	int x;
+	for (x = 0; x < width; ++x) {
+		uint8 p = src_p8[x];
+		TRGB32 color = pTexturePalette[p];
+		((TRGB32 *)dst_argb)[x] = color;
+	}
+}
+
 static const XTL::FormatToARGBRow ComponentConverters[] = {
 	nullptr, // NoCmpnts,
 	ARGB1555ToARGBRow_C, // A1R5G5B5,
@@ -734,7 +745,7 @@ static const XTL::FormatToARGBRow ComponentConverters[] = {
 	____DXT1ToARGBRow_C, // ____DXT1
 	____DXT3ToARGBRow_C, // ____DXT3
 	____DXT5ToARGBRow_C, // ____DXT5
-
+	______P8ToARGBRow_C, // ______P8
 };
 
 enum _FormatStorage {
@@ -781,7 +792,7 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x08 undefined             */ {},
 	/* 0x09 undefined             */ {},
 	/* 0x0A undefined             */ {},
-	/* 0x0B X_D3DFMT_P8           */ {  8, Swzzld, NoCmpnts, XTL::D3DFMT_P8        }, // 8-bit palletized
+	/* 0x0B X_D3DFMT_P8           */ {  8, Swzzld, ______P8, XTL::D3DFMT_P8        }, // 8-bit palletized
 	/* 0x0C X_D3DFMT_DXT1         */ {  4, Cmprsd, ____DXT1, XTL::D3DFMT_DXT1      }, // opaque/one-bit alpha // NOTE : DXT1 is half byte per pixel, so divide Size and Pitch calculations by two!
 	/* 0x0D undefined             */ {},
 	/* 0x0E X_D3DFMT_DXT3         */ {  8, Cmprsd, ____DXT3, XTL::D3DFMT_DXT3      }, // Alias : X_D3DFMT_DXT2 // linear alpha
@@ -857,7 +868,7 @@ XTL::D3DCOLOR XTL::DecodeUInt32ToColor(const ComponentEncodingInfo * encoding, c
 const XTL::ComponentEncodingInfo *XTL::EmuXBFormatComponentEncodingInfo(X_D3DFORMAT Format)
 {
 	if (Format <= X_D3DFMT_LIN_R8G8B8A8)
-		if (FormatInfos[Format].components != NoCmpnts)
+		if (FormatInfos[Format].components > NoCmpnts && FormatInfos[Format].components < ____DXT1)
 			return &(ComponentEncodingInfos[FormatInfos[Format].components]);
 
 	return nullptr;

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -397,7 +397,7 @@ typedef struct TRGB32
 // DXT1 info (MSDN Block Compression) : https://msdn.microsoft.com/en-us/library/bb694531.aspx
 // https://msdn.microsoft.com/en-us/library/windows/desktop/bb147243(v=vs.85).aspx
 void ____DXT1ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
-	int pitch = *(int*)dst_argb; // dirty hack to avoid another argument
+	int dst_pitch = *(int*)dst_argb; // dirty hack to avoid another argument
 	int x;
 	for (x = 0; x < width; x+=4) {
 		// Read two 16-bit pixels
@@ -429,14 +429,14 @@ void ____DXT1ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 		if (color_0 > color_1)
 		{
 			// Make up new color : 2/3 A + 1/3 B :
-			colormap[2].B = (uint8)((2 * colormap[0].B + colormap[1].B + 2) / 3);
-			colormap[2].G = (uint8)((2 * colormap[0].G + colormap[1].G + 2) / 3);
-			colormap[2].R = (uint8)((2 * colormap[0].R + colormap[1].R + 2) / 3);
+			colormap[2].B = (uint8)((2 * colormap[0].B + 1 * colormap[1].B + 2) / 3);
+			colormap[2].G = (uint8)((2 * colormap[0].G + 1 * colormap[1].G + 2) / 3);
+			colormap[2].R = (uint8)((2 * colormap[0].R + 1 * colormap[1].R + 2) / 3);
 			colormap[2].A = 255u;
 			// Make up new color : 1/3 A + 2/3 B :
-			colormap[3].B = (uint8)((2 * colormap[1].B + colormap[0].B + 2) / 3);
-			colormap[3].G = (uint8)((2 * colormap[1].G + colormap[0].G + 2) / 3);
-			colormap[3].R = (uint8)((2 * colormap[1].R + colormap[0].R + 2) / 3);
+			colormap[3].B = (uint8)((1 * colormap[0].B + 2 * colormap[1].B + 2) / 3);
+			colormap[3].G = (uint8)((1 * colormap[0].G + 2 * colormap[1].G + 2) / 3);
+			colormap[3].R = (uint8)((1 * colormap[0].R + 2 * colormap[1].R + 2) / 3);
 			colormap[3].A = 255u;
 		}
 		else
@@ -459,9 +459,9 @@ void ____DXT1ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 		uint8 indices3 = data[7];
 
 		TRGB32 *dst_line0 = (TRGB32*)(dst_argb);
-		TRGB32 *dst_line1 = (TRGB32*)(dst_argb + pitch);
-		TRGB32 *dst_line2 = (TRGB32*)(dst_argb + pitch * 2);
-		TRGB32 *dst_line3 = (TRGB32*)(dst_argb + pitch * 3);
+		TRGB32 *dst_line1 = (TRGB32*)(dst_argb + dst_pitch);
+		TRGB32 *dst_line2 = (TRGB32*)(dst_argb + dst_pitch * 2);
+		TRGB32 *dst_line3 = (TRGB32*)(dst_argb + dst_pitch * 3);
 
 		dst_line0[0] = colormap[indices0 & 0x03];
 		dst_line0[1] = colormap[(indices0 & 0x0c) >> 2];
@@ -491,7 +491,7 @@ void ____DXT1ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 
 // DXT3 info : https://en.wikipedia.org/wiki/S3_Texture_Compression#DXT2_and_DXT3
 void ____DXT3ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
-	int pitch = *(int*)dst_argb; // dirty hack to avoid another argument
+	int dst_pitch = *(int*)dst_argb; // dirty hack to avoid another argument
 	int x;
 	for (x = 0; x < width; x += 4) {
 		// Read 16 pixels of 4-bit alpha channel data
@@ -529,59 +529,181 @@ void ____DXT3ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 
 		// Build second half of RGB32 color map :
 		// Make up new color : 2/3 A + 1/3 B :
-		colormap[2].B = (uint8)((2 * colormap[0].B + colormap[1].B + 2) / 3);
-		colormap[2].G = (uint8)((2 * colormap[0].G + colormap[1].G + 2) / 3);
-		colormap[2].R = (uint8)((2 * colormap[0].R + colormap[1].R + 2) / 3);
+		colormap[2].B = (uint8)((2 * colormap[0].B + 1 * colormap[1].B + 2) / 3);
+		colormap[2].G = (uint8)((2 * colormap[0].G + 1 * colormap[1].G + 2) / 3);
+		colormap[2].R = (uint8)((2 * colormap[0].R + 1 * colormap[1].R + 2) / 3);
 		// Make up new color : 1/3 A + 2/3 B :
-		colormap[3].B = (uint8)((colormap[0].B + 2 * colormap[1].B + 2) / 3);
-		colormap[3].G = (uint8)((colormap[0].G + 2 * colormap[1].G + 2) / 3);
-		colormap[3].R = (uint8)((colormap[0].R + 2 * colormap[1].R + 2) / 3);
+		colormap[3].B = (uint8)((1 * colormap[0].B + 2 * colormap[1].B + 2) / 3);
+		colormap[3].G = (uint8)((1 * colormap[0].G + 2 * colormap[1].G + 2) / 3);
+		colormap[3].R = (uint8)((1 * colormap[0].R + 2 * colormap[1].R + 2) / 3);
 
-		uint8 indices0 = data[12];
-		uint8 indices1 = data[13];
-		uint8 indices2 = data[14];
-		uint8 indices3 = data[15];
+		// Read 4 bytes worth of 2-bit color indices for 16 pixels
+		uint8 colori0 = data[12];
+		uint8 colori1 = data[13];
+		uint8 colori2 = data[14];
+		uint8 colori3 = data[15];
 
 		TRGB32 *dst_line0 = (TRGB32*)(dst_argb);
-		TRGB32 *dst_line1 = (TRGB32*)(dst_argb + pitch);
-		TRGB32 *dst_line2 = (TRGB32*)(dst_argb + pitch * 2);
-		TRGB32 *dst_line3 = (TRGB32*)(dst_argb + pitch * 3);
+		TRGB32 *dst_line1 = (TRGB32*)(dst_argb + dst_pitch);
+		TRGB32 *dst_line2 = (TRGB32*)(dst_argb + dst_pitch * 2);
+		TRGB32 *dst_line3 = (TRGB32*)(dst_argb + dst_pitch * 3);
 
-		dst_line0[0] = colormap[indices0 & 0x03];
+		dst_line0[0] = colormap[colori0 & 0x03];
 		dst_line0[0].A = (alpha0 & 0x0f) | (alpha0 << 4);
-		dst_line0[1] = colormap[(indices0 & 0x0c) >> 2];
+		dst_line0[1] = colormap[(colori0 & 0x0c) >> 2];
 		dst_line0[1].A = (alpha0 & 0xf0) | (alpha0 >> 4);
-		dst_line0[2] = colormap[(indices0 & 0x30) >> 4];
+		dst_line0[2] = colormap[(colori0 & 0x30) >> 4];
 		dst_line0[2].A = (alpha1 & 0x0f) | (alpha1 << 4);
-		dst_line0[3] = colormap[indices0 >> 6];
+		dst_line0[3] = colormap[colori0 >> 6];
 		dst_line0[3].A = (alpha1 & 0xf0) | (alpha1 >> 4);
 
-		dst_line1[0] = colormap[indices1 & 0x03];
+		dst_line1[0] = colormap[colori1 & 0x03];
 		dst_line1[0].A = (alpha2 & 0x0f) | (alpha2 << 4);
-		dst_line1[1] = colormap[(indices1 & 0x0c) >> 2];
+		dst_line1[1] = colormap[(colori1 & 0x0c) >> 2];
 		dst_line1[1].A = (alpha2 & 0xf0) | (alpha2 >> 4);
-		dst_line1[2] = colormap[(indices1 & 0x30) >> 4];
+		dst_line1[2] = colormap[(colori1 & 0x30) >> 4];
 		dst_line1[2].A = (alpha3 & 0x0f) | (alpha3 << 4);
-		dst_line1[3] = colormap[indices1 >> 6];
+		dst_line1[3] = colormap[colori1 >> 6];
 		dst_line1[3].A = (alpha3 & 0xf0) | (alpha3 >> 4);
 
-		dst_line2[0] = colormap[indices2 & 0x03];
+		dst_line2[0] = colormap[colori2 & 0x03];
 		dst_line2[0].A = (alpha4 & 0x0f) | (alpha4 << 4);
-		dst_line2[1] = colormap[(indices2 & 0x0c) >> 2];
+		dst_line2[1] = colormap[(colori2 & 0x0c) >> 2];
 		dst_line2[1].A = (alpha4 & 0xf0) | (alpha4 >> 4);
-		dst_line2[2] = colormap[(indices2 & 0x30) >> 4];
+		dst_line2[2] = colormap[(colori2 & 0x30) >> 4];
 		dst_line2[2].A = (alpha5 & 0x0f) | (alpha5 << 4);
-		dst_line2[3] = colormap[indices2 >> 6];
+		dst_line2[3] = colormap[colori2 >> 6];
 		dst_line2[3].A = (alpha5 & 0xf0) | (alpha5 >> 4);
 
-		dst_line3[0] = colormap[indices3 & 0x03];
+		dst_line3[0] = colormap[colori3 & 0x03];
 		dst_line3[0].A = (alpha6 & 0x0f) | (alpha6 << 4);
-		dst_line3[1] = colormap[(indices3 & 0x0c) >> 2];
+		dst_line3[1] = colormap[(colori3 & 0x0c) >> 2];
 		dst_line3[1].A = (alpha6 & 0xf0) | (alpha6 >> 4);
-		dst_line3[2] = colormap[(indices3 & 0x30) >> 4];
+		dst_line3[2] = colormap[(colori3 & 0x30) >> 4];
 		dst_line3[2].A = (alpha7 & 0x0f) | (alpha7 << 4);
-		dst_line3[3] = colormap[indices3 >> 6];
+		dst_line3[3] = colormap[colori3 >> 6];
 		dst_line3[3].A = (alpha7 & 0xf0) | (alpha7 >> 4);
+
+		data += 16;
+		dst_argb += 16;
+	}
+}
+
+// DXT5 info : http://www.matejtomcik.com/Public/KnowHow/DXTDecompression/
+void ____DXT5ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
+	int dst_pitch = *(int*)dst_argb; // dirty hack to avoid another argument
+	int x;
+	for (x = 0; x < width; x += 4) {
+		// Read two 8-bit alphas
+		uint8 alphamap[8];
+		alphamap[0] = data[0];
+		alphamap[1] = data[1];
+
+		// Build rest of alpha map
+		if (alphamap[0] > alphamap[1]) {
+			alphamap[2] = (6 * alphamap[0] + 1 * alphamap[1] + 6) / 7;
+			alphamap[3] = (5 * alphamap[0] + 2 * alphamap[1] + 6) / 7;
+			alphamap[4] = (4 * alphamap[0] + 3 * alphamap[1] + 6) / 7;
+			alphamap[5] = (3 * alphamap[0] + 4 * alphamap[1] + 6) / 7;
+			alphamap[6] = (2 * alphamap[0] + 5 * alphamap[1] + 6) / 7;
+			alphamap[7] = (1 * alphamap[0] + 6 * alphamap[1] + 6) / 7;
+		}
+		else {
+			alphamap[2] = (4 * alphamap[0] + 1 * alphamap[1] + 4) / 5;
+			alphamap[3] = (3 * alphamap[0] + 2 * alphamap[1] + 4) / 5;
+			alphamap[4] = (2 * alphamap[0] + 3 * alphamap[1] + 4) / 5;
+			alphamap[5] = (1 * alphamap[0] + 4 * alphamap[1] + 4) / 5;
+			alphamap[6] = 0u;
+			alphamap[7] = 255u;
+		}
+
+		// Read 6 bytes worth of 3-bit alpha channal indices for 16 pixels
+		uint8 alphai0 = data[2];
+		uint8 alphai1 = data[3];
+		uint8 alphai2 = data[4];
+		uint8 alphai3 = data[5];
+		uint8 alphai4 = data[6];
+		uint8 alphai5 = data[7];
+
+		// Read two 16-bit colors
+		uint16 color_0 = data[8] | (data[9] << 8);
+		uint16 color_1 = data[10] | (data[11] << 8);
+
+		// Read 5+6+5 bit color channels
+		uint8 b0 = color_0 & 0x1f;
+		uint8 g0 = (color_0 >> 5) & 0x3f;
+		uint8 r0 = color_0 >> 11;
+
+		uint8 b1 = color_1 & 0x1f;
+		uint8 g1 = (color_1 >> 5) & 0x3f;
+		uint8 r1 = color_1 >> 11;
+
+		// Build first half of RGB32 color map (converting 5+6+5 to 8+8+8):
+		TRGB32 colormap[4];
+		colormap[0].B = (b0 << 3) | (b0 >> 2);
+		colormap[0].G = (g0 << 2) | (g0 >> 4);
+		colormap[0].R = (r0 << 3) | (r0 >> 2);
+
+		colormap[1].B = (b1 << 3) | (b1 >> 2);
+		colormap[1].G = (g1 << 2) | (g1 >> 4);
+		colormap[1].R = (r1 << 3) | (r1 >> 2);
+
+		// Build second half of RGB32 color map :
+		// Make up new color : 2/3 A + 1/3 B :
+		colormap[2].B = (uint8)((2 * colormap[0].B + 1 * colormap[1].B + 2) / 3);
+		colormap[2].G = (uint8)((2 * colormap[0].G + 1 * colormap[1].G + 2) / 3);
+		colormap[2].R = (uint8)((2 * colormap[0].R + 1 * colormap[1].R + 2) / 3);
+		// Make up new color : 1/3 A + 2/3 B :
+		colormap[3].B = (uint8)((1 * colormap[0].B + 2 * colormap[1].B + 2) / 3);
+		colormap[3].G = (uint8)((1 * colormap[0].G + 2 * colormap[1].G + 2) / 3);
+		colormap[3].R = (uint8)((1 * colormap[0].R + 2 * colormap[1].R + 2) / 3);
+
+		// Read 4 bytes worth of 2-bit color indices for 16 pixels
+		uint8 colori0 = data[12];
+		uint8 colori1 = data[13];
+		uint8 colori2 = data[14];
+		uint8 colori3 = data[15];
+
+		TRGB32 *dst_line0 = (TRGB32*)(dst_argb);
+		TRGB32 *dst_line1 = (TRGB32*)(dst_argb + dst_pitch);
+		TRGB32 *dst_line2 = (TRGB32*)(dst_argb + dst_pitch * 2);
+		TRGB32 *dst_line3 = (TRGB32*)(dst_argb + dst_pitch * 3);
+
+		dst_line0[0] = colormap[colori0 & 0x03];
+		dst_line0[0].A = alphamap[alphai0 & 0x07];
+		dst_line0[1] = colormap[(colori0 & 0x0c) >> 2];
+		dst_line0[1].A = alphamap[(alphai0 & 0x38 >> 3)];
+		dst_line0[2] = colormap[(colori0 & 0x30) >> 4];
+		dst_line0[2].A = alphamap[((alphai0 & 0xc0) >> 6) | (alphai1 & 0x01)];
+		dst_line0[3] = colormap[colori0 >> 6];
+		dst_line0[3].A = alphamap[(alphai1 & 0x0e) >> 1];
+
+		dst_line1[0] = colormap[colori1 & 0x03];
+		dst_line1[0].A = alphamap[(alphai1 & 0x70) >> 4];
+		dst_line1[1] = colormap[(colori1 & 0x0c) >> 2];
+		dst_line1[1].A = alphamap[((alphai1 & 0x80) >> 7) | ((alphai2 & 0x03) << 1)];
+		dst_line1[2] = colormap[(colori1 & 0x30) >> 4];
+		dst_line1[2].A = alphamap[(alphai2 & 0x1c) >> 2];
+		dst_line1[3] = colormap[colori1 >> 6];
+		dst_line1[3].A = alphamap[(alphai2 & 0xe0) >> 5];
+
+		dst_line2[0] = colormap[colori2 & 0x03];
+		dst_line2[0].A = alphamap[alphai3 & 0x07];
+		dst_line2[1] = colormap[(colori2 & 0x0c) >> 2];
+		dst_line2[1].A = alphamap[(alphai3 & 0x38 >> 3)];
+		dst_line2[2] = colormap[(colori2 & 0x30) >> 4];
+		dst_line2[2].A = alphamap[((alphai3 & 0xc0) >> 6) | (alphai4 & 0x01)];
+		dst_line2[3] = colormap[colori2 >> 6];
+		dst_line2[3].A = alphamap[(alphai4 & 0x0e) >> 1];
+
+		dst_line3[0] = colormap[colori3 & 0x03];
+		dst_line3[0].A = alphamap[(alphai4 & 0x70) >> 4];
+		dst_line3[1] = colormap[(colori3 & 0x0c) >> 2];
+		dst_line3[1].A = alphamap[((alphai4 & 0x80) >> 7) | ((alphai5 & 0x03) << 1)];
+		dst_line3[2] = colormap[(colori3 & 0x30) >> 4];
+		dst_line3[2].A = alphamap[(alphai5 & 0x1c) >> 2];
+		dst_line3[3] = colormap[colori3 >> 6];
+		dst_line3[3].A = alphamap[(alphai5 & 0xe0) >> 5];
 
 		data += 16;
 		dst_argb += 16;
@@ -611,7 +733,7 @@ static const XTL::FormatToARGBRow ComponentConverters[] = {
 	____A8L8ToARGBRow_C, // ____A8L8, // NOTE : R=G=B= L
 	____DXT1ToARGBRow_C, // ____DXT1
 	____DXT3ToARGBRow_C, // ____DXT3
-	____DXT3ToARGBRow_C, // ____DXT5 TODO
+	____DXT5ToARGBRow_C, // ____DXT5
 
 };
 

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -475,7 +475,7 @@ void ____DXT1ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 
 		dst_line2[0] = colormap[indices2 & 0x03];
 		dst_line2[1] = colormap[(indices2 & 0x0c) >> 2];
-		dst_line2[2] = colormap[(indices2 & 0x30) >> 4]
+		dst_line2[2] = colormap[(indices2 & 0x30) >> 4];
 
 		dst_line2[3] = colormap[indices2 >> 6];
 

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -434,9 +434,9 @@ void ____DXT1ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 			colormap[2].R = (uint8)((2 * colormap[0].R + colormap[1].R + 2) / 3);
 			colormap[2].A = 255u;
 			// Make up new color : 1/3 A + 2/3 B :
-			colormap[3].B = 255u - colormap[2].B;
-			colormap[3].G = 255u - colormap[2].G;
-			colormap[3].R = 255u - colormap[2].R;
+			colormap[3].B = (uint8)((2 * colormap[1].B + colormap[0].B + 2) / 3);
+			colormap[3].G = (uint8)((2 * colormap[1].G + colormap[0].G + 2) / 3);
+			colormap[3].R = (uint8)((2 * colormap[1].R + colormap[0].R + 2) / 3);
 			colormap[3].A = 255u;
 		}
 		else
@@ -533,9 +533,9 @@ void ____DXT3ToARGBRow_C(const uint8* data, uint8* dst_argb, int width) {
 		colormap[2].G = (uint8)((2 * colormap[0].G + colormap[1].G + 2) / 3);
 		colormap[2].R = (uint8)((2 * colormap[0].R + colormap[1].R + 2) / 3);
 		// Make up new color : 1/3 A + 2/3 B :
-		colormap[3].B = 255u - colormap[2].B;
-		colormap[3].G = 255u - colormap[2].G;
-		colormap[3].R = 255u - colormap[2].R;
+		colormap[3].B = (uint8)((colormap[0].B + 2 * colormap[1].B + 2) / 3);
+		colormap[3].G = (uint8)((colormap[0].G + 2 * colormap[1].G + 2) / 3);
+		colormap[3].R = (uint8)((colormap[0].R + 2 * colormap[1].R + 2) / 3);
 
 		uint8 indices0 = data[12];
 		uint8 indices1 = data[13];

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -36,10 +36,13 @@
 
 #include "CxbxKrnl.h"
 
+#define OLD_COLOR_CONVERSION
+
 // simple render state encoding lookup table
 #define X_D3DRSSE_UNK 0x7fffffff
 extern CONST DWORD EmuD3DRenderStateSimpleEncoded[174];
 
+#ifdef OLD_COLOR_CONVERSION
 typedef struct _ComponentEncodingInfo
 {
 	int8_t ABits, RBits, GBits, BBits;
@@ -49,6 +52,11 @@ typedef struct _ComponentEncodingInfo
 extern const ComponentEncodingInfo *EmuXBFormatComponentEncodingInfo(X_D3DFORMAT Format);
 
 extern D3DCOLOR DecodeUInt32ToColor(const ComponentEncodingInfo * encoding, const uint32 value);
+#endif // OLD_COLOR_CONVERSION
+
+typedef void(*FormatToARGBRow)(const uint8* src, uint8* dst_argb, int width);
+
+extern const FormatToARGBRow EmuXBFormatComponentConverter(X_D3DFORMAT Format);
 
 bool EmuXBFormatRequiresConversionToARGB(X_D3DFORMAT Format);
 


### PR DESCRIPTION
This adds the following :
* fixed loading of XPR logo's that use a non-default alignment
* added loading of DDS logo's
* beginnings of generic, libyuv-like row-based texture decoding
* support for decoding DXT1, DXT3 and DXT5 to ARGB
* various fixes