### PR TITLE
DSound Major Improvement + Cleanup

### DIFF
--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1351,7 +1351,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Play)
         if (pThis->EmuDirectSound3DBuffer8 != nullptr) {
             DSound3DBufferCreate(pThis->EmuDirectSoundBuffer8, pThis->EmuDirectSound3DBuffer8Region);
         }
-        DSoundBufferTransfer(pThis->EmuDirectSoundBuffer8, pThis->EmuDirectSoundBuffer8Region,
+        DSoundBufferTransferSettings(pThis->EmuDirectSoundBuffer8, pThis->EmuDirectSoundBuffer8Region,
                              pThis->EmuDirectSound3DBuffer8, pThis->EmuDirectSound3DBuffer8Region);
 
         hRet = pThis->EmuDirectSoundBuffer8Region->Lock(0, 0, &pThis->EmuLockPtr1, &pThis->EmuLockBytes1, nullptr, nullptr, DSBLOCK_ENTIREBUFFER);
@@ -1453,7 +1453,7 @@ extern "C" HRESULT __stdcall XTL::EMUPATCH(IDirectSoundBuffer_StopEx)
                 if (pThis->EmuDirectSoundBuffer8Region != nullptr) {
                     pThis->EmuDirectSoundBuffer8Region->GetStatus(&dwStatus);
 
-                    DSoundBufferTransfer(pThis->EmuDirectSoundBuffer8Region, pThis->EmuDirectSoundBuffer8,
+                    DSoundBufferTransferSettings(pThis->EmuDirectSoundBuffer8Region, pThis->EmuDirectSoundBuffer8,
                                          pThis->EmuDirectSound3DBuffer8Region, pThis->EmuDirectSound3DBuffer8);
 
                     hRet = pThis->EmuDirectSoundBuffer8Region->Stop();

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -851,7 +851,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
         if (pdsbd->dwFlags & DSBCAPS_CTRL3D) {
 
             HRESULT hRet3D = (*ppBuffer)->EmuDirectSoundBuffer8->QueryInterface(IID_IDirectSound3DBuffer8, (LPVOID*)&((*ppBuffer)->EmuDirectSound3DBuffer8));
-            if (hRet != DS_OK) {
+            if (hRet3D != DS_OK) {
                 EmuWarning("CreateSound3DBuffer8 Failed!");
                 (*ppBuffer)->EmuDirectSound3DBuffer8 = NULL;
             }
@@ -1496,7 +1496,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
         if (pDSBufferDesc->dwFlags & DSBCAPS_CTRL3D) {
 
             HRESULT hRet3D = (*ppStream)->EmuDirectSoundBuffer8->QueryInterface(IID_IDirectSound3DBuffer8, (LPVOID*)&((*ppStream)->EmuDirectSound3DBuffer8));
-            if (hRet != DS_OK) {
+            if (hRet3D != DS_OK) {
                 EmuWarning("CreateSound3DBuffer Failed!");
                 (*ppStream)->EmuDirectSound3DBuffer8 = NULL;
             }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -821,14 +821,14 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
     // TODO: Garbage Collection
     *ppBuffer = new X_CDirectSoundBuffer();
 
-    (*ppBuffer)->EmuDirectSoundBuffer8 = 0;
-    (*ppBuffer)->EmuDirectSound3DBuffer8 = 0;
-    (*ppBuffer)->EmuBuffer = 0;
+    (*ppBuffer)->EmuDirectSoundBuffer8 = nullptr;
+    (*ppBuffer)->EmuDirectSound3DBuffer8 = nullptr;
+    (*ppBuffer)->EmuBuffer = xbnullptr;
     (*ppBuffer)->EmuBufferDesc = pDSBufferDesc;
     (*ppBuffer)->EmuLockOffset = 0;
-    (*ppBuffer)->EmuLockPtr1 = 0;
+    (*ppBuffer)->EmuLockPtr1 = xbnullptr;
     (*ppBuffer)->EmuLockBytes1 = 0;
-    (*ppBuffer)->EmuLockPtr2 = 0;
+    (*ppBuffer)->EmuLockPtr2 = xbnullptr;
     (*ppBuffer)->EmuLockBytes2 = 0;
     (*ppBuffer)->EmuFlags = dwEmuFlags;
 
@@ -840,7 +840,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
 
     if (hRet != DS_OK) {
         CxbxKrnlCleanup("CreateSoundBuffer Failed!");
-        (*ppBuffer)->EmuDirectSoundBuffer8 = NULL;
+        (*ppBuffer)->EmuDirectSoundBuffer8 = nullptr;
     } else {
         hRet = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&((*ppBuffer)->EmuDirectSoundBuffer8));
         pTempBuffer->Release();
@@ -853,7 +853,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
             HRESULT hRet3D = (*ppBuffer)->EmuDirectSoundBuffer8->QueryInterface(IID_IDirectSound3DBuffer8, (LPVOID*)&((*ppBuffer)->EmuDirectSound3DBuffer8));
             if (hRet3D != DS_OK) {
                 EmuWarning("CreateSound3DBuffer8 Failed!");
-                (*ppBuffer)->EmuDirectSound3DBuffer8 = NULL;
+                (*ppBuffer)->EmuDirectSound3DBuffer8 = nullptr;
             }
 
         }
@@ -1462,13 +1462,13 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
 
     GeneratePCMFormat(pDSBufferDesc, pdssd->lpwfxFormat, dwEmuFlags);
 
-    (*ppStream)->EmuDirectSoundBuffer8 = 0;
-    (*ppStream)->EmuDirectSound3DBuffer8 = 0;
-    (*ppStream)->EmuBuffer = 0;
+    (*ppStream)->EmuDirectSoundBuffer8 = nullptr;
+    (*ppStream)->EmuDirectSound3DBuffer8 = nullptr;
+    (*ppStream)->EmuBuffer = xbnullptr;
     (*ppStream)->EmuBufferDesc = pDSBufferDesc;
-    (*ppStream)->EmuLockPtr1 = 0;
+    (*ppStream)->EmuLockPtr1 = xbnullptr;
     (*ppStream)->EmuLockBytes1 = 0;
-    (*ppStream)->EmuLockPtr2 = 0;
+    (*ppStream)->EmuLockPtr2 = xbnullptr;
     (*ppStream)->EmuLockBytes2 = 0;
     (*ppStream)->EmuFlags = dwEmuFlags;
     (*ppStream)->EmuPlayFlags = DSBPLAY_LOOPING;
@@ -1481,7 +1481,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
 
     if (hRet != DS_OK) {
         CxbxKrnlCleanup("CreateSoundBuffer Failed!");
-        (*ppStream)->EmuDirectSoundBuffer8 = NULL;
+        (*ppStream)->EmuDirectSoundBuffer8 = nullptr;
     } else {
         hRet = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&((*ppStream)->EmuDirectSoundBuffer8));
         pTempBuffer->Release();
@@ -1498,7 +1498,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
             HRESULT hRet3D = (*ppStream)->EmuDirectSoundBuffer8->QueryInterface(IID_IDirectSound3DBuffer8, (LPVOID*)&((*ppStream)->EmuDirectSound3DBuffer8));
             if (hRet3D != DS_OK) {
                 EmuWarning("CreateSound3DBuffer Failed!");
-                (*ppStream)->EmuDirectSound3DBuffer8 = NULL;
+                (*ppStream)->EmuDirectSound3DBuffer8 = nullptr;
             }
         }
     }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -539,7 +539,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetDopplerFactor)
 HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetI3DL2Listener)
 (
     LPDIRECTSOUND8          pThis,
-    PVOID                   pDummy, // TODO: fill this out
+    X_DSI3DL2LISTENER      *pds3dl,
     DWORD                   dwApply)
 {
     FUNC_EXPORTS;
@@ -548,7 +548,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetI3DL2Listener)
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
-		LOG_FUNC_ARG(pDummy)
+		LOG_FUNC_ARG(pds3dl)
 		LOG_FUNC_ARG(dwApply)
 		LOG_FUNC_END;
 
@@ -731,6 +731,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetVelocity)
 // ******************************************************************
 // * patch: IDirectSound_SetAllParameters
 // ******************************************************************
+// NOTE: No conversion requirement for XB to PC.
 HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetAllParameters)
 (
     LPDIRECTSOUND8          pThis,
@@ -1982,7 +1983,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetConeOutsideVolume)
 HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetAllParameters)
 (
     X_CDirectSoundStream*   pThis,
-    LPCDS3DBUFFER           pc3DBufferParameters,
+    X_DS3DBUFFER*           pc3DBufferParameters,
     DWORD                   dwApply)
 {
     FUNC_EXPORTS;
@@ -2131,25 +2132,13 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFrequency)
 // ******************************************************************
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetI3DL2Source)
 (
-    PVOID   pThis,
-    PVOID   pds3db,
-    DWORD   dwApply)
+    X_CDirectSoundStream*   pThis,
+    X_DSI3DL2BUFFER*        pds3db,
+    DWORD                   dwApply)
 {
     FUNC_EXPORTS;
 
-    enterCriticalSection;
-
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(pThis)
-		LOG_FUNC_ARG(pds3db)
-		LOG_FUNC_ARG(dwApply)
-		LOG_FUNC_END;
-
-    LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
-
-    return S_OK;
+    return XTL::EMUPATCH(CDirectSoundStream_SetI3DL2Source)(pThis, pds3db, dwApply);
 }
 
 // ******************************************************************
