### PR TITLE
NV2A/CreateDevice (The function, not the XDK sample) can now run Unpatched

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -880,6 +880,9 @@ void CxbxKrnlInit
 
 	EmuHLEIntercept(pXbeHeader);
 
+	// Always initialise NV2A: We may need it for disabled HLE patches too!
+	EmuNV2A_Init();
+
 	if (bLLE_GPU)
 	{
 		DbgPrintf("EmuMain: Initializing OpenGL.\n");

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -237,7 +237,7 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 {
 	// First, try to open an existing memory.bin file :
 	HANDLE hFile = CreateFile(szFilePath_memory_bin,
-		GENERIC_READ | GENERIC_WRITE,
+		GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE, 
 		FILE_SHARE_READ | FILE_SHARE_WRITE,
 		/* lpSecurityAttributes */nullptr,
 		OPEN_EXISTING,
@@ -249,7 +249,7 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 	{
 		// If the memory.bin file doesn't exist yet, create it :
 		hFile = CreateFile(szFilePath_memory_bin,
-			GENERIC_READ | GENERIC_WRITE,
+			GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE,
 			FILE_SHARE_READ | FILE_SHARE_WRITE,
 			/* lpSecurityAttributes */nullptr,
 			OPEN_ALWAYS,
@@ -267,7 +267,7 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 	HANDLE hFileMapping = CreateFileMapping(
 		hFile,
 		/* lpFileMappingAttributes */nullptr,
-		PAGE_READWRITE,
+		PAGE_EXECUTE_READWRITE,
 		/* dwMaximumSizeHigh */0,
 		/* dwMaximumSizeLow */CONTIGUOUS_MEMORY_SIZE,
 		/**/nullptr);
@@ -280,7 +280,7 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 	// Map memory.bin contents into memory :
 	void *memory = (void *)MapViewOfFileEx(
 		hFileMapping,
-		FILE_MAP_READ | FILE_MAP_WRITE,
+		FILE_MAP_READ | FILE_MAP_WRITE | FILE_MAP_EXECUTE,
 		/* dwFileOffsetHigh */0,
 		/* dwFileOffsetLow */0,
 		CONTIGUOUS_MEMORY_SIZE,
@@ -302,7 +302,7 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 	// Map memory.bin contents into tiled memory too :
 	void *tiled_memory = (void *)MapViewOfFileEx(
 		hFileMapping,
-		FILE_MAP_READ | FILE_MAP_WRITE,
+		FILE_MAP_READ | FILE_MAP_WRITE | FILE_MAP_EXECUTE,
 		/* dwFileOffsetHigh */0,
 		/* dwFileOffsetLow */0,
 		CONTIGUOUS_MEMORY_SIZE,

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -320,7 +320,7 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 
 #pragma optimize("", off)
 
-void CxbxPopupMessage(const char *message)
+void CxbxPopupMessage(char *message)
 {
 	DbgPrintf("Popup : %s\n", message);
 	MessageBox(NULL, message, "Cxbx-Reloaded", MB_OK | MB_ICONEXCLAMATION);

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -121,7 +121,7 @@ typedef uint32 xbaddr;
 #define VECTOR2IRQ(vector)  ((vector)-IRQ_BASE)
 #define VECTOR2IRQL(vector) (PROFILE_LEVEL - VECTOR2IRQ(vector))
 
-void CxbxPopupMessage(const char *message);
+void CxbxPopupMessage(char *message);
 
 extern Xbe::Certificate *g_pCertificate;
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4864,7 +4864,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexDataColor)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_End)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC();
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -58,6 +58,7 @@ namespace xboxkrnl
 #include "HLEDatabase.h"
 #include "Logging.h"
 #include "EmuD3D8Logging.h"
+#include "HLEIntercept.h" // for bLLE_GPU
 
 #include <assert.h>
 #include <process.h>
@@ -1451,7 +1452,7 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
     return D3D_OK; // = 0
 }
 
-static clock_t GetNextVBlankTime()
+clock_t GetNextVBlankTime()
 {
 	// TODO: Read display frequency from Xbox Display Adapter
 	// This is accessed by calling CMiniport::GetRefreshRate(); 
@@ -1525,7 +1526,8 @@ static DWORD WINAPI EmuUpdateTickCount(LPVOID)
 		// If VBlank Interval has passed, trigger VBlank callback
         // Note: This whole code block can be removed once NV2A interrupts are implemented
 		// Once that is in place, MiniPort + Direct3D will handle this on it's own!
-		if (clock() > nextVBlankTime)
+		// We check for LLE flag as NV2A handles it's own VBLANK if LLE is enabled!
+		if (!(bLLE_GPU) && clock() > nextVBlankTime)
         {
 			nextVBlankTime = GetNextVBlankTime();
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2745,7 +2745,7 @@ VOID WINAPI XTL::EMUPATCH(D3D_KickOffAndWaitForIdle)()
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3D_KickOffAndWaitForIdle2)(DWORD dwDummy1, DWORD dwDummy2)
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(dwDummy1)
@@ -2792,7 +2792,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetGammaRamp)
 // ******************************************************************
 ULONG WINAPI XTL::EMUPATCH(D3DDevice_AddRef)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC();
 
@@ -3229,7 +3229,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_Reset)
     X_D3DPRESENT_PARAMETERS *pPresentationParameters
 )
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC_ONE_ARG(pPresentationParameters);
 
@@ -6482,7 +6482,7 @@ VOID WINAPI XTL::EMUPATCH(D3DCubeTexture_LockRect)
 // ******************************************************************
 ULONG WINAPI XTL::EMUPATCH(D3DDevice_Release)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC();
 
@@ -9522,7 +9522,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_KickOff)()
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_KickPushBuffer)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC();
 
@@ -9870,7 +9870,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_BeginPushBuffer)
 	X_D3DPushBuffer *pPushBuffer
 )
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC_ONE_ARG(pPushBuffer);
 
@@ -9887,7 +9887,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_BeginPushBuffer)
 // ******************************************************************
 HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndPushBuffer)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC();
 
@@ -9901,7 +9901,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndPushBuffer)()
 // ******************************************************************
 PDWORD WINAPI XTL::EMUPATCH(XMETAL_StartPush)(void* Unknown)
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC_ONE_ARG(Unknown);
 
