### PR TITLE
Reinstate JSRF Hack

### DIFF
--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -114,13 +114,18 @@ void NTAPI EmuWarning(const char *szWarningMessage, ...)
 
 std::string EIPToString(xbaddr EIP)
 {
-	int symbolOffset = 0;
-	std::string symbolName = GetDetectedSymbolName(EIP, &symbolOffset);
-
 	char buffer[256];
-	sprintf(buffer, "0x%.08X(=%s+0x%x)", EIP, symbolName.c_str(), symbolOffset);
-
+	
+	if (EIP < XBOX_MEMORY_SIZE) {
+		int symbolOffset = 0;
+		std::string symbolName = GetDetectedSymbolName(EIP, &symbolOffset);
+		sprintf(buffer, "0x%.08X(=%s+0x%x)", EIP, symbolName.c_str(), symbolOffset);
+	} else {
+		sprintf(buffer, "0x%.08X", EIP);
+	}
+	
 	std::string result = buffer;
+
 	return result;
 }
 

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -153,10 +153,21 @@ void SetupXboxDeviceTypes()
 		// Set the device as connected
 		// We need to set the ChangeConnected attribute so that titles calling
 		// XGetDeviceChanges before calling XGetDevices work as expected
-		// This fixes input in Far Cry Instincts.
+		// This fixes input in Far Cry Instincts
 		gDeviceType_Gamepad->CurrentConnected = 1;
 		gDeviceType_Gamepad->ChangeConnected = 1;
 		gDeviceType_Gamepad->PreviousConnected = 0;
+
+		// JSRF Hack: Don't set the ChangeConnected flag. 
+		// Without this, JSRF hard crashes 
+		// TODO: Why is this still needed? 
+		// TODO: Perhaps we should implement LLE for OHCI/USB much sooner than planned
+		// TitleID 0x49470018 = JSRF NTSC-U
+		// TitleID 0x5345000A = JSRF PAL, NTSC-J
+		// TitleID 0x53450016 = JSRF NTSC-J (Demo)
+		if (g_pCertificate->dwTitleId == 0x49470018 || g_pCertificate->dwTitleId == 0x5345000A || g_pCertificate->dwTitleId == 0x53450016) {
+			gDeviceType_Gamepad->ChangeConnected = 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Annoyingly, this is still necessary.

Without this, we have a choice between JSRF working and some titles not detecting input
Or JSRF not working, but many titles detecting input correctly. 