@@ -2433,7 +2422,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetDopplerFactor)
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetI3DL2Source)
 (
     X_CDirectSoundBuffer*   pThis,
-    LPCDSI3DL2BUFFER        pds3db,
+    X_DSI3DL2BUFFER*        pds3db,
     DWORD                   dwApply)
 {
     FUNC_EXPORTS;
@@ -2446,6 +2435,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetI3DL2Source)
 		LOG_FUNC_ARG(dwApply)
 		LOG_FUNC_END;
 
+    // NOTE: SetI3DL2Source is using DSFXI3DL2Reverb structure, aka different interface.
     LOG_UNIMPLEMENTED_DSOUND();
 
     leaveCriticalSection;
@@ -3158,7 +3148,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
 HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetI3DL2Source)
 (
     X_CDirectSoundStream*   pThis,
-    PVOID                   pds3db,
+    X_DSI3DL2BUFFER*        pds3db,
     DWORD                   dwApply)
 {
     FUNC_EXPORTS;
@@ -3171,6 +3161,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetI3DL2Source)
 		LOG_FUNC_ARG(dwApply)
 		LOG_FUNC_END;
 
+    // NOTE: SetI3DL2Source is using DSFXI3DL2Reverb structure, aka different interface.
     LOG_UNIMPLEMENTED_DSOUND();
 
     leaveCriticalSection;