@@ -9990,7 +9990,7 @@ PDWORD WINAPI XTL::EMUPATCH(D3D_MakeRequestedSpace)
 	DWORD RequestedSpace
 )
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(MinimumSpace)
@@ -10090,7 +10090,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetPushBufferOffset)
 	DWORD *pOffset
 )
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC_ONE_ARG(pOffset);
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2227,7 +2227,7 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice)
     IDirect3DDevice8          **ppReturnedDeviceInterface
 )
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Adapter)
@@ -2724,7 +2724,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShader)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3D_KickOffAndWaitForIdle)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC();
 
@@ -9495,7 +9495,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetProjectionViewportMatrix)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_KickOff)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 		
 	LOG_FUNC();
 

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -107,7 +107,6 @@ XBSYSAPI EXPORTNUM(38) xboxkrnl::VOID FASTCALL xboxkrnl::HalClearSoftwareInterru
 )
 {
 	LOG_FUNC_ONE_ARG(Request);
-
 	LOG_UNIMPLEMENTED();
 }
 

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -43,6 +43,7 @@
 #define _XBOXKRNL_DEFEXTRN_
 
 #include <process.h> // For __beginthreadex(), etc.
+#include "vga.h"
 
 // prevent name collisions
 namespace xboxkrnl
@@ -390,6 +391,12 @@ struct {
 struct {
 	ChannelControl channel_control[NV2A_NUM_CHANNELS];
 } user;
+
+// PRMCIO (Actually the VGA controller)
+struct {
+	uint8_t cr_index;
+	uint8_t cr[256]; /* CRT registers */
+} prmcio;
 
 struct {
 	std::mutex mutex;
@@ -819,6 +826,25 @@ DEBUG_START(PCRTC)
 DEBUG_END(PCRTC)
 
 DEBUG_START(PRMCIO)
+	DEBUG_CASE(VGA_CRT_DC);
+	DEBUG_CASE(VGA_CRT_DM);
+	DEBUG_CASE(VGA_ATT_R);
+	DEBUG_CASE(VGA_ATT_W);
+	DEBUG_CASE(VGA_GFX_D);
+	DEBUG_CASE(VGA_SEQ_D);
+	DEBUG_CASE(VGA_MIS_R);
+	DEBUG_CASE(VGA_MIS_W);
+	DEBUG_CASE(VGA_FTC_R);
+	DEBUG_CASE(VGA_IS1_RC);
+	DEBUG_CASE(VGA_IS1_RM);
+	DEBUG_CASE(VGA_PEL_D);
+	DEBUG_CASE(VGA_PEL_MSK);
+	DEBUG_CASE(VGA_CRT_IC);
+	DEBUG_CASE(VGA_CRT_IM);
+	DEBUG_CASE(VGA_GFX_I);
+	DEBUG_CASE(VGA_SEQ_I);
+	DEBUG_CASE(VGA_PEL_IW);
+	DEBUG_CASE(VGA_PEL_IR);
 DEBUG_END(PRMCIO)
 
 DEBUG_START(PRAMDAC)
@@ -2952,8 +2978,19 @@ DEVICE_WRITE32(PCRTC)
 DEVICE_READ32(PRMCIO)
 {
 	DEVICE_READ32_SWITCH() {
+	case VGA_CRT_IM:
+	case VGA_CRT_IC:
+		result = prmcio.cr_index;
+		break;
+	case VGA_CRT_DM:
+	case VGA_CRT_DC:
+		result = prmcio.cr[prmcio.cr_index];
+	
+		printf("vga: read CR%x = 0x%02x\n", prmcio.cr_index, result);
+		break;
 	default:
 		DEBUG_READ32_UNHANDLED(PRMCIO);
+		printf("vga: UNHANDLED ADDR %s\n", addr);
 		break;
 	}
 
@@ -2963,6 +3000,44 @@ DEVICE_READ32(PRMCIO)
 DEVICE_WRITE32(PRMCIO)
 {
 	switch (addr) {
+	case VGA_CRT_IM:
+	case VGA_CRT_IC:
+		prmcio.cr_index = value;
+		break;
+	case VGA_CRT_DM:
+	case VGA_CRT_DC:
+		printf("vga: write CR%x = 0x%02x\n", prmcio.cr_index, value);
+
+		/* handle CR0-7 protection */
+		if ((prmcio.cr[VGA_CRTC_V_SYNC_END] & VGA_CR11_LOCK_CR0_CR7) &&
+			prmcio.cr_index <= VGA_CRTC_OVERFLOW) {
+			/* can always write bit 4 of CR7 */
+			if (prmcio.cr_index == VGA_CRTC_OVERFLOW) {
+				prmcio.cr[VGA_CRTC_OVERFLOW] = (prmcio.cr[VGA_CRTC_OVERFLOW] & ~0x10) |
+					(value & 0x10);
+				EmuWarning("TODO: vbe_update_vgaregs");
+				//vbe_update_vgaregs();
+			}
+			return;
+		}
+
+		prmcio.cr[prmcio.cr_index] = value;
+		EmuWarning("TODO: vbe_update_vgaregs");
+		//vbe_update_vgaregs();
+
+		switch (prmcio.cr_index) {
+			case VGA_CRTC_H_TOTAL:
+			case VGA_CRTC_H_SYNC_START:
+			case VGA_CRTC_H_SYNC_END:
+			case VGA_CRTC_V_TOTAL:
+			case VGA_CRTC_OVERFLOW:
+			case VGA_CRTC_V_SYNC_END:
+			case VGA_CRTC_MODE:
+				// TODO: s->update_retrace_info(s);
+				EmuWarning("TODO: update_retrace_info");
+				break;
+			}
+		break;
 	default:
 		DEBUG_WRITE32_UNHANDLED(PRMCIO); // TODO : DEVICE_WRITE32_REG(prmcio);
 		break;

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -1170,6 +1170,8 @@ static void pgraph_method_log(unsigned int subchannel,	unsigned int graphics_cla
 
 static void pgraph_method(unsigned int subchannel,	unsigned int method, uint32_t parameter)
 {
+	std::lock_guard<std::mutex> lk(pgraph.mutex);
+
 	int i;
 	GraphicsSubchannel *subchannel_data;
 	GraphicsObject *object;
@@ -1213,8 +1215,6 @@ static void* pfifo_puller_thread()
 		}
 
 		printf("Cache is not empty! \n");
-
-		std::lock_guard<std::mutex> lk(pgraph.mutex);
 
 		while (!state->working_cache.empty()) {
 			CacheEntry* command = state->working_cache.front();

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -1523,23 +1523,6 @@ static void pgraph_method(unsigned int subchannel, unsigned int method, uint32_t
 
 			pgraph.surface_zeta.offset = parameter;
 			break;
-		// TODO: Is there a better way to do this?
-		// MSVC doesn't support GCC's case_range extention
-		// this prevents use of NV097_SET_COMBINER_ALPHA_ICW ... NV097_SET_COMBINER_ALPHA_ICW + 28
-		// Investigated making a macro, but doesn't seem possible to do a variable number of results
-		case NV097_SET_COMBINER_ALPHA_ICW: case NV097_SET_COMBINER_ALPHA_ICW + 1: case NV097_SET_COMBINER_ALPHA_ICW + 2:
-		case NV097_SET_COMBINER_ALPHA_ICW + 3:	case NV097_SET_COMBINER_ALPHA_ICW + 4:	case NV097_SET_COMBINER_ALPHA_ICW + 5:
-		case NV097_SET_COMBINER_ALPHA_ICW + 6:	case NV097_SET_COMBINER_ALPHA_ICW + 7:	case NV097_SET_COMBINER_ALPHA_ICW + 8:
-		case NV097_SET_COMBINER_ALPHA_ICW + 9:	case NV097_SET_COMBINER_ALPHA_ICW + 10:	case NV097_SET_COMBINER_ALPHA_ICW + 11:
-		case NV097_SET_COMBINER_ALPHA_ICW + 12:	case NV097_SET_COMBINER_ALPHA_ICW + 13:	case NV097_SET_COMBINER_ALPHA_ICW + 14:
-		case NV097_SET_COMBINER_ALPHA_ICW + 15:	case NV097_SET_COMBINER_ALPHA_ICW + 16:	case NV097_SET_COMBINER_ALPHA_ICW + 17:
-		case NV097_SET_COMBINER_ALPHA_ICW + 18:	case NV097_SET_COMBINER_ALPHA_ICW + 19:	case NV097_SET_COMBINER_ALPHA_ICW + 20:
-		case NV097_SET_COMBINER_ALPHA_ICW + 21:	case NV097_SET_COMBINER_ALPHA_ICW + 22:	case NV097_SET_COMBINER_ALPHA_ICW + 23:
-		case NV097_SET_COMBINER_ALPHA_ICW + 24:	case NV097_SET_COMBINER_ALPHA_ICW + 25:	case NV097_SET_COMBINER_ALPHA_ICW + 26:
-		case NV097_SET_COMBINER_ALPHA_ICW + 27:	case NV097_SET_COMBINER_ALPHA_ICW + 28:
-				slot = (method - NV097_SET_COMBINER_ALPHA_ICW) / 4;
-				pgraph.regs[NV_PGRAPH_COMBINEALPHAI0 + slot * 4] = parameter;
-				break;
 		case NV097_SET_COMBINER_SPECULAR_FOG_CW0:
 			pgraph.regs[NV_PGRAPH_COMBINESPECFOG0] = parameter;
 			break;
@@ -1934,48 +1917,189 @@ static void pgraph_method(unsigned int subchannel, unsigned int method, uint32_t
 				parameter);
 			break;
 
-			CASE_4(NV097_SET_TEXGEN_S, 16) : {
-				slot = (method - NV097_SET_TEXGEN_S) / 16;
-				unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
-					: NV_PGRAPH_CSV1_B;
-				unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_S
-					: NV_PGRAPH_CSV1_A_T0_S;
-				SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 0));
-				break;
-			}
-			CASE_4(NV097_SET_TEXGEN_T, 16) : {
-				slot = (method - NV097_SET_TEXGEN_T) / 16;
-				unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
-					: NV_PGRAPH_CSV1_B;
-				unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_T
-					: NV_PGRAPH_CSV1_A_T0_T;
-				SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 1));
-				break;
-			}
-			CASE_4(NV097_SET_TEXGEN_R, 16) : {
-				slot = (method - NV097_SET_TEXGEN_R) / 16;
-				unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
-					: NV_PGRAPH_CSV1_B;
-				unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_R
-					: NV_PGRAPH_CSV1_A_T0_R;
-				SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 2));
-				break;
-			}
-			CASE_4(NV097_SET_TEXGEN_Q, 16) : {
-				slot = (method - NV097_SET_TEXGEN_Q) / 16;
-				unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
-					: NV_PGRAPH_CSV1_B;
-				unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_Q
-					: NV_PGRAPH_CSV1_A_T0_Q;
-				SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 3));
-				break;
-			}
-			CASE_4(NV097_SET_TEXTURE_MATRIX_ENABLE, 4) :
-				slot = (method - NV097_SET_TEXTURE_MATRIX_ENABLE) / 4;
-			pgraph.texture_matrix_enable[slot] = parameter;
+		CASE_4(NV097_SET_TEXGEN_S, 16) : {
+			slot = (method - NV097_SET_TEXGEN_S) / 16;
+			unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
+				: NV_PGRAPH_CSV1_B;
+			unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_S
+				: NV_PGRAPH_CSV1_A_T0_S;
+			SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 0));
 			break;
