### PR TITLE
MemoryManager : Fixed block-lookup with non-base addresses, by using …

### DIFF
--- a/src/CxbxKrnl/MemoryManager.h
+++ b/src/CxbxKrnl/MemoryManager.h
@@ -44,7 +44,8 @@
 
 typedef struct {
 	void *addr;
-	size_t size;
+	void *upper_bound;
+	void init(void * base, size_t size) { addr = base; upper_bound = (void *)((uintptr_t)base + size - 1); }
 } MemoryBlock;
 
 enum struct MemoryType {


### PR DESCRIPTION
MemoryManager : Fixed block-lookup with non-base addresses, by using block.upper_bound as key.

This resolves crashes in Cartoon sample (and potentially many other titles).