@@ -3184,7 +3175,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetI3DL2Source)
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetAllParameters)
 (
     X_CDirectSoundBuffer*    pThis,
-    LPCDS3DBUFFER            pc3DBufferParameters,
+    X_DS3DBUFFER*            pc3DBufferParameters,
     DWORD                    dwApply)
 {
     FUNC_EXPORTS;

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1195,20 +1195,12 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPitch)
 {
     FUNC_EXPORTS;
 
-    enterCriticalSection;
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(lPitch)
 		LOG_FUNC_END;
 
-    // TODO: Translate params, then make the PC DirectSound call
-
-    LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
-
-    return DS_OK;
+    return HybridDirectSoundBuffer_SetPitch(pThis->EmuDirectSoundBuffer8, lPitch);
 }
 
 // ******************************************************************
@@ -3043,20 +3035,12 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetPitch)
 {
     FUNC_EXPORTS;
 
-    enterCriticalSection;
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(lPitch)
         LOG_FUNC_END;
 
-    HRESULT hRet = S_OK;
-
-    LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
-
-    return hRet;
+    return HybridDirectSoundBuffer_SetPitch(pThis->EmuDirectSoundBuffer8, lPitch);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -37,6 +37,7 @@
 #undef FIELD_OFFSET     // prevent macro redefinition warnings
 
 #include <dsound.h>
+#include <d3dx8math.h>
 #include "CxbxKrnl.h"
 #include "Emu.h"
 
@@ -217,7 +218,56 @@ struct X_DSCAPS
 #define X_DSSPEAKER_ENABLE_AC3      0x00010000
 #define X_DSSPEAKER_ENABLE_DTS      0x00020000
 
+struct X_DS3DBUFFER {
+    DWORD dwSize;
+    D3DXVECTOR3 vPosition;
+    D3DXVECTOR3 vVelocity;
+    DWORD dwInsideConeAngle;
+    DWORD  dwOutsideConeAngle;
+    D3DXVECTOR3 vConeOrientation;
+    LONG lConeOutsideVolume;
+    FLOAT flMinDistance;
+    FLOAT flMaxDistance;
+    DWORD dwMode;
+    FLOAT flDistanceFactor;
+    FLOAT flRolloffFactor;
+    FLOAT flDopplerFactor;
+};
 
+struct X_DSI3DL2LISTENER {
+    LONG lRoom;
+    LONG lRoomHF;
+    FLOAT flRoomRolloffFactor;
+    FLOAT flDecayTime;
+    FLOAT flDecayHFRatio;
+    LONG  lReflections;
+    FLOAT flReflectionsDelay;
+    LONG  lReverb;
+    FLOAT flReverbDelay;
+    FLOAT flDiffusion;
+    FLOAT flDensity;
+    FLOAT flHFReference;
+};
+
+struct X_DSI3DL2OBSTRUCTION {
+    LONG            lHFLevel;
+    FLOAT           flLFRatio;
+};
+
+struct X_DSI3DL2OCCLUSION {
+    LONG            lHFLevel;
+    FLOAT           flLFRatio;
+};
+
+struct X_DSI3DL2BUFFER {
+    LONG lDirect;
+    LONG lDirectHF;
+    LONG lRoom;
+    LONG lRoomHF;
+    FLOAT flRoomRolloffFactor;
+    X_DSI3DL2OBSTRUCTION Obstruction;
+    X_DSI3DL2OCCLUSION Occlusion;
+};
 
 typedef struct IDirectSoundStream IDirectSoundStream;
 typedef IDirectSoundStream *LPDIRECTSOUNDSTREAM;
@@ -566,7 +616,7 @@ HRESULT WINAPI EMUPATCH(IDirectSound_SetDopplerFactor)
 HRESULT WINAPI EMUPATCH(IDirectSound_SetI3DL2Listener)
 (
     LPDIRECTSOUND8          pThis,
-    PVOID                   pDummy, // TODO: fill this out
+    X_DSI3DL2LISTENER      *pds3dl,
     DWORD                   dwApply
 );
 
@@ -966,7 +1016,7 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetHeadroom)
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetAllParameters)
 (
     X_CDirectSoundStream*   pThis,
-    LPCDS3DBUFFER           pc3DBufferParameters,
+    X_DS3DBUFFER*           pc3DBufferParameters,
     DWORD                   dwApply
 );
 