+		}
+		CASE_4(NV097_SET_TEXGEN_T, 16) : {
+			slot = (method - NV097_SET_TEXGEN_T) / 16;
+			unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
+				: NV_PGRAPH_CSV1_B;
+			unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_T
+				: NV_PGRAPH_CSV1_A_T0_T;
+			SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 1));
+			break;
+		}
+		CASE_4(NV097_SET_TEXGEN_R, 16) : {
+			slot = (method - NV097_SET_TEXGEN_R) / 16;
+			unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
+				: NV_PGRAPH_CSV1_B;
+			unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_R
+				: NV_PGRAPH_CSV1_A_T0_R;
+			SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 2));
+			break;
+		}
+		CASE_4(NV097_SET_TEXGEN_Q, 16) : {
+			slot = (method - NV097_SET_TEXGEN_Q) / 16;
+			unsigned int reg = (slot < 2) ? NV_PGRAPH_CSV1_A
+				: NV_PGRAPH_CSV1_B;
+			unsigned int mask = (slot % 2) ? NV_PGRAPH_CSV1_A_T1_Q
+				: NV_PGRAPH_CSV1_A_T0_Q;
+			SET_MASK(pgraph.regs[reg], mask, kelvin_map_texgen(parameter, 3));
+			break;
+		}
+		CASE_4(NV097_SET_TEXTURE_MATRIX_ENABLE, 4) :
+			slot = (method - NV097_SET_TEXTURE_MATRIX_ENABLE) / 4;
+		pgraph.texture_matrix_enable[slot] = parameter;
+		break;
 
