### PR TITLE
Fix for issue #746

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ phire
 x1mixmzeng
 RadWolfie
 Luca D'Amico (Luca1991/Luca91)
+ergo720
 
 Supporters:
 Cisco	Martinez

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -1004,3 +1004,12 @@ void *Xbe::FindSection(char *zsSectionName)
 
 	return NULL;
 }
+
+void Xbe::PurgeBadChar(std::string &s, const std::string &illegalChars)
+{
+	for (auto it = s.begin(); it < s.end(); ++it)
+	{
+		bool found = illegalChars.find(*it) != std::string::npos;
+		if (found) { *it = ' '; }
+	}
+}

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -1010,6 +1010,6 @@ void Xbe::PurgeBadChar(std::string &s, const std::string &illegalChars)
 	for (auto it = s.begin(); it < s.end(); ++it)
 	{
 		bool found = illegalChars.find(*it) != std::string::npos;
-		if (found) { *it = ' '; }
+		if (found) { *it = '_'; }
 	}
 }

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -71,6 +71,9 @@ class Xbe : public Error
         // export logo bitmap to raw monochrome data
         void ExportLogoBitmap(uint08 x_Gray[100*17]);
 
+		// purge illegal characters in Windows filenames or other OS's
+		void PurgeBadChar(std::string &s, const std::string &illegalChars = "\\/:?\"<>|");
+
         // Xbe header
         #include "AlignPrefix1.h"
         struct Header

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -1010,7 +1010,9 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				// Hash the loaded XBE's header, use it as a filename
 				uint32_t uiHash = XXHash32::hash((void*)&m_Xbe->m_Header, sizeof(Xbe::Header), 0);
 				std::stringstream sstream;
-				sstream << cacheDir << std::hex << uiHash << ".ini";
+				std::string szTitleName(m_Xbe->m_szAsciiTitle);
+				m_Xbe->PurgeBadChar(szTitleName);
+				sstream << cacheDir << szTitleName << "-" << std::hex << uiHash << ".ini";
 				std::string fullpath = sstream.str();
 
 				if (DeleteFile(fullpath.c_str())) {

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -144,7 +144,6 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	CxbxKrnl_Xbe->PurgeBadChar(szTitleName);
 	sstream << cachePath << szTitleName << "-" << std::hex << uiHash << ".ini";
 	std::string filename = sstream.str();
-	setlocale(LC_ALL, "");
 
 	if (PathFileExists(filename.c_str())) {
 		printf("Found HLE Cache File: %08X.ini\n", uiHash);
@@ -593,7 +592,6 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	WritePrivateProfileString("Info", "HLEDatabaseVersion", szHLELastCompileTime, filename.c_str());
 
 	// Write the Certificate Details to the cache file
-	setlocale(LC_ALL, "English");
 	WritePrivateProfileString("Certificate", "Name", tAsciiTitle, filename.c_str());
 
 	std::stringstream titleId;

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -137,8 +137,14 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	// Hash the loaded XBE's header, use it as a filename
 	uint32_t uiHash = XXHash32::hash((void*)&CxbxKrnl_Xbe->m_Header, sizeof(Xbe::Header), 0);
 	std::stringstream sstream;
-	sstream << cachePath << std::hex << uiHash << ".ini";
+	char tAsciiTitle[40] = "Unknown";
+	setlocale(LC_ALL, "English");
+	wcstombs(tAsciiTitle, g_pCertificate->wszTitleName, sizeof(tAsciiTitle));
+	std::string szTitleName(tAsciiTitle);
+	CxbxKrnl_Xbe->PurgeBadChar(szTitleName);
+	sstream << cachePath << szTitleName << "-" << std::hex << uiHash << ".ini";
 	std::string filename = sstream.str();
+	setlocale(LC_ALL, "");
 
 	if (PathFileExists(filename.c_str())) {
 		printf("Found HLE Cache File: %08X.ini\n", uiHash);
@@ -587,9 +593,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	WritePrivateProfileString("Info", "HLEDatabaseVersion", szHLELastCompileTime, filename.c_str());
 
 	// Write the Certificate Details to the cache file
-	char tAsciiTitle[40] = "Unknown";
 	setlocale(LC_ALL, "English");
-	wcstombs(tAsciiTitle, g_pCertificate->wszTitleName, sizeof(tAsciiTitle));
 	WritePrivateProfileString("Certificate", "Name", tAsciiTitle, filename.c_str());
 
 	std::stringstream titleId;


### PR DESCRIPTION
I tested games with UNICODE characters (The Return of the King™), with illegal characters (Tenchu: Return from Darkness has a colon) and multi-xbe titles (DEAD OR ALIVE ULTIMATE). The generated cache files are the same (except for the date which is normal) and the clear cache options work as well. 
I also added myself to the list of contributing devs: if you don't want, tell me and I will remove it
[cache-files.zip](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/files/1376753/cache-files.zip)