@@ -1061,9 +1111,9 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetFrequency)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetI3DL2Source)
 (
-    PVOID   pThis,
-    PVOID   pds3db,
-    DWORD   dwApply
+    X_CDirectSoundStream*   pThis,
+    X_DSI3DL2BUFFER*        pds3db,
+    DWORD                   dwApply
 );
 
 // ******************************************************************
@@ -1192,15 +1242,13 @@ HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetDopplerFactor)
     DWORD                   dwApply
 );
 
-typedef void* LPCDSI3DL2BUFFER;
-
 // ******************************************************************
 // * patch: IDirectSoundBuffer_SetI3DL2Source
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetI3DL2Source)
 (
     X_CDirectSoundBuffer*   pThis,
-    LPCDSI3DL2BUFFER        pds3db,
+    X_DSI3DL2BUFFER*        pds3db,
     DWORD                   dwApply
 );
 // +s
@@ -1445,8 +1493,8 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetI3DL2Source)
 (
     X_CDirectSoundStream*   pThis,
-    PVOID   pds3db,
-    DWORD   dwApply
+    X_DSI3DL2BUFFER*        pds3db,
+    DWORD                   dwApply
 );
 
 // ******************************************************************
@@ -1455,7 +1503,7 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetI3DL2Source)
 HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetAllParameters)
 (
     X_CDirectSoundBuffer*    pThis,
-    LPCDS3DBUFFER            pc3DBufferParameters,
+    X_DS3DBUFFER*            pc3DBufferParameters,
     DWORD                    dwApply
 );
 

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -67,6 +67,11 @@ void CxbxInitAudio();
 #define X_DSSPAUSE_SYNCHPLAYBACK      0x00000002
 #define X_DSSPAUSE_PAUSENOACTIVATE    0x00000003
 
+// EmuIDirectSoundBuffer_StopEx flags
+#define X_DSBSTOPEX_IMMEDIATE         0x00000000
+#define X_DSBSTOPEX_ENVELOPE          0x00000001
+#define X_DSBSTOPEX_RELEASEWAVEFORM   0x00000002
+
 
 // ******************************************************************
 // * X_DSBUFFERDESC
@@ -280,6 +285,12 @@ struct X_CDirectSound
     // TODO: Fill this in?
 };
 
+enum X_DSB_TOGGLE {
+    X_DSB_TOGGLE_DEFAULT = 0,
+    X_DSB_TOGGLE_PLAY,
+    X_DSB_TOGGLE_LOOP
+};
+
 // ******************************************************************
 // * X_CDirectSoundBuffer
 // ******************************************************************
@@ -305,6 +316,14 @@ struct X_CDirectSoundBuffer
     LPDIRECTSOUND3DBUFFER8  EmuDirectSound3DBuffer8;
     DWORD                   EmuLockOffset;
     DWORD                   EmuLockFlags;