+		case NV097_SET_TEXGEN_VIEW_MODEL:
+			SET_MASK(pgraph.regs[NV_PGRAPH_CSV0_D], NV_PGRAPH_CSV0_D_TEXGEN_REF, parameter);
+			break;
 		default:
+			if (method >= NV097_SET_COMBINER_ALPHA_ICW && method <= NV097_SET_COMBINER_ALPHA_ICW + 28) {
+				slot = (method - NV097_SET_COMBINER_ALPHA_ICW) / 4;
+				pgraph.regs[NV_PGRAPH_COMBINEALPHAI0 + slot * 4] = parameter;
+				break;
+			}
+
+			if (method >= NV097_SET_PROJECTION_MATRIX && method <= NV097_SET_PROJECTION_MATRIX + 0x3c) {
+				slot = (method - NV097_SET_PROJECTION_MATRIX) / 4;
+				// pg->projection_matrix[slot] = *(float*)&parameter;
+				unsigned int row = NV_IGRAPH_XF_XFCTX_PMAT0 + slot / 4;
+				pgraph.vsh_constants[row][slot % 4] = parameter;
+				pgraph.vsh_constants_dirty[row] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_MODEL_VIEW_MATRIX && method <= NV097_SET_MODEL_VIEW_MATRIX + 0xfc) {
+				slot = (method - NV097_SET_MODEL_VIEW_MATRIX) / 4;
+				unsigned int matnum = slot / 16;
+				unsigned int entry = slot % 16;
+				unsigned int row = NV_IGRAPH_XF_XFCTX_MMAT0 + matnum * 8 + entry / 4;
+				pgraph.vsh_constants[row][entry % 4] = parameter;
+				pgraph.vsh_constants_dirty[row] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_INVERSE_MODEL_VIEW_MATRIX && method <= NV097_SET_INVERSE_MODEL_VIEW_MATRIX + 0xfc) {
+				slot = (method - NV097_SET_INVERSE_MODEL_VIEW_MATRIX) / 4;
+				unsigned int matnum = slot / 16;
+				unsigned int entry = slot % 16;
+				unsigned int row = NV_IGRAPH_XF_XFCTX_IMMAT0 + matnum * 8 + entry / 4;
+				pgraph.vsh_constants[row][entry % 4] = parameter;
+				pgraph.vsh_constants_dirty[row] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_COMPOSITE_MATRIX && method <= NV097_SET_COMPOSITE_MATRIX + 0x3c) {
+				slot = (method - NV097_SET_COMPOSITE_MATRIX) / 4;
+				unsigned int row = NV_IGRAPH_XF_XFCTX_CMAT0 + slot / 4;
+				pgraph.vsh_constants[row][slot % 4] = parameter;
+				pgraph.vsh_constants_dirty[row] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_TEXTURE_MATRIX && method <= NV097_SET_TEXTURE_MATRIX + 0xfc) {
+				slot = (method - NV097_SET_TEXTURE_MATRIX) / 4;
+				unsigned int tex = slot / 16;
+				unsigned int entry = slot % 16;
+				unsigned int row = NV_IGRAPH_XF_XFCTX_T0MAT + tex * 8 + entry / 4;
+				pgraph.vsh_constants[row][entry % 4] = parameter;
+				pgraph.vsh_constants_dirty[row] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_FOG_PARAMS && method <= NV097_SET_FOG_PARAMS + 8) {
+				slot = (method - NV097_SET_FOG_PARAMS) / 4;
+				if (slot < 2) {
+					pgraph.regs[NV_PGRAPH_FOGPARAM0 + slot * 4] = parameter;
+				}
+				else {
+					/* FIXME: No idea where slot = 2 is */
+				}
+
+				pgraph.ltctxa[NV_IGRAPH_XF_LTCTXA_FOG_K][slot] = parameter;
+				pgraph.ltctxa_dirty[NV_IGRAPH_XF_LTCTXA_FOG_K] = true;
+				break;
+			}
+				
+			/* Handles NV097_SET_TEXGEN_PLANE_S,T,R,Q */
+			if (method >= NV097_SET_TEXGEN_PLANE_S && method <=	NV097_SET_TEXGEN_PLANE_S + 0xfc) {
+				slot = (method - NV097_SET_TEXGEN_PLANE_S) / 4;
+				unsigned int tex = slot / 16;
+				unsigned int entry = slot % 16;
+				unsigned int row = NV_IGRAPH_XF_XFCTX_TG0MAT + tex * 8 + entry / 4;
+				pgraph.vsh_constants[row][entry % 4] = parameter;
+				pgraph.vsh_constants_dirty[row] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_FOG_PLANE && method <= NV097_SET_FOG_PLANE + 12) {
+				slot = (method - NV097_SET_FOG_PLANE) / 4;
+				pgraph.vsh_constants[NV_IGRAPH_XF_XFCTX_FOG][slot] = parameter;
+				pgraph.vsh_constants_dirty[NV_IGRAPH_XF_XFCTX_FOG] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_SCENE_AMBIENT_COLOR && method <= NV097_SET_SCENE_AMBIENT_COLOR + 8) {
+				slot = (method - NV097_SET_SCENE_AMBIENT_COLOR) / 4;
+				// ??
+				pgraph.ltctxa[NV_IGRAPH_XF_LTCTXA_FR_AMB][slot] = parameter;
+				pgraph.ltctxa_dirty[NV_IGRAPH_XF_LTCTXA_FR_AMB] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_VIEWPORT_OFFSET && method <= NV097_SET_VIEWPORT_OFFSET + 12) {
+				slot = (method - NV097_SET_VIEWPORT_OFFSET) / 4;
+				pgraph.vsh_constants[NV_IGRAPH_XF_XFCTX_VPOFF][slot] = parameter;
+				pgraph.vsh_constants_dirty[NV_IGRAPH_XF_XFCTX_VPOFF] = true;
+				break; 
+			}
+
+			if (method >= NV097_SET_EYE_POSITION  && method <= NV097_SET_EYE_POSITION + 12) {
+				slot = (method - NV097_SET_EYE_POSITION) / 4;
+				pgraph.vsh_constants[NV_IGRAPH_XF_XFCTX_EYEP][slot] = parameter;
+				pgraph.vsh_constants_dirty[NV_IGRAPH_XF_XFCTX_EYEP] = true;
+				break;
+			}
+
+			if (method >= NV097_SET_COMBINER_FACTOR0 && method <= NV097_SET_COMBINER_FACTOR0 + 28) {
+				slot = (method - NV097_SET_COMBINER_FACTOR0) / 4;
+				pgraph.regs[NV_PGRAPH_COMBINEFACTOR0 + slot * 4] = parameter;
+				break;
+			}
+
+			if (method >= NV097_SET_COMBINER_FACTOR1 && method <= NV097_SET_COMBINER_FACTOR1 + 28) {
+				slot = (method - NV097_SET_COMBINER_FACTOR1) / 4;
+				pgraph.regs[NV_PGRAPH_COMBINEFACTOR1 + slot * 4] = parameter;
+				break;
+			}
+
+			if (method >= NV097_SET_COMBINER_ALPHA_OCW && method <= NV097_SET_COMBINER_ALPHA_OCW + 28) {
+				slot = (method - NV097_SET_COMBINER_ALPHA_OCW) / 4;
+				pgraph.regs[NV_PGRAPH_COMBINEALPHAO0 + slot * 4] = parameter;
+				break;
+			}
+
+			if (method >= NV097_SET_COMBINER_COLOR_ICW && method <= NV097_SET_COMBINER_COLOR_ICW + 28) {
+				slot = (method - NV097_SET_COMBINER_COLOR_ICW) / 4;
+				pgraph.regs[NV_PGRAPH_COMBINECOLORI0 + slot * 4] = parameter;
+				break;
+			}
+
+			if (method >= NV097_SET_VIEWPORT_SCALE && method <= NV097_SET_VIEWPORT_SCALE + 12) {
+				slot = (method - NV097_SET_VIEWPORT_SCALE) / 4;
+				pgraph.vsh_constants[NV_IGRAPH_XF_XFCTX_VPSCL][slot] = parameter;
+				pgraph.vsh_constants_dirty[NV_IGRAPH_XF_XFCTX_VPSCL] = true;
+				break;
+			}
+
 			EmuWarning("EmuNV2A: Unknown NV_KELVIN_PRIMITIVE Method: 0x%08X\n", method);
 		}
 		break;

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -2690,9 +2690,8 @@ void EmuNV2A_Init()
 	pramdac.memory_clock_coeff = 0;
 	pramdac.video_clock_coeff = 0x0003C20D; /* 25182Khz...? */
 
