### PR TITLE
Fix JSRF Regression after NV2A merge

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4864,7 +4864,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexDataColor)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_End)()
 {
-	//FUNC_EXPORTS
+	FUNC_EXPORTS
 
 	LOG_FUNC();
 

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -71,6 +71,7 @@ namespace xboxkrnl
 #include "EmuFS.h"
 #include "EmuKrnl.h"
 #include "EmuNV2A.h"
+#include "HLEIntercept.h"
 #include "nv2a_int.h" // from https://github.com/espes/xqemu/tree/xbox/hw/xbox
 
 #include <gl\glew.h>
@@ -3749,5 +3750,8 @@ void EmuNV2A_Init()
 
 	pfifo.puller_thread = std::thread(pfifo_puller_thread);
 	
-	vblank_thread = std::thread(nv2a_vblank_thread);;
+	// Only spawn VBlank thread when LLE is enabled
+	if (bLLE_GPU) {
+		vblank_thread = std::thread(nv2a_vblank_thread);;
+	}
 }


### PR DESCRIPTION
The cause of this regression was two fold: The NV2A VBlank thread and the HLE VBlank thread were both running, leading to timing issues as the games VBlank routine was being called too often.

This was fixed by only running the NV2A VBlank thread when in LLE mode.

The second cause was the unpatching of Device_End. This parses display commands and is required for HLE to function correctly.