+    // Play/Loop Region Section
+    X_DSB_TOGGLE            EmuBufferToggle;
+    DWORD                   EmuRegionLoopStartOffset;
+    DWORD                   EmuRegionLoopLength;
+    DWORD                   EmuRegionPlayStartOffset;
+    DWORD                   EmuRegionPlayLength;
+    LPDIRECTSOUNDBUFFER8    EmuDirectSoundBuffer8Region;
+    LPDIRECTSOUND3DBUFFER8  EmuDirectSound3DBuffer8Region;
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -331,12 +331,12 @@ inline void DSoundGenericUnlock(
     DWORD                   dwOffset,
     LPVOID                 &pLockPtr1,
     DWORD                   dwLockBytes1,
-    LPVOID                  pLockPtr2,
+    LPVOID                 &pLockPtr2,
     DWORD                   dwLockBytes2,
     DWORD                   dwLockFlags)
 {
     // close any existing locks
-    if (pLockPtr1 != nullptr) {
+    if (pLockPtr1 != xbnullptr) {
         if (dwEmuFlags & DSB_FLAG_XADPCM) {
 
             //Since it is already locked, don't even need this.
@@ -360,7 +360,8 @@ inline void DSoundGenericUnlock(
             pDSBuffer->Unlock(pLockPtr1, dwLockBytes1, pLockPtr2, dwLockBytes2);
         }
 
-        pLockPtr1 = 0;
+        pLockPtr1 = xbnullptr;
+        pLockPtr2 = xbnullptr;
     }
 
 }

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1139,8 +1139,7 @@ inline HRESULT HybridDirectSoundBuffer_SetOutputBuffer(
 
     return DS_OK;
 }
-
-//TODO: PC DirectSound does not have SetPitch method function.
+*/
 //IDirectSoundStream
 //IDirectSoundBuffer
 inline HRESULT HybridDirectSoundBuffer_SetPitch(
@@ -1148,12 +1147,29 @@ inline HRESULT HybridDirectSoundBuffer_SetPitch(
     LONG                lPitch)
 {
 
-    // TODO: Translate params, then make the PC DirectSound call
+    // Convert pitch back to frequency
+    if (lPitch == 0) {
+        lPitch = 48000; // NOTE: pitch = 0 is equal to 48 KHz.
+    } else {
+        lPitch = static_cast<LONG>(exp((lPitch / 4096.0f) * log(2)) * 48000.0f);
+    }
 
-    return DS_OK;
+    /* For research purpose of how to convert frequency to pitch and back to frequency.
+    // Edit hertz variable to see the result.
+    float hertz = 12000.0f;
+
+    float hertzRatio = 48000.0f;
+    float pitchRatio = 4096.0f;
+
+    // Convert hertz to pitch
+    float pitch = log2(hertz / hertzRatio) * pitchRatio;
+
+    // Convert pitch to hertz
+    hertz = exp((pitch / pitchRatio) * log(2)) * hertzRatio;*/
+
+    RETURN_RESULT_CHECK(pDSBuffer->SetFrequency(lPitch));
 }
-
-//TODO: PC DirectSound does not have SetPitch method function.
+/*
 //Only has one function, this is not a requirement.
 //IDirectSoundBuffer
 inline HRESULT HybridDirectSoundBuffer_SetPlayRegion(

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -818,7 +818,12 @@ inline HRESULT HybridDirectSound3DBuffer_SetConeOrientation(
 
     HRESULT hRet = DS_OK;
     if (pDS3DBuffer != nullptr) {
-        hRet = pDS3DBuffer->SetConeOrientation(x, y, z, dwApply);
+        // Test case: Turok Evolution, Jet Set Radio Future, ?
+        if (x == 0.0f && y == 0.0f && z == 0.0f) {
+            printf("WARNING: SetConeOrientation was called with x = 0, y = 0, and z = 0. Current action is ignore call to PC.\n");
+        } else {
+            hRet = pDS3DBuffer->SetConeOrientation(x, y, z, dwApply);
+        }
     }
 
     leaveCriticalSection;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -433,7 +433,7 @@ inline void DSoundBufferRegionRelease(XTL::X_CDirectSoundBuffer *pThis)
     DSoundBufferRegionSetDefault(pThis);
 }
 
-inline void DSoundBufferTransfer(
+inline void DSoundBufferTransferSettings(
     LPDIRECTSOUNDBUFFER8       &pDSBufferOld,
     LPDIRECTSOUNDBUFFER8       &pDSBufferNew,
     LPDIRECTSOUND3DBUFFER8     &pDS3DBufferOld,
@@ -474,7 +474,7 @@ inline void DSoundBufferReplace(
         DSound3DBufferCreate(pDSBuffer, pDS3DBufferNew);
     }
 
-    DSoundBufferTransfer(pDSBuffer, pDSBufferNew, pDS3DBuffer, pDS3DBufferNew);
+    DSoundBufferTransferSettings(pDSBuffer, pDSBufferNew, pDS3DBuffer, pDS3DBufferNew);
 
     // NOTE: pDS3DBuffer will be set from almost the end of the function with pDS3DBufferNew.
     if (pDS3DBuffer != nullptr) {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -445,23 +445,15 @@ inline void DSoundBufferTransfer(
     pDSBufferOld->GetFrequency(&dwFrequency);
     pDSBufferOld->GetPan(&lPan);
 
-    if (pDS3DBufferOld != nullptr && pDS3DBufferNew != nullptr) {
-        pDS3DBufferOld->GetAllParameters(&ds3dBuffer);
-    }
-
-    if (pDS3DBufferOld != nullptr && pDS3DBufferNew != nullptr) {
-        HRESULT hRet3D = pDSBufferOld->QueryInterface(IID_IDirectSound3DBuffer, (LPVOID*)&(pDS3DBufferOld));
-        if (hRet3D != DS_OK) {
-            EmuWarning("CreateSound3DBuffer Failed!");
-            pDS3DBufferOld = nullptr;
-        } else {
-            pDS3DBufferNew->SetAllParameters(&ds3dBuffer, DS3D_IMMEDIATE);
-        }
-    }
-
     pDSBufferNew->SetPan(lPan);
     pDSBufferNew->SetFrequency(dwFrequency);
     pDSBufferNew->SetVolume(lVolume);
+
+    if (pDS3DBufferOld != nullptr && pDS3DBufferNew != nullptr) {
+        pDS3DBufferOld->GetAllParameters(&ds3dBuffer);
+
+        pDS3DBufferNew->SetAllParameters(&ds3dBuffer, DS3D_IMMEDIATE);
+    }
 }
 
 inline void DSoundBufferReplace(

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -430,8 +430,8 @@ inline void ResizeIDirectSoundBuffer(
         while (pDSBuffer->AddRef() < refCount);
     }
     if (pDS3DBuffer != xbnullptr && pDSBufferDesc->dwFlags & DSBCAPS_CTRL3D) {
-        hRet = pDSBuffer->QueryInterface(IID_IDirectSound3DBuffer, (LPVOID*)&(pDS3DBuffer));
-        if (hRet != DS_OK) {
+        HRESULT hRet3D = pDSBuffer->QueryInterface(IID_IDirectSound3DBuffer, (LPVOID*)&(pDS3DBuffer));
+        if (hRet3D != DS_OK) {
             EmuWarning("CreateSound3DBuffer Failed!");
             pDS3DBuffer = xbnullptr;
         } else {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1384,8 +1384,8 @@ inline HRESULT HybridDirectSoundBuffer_SetVolume(
             lVolume = -10000;
         }
     }
-    if (lVolume > -10000 && lVolume <= -6400) {
-        lVolume = -10000;
+    if (lVolume <= -6400) {
+        lVolume = DSBVOLUME_MIN;
     } else if (lVolume > 0) {
         EmuWarning("HybridDirectSoundBuffer_SetVolume has received greater than 0: %d", lVolume);
         lVolume = 0;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -82,7 +82,7 @@ void DSoundBufferXboxAdpcmDecoder(
 
     // Allocate some temp buffers
     uint8_t* buffer1 = (uint8_t*)malloc(dwDecodedAudioBytes);
-    uint8_t* buffer2 = NULL;
+    uint8_t* buffer2 = nullptr;
 
     if (dwAudioBytes2 != 0) {
         buffer2 = (uint8_t*)malloc(dwDecodedAudioBytes2);
@@ -94,7 +94,7 @@ void DSoundBufferXboxAdpcmDecoder(
         TXboxAdpcmDecoder_Decode_Memory((uint8_t*)pAudioPtr2, dwAudioBytes2, &buffer2[0], pDSBufferDesc->lpwfxFormat->nChannels);
     }
     // Lock this Xbox ADPCM buffer
-    void* pPtrX = NULL, *pPtrX2 = NULL;
+    void* pPtrX = xbnullptr, *pPtrX2 = xbnullptr;
     DWORD dwBytesX = 0, dwBytesX2 = 0;
 
     HRESULT hr = DS_OK;
@@ -109,7 +109,7 @@ void DSoundBufferXboxAdpcmDecoder(
             if (dwDecodedAudioBytes > dwBytesX) dwDecodedAudioBytes = dwBytesX;
             memcpy(pPtrX, buffer1, dwDecodedAudioBytes);
 
-            if (pPtrX2 != NULL) {
+            if (pPtrX2 != xbnullptr) {
                 if (dwDecodedAudioBytes2 > dwBytesX2) dwDecodedAudioBytes2 = dwBytesX2;
                 memcpy(pPtrX2, buffer2, dwDecodedAudioBytes2);
             }
@@ -121,7 +121,7 @@ void DSoundBufferXboxAdpcmDecoder(
             if (dwDecodedAudioBytes > dwAudioBytes) dwDecodedAudioBytes = dwAudioBytes;
             memcpy(pAudioPtr, buffer1, dwDecodedAudioBytes);
 
-            if (pAudioPtr2 != NULL) {
+            if (pAudioPtr2 != xbnullptr) {
                 if (dwDecodedAudioBytes2 > dwAudioBytes2) dwDecodedAudioBytes2 = dwAudioBytes2;
                 memcpy(pAudioPtr2, buffer2, dwDecodedAudioBytes2);
             }
@@ -219,7 +219,7 @@ inline void GeneratePCMFormat(
         }
         pDSBufferDesc->dwReserved = 0;
 
-        if (lpwfxFormat != NULL) {
+        if (lpwfxFormat != xbnullptr) {
 
             //TODO: RadWolfie - Need implement support for WAVEFORMATEXTENSIBLE as stated in CDirectSoundStream_SetFormat function note below
             // Do we need to convert it? Or just only do the WAVEFORMATEX only?
@@ -260,7 +260,7 @@ inline void GeneratePCMFormat(
             bIsSpecial = true;
             dwEmuFlags |= DSB_FLAG_RECIEVEDATA;
 
-            EmuWarning("Creating dummy WAVEFORMATEX (pdsbd->lpwfxFormat = NULL)...");
+            EmuWarning("Creating dummy WAVEFORMATEX (pdsbd->lpwfxFormat = xbnullptr)...");
 
             // HACK: This is a special sound buffer, create dummy WAVEFORMATEX data.
             // It's supposed to recieve data rather than generate it.  Buffers created
@@ -313,7 +313,7 @@ inline void GeneratePCMFormat(
     }
 
     //TODO: is this needed?
-    if (pDSBufferDesc->lpwfxFormat != NULL) {
+    if (pDSBufferDesc->lpwfxFormat != nullptr) {
         // we only support 2 channels right now
         if (pDSBufferDesc->lpwfxFormat->nChannels > 2) {
             pDSBufferDesc->lpwfxFormat->nChannels = 2;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -465,7 +465,7 @@ inline void DSoundBufferReplace(
     DWORD                       PlayFlags,
     LPDIRECTSOUND3DBUFFER8     &pDS3DBuffer)
 {
-    DWORD refCount, dwPlayCursor, dwWriteCursor, dwStatus;
+    DWORD refCount, dwPlayCursor, dwStatus;
     LPDIRECTSOUNDBUFFER8       pDSBufferNew = nullptr;
     LPDIRECTSOUND3DBUFFER8       pDS3DBufferNew = nullptr;
 
@@ -481,19 +481,19 @@ inline void DSoundBufferReplace(
     if (pDS3DBuffer != nullptr) {
         pDS3DBuffer->Release();
     }
-
-    HRESULT hRet = pDSBuffer->GetCurrentPosition(&dwPlayCursor, &dwWriteCursor);
-
-    if (hRet != DS_OK) {
-        CxbxKrnlCleanup("Unable to retrieve current position for resize reallocation!");
-    }
-    hRet = pDSBuffer->GetStatus(&dwStatus);
+    HRESULT hRet = pDSBuffer->GetStatus(&dwStatus);
 
     if (hRet != DS_OK) {
-        CxbxKrnlCleanup("Unable to retrieve current status for resize reallocation!");
+        CxbxKrnlCleanup("Unable to retrieve current status for replace DS buffer!");
     }
 
     pDSBuffer->Stop();
+
+    hRet = pDSBuffer->GetCurrentPosition(&dwPlayCursor, nullptr);
+
+    if (hRet != DS_OK) {
+        CxbxKrnlCleanup("Unable to retrieve current position for replace DS buffer!");
+    }
 
     // TODO: Untested if transfer buffer to new audio buffer is necessary.
     PVOID pLockPtr1Old, pLockPtr1New;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -420,6 +420,8 @@ inline void DSoundBufferRegionSetDefault(XTL::X_CDirectSoundBuffer *pThis) {
 
 inline void DSoundBufferRegionRelease(XTL::X_CDirectSoundBuffer *pThis)
 {
+    // NOTE: DSB Buffer8Region and 3DBuffer8Region are set
+    // to nullptr inside DSoundBufferRegionSetDefault function.
     if (pThis->EmuDirectSoundBuffer8Region != nullptr) {
         pThis->EmuDirectSoundBuffer8Region->Release();
 
@@ -474,6 +476,7 @@ inline void DSoundBufferReplace(
 
     DSoundBufferTransfer(pDSBuffer, pDSBufferNew, pDS3DBuffer, pDS3DBufferNew);
 
+    // NOTE: pDS3DBuffer will be set from almost the end of the function with pDS3DBufferNew.
     if (pDS3DBuffer != nullptr) {
         pDS3DBuffer->Release();
     }
@@ -513,6 +516,9 @@ inline void DSoundBufferReplace(
     // release old buffer
     refCount = pDSBuffer->Release();
     if (refCount) {
+        // NOTE: This is base on AddRef call, so this is a requirement.
+        // The reason is to have ability "transfer" ref count is due to some titles doesn't care about ref count.
+        // If AddRef was called, then it will "internally" increment the ref count, not the return value check.
         while (pDSBuffer->Release() > 0) {}
     }
 

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -759,14 +759,42 @@ inline HRESULT HybridDirectSoundBuffer_Restore(
 //IDirectSoundBuffer
 inline HRESULT HybridDirectSound3DBuffer_SetAllParameters(
     LPDIRECTSOUND3DBUFFER8  pDS3DBuffer,
-    LPCDS3DBUFFER           pDS3DBufferParams,
+    XTL::X_DS3DBUFFER*      pDS3DBufferParams,
     DWORD                   dwApply)
 {
     enterCriticalSection;
 
     HRESULT hRet = DS_OK;
     if (pDS3DBuffer != nullptr) {
-        hRet = pDS3DBuffer->SetAllParameters(pDS3DBufferParams, dwApply);
+
+        DS3DBUFFER pDS3DBufferParamsTemp;
+        pDS3DBufferParamsTemp.dwSize = sizeof(DS3DBUFFER);
+        pDS3DBufferParamsTemp.vPosition = pDS3DBufferParams->vPosition;
+        pDS3DBufferParamsTemp.vVelocity = pDS3DBufferParams->vVelocity;
+        pDS3DBufferParamsTemp.dwInsideConeAngle = pDS3DBufferParams->dwInsideConeAngle;
+        pDS3DBufferParamsTemp.dwOutsideConeAngle = pDS3DBufferParams->dwOutsideConeAngle;
+        pDS3DBufferParamsTemp.vConeOrientation = pDS3DBufferParams->vConeOrientation;
+        pDS3DBufferParamsTemp.lConeOutsideVolume = pDS3DBufferParams->lConeOutsideVolume;
+        pDS3DBufferParamsTemp.flMinDistance = pDS3DBufferParams->flMinDistance;
+        pDS3DBufferParamsTemp.flMaxDistance = pDS3DBufferParams->flMaxDistance;
+        pDS3DBufferParamsTemp.dwMode = pDS3DBufferParams->dwMode;
+
+        hRet = pDS3DBuffer->SetAllParameters(&pDS3DBufferParamsTemp, dwApply);
+        if (hRet != DS_OK) {
+            RETURN_RESULT_CHECK(hRet);
+        }
+
+        hRet = g_pDSoundPrimary3DListener8->SetDistanceFactor(pDS3DBufferParams->flDistanceFactor, dwApply);
+        if (hRet != DS_OK) {
+            RETURN_RESULT_CHECK(hRet);
+        }
+
+        hRet = g_pDSoundPrimary3DListener8->SetRolloffFactor(pDS3DBufferParams->flRolloffFactor, dwApply);
+        if (hRet != DS_OK) {
+            RETURN_RESULT_CHECK(hRet);
+        }
+
+        hRet = g_pDSoundPrimary3DListener8->SetDopplerFactor(pDS3DBufferParams->flDopplerFactor, dwApply);
     }
 
     leaveCriticalSection;


### PR DESCRIPTION
- Major improvement overall.
- Reduced duplicate as possible into one inline function each.
- SetLoopRegion and SetPlayRegion are now supported.
- And major clean up.

WaveBank Sample now play audio properly. Some titles do have improvements such as Gaunlet: Dark Legacy.

DS Buffer's StopEx needs more research to finalize its purpose base on flag pass down.