-	MessageBoxA(NULL, "TEST", "TEST", 0);
 	pfifo.puller_thread = std::thread(pfifo_puller_thread);
-
+	
 	vblank_thread = std::thread(nv2a_vblank_thread);
 
 	// Start an Xbox Thread for Interrupt Processing!

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -3720,14 +3720,14 @@ void InitOpenGLContext()
 // HACK: Until we implement VGA/proper interrupt generation
 // we simulate VBLANK by calling the interrupt at 60Hz
 std::thread vblank_thread;
-extern clock_t GetNextVBlankTime();
+extern std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double, std::nano>> GetNextVBlankTime();
 static void nv2a_vblank_thread()
 {
-	clock_t nextVBlankTime = GetNextVBlankTime();
+	auto nextVBlankTime = GetNextVBlankTime();
 
 	while (true) {
 		// Handle VBlank
-		if (clock() > nextVBlankTime) {
+		if (std::chrono::steady_clock::now() > nextVBlankTime) {
 			pcrtc.pending_interrupts |= NV_PCRTC_INTR_0_VBLANK;
 			update_irq();
 			nextVBlankTime = GetNextVBlankTime();

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -2674,9 +2674,10 @@ static unsigned int WINAPI EmuNV2A_InterruptThread(PVOID param)
 					// If GPU Interrupt is connected, call the interrupt service routine
 					if (EmuInterruptList[3]->Connected) {
 						// Get a function pointer to the service routine
-						void(*ServiceRoutine)(xboxkrnl::PKINTERRUPT, void*) = (void(*)(xboxkrnl::PKINTERRUPT, void*))EmuInterruptList[3]->ServiceRoutine;
+						BOOLEAN(__stdcall *ServiceRoutine)(xboxkrnl::PKINTERRUPT, void*) = (BOOLEAN(__stdcall *)(xboxkrnl::PKINTERRUPT, void*))EmuInterruptList[3]->ServiceRoutine;
 						// Call the routine, passing the service context and interrupt object
-						ServiceRoutine(EmuInterruptList[3], EmuInterruptList[3]->ServiceContext);
+						BOOLEAN result = ServiceRoutine(EmuInterruptList[3], EmuInterruptList[3]->ServiceContext);
+						// TODO: What is the result for?
 					}
 				}
 				else {

--- a/src/CxbxKrnl/EmuNV2A.h
+++ b/src/CxbxKrnl/EmuNV2A.h
@@ -40,6 +40,47 @@
 #define NV2A_ADDR  0xFD000000
 #define NV2A_SIZE             0x01000000
 
+#define NV_PMC_ADDR      0x00000000
+#define NV_PMC_SIZE                 0x001000
+#define NV_PBUS_ADDR     0x00001000
+#define NV_PBUS_SIZE                0x001000
+#define NV_PFIFO_ADDR    0x00002000
+#define NV_PFIFO_SIZE               0x002000
+#define NV_PRMA_ADDR     0x00007000
+#define NV_PRMA_SIZE                0x001000
+#define NV_PVIDEO_ADDR   0x00008000
+#define NV_PVIDEO_SIZE              0x001000
+#define NV_PTIMER_ADDR   0x00009000
+#define NV_PTIMER_SIZE              0x001000
+#define NV_PCOUNTER_ADDR 0x0000A000
+#define NV_PCOUNTER_SIZE            0x001000
+#define NV_PVPE_ADDR     0x0000B000
+#define NV_PVPE_SIZE                0x001000
+#define NV_PTV_ADDR      0x0000D000
+#define NV_PTV_SIZE                 0x001000
+#define NV_PRMFB_ADDR    0x000A0000
+#define NV_PRMFB_SIZE               0x020000
+#define NV_PRMVIO_ADDR   0x000C0000
+#define NV_PRMVIO_SIZE              0x001000
+#define NV_PFB_ADDR      0x00100000
+#define NV_PFB_SIZE                 0x001000
+#define NV_PSTRAPS_ADDR  0x00101000
+#define NV_PSTRAPS_SIZE             0x001000
+#define NV_PGRAPH_ADDR   0x00400000
+#define NV_PGRAPH_SIZE              0x002000
+#define NV_PCRTC_ADDR    0x00600000
+#define NV_PCRTC_SIZE               0x001000
+#define NV_PRMCIO_ADDR   0x00601000
+#define NV_PRMCIO_SIZE              0x001000
+#define NV_PRAMDAC_ADDR  0x00680000
+#define NV_PRAMDAC_SIZE             0x001000
+#define NV_PRMDIO_ADDR   0x00681000
+#define NV_PRMDIO_SIZE              0x001000
+#define NV_PRAMIN_ADDR   0x00700000
+#define NV_PRAMIN_SIZE              0x100000
+#define NV_USER_ADDR     0x00800000
+#define NV_USER_SIZE                0x800000
+
 typedef struct {
 	DWORD Ignored[0x10];
 	DWORD* Put; // On Xbox1, this field is only written to by the CPU (the GPU uses this as a trigger to start executing from the given address)
@@ -50,6 +91,7 @@ typedef struct {
 
 uint32_t EmuNV2A_Read(xbaddr addr, int size);
 void EmuNV2A_Write(xbaddr addr, uint32_t value, int size);
+void EmuNV2A_Init();
 
 void InitOpenGLContext();
 

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -812,7 +812,7 @@ bool  EmuX86_Opcode_CMP(LPEXCEPTION_POINTERS e, _DInst& info)
 		return false;
 
 	// SUB Destination with src (cmp internally is a discarded subtract)
-	uint32_t result = dest - src;
+	uint64_t result = dest - src;
 
 	EmuX86_SetFlag(e, EMUX86_EFLAG_CF, (result >> 32) > 0);
 	EmuX86_SetFlag(e, EMUX86_EFLAG_OF, (result >> 31) != (dest >> 31));
@@ -923,7 +923,7 @@ bool EmuX86_Opcode_SUB(LPEXCEPTION_POINTERS e, _DInst& info)
 		return false;
 
 	// SUB Destination with src 
-	uint32_t result = dest - src;
+	uint64_t result = dest - src;
 
 	// Write result back
 	EmuX86_Operand_Write(e, info, 0, result);

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -168,11 +168,6 @@ uint32_t EmuX86_Read32Aligned(xbaddr addr)
 	uint32_t value;
 
 	if (addr >= NV2A_ADDR && addr < NV2A_ADDR + NV2A_SIZE) {
-		if (!bLLE_GPU) {
-			EmuWarning("EmuX86_Read32Aligned(0x%08X) Unexpected NV2A access, missing a HLE patch. " \
-				"Please notify https://github.com/Cxbx-Reloaded/Cxbx-Reloaded which title raised this!", addr);
-		}
-
 		// Access NV2A regardless weither HLE is disabled or not 
 		value = EmuNV2A_Read(addr - NV2A_ADDR, 32);
 		// Note : EmuNV2A_Read32 does it's own logging
@@ -213,11 +208,6 @@ uint16_t EmuX86_Read16(xbaddr addr)
 	uint16_t value;
 
 	if (addr >= NV2A_ADDR && addr < NV2A_ADDR + NV2A_SIZE) {
-		if (!bLLE_GPU) {
-			EmuWarning("EmuX86_Read32Aligned(0x%08X) Unexpected NV2A access, missing a HLE patch. " \
-				"Please notify https://github.com/Cxbx-Reloaded/Cxbx-Reloaded which title raised this!", addr);
-		}
-
 		// Access NV2A regardless weither HLE is disabled or not 
 		value = EmuNV2A_Read(addr - NV2A_ADDR, 16);
 		// Note : EmuNV2A_Read32 does it's own logging
@@ -244,11 +234,6 @@ uint8_t EmuX86_Read8(xbaddr addr)
 	uint8_t value;
 
 	if (addr >= NV2A_ADDR && addr < NV2A_ADDR + NV2A_SIZE) {
-		if (!bLLE_GPU) {
-			EmuWarning("EmuX86_Read32Aligned(0x%08X) Unexpected NV2A access, missing a HLE patch. " \
-				"Please notify https://github.com/Cxbx-Reloaded/Cxbx-Reloaded which title raised this!", addr);
-		}
-
 		// Access NV2A regardless weither HLE is disabled or not 
 		value = EmuNV2A_Read(addr - NV2A_ADDR, 8);
 		// Note : EmuNV2A_Read32 does it's own logging
@@ -276,11 +261,6 @@ void EmuX86_Write32Aligned(xbaddr addr, uint32_t value)
 	assert((addr & 3) == 0);
 
 	if (addr >= NV2A_ADDR && addr < NV2A_ADDR + NV2A_SIZE) {
-		if (!bLLE_GPU) {
-			EmuWarning("EmuX86_Write32Aligned(0x%08X, 0x%08X) Unexpected NV2A access, missing a HLE patch. " \
-				"Please notify https://github.com/Cxbx-Reloaded/Cxbx-Reloaded which title raised this!", addr);
-		}
-
 		// Access NV2A regardless weither HLE is disabled or not 
 		EmuNV2A_Write(addr - NV2A_ADDR, value, 32);
 		// Note : EmuNV2A_Write32 does it's own logging
@@ -319,10 +299,6 @@ void EmuX86_Write32(xbaddr addr, uint32_t value)
 void EmuX86_Write16(xbaddr addr, uint16_t value)
 {
 	if (addr >= NV2A_ADDR && addr < NV2A_ADDR + NV2A_SIZE) {
-		if (!bLLE_GPU) {
-			EmuWarning("EmuX86_Write32Aligned(0x%08X, 0x%08X) Unexpected NV2A access, missing a HLE patch. " \
-				"Please notify https://github.com/Cxbx-Reloaded/Cxbx-Reloaded which title raised this!", addr);
-		}
 
 		// Access NV2A regardless weither HLE is disabled or not 
 		EmuNV2A_Write(addr - NV2A_ADDR, value, 16);
@@ -354,11 +330,6 @@ void EmuX86_Write8(xbaddr addr, uint8_t value)
 {
 
 	if (addr >= NV2A_ADDR && addr < NV2A_ADDR + NV2A_SIZE) {
-		if (!bLLE_GPU) {
-			EmuWarning("EmuX86_Write32Aligned(0x%08X, 0x%08X) Unexpected NV2A access, missing a HLE patch. " \
-				"Please notify https://github.com/Cxbx-Reloaded/Cxbx-Reloaded which title raised this!", addr);
-		}
-
 		// Access NV2A regardless weither HLE is disabled or not 
 		EmuNV2A_Write(addr - NV2A_ADDR, value, 8);
 		// Note : EmuNV2A_Write32 does it's own logging

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -69,7 +69,6 @@ uint32_t EmuX86_IORead32(xbaddr addr)
 		QueryPerformanceCounter(&performanceCount);
 		return performanceCount.QuadPart;
 		break;
-		
 	}
 
 	EmuWarning("EmuX86_IORead32(0x%08X) [Unknown address]", addr);
@@ -82,8 +81,17 @@ uint16_t EmuX86_IORead16(xbaddr addr)
 	return 0;
 }
 
+static int field_pin = 0;
 uint8_t EmuX86_IORead8(xbaddr addr)
 {
+	switch (addr) {
+		case 0x80C0:
+			// field pin from tv encoder?
+			field_pin = (field_pin + 1) & 1;
+			return field_pin << 5;
+			break;
+	}
+
 	EmuWarning("EmuX86_IORead8(0x%08X) [Unknown address]", addr);
 	return 0;
 }

--- a/src/CxbxKrnl/nv2a_int.h
+++ b/src/CxbxKrnl/nv2a_int.h
@@ -704,6 +704,7 @@
 #   define NV062_SET_CONTEXT_DMA_IMAGE_DESTIN                 0x00000188
 #   define NV062_SET_COLOR_FORMAT                             0x00000300
 #       define NV062_SET_COLOR_FORMAT_LE_Y8                    0x01
+#		define NV062_SET_COLOR_FORMAT_LE_R5G6B5                0x04
 #       define NV062_SET_COLOR_FORMAT_LE_A8R8G8B8              0x0A
 #   define NV062_SET_PITCH                                    0x00000304
 #   define NV062_SET_OFFSET_SOURCE                            0x00000308

--- a/src/CxbxKrnl/vga.h
+++ b/src/CxbxKrnl/vga.h
@@ -1,0 +1,159 @@
+/*
+ * linux/include/video/vga.h -- standard VGA chipset interaction
+ *
+ * Copyright 1999 Jeff Garzik <jgarzik@pobox.com>
+ *
+ * Copyright history from vga16fb.c:
+ *	Copyright 1999 Ben Pfaff and Petr Vandrovec
+ *	Based on VGA info at http://www.osdever.net/FreeVGA/home.htm
+ *	Based on VESA framebuffer (c) 1998 Gerd Knorr
+ *
+ * This file is subject to the terms and conditions of the GNU General
+ * Public License.  See the file COPYING in the main directory of this
+ * archive for more details.
+ *
+ */
+
+#ifndef LINUX_VIDEO_VGA_H
+#define LINUX_VIDEO_VGA_H
+
+/* Some of the code below is taken from SVGAlib.  The original,
+   unmodified copyright notice for that code is below. */
+/* VGAlib version 1.2 - (c) 1993 Tommy Frandsen                    */
+/*                                                                 */
+/* This library is free software; you can redistribute it and/or   */
+/* modify it without any restrictions. This library is distributed */
+/* in the hope that it will be useful, but without any warranty.   */
+
+/* Multi-chipset support Copyright 1993 Harm Hanemaayer */
+/* partially copyrighted (C) 1993 by Hartmut Schirmer */
+
+/* VGA data register ports */
+#define VGA_CRT_DC      0x3D5   /* CRT Controller Data Register - color emulation */
+#define VGA_CRT_DM      0x3B5   /* CRT Controller Data Register - mono emulation */
+#define VGA_ATT_R       0x3C1   /* Attribute Controller Data Read Register */
+#define VGA_ATT_W       0x3C0   /* Attribute Controller Data Write Register */
+#define VGA_GFX_D       0x3CF   /* Graphics Controller Data Register */
+#define VGA_SEQ_D       0x3C5   /* Sequencer Data Register */
+#define VGA_MIS_R       0x3CC   /* Misc Output Read Register */
+#define VGA_MIS_W       0x3C2   /* Misc Output Write Register */
+#define VGA_FTC_R       0x3CA   /* Feature Control Read Register */
+#define VGA_IS1_RC      0x3DA   /* Input Status Register 1 - color emulation */
+#define VGA_IS1_RM      0x3BA   /* Input Status Register 1 - mono emulation */
+#define VGA_PEL_D       0x3C9   /* PEL Data Register */
+#define VGA_PEL_MSK     0x3C6   /* PEL mask register */
+
+/* EGA-specific registers */
+#define EGA_GFX_E0      0x3CC   /* Graphics enable processor 0 */
+#define EGA_GFX_E1      0x3CA   /* Graphics enable processor 1 */
+
+/* VGA index register ports */
+#define VGA_CRT_IC      0x3D4   /* CRT Controller Index - color emulation */
+#define VGA_CRT_IM      0x3B4   /* CRT Controller Index - mono emulation */
+#define VGA_ATT_IW      0x3C0   /* Attribute Controller Index & Data Write Register */
+#define VGA_GFX_I       0x3CE   /* Graphics Controller Index */
+#define VGA_SEQ_I       0x3C4   /* Sequencer Index */
+#define VGA_PEL_IW      0x3C8   /* PEL Write Index */
+#define VGA_PEL_IR      0x3C7   /* PEL Read Index */
+
+/* standard VGA indexes max counts */
+#define VGA_CRT_C       0x19    /* Number of CRT Controller Registers */
+#define VGA_ATT_C       0x15    /* Number of Attribute Controller Registers */
+#define VGA_GFX_C       0x09    /* Number of Graphics Controller Registers */
+#define VGA_SEQ_C       0x05    /* Number of Sequencer Registers */
+#define VGA_MIS_C       0x01    /* Number of Misc Output Register */
+
+/* VGA misc register bit masks */
+#define VGA_MIS_COLOR           0x01
+#define VGA_MIS_ENB_MEM_ACCESS  0x02
+#define VGA_MIS_DCLK_28322_720  0x04
+#define VGA_MIS_ENB_PLL_LOAD    (0x04 | 0x08)
+#define VGA_MIS_SEL_HIGH_PAGE   0x20
+
+/* VGA CRT controller register indices */
+#define VGA_CRTC_H_TOTAL        0
+#define VGA_CRTC_H_DISP         1
+#define VGA_CRTC_H_BLANK_START  2
+#define VGA_CRTC_H_BLANK_END    3
+#define VGA_CRTC_H_SYNC_START   4
+#define VGA_CRTC_H_SYNC_END     5
+#define VGA_CRTC_V_TOTAL        6
+#define VGA_CRTC_OVERFLOW       7
+#define VGA_CRTC_PRESET_ROW     8
+#define VGA_CRTC_MAX_SCAN       9
+#define VGA_CRTC_CURSOR_START   0x0A
+#define VGA_CRTC_CURSOR_END     0x0B
+#define VGA_CRTC_START_HI       0x0C
+#define VGA_CRTC_START_LO       0x0D
+#define VGA_CRTC_CURSOR_HI      0x0E
+#define VGA_CRTC_CURSOR_LO      0x0F
+#define VGA_CRTC_V_SYNC_START   0x10
+#define VGA_CRTC_V_SYNC_END     0x11
+#define VGA_CRTC_V_DISP_END     0x12
+#define VGA_CRTC_OFFSET         0x13
+#define VGA_CRTC_UNDERLINE      0x14
+#define VGA_CRTC_V_BLANK_START  0x15
+#define VGA_CRTC_V_BLANK_END    0x16
+#define VGA_CRTC_MODE           0x17
+#define VGA_CRTC_LINE_COMPARE   0x18
+#define VGA_CRTC_REGS           VGA_CRT_C
+
+/* VGA CRT controller bit masks */
+#define VGA_CR11_LOCK_CR0_CR7   0x80 /* lock writes to CR0 - CR7 */
+#define VGA_CR17_H_V_SIGNALS_ENABLED 0x80
+
+/* VGA attribute controller register indices */
+#define VGA_ATC_PALETTE0        0x00
+#define VGA_ATC_PALETTE1        0x01
+#define VGA_ATC_PALETTE2        0x02
+#define VGA_ATC_PALETTE3        0x03
+#define VGA_ATC_PALETTE4        0x04
+#define VGA_ATC_PALETTE5        0x05
+#define VGA_ATC_PALETTE6        0x06
+#define VGA_ATC_PALETTE7        0x07
+#define VGA_ATC_PALETTE8        0x08
+#define VGA_ATC_PALETTE9        0x09
+#define VGA_ATC_PALETTEA        0x0A
+#define VGA_ATC_PALETTEB        0x0B
+#define VGA_ATC_PALETTEC        0x0C
+#define VGA_ATC_PALETTED        0x0D
+#define VGA_ATC_PALETTEE        0x0E
+#define VGA_ATC_PALETTEF        0x0F
+#define VGA_ATC_MODE            0x10
+#define VGA_ATC_OVERSCAN        0x11
+#define VGA_ATC_PLANE_ENABLE    0x12
+#define VGA_ATC_PEL             0x13
+#define VGA_ATC_COLOR_PAGE      0x14
+
+#define VGA_AR_ENABLE_DISPLAY   0x20
+
+/* VGA sequencer register indices */
+#define VGA_SEQ_RESET           0x00
+#define VGA_SEQ_CLOCK_MODE      0x01
+#define VGA_SEQ_PLANE_WRITE     0x02
+#define VGA_SEQ_CHARACTER_MAP   0x03
+#define VGA_SEQ_MEMORY_MODE     0x04
+
+/* VGA sequencer register bit masks */
+#define VGA_SR01_CHAR_CLK_8DOTS 0x01 /* bit 0: character clocks 8 dots wide are generated */
+#define VGA_SR01_SCREEN_OFF     0x20 /* bit 5: Screen is off */
+#define VGA_SR02_ALL_PLANES     0x0F /* bits 3-0: enable access to all planes */
+#define VGA_SR04_EXT_MEM        0x02 /* bit 1: allows complete mem access to 256K */
+#define VGA_SR04_SEQ_MODE       0x04 /* bit 2: directs system to use a sequential addressing mode */
+#define VGA_SR04_CHN_4M         0x08 /* bit 3: selects modulo 4 addressing for CPU access to display memory */
+
+/* VGA graphics controller register indices */
+#define VGA_GFX_SR_VALUE        0x00
+#define VGA_GFX_SR_ENABLE       0x01
+#define VGA_GFX_COMPARE_VALUE   0x02
+#define VGA_GFX_DATA_ROTATE     0x03
+#define VGA_GFX_PLANE_READ      0x04
+#define VGA_GFX_MODE            0x05
+#define VGA_GFX_MISC            0x06
+#define VGA_GFX_COMPARE_MASK    0x07
+#define VGA_GFX_BIT_MASK        0x08
+
+/* VGA graphics controller bit masks */
+#define VGA_GR06_GRAPHICS_MODE  0x01
+
+#endif /* LINUX_VIDEO_VGA_H */


### PR DESCRIPTION
This pull-request brings a partial port of XQEMU's NV2A emulation into Cxbx-Reloaded

This emulation is still largely incomplete, and doesn't function in LLE mode just yet, however, it is *good enough* to allow for many HLE patches to be removed completely. The code quality of the NV2A implementation is hacky in places to work around Cxbx-Reloaded limitations: This will be improved in the future, but for now, this will greatly help even the HLE emulation.

The following patches are no longer required:

- Direct3D_CreateDevice
- D3D_KickOffAndWaitForIdle
- D3D_KickOffAndWaitForIdle2
- D3DDevice_AddRef
- D3DDevice_Reset	
- D3DDevice_End
- D3DDevice_Release
- D3DDevice_KickOff
- D3DDevice_KickPushBuffer
- D3DDevice_EndPushBuffer
- XMETAL_StartPush
- D3D_MakeRequestedSpace
- D3DDevice_GetPushBufferOffset

Along with this NV2A work/hybrid HLE/LLE support, the following changes are also included

- Improved VBlank timing, due to using a higher precision clock source
- Kernel memory region has been made executable (no behavioral change yet, but opens the door for loading a real kernel in the distant future)
- EmuX86: Implemented DEC, SUB and INC opcodes
- EmuX86: Fixed a bug where the carry flag was being calculated incorrectly

I have tested over 40 titles so far, and not noticed any regressions, so I'm confident this can be merged without any major issues.

NOTE: This is a prerequisite for real NV2A LLE, for Patrick's Texture Conversion branch, and Patrick's improved pixel shader conversions, so it is important to get this merged rather quickly.