### PR TITLE
Add DSound OOVPA

### DIFF
--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -291,7 +291,9 @@ $(SOLUTIONDIR)Export.bat</Command>
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4242.inl" />
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4361.inl" />
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4432.inl" />
+    <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4531.inl" />
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4627.inl" />
+    <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4721.inl" />
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.5028.inl" />
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.5233.inl" />
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.5344.inl" />

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -524,7 +524,13 @@
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4432.inl">
       <Filter>HLEDatabase\DSound</Filter>
     </None>
+    <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4531.inl">
+      <Filter>HLEDatabase\DSound</Filter>
+    </None>
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4627.inl">
+      <Filter>HLEDatabase\DSound</Filter>
+    </None>
+    <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.4721.inl">
       <Filter>HLEDatabase\DSound</Filter>
     </None>
     <None Include="..\..\src\CxbxKrnl\HLEDataBase\DSound.1.0.5028.inl">

--- a/src/CxbxKrnl/HLEDataBase.h
+++ b/src/CxbxKrnl/HLEDataBase.h
@@ -312,6 +312,10 @@ enum XRefDataBaseOffset
     XREF_CDirectSound3DCalculator_Calculate3D,
     XREF_CDirectSound_UnmapBufferData,
     XREF_CDirectSound_MapBufferData,
+    XREF_CFullHrtfSource_GetHrtfFilterPair,
+    XREF_CHrtfSource_SetAlgorithm_FullHrtf,
+    XREF_CHrtfSource_SetAlgorithm_LightHrtf,
+    XREF_CLightHrtfSource_GetHrtfFilterPair,
 	// XACT
 	// +s
 	XREF_XACT_CEngine_RegisterWaveBank,

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.4134.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.4134.inl
@@ -3259,7 +3259,7 @@ OOVPA_END;
 // ******************************************************************
 // * DirectSoundUseFullHRTF
 // ******************************************************************
-// Generic OOVPA as of 4134 and newer.
+// Generic OOVPA as of 4134 plus 5344 and newer.
 OOVPA_XREF(DirectSoundUseFullHRTF, 4134, 1+7,
 
     XRefNoSaveIndex,
@@ -3523,6 +3523,44 @@ OOVPA_END;
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
+OOVPA_XREF(CMcpxStream_Flush, 4134, 18,
+
+    XREF_CMcpxStream_Flush,
+    XRefZero)
+
+        // CMcpxStream_Flush+0x00 : push ebp; mov ebp, esp; sub esp, 10h
+        { 0x00, 0x55 },
+        { 0x01, 0x8B },
+        { 0x02, 0xEC },
+        { 0x03, 0x83 },
+        { 0x04, 0xEC },
+        { 0x05, 0x10 },
+
+        // Offset is unique for this asm code.
+        // CMcpxStream_Flush+0x0A : movzx eax,byte ptr fs:[24h]
+        { 0x0A, 0x64 },
+        { 0x0B, 0x0F },
+        { 0x0C, 0xB6 },
+        { 0x0D, 0x05 },
+        { 0x0E, 0x24 },
+        { 0x0F, 0x00 },
+        { 0x10, 0x00 },
+        { 0x11, 0x00 },
+
+        // Offset is not match for revision 5455.
+        // CMcpxStream_Flush+0x7F : lea eax, [???+XXXh]
+        { 0x7F, 0x8D },
+        { 0x83, 0x00 },
+        { 0x84, 0x00 },
+
+        // CMcpxStream_Flush+0x85 : push eax
+        { 0x85, 0x50 },
+OOVPA_END;
+
+#if 0 // No longer used, replaced by generic 4134 version
+// ******************************************************************
+// * CMcpxStream_Flush
+// ******************************************************************
 OOVPA_XREF(CMcpxStream_Flush, 4134, 10,
     XREF_CMcpxStream_Flush,
     XRefZero)
@@ -3543,6 +3581,7 @@ OOVPA_XREF(CMcpxStream_Flush, 4134, 10,
         { 0xD0, 0xC9 },
         { 0xD1, 0xC3 },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * CDirectSoundStream_Flush
@@ -4314,8 +4353,10 @@ OOVPA_XREF(CDirectSound_EnableHeadphones, 4134, 12,
         { 0x52, 0x0D },
         { 0x53, 0x00 },
 
-        { 0x82, 0xC2 },
-        { 0x83, 0x08 },
+        { 0x63, 0x0C },
+        { 0x64, 0xE8 },
+        //{ 0x82, 0xC2 }, 4242 Different length
+        //{ 0x83, 0x08 },
 OOVPA_END;
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.4242.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.4242.inl
@@ -216,6 +216,7 @@ OOVPA_XREF(CMcpxBuffer_Stop, 4242, 9,
         { 0x1D, 0x02 },
 OOVPA_END;
 
+#if 0 // No longer used, replaced by generic 4134 version
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
@@ -240,7 +241,7 @@ OOVPA_XREF(CMcpxStream_Flush, 4242, 10,
         { 0xD1, 0xC9 },
         { 0xD2, 0xC3 },
 OOVPA_END;
-
+#endif
 #if 0 // Moved to 4039
 // ******************************************************************
 // * IDirectSoundStream_SetFormat
@@ -283,4 +284,196 @@ OOVPA_XREF(CDirectSoundBuffer_SetNotificationPositions, 4242, 11,
 
         { 0x47, 0xE8 },
         { 0x5D, 0x8B },
+OOVPA_END;
+
+// ******************************************************************
+// * CDirectSound_GetSpeakerConfig
+// ******************************************************************
+OOVPA_XREF(CDirectSound_GetSpeakerConfig, 4242, 12,
+
+    XREF_CDirectSound_GetSpeakerConfig,
+    XRefZero)
+
+        { 0x00, 0xE8 },
+        { 0x20, 0xB8 },
+
+        { 0x27, 0x8B },
+        { 0x28, 0x4C },
+        { 0x29, 0x24 },
+        { 0x2A, 0x04 },
+        { 0x2B, 0x8B },
+        { 0x2C, 0x49 },
+        { 0x2D, 0x08 },
+        { 0x2E, 0x8B },
+
+        { 0x4E, 0xC2 },
+        { 0x4F, 0x08 },
+OOVPA_END;
+
+// ******************************************************************
+// * CFullHrtfSource_GetHrtfFilterPair
+// ******************************************************************
+OOVPA_XREF(CFullHrtfSource_GetHrtfFilterPair, 4242, 15,
+
+    XREF_CFullHrtfSource_GetHrtfFilterPair,
+    XRefZero)
+
+        { 0x00, 0x56 },
+        { 0x01, 0x8B },
+        { 0x02, 0x74 },
+        { 0x03, 0x24 },
+        { 0x04, 0x08 },
+        { 0x05, 0xD9 },
+        { 0x06, 0x46 },
+        { 0x07, 0x14 },
+        { 0x08, 0x51 },
+        { 0x09, 0xD8 },
+        { 0x0A, 0x1D },
+
+        { 0x1A, 0x05 },
+        { 0x1F, 0xEB },
+
+        { 0x58, 0xD8 },
+        { 0x59, 0x05 },
+OOVPA_END;
+
+// ******************************************************************
+// * CHrtfSource_SetAlgorithm_FullHrtf
+// ******************************************************************
+OOVPA_XREF(CHrtfSource_SetAlgorithm_FullHrtf, 4242, 1+8,
+
+    XREF_CHrtfSource_SetAlgorithm_FullHrtf,
+    XRefOne)
+
+        XREF_ENTRY( 0x17, XREF_CFullHrtfSource_GetHrtfFilterPair ),
+
+        { 0x00, 0x83 },
+        { 0x01, 0x25 },
+        { 0x06, 0x00 },
+        { 0x07, 0xC7 },
+        { 0x08, 0x05 },
+        { 0x11, 0xC7 },
+        { 0x12, 0x05 },
+        { 0x1B, 0xC3 },
+OOVPA_END;
+
+// ******************************************************************
+// * DirectSoundUseFullHRTF
+// ******************************************************************
+OOVPA_XREF(DirectSoundUseFullHRTF, 4242, 1+8,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY(0x13, XREF_CHrtfSource_SetAlgorithm_FullHrtf ),
+
+        { 0x00, 0x56 },
+        { 0x01, 0xE8 },
+        { 0x06, 0x83 },
+        { 0x07, 0x3D },
+        { 0x0C, 0x02 },
+        { 0x1A, 0x74 },
+        { 0x1B, 0x0B },
+        { 0x1C, 0x68 },
+OOVPA_END;
+
+// ******************************************************************
+// * CLightHrtfSource_GetHrtfFilterPair
+// ******************************************************************
+OOVPA_XREF(CLightHrtfSource_GetHrtfFilterPair, 4242, 16,
+
+    XREF_CLightHrtfSource_GetHrtfFilterPair,
+    XRefZero)
+
+        { 0x00, 0x56 },
+        { 0x01, 0x8B },
+        { 0x02, 0x74 },
+        { 0x03, 0x24 },
+        { 0x04, 0x08 },
+        { 0x05, 0xD9 },
+        { 0x06, 0x46 },
+        { 0x07, 0x10 },
+        { 0x08, 0x51 },
+        { 0x09, 0xD9 },
+        { 0x0A, 0xE1 },
+        { 0x0B, 0xD8 },
+        { 0x0C, 0x05 },
+
+        { 0x19, 0x99 },
+        { 0x1A, 0x6A },
+
+        { 0x8B, 0x89 },
+OOVPA_END;
+
+// ******************************************************************
+// * CHrtfSource_SetAlgorithm_LightHrtf
+// ******************************************************************
+OOVPA_XREF(CHrtfSource_SetAlgorithm_LightHrtf, 4242, 1+11,
+
+    XREF_CHrtfSource_SetAlgorithm_LightHrtf,
+    XRefOne)
+
+        XREF_ENTRY(0x1A, XREF_CLightHrtfSource_GetHrtfFilterPair ),
+
+        { 0x00, 0xC7 },
+        { 0x01, 0x05 },
+        { 0x06, 0x01 },
+        { 0x07, 0x00 },
+        { 0x08, 0x00 },
+        { 0x09, 0x00 },
+        { 0x0A, 0xC7 },
+        { 0x0B, 0x05 },
+        { 0x14, 0xC7 },
+        { 0x15, 0x05 },
+        { 0x1E, 0xC3 },
+OOVPA_END;
+
+// ******************************************************************
+// * DirectSoundUseLightHRTF
+// ******************************************************************
+OOVPA_XREF(DirectSoundUseLightHRTF, 4242, 1+8,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY(0x13, XREF_CHrtfSource_SetAlgorithm_LightHrtf ),
+
+        { 0x00, 0x56 },
+        { 0x01, 0xE8 },
+        { 0x06, 0x83 },
+        { 0x07, 0x3D },
+        { 0x0C, 0x02 },
+        { 0x1A, 0x74 },
+        { 0x1B, 0x0B },
+        { 0x1C, 0x68 },
+OOVPA_END;
+
+// ******************************************************************
+// * WaveFormat::CreateXboxAdpcmFormat
+// ******************************************************************
+OOVPA_XREF(WaveFormat_CreateXboxAdpcmFormat, 4242, 7,
+
+    XREF_WaveFormat_CreateXboxAdpcmFormat,
+    XRefZero)
+
+        { 0x07, 0x08 },
+        { 0x10, 0xE9 },
+        { 0x19, 0x8D },
+        { 0x22, 0x66 },
+        { 0x2B, 0x04 },
+        { 0x34, 0x66 },
+        { 0x3D, 0x12 },
+OOVPA_END;
+
+// ******************************************************************
+// * XAudioCreateAdpcmFormat
+// ******************************************************************
+OOVPA_XREF(XAudioCreateAdpcmFormat, 4242, 1+1,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY( 0x01, XREF_WaveFormat_CreateXboxAdpcmFormat ),
+
+        { 0x00, 0xE9 },
 OOVPA_END;

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.4361.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.4361.inl
@@ -372,7 +372,7 @@ OOVPA_XREF(CDirectSoundBuffer_PlayEx, 4361, 1+7,
         { 0x52, 0x8B },
 OOVPA_END;
 #endif
-
+#if 0 // No longer used, replaced by generic 4134 version
 // ******************************************************************
 // * CMcpxBuffer::Stop2
 // ******************************************************************
@@ -397,7 +397,7 @@ OOVPA_XREF(CMcpxBuffer_Stop2, 4361, 1+9,
         { 0x36, 0xC2 },
         { 0x37, 0x0C },
 OOVPA_END;
-
+#endif
 #if 0 // Moved to 4134
 // ******************************************************************
 // * DirectSound::CDirectSoundBuffer::StopEx
@@ -438,7 +438,7 @@ OOVPA_XREF(IDirectSoundBuffer_StopEx, 4361, 1+7,
         { 0x21, 0xC2 },
 OOVPA_END;
 #endif
-
+#if 0 // No longer used, replaced by generic 4039 version
 // ******************************************************************
 // * public: long __thiscall DirectSound::CMcpxBuffer::Play(__int64,unsigned long)
 // ******************************************************************
@@ -456,7 +456,7 @@ OOVPA_XREF(CMcpxBuffer_Play2, 4361, 8,
         { 0x2F, 0x8B },
         { 0x36, 0xC2 },
 OOVPA_END;
-
+#endif
 #if 0 // For research purpose, need to strengthen it up.
 // ******************************************************************
 // * public: long __thiscall DirectSound::CMcpxBuffer::Play(__int64,unsigned long)
@@ -616,4 +616,60 @@ OOVPA_XREF(CMcpxStream_Flush, 4361, 10,
         // Might not be a requirement? Aka comment this out might will enable support detection later XDK revisions.
         { 0xD1, 0xC9 },
         { 0xD2, 0xC3 },
+OOVPA_END;
+
+// ******************************************************************
+// * CDirectSoundVoice::SetDistanceFactor
+// ******************************************************************
+OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 4361, 12,
+
+    XREF_CDirectSoundVoice_SetDistanceFactor,
+    XRefZero)
+
+        // CDirectSoundVoice_SetDistanceFactor+0x0D : mov edx, [esp+arg_4]
+        { 0x0D, 0x8B },
+        { 0x0E, 0x54 },
+        { 0x0F, 0x24 },
+        { 0x10, 0x08 },
+
+        // CDirectSoundVoice_SetDistanceFactor+0x11 : mov [eax+40h], edx
+        { 0x11, 0x89 },
+        { 0x12, 0x50 },
+        { 0x13, 0x40 },
+
+        { 0x14, 0x8B },
+        { 0x1D, 0x83 },
+        { 0x1F, 0x78 },
+
+        // CDirectSoundVoice_SetDistanceFactor+0x30 : retn 0Ch
+        { 0x31, 0x0C },
+        { 0x32, 0x00 },
+OOVPA_END;
+
+// ******************************************************************
+// * CDirectSoundVoice::SetDopplerFactor
+// ******************************************************************
+OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4361, 12,
+
+	XREF_CDirectSoundVoice_SetDopplerFactor,
+    XRefZero)
+
+        // CDirectSoundVoice_SetDopplerFactor+0x0D : mov edx, [esp+arg_4]
+        { 0x0D, 0x8B },
+        { 0x0E, 0x54 },
+        { 0x0F, 0x24 },
+        { 0x10, 0x08 },
+
+        // CDirectSoundVoice_SetDopplerFactor+0x12 : mov [eax+48h], edx
+        { 0x11, 0x89 },
+        { 0x12, 0x50 },
+        { 0x13, 0x48 },
+
+        { 0x14, 0x8B },
+        { 0x1D, 0x83 },
+        { 0x1F, 0x78 },
+
+        // CDirectSoundVoice_SetDopplerFactor+0x31 : retn 0Ch
+        { 0x31, 0x0C },
+        { 0x32, 0x00 }
 OOVPA_END;

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.4531.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.4531.inl
@@ -1,0 +1,59 @@
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->Win32->CxbxKrnl->HLEDataBase->DSound.1.0.4531.inl
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2017 jarupxx
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+// ******************************************************************
+// * CMcpxStream_Discontinuity
+// ******************************************************************
+OOVPA_XREF(CMcpxStream_Discontinuity, 4531, 9,
+
+    XREF_CMcpxStream_Discontinuity,
+    XRefZero)
+
+        // CMcpxStream_Discontinuity+0x00 : push esi; push edi
+        { 0x00, 0x56 },
+        { 0x01, 0x57 },
+
+        // CMcpxStream_Discontinuity+0x12 : mov dx,0x800
+        { 0x12, 0x66 },
+        { 0x13, 0xBA },
+        { 0x14, 0x00 },
+        { 0x15, 0x08 },
+
+        // CMcpxStream_Discontinuity+0x23 : call Stop@CMcpxStream@DirectSound@@QAEJ_JK@Z
+        { 0x23, 0xE8 },
+
+        // CMcpxStream_Discontinuity+0x2D : pop esi; ret
+        { 0x2D, 0x5E },
+        { 0x2E, 0xC3 },
+OOVPA_END;

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.4627.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.4627.inl
@@ -142,6 +142,7 @@ OOVPA_XREF(CDirectSound_SetAllParametersA, 4721, 10,
         { 0x89, 0x08 },
 OOVPA_END;
 
+#if 0 // No longer used, replaced by generic 4134 version
 // ******************************************************************
 // * DirectSound::CDirectSound::SetAllParameters
 // ******************************************************************
@@ -159,6 +160,7 @@ OOVPA_XREF(CDirectSound_SetAllParameters, 4831, 8,
         { 0xC9, 0x10 },
         { 0xE6, 0x0C },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * CDirectSound_SetPosition
@@ -218,7 +220,7 @@ OOVPA_XREF(DirectSoundCreateBuffer, 4242, 1+11,
         { 0x55, 0x08 },
 OOVPA_END;
 #endif
-
+#if 0 // No longer used, replaced by generic 4721 version
 // ******************************************************************
 // * CMcpxBuffer_GetStatus
 // ******************************************************************
@@ -254,6 +256,7 @@ OOVPA_XREF(CMcpxBuffer_GetStatus, 4721, 17,
 
 		{ 0x3D, 0x33 },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * CMcpxBuffer_GetStatus
@@ -515,6 +518,7 @@ OOVPA_XREF(CMcpxStream_Pause, 4831, 11,
         { 0x8C, 0x04 },
 OOVPA_END;
 
+#if 0 // No longer used, replaced by generic 4134 version
 // ******************************************************************
 // * DirectSound::CDirectSound::EnableHeadphones (incorrect?)
 // ******************************************************************
@@ -550,6 +554,7 @@ OOVPA_XREF(CDirectSound_EnableHeadphones, 4627, 16,
         { 0x98, 0xC2 },
         { 0x99, 0x08 },
 OOVPA_END;
+#endif
 #if 0 // Replaced with generic OOVPA 3911
 // ******************************************************************
 // * IDirectSound_EnableHeadphones
@@ -652,48 +657,6 @@ OOVPA_XREF(CMcpxBuffer_Pause, 4831, 7,
         { 0x49, 0x7D },
         { 0x58, 0xEB },
         { 0x67, 0xE8 },
-OOVPA_END;
-
-// ******************************************************************
-// * DirectSound::CDirectSoundBuffer::Pause
-// ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_Pause, 4928, 1+10,
-
-    XREF_CDirectSoundBuffer_Pause,
-    XRefOne)
-
-        XREF_ENTRY( 0x35, XREF_CMcpxBuffer_Pause ),
-
-        { 0x00, 0x56 },
-
-        { 0x0C, 0x00 },
-        { 0x14, 0x74 },
-        { 0x21, 0xB8 },
-        { 0x2A, 0x24 },
-        { 0x39, 0x85 },
-        { 0x44, 0xFF },
-        { 0x4B, 0xC7 },
-        { 0x4E, 0xC2 },
-        { 0x4F, 0x08 },
-OOVPA_END;
-
-// ******************************************************************
-// * IDirectSoundBuffer_Pause
-// ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_Pause, 4928, 1+7,
-
-    XRefNoSaveIndex,
-    XRefOne)
-
-        XREF_ENTRY( 0x15, XREF_CDirectSoundBuffer_Pause ),
-
-        { 0x02, 0x24 },
-        { 0x06, 0x24 },
-        { 0x0A, 0x83 },
-        { 0x0E, 0xD9 },
-        { 0x12, 0xC8 },
-        { 0x19, 0xC2 },
-        { 0x1A, 0x08 },
 OOVPA_END;
 
 #if 0 // Used 4134

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.4721.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.4721.inl
@@ -1,0 +1,296 @@
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->Win32->CxbxKrnl->HLEDataBase->DSound.1.0.4721.inl
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2017 jarupxx
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+// ******************************************************************
+// * CMcpxStream_GetStatus
+// ******************************************************************
+OOVPA_XREF(CMcpxStream_GetStatus, 4721, 14,
+
+    XREF_CMcpxStream_GetStatus,
+    XRefZero)
+
+        { 0x00, 0x0F },
+
+        { 0x09, 0x00 },
+        { 0x0A, 0x33 },
+        { 0x0B, 0xC9 },
+        { 0x0C, 0x39 },
+        { 0x0D, 0x00 },
+        { 0x0E, 0x8B },
+        { 0x0F, 0x44 },
+        { 0x10, 0x24 },
+        { 0x11, 0x04 },
+        { 0x12, 0x0F },
+        { 0x13, 0x95 },
+
+        { 0x1C, 0x80 },
+        { 0x41, 0x00 },
+OOVPA_END;
+
+// ******************************************************************
+// * CMcpxBuffer_GetStatus
+// ******************************************************************
+OOVPA_XREF(CMcpxBuffer_GetStatus, 4721, 17,
+
+	XREF_CMcpxBuffer_GetStatus,
+    XRefZero)
+
+        { 0x00, 0x0F },
+        { 0x01, 0xB7 },
+        { 0x02, 0x41 },
+        { 0x03, 0x12 },
+        { 0x04, 0x8B },
+        { 0x05, 0xC8 },
+        { 0x06, 0x83 },
+        { 0x07, 0xE1 },
+        { 0x08, 0x03 },
+        { 0x09, 0x80 },
+        { 0x0A, 0xF9 },
+        { 0x0B, 0x03 },
+        { 0x0C, 0x75 },
+
+        { 0x25, 0xEB },
+        { 0x26, 0x14 },
+
+        { 0x3D, 0xC2 },
+        { 0x3E, 0x04 },
+OOVPA_END;
+
+// ******************************************************************
+// * CMcpxBuffer_Pause
+// ******************************************************************
+OOVPA_XREF(CMcpxBuffer_Pause, 4721, 12,
+
+	XREF_CMcpxBuffer_Pause,
+    XRefZero)
+
+        { 0x00, 0x55 },
+        { 0x14, 0x8A },
+
+        { 0x20, 0x01 },
+        { 0x21, 0x75 },
+        { 0x22, 0x04 },
+        { 0x23, 0x6A },
+        { 0x24, 0x04 },
+        { 0x25, 0xEB },
+        { 0x26, 0x08 },
+        { 0x27, 0x83 },
+
+        { 0x42, 0xC2 },
+        { 0x43, 0x04 },
+OOVPA_END;
+
+// ******************************************************************
+// * DirectSound::CDirectSoundBuffer::PauseEx
+// ******************************************************************
+// Generic OOVPA as of 4721 and newer
+OOVPA_XREF(CDirectSoundBuffer_PauseEx, 4721, 1+10,
+
+    XREF_CDirectSoundBuffer_PauseEx,
+    XRefOne)
+
+        XREF_ENTRY( 0x3D, XREF_CMcpxBuffer_Pause_Ex ),
+
+        { 0x00, 0x56 },
+
+        { 0x0C, 0x00 },
+        { 0x14, 0x74 },
+        { 0x21, 0xB8 },
+        { 0x2A, 0x24 },
+        { 0x41, 0x85 },
+        { 0x4C, 0xFF },
+        { 0x53, 0xC7 },
+
+        { 0x56, 0xC2 },
+        { 0x57, 0x10 },
+OOVPA_END;
+
+// ******************************************************************
+// * IDirectSoundBuffer_PauseEx
+// ******************************************************************
+// Generic OOVPA as of 4721 and newer
+OOVPA_XREF(IDirectSoundBuffer_PauseEx, 4721, 1+7,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY( 0x1D, XREF_CDirectSoundBuffer_PauseEx ),
+
+        { 0x02, 0x24 },
+        { 0x06, 0x24 },
+        { 0x12, 0x83 },
+        { 0x16, 0xD9 },
+        { 0x1A, 0xC8 },
+        { 0x21, 0xC2 },
+        { 0x22, 0x10 },
+OOVPA_END;
+
+// ******************************************************************
+// * DirectSound::CMcpxBuffer::Pause
+// ******************************************************************
+// Generic OOVPA as of 4721 and newer
+OOVPA_XREF(CMcpxBuffer_Pause_Ex, 4721, 1+8,
+
+    XREF_CMcpxBuffer_Pause_Ex,
+    XRefOne)
+
+        XREF_ENTRY( 0x2B, XREF_CMcpxBuffer_Pause ),
+
+        { 0x00, 0x55 },
+
+        { 0x0D, 0x8B },
+
+        { 0x1C, 0x6A },
+        { 0x1D, 0x05 },
+
+        { 0x23, 0x75 },
+
+        { 0x2A, 0xE8 },
+
+        { 0x36, 0xC2 },
+        { 0x37, 0x0C },
+OOVPA_END;
+
+// ******************************************************************
+// * DirectSound::CMcpxStream::Pause2
+// ******************************************************************
+// Generic OOVPA as of 4721 and newer
+OOVPA_XREF(CMcpxStream_Pause_Ex, 4721, 1+8,
+
+    XREF_CMcpxStream_Pause_Ex,
+    XRefOne)
+
+        XREF_ENTRY( 0x2B, XREF_CMcpxStream_Pause ),
+
+        { 0x00, 0x55 },
+
+        { 0x0D, 0x8B },
+
+        { 0x1C, 0x6A },
+        { 0x1D, 0x05 },
+
+        { 0x23, 0x75 },
+
+        { 0x2A, 0xE8 },
+
+        { 0x36, 0xC2 },
+        { 0x37, 0x0C },
+OOVPA_END;
+
+// ******************************************************************
+// * DirectSound::CDirectSoundStream::PauseEx
+// ******************************************************************
+// Generic OOVPA as of 4721 and newer
+OOVPA_XREF(CDirectSoundStream_PauseEx, 4721, 1+10,
+
+    XREF_CDirectSoundStream_PauseEx,
+    XRefOne)
+
+        XREF_ENTRY( 0x3D, XREF_CMcpxStream_Pause_Ex ),
+
+        { 0x00, 0x56 },
+
+        { 0x0C, 0x00 },
+        { 0x14, 0x74 },
+        { 0x21, 0xB8 },
+        { 0x2A, 0x24 },
+        { 0x41, 0x85 },
+        { 0x4C, 0xFF },
+        { 0x53, 0xC7 },
+
+        { 0x56, 0xC2 },
+        { 0x57, 0x10 },
+OOVPA_END;
+
+// ******************************************************************
+// * IDirectSoundStream_PauseEx
+// ******************************************************************
+// Generic OOVPA as of 4721 and newer
+OOVPA_XREF(IDirectSoundStream_PauseEx, 4721, 1+7,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY( 0x11, XREF_CDirectSoundStream_PauseEx ),
+
+        { 0x02, 0x24 },
+        { 0x06, 0x24 },
+        { 0x0A, 0x24 },
+        { 0x0E, 0x24 },
+        { 0x10, 0xE8 },
+        { 0x15, 0xC2 },
+        { 0x16, 0x10 },
+OOVPA_END;
+
+// ******************************************************************
+// * DirectSound::CDirectSoundBuffer::Pause
+// ******************************************************************
+OOVPA_XREF(CDirectSoundBuffer_Pause, 4721, 1+10,
+
+    XREF_CDirectSoundBuffer_Pause,
+    XRefOne)
+
+        XREF_ENTRY( 0x35, XREF_CMcpxBuffer_Pause ),
+
+        { 0x00, 0x56 },
+
+        { 0x0C, 0x00 },
+        { 0x14, 0x74 },
+        { 0x21, 0xB8 },
+        { 0x2A, 0x24 },
+        { 0x39, 0x85 },
+        { 0x44, 0xFF },
+        { 0x4B, 0xC7 },
+        { 0x4E, 0xC2 },
+        { 0x4F, 0x08 },
+OOVPA_END;
+
+// ******************************************************************
+// * IDirectSoundBuffer_Pause
+// ******************************************************************
+OOVPA_XREF(IDirectSoundBuffer_Pause, 4721, 1+7,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY( 0x15, XREF_CDirectSoundBuffer_Pause ),
+
+        { 0x02, 0x24 },
+        { 0x06, 0x24 },
+        { 0x0A, 0x83 },
+        { 0x0E, 0xD9 },
+        { 0x12, 0xC8 },
+        { 0x19, 0xC2 },
+        { 0x1A, 0x08 },
+OOVPA_END;

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5028.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5028.inl
@@ -46,3 +46,62 @@ OOVPA_NO_XREF(XFileCreateMediaObjectEx, 5028, 8)
         { 0xAC, 0x0C },
         { 0xAD, 0x57 },
 OOVPA_END;
+
+// ******************************************************************
+// * CDirectSoundStream_Flush
+// ******************************************************************
+// Generic OOVPA as of 5028 and newer
+OOVPA_XREF(CDirectSoundStream_Flush, 5028, 1+8,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        //CDirectSoundStream_Flush+0x31 : call [CMcpxStream_Flush]
+        XREF_ENTRY( 0x32, XREF_CMcpxStream_Flush ),
+
+        { 0x00, 0x56 },
+
+        { 0x28, 0x8B },
+        { 0x2B, 0x08 },
+
+        { 0x2C, 0x8B },
+        { 0x2E, 0x24 },
+
+        { 0x31, 0xE8 },
+
+        //CDirectSoundStream_Flush+0x48 : ret 4
+        { 0x48, 0xC2 },
+        { 0x49, 0x04 },
+OOVPA_END;
+
+// ******************************************************************
+// * CDirectSoundStream_FlushEx
+// ******************************************************************
+// Generic OOVPA as of 5028 and newer
+OOVPA_XREF(CDirectSoundStream_FlushEx, 5028, 16,
+
+    XREF_CDirectSoundStream_FlushEx,
+    XRefZero)
+
+        { 0x00, 0x55 },
+
+        { 0x24, 0xB8 },
+        { 0x25, 0x05 },
+        { 0x26, 0x40 },
+        { 0x27, 0x00 },
+        { 0x28, 0x80 },
+
+        { 0x29, 0xEB },
+        { 0x2A, 0x3A },
+        { 0x2B, 0x83 },
+        { 0x2C, 0x7D },
+
+        { 0x36, 0x74 },
+        { 0x37, 0x12 },
+
+        { 0x3E, 0xFF },
+        { 0x40, 0x0C },
+
+        { 0x67, 0xC2 },
+        { 0x68, 0x10 },
+OOVPA_END;

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5233.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5233.inl
@@ -75,37 +75,6 @@ OOVPA_XREF(IDirectSound_EnableHeadphones, 5233, 1+7,
         { 0x1A, 0x08 },
 OOVPA_END;
 #endif
-// ******************************************************************
-// * CDirectSoundStream_FlushEx
-// ******************************************************************
-// Generic OOVPA as of 5233 and newer
-OOVPA_XREF(CDirectSoundStream_FlushEx, 5233, 16,
-
-    XREF_CDirectSoundStream_FlushEx,
-    XRefZero)
-
-        { 0x00, 0x55 },
-
-        { 0x24, 0xB8 },
-        { 0x25, 0x05 },
-        { 0x26, 0x40 },
-        { 0x27, 0x00 },
-        { 0x28, 0x80 },
-
-        { 0x29, 0xEB },
-        { 0x2A, 0x3A },
-        { 0x2B, 0x83 },
-        { 0x2C, 0x7D },
-
-        { 0x36, 0x74 },
-        { 0x37, 0x12 },
-
-        { 0x3E, 0xFF },
-        { 0x40, 0x0C },
-
-        { 0x67, 0xC2 },
-        { 0x68, 0x10 },
-OOVPA_END;
 
 #if 0 // Used 4627
 // ******************************************************************
@@ -274,7 +243,7 @@ OOVPA_XREF(CDirectSoundVoice_SetRolloffCurve, 5233, 8,
         { 0x3E, 0x33 },
 OOVPA_END;
 #endif
-
+#if 0 // No longer used, replaced by generic 4721 version
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
@@ -305,3 +274,4 @@ OOVPA_XREF(CMcpxStream_GetStatus, 5233, 14,
         //{ 0x57, 0xC2 },
         //{ 0x58, 0x04 },
 OOVPA_END;
+#endif

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5344.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5344.inl
@@ -624,36 +624,6 @@ OOVPA_XREF(CDirectSoundVoice_SetRolloffCurve, 5344, 8,
 OOVPA_END;
 
 // ******************************************************************
-// * WaveFormat::CreateXboxAdpcmFormat
-// ******************************************************************
-OOVPA_XREF(WaveFormat_CreateXboxAdpcmFormat, 5344, 7,
-
-    XREF_WaveFormat_CreateXboxAdpcmFormat,
-    XRefZero)
-
-        { 0x07, 0x08 },
-        { 0x10, 0xE9 },
-        { 0x19, 0x8D },
-        { 0x22, 0x66 },
-        { 0x2B, 0x04 },
-        { 0x34, 0x66 },
-        { 0x3D, 0x12 },
-OOVPA_END;
-
-// ******************************************************************
-// * XAudioCreateAdpcmFormat
-// ******************************************************************
-OOVPA_XREF(XAudioCreateAdpcmFormat, 5344, 1+1,
-
-    XRefNoSaveIndex,
-    XRefOne)
-
-        XREF_ENTRY( 0x01, XREF_WaveFormat_CreateXboxAdpcmFormat ),
-
-        { 0x00, 0xE9 },
-OOVPA_END;
-
-// ******************************************************************
 // * CDirectSoundVoice::SetConeAngles
 // ******************************************************************
 OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 5344, 9,
@@ -756,32 +726,7 @@ OOVPA_XREF(CMcpxStream_Flush, 5344, 14,
         { 0x11, 0x00 },
 OOVPA_END;
 
-// ******************************************************************
-// * CDirectSoundStream_Flush
-// ******************************************************************
-// Generic OOVPA as of ____? and newer
-OOVPA_XREF(CDirectSoundStream_Flush, 5344, 1+8,
-    XRefNoSaveIndex,
-    XRefOne)
-
-        //CDirectSoundStream_Flush+0x31 : call [CMcpxStream_Flush]
-        XREF_ENTRY( 0x32, XREF_CMcpxStream_Flush ),
-
-        { 0x00, 0x56 },
-
-        { 0x28, 0x8B },
-        { 0x2B, 0x08 },
-
-        { 0x2C, 0x8B },
-        { 0x2E, 0x24 },
-
-        { 0x31, 0xE8 },
-
-        //CDirectSoundStream_Flush+0x48 : ret 4
-        { 0x48, 0xC2 },
-        { 0x49, 0x04 },
-OOVPA_END;
-
+#if 0 // Moved to 4531
 // ******************************************************************
 // * CMcpxStream_Discontinuity
 // ******************************************************************
@@ -806,6 +751,7 @@ OOVPA_XREF(CMcpxStream_Discontinuity, 5344, 9,
         { 0x2D, 0x5E },
         { 0x2E, 0xC3 },
 OOVPA_END;
+#endif
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetMixBins
@@ -1233,148 +1179,6 @@ OOVPA_XREF(DirectSoundUseLightHRTF4Channel, 5344, 1+7,
         { 0x12, 0x0B },
         { 0x18, 0xFF },
         { 0x1E, 0xC3 },
-OOVPA_END;
-
-// ******************************************************************
-// * DirectSound::CMcpxBuffer::Pause
-// ******************************************************************
-// Generic OOVPA as of ____? and newer
-OOVPA_XREF(CMcpxBuffer_Pause_Ex, 5344, 1+8,
-
-    XREF_CMcpxBuffer_Pause_Ex,
-    XRefOne)
-
-        XREF_ENTRY( 0x2B, XREF_CMcpxBuffer_Pause ),
-
-        { 0x00, 0x55 },
-
-        { 0x0D, 0x8B },
-
-        { 0x1C, 0x6A },
-        { 0x1D, 0x05 },
-
-        { 0x23, 0x75 },
-
-        { 0x2A, 0xE8 },
-
-        { 0x36, 0xC2 },
-        { 0x37, 0x0C },
-OOVPA_END;
-
-// ******************************************************************
-// * DirectSound::CDirectSoundBuffer::PauseEx
-// ******************************************************************
-// Generic OOVPA as of ____? and newer
-OOVPA_XREF(CDirectSoundBuffer_PauseEx, 5344, 1+10,
-
-    XREF_CDirectSoundBuffer_PauseEx,
-    XRefOne)
-
-        XREF_ENTRY( 0x3D, XREF_CMcpxBuffer_Pause_Ex ),
-
-        { 0x00, 0x56 },
-
-        { 0x0C, 0x00 },
-        { 0x14, 0x74 },
-        { 0x21, 0xB8 },
-        { 0x2A, 0x24 },
-        { 0x41, 0x85 },
-        { 0x4C, 0xFF },
-        { 0x53, 0xC7 },
-
-        { 0x56, 0xC2 },
-        { 0x57, 0x10 },
-OOVPA_END;
-
-// ******************************************************************
-// * IDirectSoundBuffer_PauseEx
-// ******************************************************************
-// Generic OOVPA as of ____? and newer
-OOVPA_XREF(IDirectSoundBuffer_PauseEx, 5344, 1+7,
-
-    XRefNoSaveIndex,
-    XRefOne)
-
-        XREF_ENTRY( 0x1D, XREF_CDirectSoundBuffer_PauseEx ),
-
-        { 0x02, 0x24 },
-        { 0x06, 0x24 },
-        { 0x12, 0x83 },
-        { 0x16, 0xD9 },
-        { 0x1A, 0xC8 },
-        { 0x21, 0xC2 },
-        { 0x22, 0x10 },
-OOVPA_END;
-
-// ******************************************************************
-// * DirectSound::CMcpxStream::Pause2
-// ******************************************************************
-// Generic OOVPA as of ____? and newer
-OOVPA_XREF(CMcpxStream_Pause_Ex, 5344, 1+8,
-
-    XREF_CMcpxStream_Pause_Ex,
-    XRefOne)
-
-        XREF_ENTRY( 0x2B, XREF_CMcpxStream_Pause ),
-
-        { 0x00, 0x55 },
-
-        { 0x0D, 0x8B },
-
-        { 0x1C, 0x6A },
-        { 0x1D, 0x05 },
-
-        { 0x23, 0x75 },
-
-        { 0x2A, 0xE8 },
-
-        { 0x36, 0xC2 },
-        { 0x37, 0x0C },
-OOVPA_END;
-
-// ******************************************************************
-// * DirectSound::CDirectSoundStream::PauseEx
-// ******************************************************************
-// Generic OOVPA as of ____? and newer
-OOVPA_XREF(CDirectSoundStream_PauseEx, 5344, 1+10,
-
-    XREF_CDirectSoundStream_PauseEx,
-    XRefOne)
-
-        XREF_ENTRY( 0x3D, XREF_CMcpxStream_Pause_Ex ),
-
-        { 0x00, 0x56 },
-
-        { 0x0C, 0x00 },
-        { 0x14, 0x74 },
-        { 0x21, 0xB8 },
-        { 0x2A, 0x24 },
-        { 0x41, 0x85 },
-        { 0x4C, 0xFF },
-        { 0x53, 0xC7 },
-
-        { 0x56, 0xC2 },
-        { 0x57, 0x10 },
-OOVPA_END;
-
-// ******************************************************************
-// * IDirectSoundStream_PauseEx
-// ******************************************************************
-// Generic OOVPA as of ____? and newer
-OOVPA_XREF(IDirectSoundStream_PauseEx, 5344, 1+7,
-
-    XRefNoSaveIndex,
-    XRefOne)
-
-        XREF_ENTRY( 0x11, XREF_CDirectSoundStream_PauseEx ),
-
-        { 0x02, 0x24 },
-        { 0x06, 0x24 },
-        { 0x0A, 0x24 },
-        { 0x0E, 0x24 },
-        { 0x10, 0xE8 },
-        { 0x15, 0xC2 },
-        { 0x16, 0x10 },
 OOVPA_END;
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5455.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5455.inl
@@ -396,3 +396,39 @@ OOVPA_XREF(CDirectSound_GetSpeakerConfig, 5455, 14,
         { 0x4A, 0xC2 },
         { 0x4B, 0x08 },
 OOVPA_END;
+
+// ******************************************************************
+// * CMcpxStream_Flush
+// ******************************************************************
+// Might not be ideal, however I had not see any changes from these
+// Offsets.
+OOVPA_XREF(CMcpxStream_Flush, 5455, 16,
+
+    XREF_CMcpxStream_Flush,
+    XRefZero)
+
+        // CMcpxStream_Flush+0x00 : push ebp; mov ebp, esp; sub esp, 10h
+        { 0x00, 0x55 },
+        { 0x01, 0x8B },
+        { 0x02, 0xEC },
+        { 0x03, 0x83 },
+        { 0x04, 0xEC },
+        { 0x05, 0x10 },
+
+        // Offset is unique for this asm code.
+        // CMcpxStream_Flush+0x0A : movzx eax,byte ptr fs:[24h]
+        { 0x0A, 0x64 },
+        { 0x0B, 0x0F },
+        { 0x0C, 0xB6 },
+        { 0x0D, 0x05 },
+        { 0x0E, 0x24 },
+        { 0x0F, 0x00 },
+        { 0x10, 0x00 },
+        { 0x11, 0x00 },
+
+        // CMcpxStream_Flush+0x2F : mov
+        { 0x2F, 0x8B },
+
+        // CMcpxStream_Flush+0x6A : Call [CIrql_Lower]
+        { 0x6A, 0xE8 },
+OOVPA_END;

--- a/src/CxbxKrnl/HLEDataBase/DSound.1.0.5558.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.1.0.5558.inl
@@ -751,3 +751,8 @@ OOVPA_XREF(IDirectSoundStream_Set3DVoiceData, 5558, 1+1,
         // IDirectSoundStream_Set3DVoiceData+0x00 : jmp 0x........
         { 0x00, 0xE9 },
 OOVPA_END;
+
+// ******************************************************************
+// * Rollback support signature(s)
+// ******************************************************************
+#define CMcpxStream_Flush_5558 CMcpxStream_Flush_4134

--- a/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
@@ -63,8 +63,8 @@
 //   * IDirectSoundBuffer_SetDopplerFactor      (Lowest found was 4134)
 //   * IDirectSoundBuffer_SetRolloffFactor      (Lowest found was 4134)
 //   * IDirectSoundBuffer_SetRolloffCurve       (Lowest found was 4361)
-//   * IDirectSoundBuffer_Pause                 (Lowest found was 4928)
-//   * IDirectSoundBuffer_PauseEx               (Lowest found was 5344, could be 4928 or lower)
+//   * IDirectSoundBuffer_Pause                 (Lowest found was 4721)
+//   * IDirectSoundBuffer_PauseEx               (Lowest found was 4721)
 //   * IDirectSoundBuffer_SetPlayRegion         (Introduce in 4039, last known earliest revision)
 //   * IDirectSoundStream_FlushEx               (Lowest found was 4361)
 //   * IDirectSoundStream_GetVoiceProperties    (Lowest found was 5344)
@@ -120,36 +120,37 @@
 //   * Need to review what's the difference and why is it necessary to be separated.
 //   * It also have various revisions, we should be able to narrow it down to remove duplicates.
 // * 4039 CDirectSoundVoice_SetPitch need to be strengthen by using XREF to CMcpxVoiceClient_SetPitch function.
-// * CMcpxStream_Flush 4134, 4242, and 4361 has only one value changed at offset 0x3F (except 4134 is off by -1 offset for the leave/return op code)
-//   * It is possible to re-make this into generic support for 4134 to 5849.
 // * List of OOVPAs may could be lower to include support older titles.
 //   * CDirectSoundStream_Flush (5344)
 //   * CMcpxStream_Flush (5344)
 //   * CMcpxStream_Discontinuity (5344)
-//   * CMcpxStream_GetStatus (4928 is not detected)
+//   * CMcpxStream_GetStatus (4721)
 //   * CMcpxVoiceClient_SetMixBins (5344)
 //   * CDirectSoundVoice_SetI3DL2Source (5344)
 //   * CDirectSound_SetDopplerFactor (5344)
 //   * CDirectSound_SetRolloffFactor (5344)
 //   * CDirectSound_SetDistanceFactor (5344)
 //   * CDirectSound_SetI3DL2Listener (5344)
-//   * CMcpxBuffer_Pause_Ex (5344)
-//   * IDirectSoundBuffer_PauseEx (5344)
-//   * CDirectSoundBuffer_PauseEx (5344)
-//   * CMcpxStream_Pause_Ex (5344)
-//   * CDirectSoundStream_PauseEx (5344)
-//   * IDirectSoundStream_PauseEx (5344)
+//   * CMcpxBuffer_Pause_Ex (4721)
+//   * IDirectSoundBuffer_PauseEx (4721)
+//   * CDirectSoundBuffer_PauseEx (4721)
+//   * CMcpxStream_Pause_Ex (4721)
+//   * CDirectSoundStream_PauseEx (4721)
+//   * IDirectSoundStream_PauseEx (4721)
 // * CDirectSoundVoice_SetMixBins need to use XREF_CMcpxVoiceClient_SetMixBins instead of XREF_CDirectSoundVoiceSettings_SetMixBins.
 //   * This way we can use less OOVPA revisions.
-// * CDirectSound_EnableHeadphones (5233) need evaluate, most likely false detection.
 // * Missing OOVPAs
-//   * CHRTFSource_SetFullHRTF5Channel (4928 - 5233) Maybe even lower too.
-//   * CHRTFSource_SetLightHRTF5Channel (4928 - 5233) Maybe even lower too.
-//   * CHRTFSource_SetFullHRTF4Channel (4928 - 5233) Maybe even lower too.
-//   * CHRTFSource_SetLightHRTF4Channel (4928 - 5233) Maybe even lower too.
+//   * CHRTFSource_SetFullHRTF5Channel (4242 - 5233) Maybe use instead of CHrtfSource_SetAlgorithm_FullHrtf.
+//   * CHRTFSource_SetLightHRTF5Channel (4242 - 5233) Maybe use instead of CHrtfSource_SetAlgorithm_LightHrtf.
+//   * CHRTFSource_SetFullHRTF4Channel (4242 - 5233)
+//   * CHRTFSource_SetLightHRTF4Channel (4242 - 5233)
 //   * DirectSoundUseLightHRTF (4928 - 5233) Maybe even lower too.
-//   * DirectSoundUseFullHRTF4Channel (4928 - 5233) Maybe even lower too.
-//   * DirectSoundUseLightHRTF4Channel (4928 - 5233) Maybe even lower too.
+//   * DirectSoundUseFullHRTF4Channel (4242 - 5233)
+//   * DirectSoundUseLightHRTF4Channel (4242 - 5233)
+//   * CFullHrtfSource_GetHrtfFilterPair (3911 - 4134, 5344 - 5849)
+//   * CLightHrtfSource_GetHrtfFilterPair (3911 - 4134, 5344 - 5849)
+//   * CHrtfSource_SetAlgorithm_FullHrtf (3911 - 4134, 5344 - 5849)
+//   * CHrtfSource_SetAlgorithm_LightHrtf (3911 - 4134, 5344 - 5849)
 
 
 #ifndef DSOUND_OOVPA_INL
@@ -164,7 +165,9 @@
 #include "DSound.1.0.4242.inl"
 #include "DSound.1.0.4361.inl"
 #include "DSound.1.0.4432.inl"
+#include "DSound.1.0.4531.inl"
 #include "DSound.1.0.4627.inl"
+#include "DSound.1.0.4721.inl"
 #include "DSound.1.0.5028.inl"
 #include "DSound.1.0.5233.inl"
 #include "DSound.1.0.5344.inl"
@@ -194,19 +197,19 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(CMcpxAPU_SynchPlayback, XREF, 5233),
     REGISTER_OOVPAS(CMcpxBuffer_GetCurrentPosition, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CMcpxBuffer_GetStatus, XREF, 3911, 4039, 4134, 4721, 4831),
-    REGISTER_OOVPAS(CMcpxBuffer_Pause, XREF, 4831),
-    REGISTER_OOVPAS(CMcpxBuffer_Pause_Ex, XREF, 5344),
+    REGISTER_OOVPAS(CMcpxBuffer_Pause, XREF, 4721, 4831),
+    REGISTER_OOVPAS(CMcpxBuffer_Pause_Ex, XREF, 4721),
     REGISTER_OOVPAS(CMcpxBuffer_Play, XREF, 3911, 4039, 4134, 4721, 4831), // NOTE: ?Play@CMcpxBuffer@DirectSound@@QAEJK@Z
-    REGISTER_OOVPAS(CMcpxBuffer_Play2, XREF, 4039, 4361), // NOTE: ?Play@CMcpxBuffer@DirectSound@@QAEJ_JK@Z
+    REGISTER_OOVPAS(CMcpxBuffer_Play2, XREF, 4039/*, 4361*/), // NOTE: ?Play@CMcpxBuffer@DirectSound@@QAEJ_JK@Z
     REGISTER_OOVPAS(CMcpxBuffer_SetBufferData, XREF, 4134, 5455),
     REGISTER_OOVPAS(CMcpxBuffer_SetCurrentPosition, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CMcpxBuffer_Stop, XREF, 3911, 4134, 4242), // NOTE: ?Stop@CMcpxBuffer@DirectSound@@QAEJK@Z
-    REGISTER_OOVPAS(CMcpxBuffer_Stop2, XREF, 4134, 4361), // NOTE: ?Stop@CMcpxBuffer@DirectSound@@QAEJ_JK@Z
-    REGISTER_OOVPAS(CMcpxStream_Discontinuity, XREF, 3911, 4039, 4134, 5344, 5455),
-    REGISTER_OOVPAS(CMcpxStream_Flush, XREF, 3911, 3936, 4039, 4134, 4242, 4361, 5344),
-    REGISTER_OOVPAS(CMcpxStream_GetStatus, XREF, 4134, 5233),
+    REGISTER_OOVPAS(CMcpxBuffer_Stop2, XREF, 4134/*, 4361*/), // NOTE: ?Stop@CMcpxBuffer@DirectSound@@QAEJ_JK@Z
+    REGISTER_OOVPAS(CMcpxStream_Discontinuity, XREF, 3911, 4039, 4134, 4531/*, 5344*/, 5455),
+    REGISTER_OOVPAS(CMcpxStream_Flush, XREF, 3911, 3936, 4039, 4134/*, 4242, 4361, 5344*/, 5455),
+    REGISTER_OOVPAS(CMcpxStream_GetStatus, XREF, 4134, 4721/*, 5233*/),
     REGISTER_OOVPAS(CMcpxStream_Pause, XREF, 3911, 4039, 4134, /*4361,*/ 4831),
-    REGISTER_OOVPAS(CMcpxStream_Pause_Ex, XREF, 5344),
+    REGISTER_OOVPAS(CMcpxStream_Pause_Ex, XREF, 4721),
     REGISTER_OOVPAS(CSensaura3d_GetFullHRTFFilterPair, XREF, 3911, 3936),
     REGISTER_OOVPAS(CSensaura3d_GetLiteHRTFFilterPair, XREF, 3911, 3936),
     REGISTER_OOVPAS(CMcpxVoiceClient_Commit3dSettings, XREF, 3911),
@@ -237,8 +240,8 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(CDirectSoundVoice_SetConeAngles, XREF, 3911, 4039, 4134, 5344),
     REGISTER_OOVPAS(CDirectSoundVoice_SetConeOrientation, XREF, 3911, 4039, 4134, 5344),
     REGISTER_OOVPAS(CDirectSoundVoice_SetConeOutsideVolume, XREF, 3911, 4039, 4134, 4361, 5344),
-    REGISTER_OOVPAS(CDirectSoundVoice_SetDistanceFactor, XREF, 4134, 4627, 5344),
-    REGISTER_OOVPAS(CDirectSoundVoice_SetDopplerFactor, XREF, 4134, 4627, 5344),
+    REGISTER_OOVPAS(CDirectSoundVoice_SetDistanceFactor, XREF, 4134, 4361, 4627, 5344),
+    REGISTER_OOVPAS(CDirectSoundVoice_SetDopplerFactor, XREF, 4134, 4361, 4627, 5344),
     REGISTER_OOVPAS(CDirectSoundVoice_SetEG, XREF, 3911, 4039),
     REGISTER_OOVPAS(CDirectSoundVoice_SetFilter, XREF, 3911, 4039),
     REGISTER_OOVPAS(CDirectSoundVoice_SetFormat, XREF, 4039, 4721),
@@ -267,8 +270,8 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(CDirectSoundBuffer_GetStatus, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundBuffer_GetVoiceProperties, PATCH, 5344),
     REGISTER_OOVPAS(CDirectSoundBuffer_Lock, XREF, 3911, 4039, 4134),
-    REGISTER_OOVPAS(CDirectSoundBuffer_Pause, XREF, 4928),
-    REGISTER_OOVPAS(CDirectSoundBuffer_PauseEx, XREF, 5344),
+    REGISTER_OOVPAS(CDirectSoundBuffer_Pause, XREF, 4721),
+    REGISTER_OOVPAS(CDirectSoundBuffer_PauseEx, XREF, 4721),
     REGISTER_OOVPAS(CDirectSoundBuffer_Play, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundBuffer_PlayEx, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundBuffer_Set3DVoiceData, XREF, 5558),
@@ -307,13 +310,13 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(CDirectSoundBuffer_Use3DVoiceData, XREF, 5558),
     REGISTER_OOVPAS(CDirectSoundStream_AddRef, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_Discontinuity, PATCH, 3911, 4039, 4134),
-    REGISTER_OOVPAS(CDirectSoundStream_Flush, PATCH, 3911, 4039, 4134, 5344),
-    REGISTER_OOVPAS(CDirectSoundStream_FlushEx, PATCH, 4134, 5233),
+    REGISTER_OOVPAS(CDirectSoundStream_Flush, PATCH, 3911, 4039, 4134, 5028),
+    REGISTER_OOVPAS(CDirectSoundStream_FlushEx, XREF, 4134, 5028),
     REGISTER_OOVPAS(CDirectSoundStream_GetInfo, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_GetStatus, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_GetVoiceProperties, PATCH, 5344),
     REGISTER_OOVPAS(CDirectSoundStream_Pause, PATCH, 3911, 4039, 4134 /*, 4361, 5558*/),
-    REGISTER_OOVPAS(CDirectSoundStream_PauseEx, PATCH, 5344),
+    REGISTER_OOVPAS(CDirectSoundStream_PauseEx, PATCH, 4721),
     REGISTER_OOVPAS(CDirectSoundStream_Process, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_Release, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_Set3DVoiceData, PATCH, 5558),
@@ -350,14 +353,14 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(CDirectSound_CreateSoundStream, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSound_DownloadEffectsImage, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSound_DoWork, XREF, 3911, 4039),
-    REGISTER_OOVPAS(CDirectSound_EnableHeadphones, XREF, 3911, 4039, 4134, 4627, 5233, 5344, 5455),
+    REGISTER_OOVPAS(CDirectSound_EnableHeadphones, XREF, 3911, 4039, 4134/*, 4627, 5233*/, 5344, 5455),
     REGISTER_OOVPAS(CDirectSound_GetCaps, XREF, 3911, 4039, 4134, 4361),
     REGISTER_OOVPAS(CDirectSound_GetEffectData, XREF, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSound_GetOutputLevels, XREF, 4627),
-    REGISTER_OOVPAS(CDirectSound_GetSpeakerConfig, PATCH, 3911, 4627, 5455),
+    REGISTER_OOVPAS(CDirectSound_GetSpeakerConfig, PATCH, 3911, 4242, 4627, 5455),
     REGISTER_OOVPAS(CDirectSound_GetTime, XREF, 3911),
     REGISTER_OOVPAS(CDirectSound_MapBufferData, XREF, 5344),
-    REGISTER_OOVPAS(CDirectSound_SetAllParameters, XREF, 3911, 4039, 4134, 4831, 5558), //TODO: Need to improvise after 4134
+    REGISTER_OOVPAS(CDirectSound_SetAllParameters, XREF, 3911, 4039, 4134/*, 4831*/, 5558), //TODO: Need to improvise after 4134
     REGISTER_OOVPAS(CDirectSound_SetAllParametersA, XREF, 4627, 4721, 4831), //TODO: Need to improvise after 4134 then move in CDirectSound_SetAllParameters
     REGISTER_OOVPAS(CDirectSound_SetDistanceFactor, XREF, 3911, 4039, 4134, 4627, 5344),
     REGISTER_OOVPAS(CDirectSound_SetDopplerFactor, XREF, 3911, 4039, 4134, 4627, 5344),
@@ -379,8 +382,8 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(IDirectSoundBuffer_GetStatus, PATCH, 3911),
     REGISTER_OOVPAS(IDirectSoundBuffer_GetVoiceProperties, PATCH, 5344),
     REGISTER_OOVPAS(IDirectSoundBuffer_Lock, PATCH, 3911),
-    REGISTER_OOVPAS(IDirectSoundBuffer_Pause, PATCH, 4928),
-    REGISTER_OOVPAS(IDirectSoundBuffer_PauseEx, PATCH, 5344),
+    REGISTER_OOVPAS(IDirectSoundBuffer_Pause, PATCH, 4721),
+    REGISTER_OOVPAS(IDirectSoundBuffer_PauseEx, PATCH, 4721),
     REGISTER_OOVPAS(IDirectSoundBuffer_Play, PATCH, 3911),
     REGISTER_OOVPAS(IDirectSoundBuffer_PlayEx, PATCH, 3911),
     REGISTER_OOVPAS(IDirectSoundBuffer_Release, PATCH, 3911),
@@ -424,7 +427,7 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(IDirectSoundStream_GetVoiceProperties, UNPATCHED, 5344), // jmp only
     REGISTER_OOVPAS(IDirectSoundStream_FlushEx, UNPATCHED, 4134),
     REGISTER_OOVPAS(IDirectSoundStream_Pause, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, later XDK revision may need a patch?
-    REGISTER_OOVPAS(IDirectSoundStream_PauseEx, UNPATCHED, 5344),
+    REGISTER_OOVPAS(IDirectSoundStream_PauseEx, UNPATCHED, 4721),
     REGISTER_OOVPAS(IDirectSoundStream_Set3DVoiceData, UNPATCHED, 5558), // jmp only
     REGISTER_OOVPAS(IDirectSoundStream_SetAllParameters, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, later XDK revision may need a patch?
     REGISTER_OOVPAS(IDirectSoundStream_SetConeAngles, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, later XDK revision may need a patch?
@@ -486,23 +489,27 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(CHRTFSource_SetLightHRTF5Channel, XREF, 5344),
     REGISTER_OOVPAS(CHRTFSource_SetFullHRTF4Channel, XREF, 5344),
     REGISTER_OOVPAS(CHRTFSource_SetLightHRTF4Channel, XREF, 5344),
+    REGISTER_OOVPAS(CFullHrtfSource_GetHrtfFilterPair, XREF, 4242),
+    REGISTER_OOVPAS(CLightHrtfSource_GetHrtfFilterPair, XREF, 4242),
+    REGISTER_OOVPAS(CHrtfSource_SetAlgorithm_FullHrtf, XREF, 4242),
+    REGISTER_OOVPAS(CHrtfSource_SetAlgorithm_LightHrtf, XREF, 4242),
 
     REGISTER_OOVPAS(DirectSoundCreate, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(DirectSoundCreateBuffer, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(DirectSoundCreateStream, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(DirectSoundDoWork, PATCH, 3911, 4134),
     REGISTER_OOVPAS(DirectSoundGetSampleTime, PATCH, 3911, 4361),
-    REGISTER_OOVPAS(DirectSoundUseFullHRTF, PATCH, 3911, 4039, 4134, 5344),
-    REGISTER_OOVPAS(DirectSoundUseLightHRTF, PATCH, 3911, 5344),
+    REGISTER_OOVPAS(DirectSoundUseFullHRTF, PATCH, 3911, 4039, 4134, 4242, 5344),
+    REGISTER_OOVPAS(DirectSoundUseLightHRTF, PATCH, 3911, 4242, 5344),
     REGISTER_OOVPAS(DirectSoundUseFullHRTF4Channel, PATCH, 5344), // undocument
     REGISTER_OOVPAS(DirectSoundUseLightHRTF4Channel, PATCH, 5344), // undocument
 
-    REGISTER_OOVPAS(WaveFormat_CreateXboxAdpcmFormat, XREF, 5344),
+    REGISTER_OOVPAS(WaveFormat_CreateXboxAdpcmFormat, XREF, 4242),
     REGISTER_OOVPAS(XAudioDownloadEffectsImage, PATCH, 4134),
     REGISTER_OOVPAS(XAudioSetEffectData, PATCH, 5344),
     REGISTER_OOVPAS(IsValidFormat, UNPATCHED, 3911, 4039),
     REGISTER_OOVPAS(XAudioCreatePcmFormat, UNPATCHED, 3911),
-    REGISTER_OOVPAS(XAudioCreateAdpcmFormat, PATCH, 3911, 5344),
+    REGISTER_OOVPAS(XAudioCreateAdpcmFormat, PATCH, 3911, 4242),
     REGISTER_OOVPAS(XFileCreateMediaObject, PATCH, 5344),
     REGISTER_OOVPAS(XFileCreateMediaObjectAsync, PATCH, 5344),
     REGISTER_OOVPAS(XFileCreateMediaObjectEx, PATCH, 4627, 5028),

--- a/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
@@ -34,17 +34,34 @@
 // ******************************************************************
 
 // Titles which did compiled with full library version
-//   [LibV] Title Name          |  Verify   |   Comments
+//   [LibV] Title Name                       |  Verify   |   Comments
 //-------------------------------------------------------------------
-// * [3925] Cel Damage          |   100%    | Contain full library.
-// * [3936] Silent Hill 2       |   100%    | Contain full library.
-// * [4039] Nightcaster         |   100%    | Only has 90% of the library compiled with xbe build.
-// * [4134] RaceX (Demo)        |     -%    | Only has a few library.
-// * [4134] Blood Omen 2        |    80%    | Does not have full library.
-// * [4134] JSRF                |     1%    | Does not have Stream class. DS and Buffer might be full.
-// * [....]
-// * [5455] GR: Island Thunder  |   100%    | Only has 50%-ish of the library compiled with xbe build.
-// * [5558] Dino Crisis 3       |   100%    | Contain full library.
+// * [3925] Cel Damage                       |   100%    | Contain full library.
+// * [3936] Silent Hill 2                    |   100%    | Contain full library.
+// * [4039] Nightcaster                      |   100%    | Only has 90% of the library compiled with xbe build.
+// * [4039] Azurik PAL                       |   100%    | Contain full library.
+// * [4134] RaceX (Demo)                     |     -%    | Only has a few library.
+// * [4134] Blood Omen 2                     |    80%    | Does not have full library.
+// * [4134] JSRF                             |     1%    | Does not have Stream class. DS and Buffer might be full.
+// * [4134] Double-S.T.E.A.L                 |   100%    | Contain full library.
+// * [4242] NFL Blitz 2002                   |    20%    | Might be full library.
+// * [4361] Flight Academy                   |    20%    | Only has 50%-ish of the library compiled with xbe build.
+// * [4432] RedCard 2003                     |    20%    | Might be full library.
+// * [4627] MLB SlugFest 2003                |    20%    | Might be full library.
+// * [4721] Terminator Dawn of Fate          |    20%    | Might be full library.
+// * [4831] Whacked!                         |    20%    | Might be full library.
+// * [4928] Drihoo                           |    20%    | Might be full library.
+// * [5028] Shikigami no Shiro Evolution     |    20%    | Might be full library.
+// * [5120] N.U.D.E.@                        |    20%    | Might be full library.
+// * [5233] Evil Dead                        |    20%    | Might be full library.
+// * [5344] Gladius OXM Demo Disc 20         |    20%    | Might be full library.
+// * [5455] GR: Island Thunder               |   100%    | Only has 50%-ish of the library compiled with xbe build.
+// * [5455] Dinosaur Hunting                 |    20%    | Might be full library.
+// * [5558] Dino Crisis 3                    |   100%    | Contain full library.
+// * [5659] Midway Arcade Treasures Paperboy |    20%    | Might be full library.
+// * [5788] Digimon Battle Chronicle         |    20%    | Might be full library.
+// * [5849] Nickelodeon Tak 2                |    20%    | Might be full library.
+
 
 // TODO: Known DSound OOVPA issue list
 // * 3911 to 5933: Cannot make OOVPAs
@@ -140,17 +157,9 @@
 // * CDirectSoundVoice_SetMixBins need to use XREF_CMcpxVoiceClient_SetMixBins instead of XREF_CDirectSoundVoiceSettings_SetMixBins.
 //   * This way we can use less OOVPA revisions.
 // * Missing OOVPAs
-//   * CHRTFSource_SetFullHRTF5Channel (4242 - 5233) Maybe use instead of CHrtfSource_SetAlgorithm_FullHrtf.
-//   * CHRTFSource_SetLightHRTF5Channel (4242 - 5233) Maybe use instead of CHrtfSource_SetAlgorithm_LightHrtf.
-//   * CHRTFSource_SetFullHRTF4Channel (4242 - 5233)
-//   * CHRTFSource_SetLightHRTF4Channel (4242 - 5233)
 //   * DirectSoundUseLightHRTF (4928 - 5233) Maybe even lower too.
 //   * DirectSoundUseFullHRTF4Channel (4242 - 5233)
 //   * DirectSoundUseLightHRTF4Channel (4242 - 5233)
-//   * CFullHrtfSource_GetHrtfFilterPair (3911 - 4134, 5344 - 5849)
-//   * CLightHrtfSource_GetHrtfFilterPair (3911 - 4134, 5344 - 5849)
-//   * CHrtfSource_SetAlgorithm_FullHrtf (3911 - 4134, 5344 - 5849)
-//   * CHrtfSource_SetAlgorithm_LightHrtf (3911 - 4134, 5344 - 5849)
 
 
 #ifndef DSOUND_OOVPA_INL


### PR DESCRIPTION
Fixed CDirectSound_EnableHeadphones (5233) need evaluate, most likely false detection.
Added almost all missing OOVPA.

Verified with
- [4039] Azurik PAL
- [4134] Double-S.T.E.A.L
- [4242] NFL Blitz 2002
- [4361] Flight Academy
- [4432] RedCard 2003
- [4531] NHL Hitz 2003
- [4627] MLB SlugFest 2003
- [4721] Terminator - Dawn of Fate
- [4831] Whacked!
- [4928] Drihoo
- [5028] Shikigami no Shiro Evolution
- [5120] N.U.D.E.@
- [5233] Evil Dead
- [5344] Gladius OXM Demo Disc 20
- [5455] Dinosaur Hunting
- [5558] NHL HITZ Pro 2004
- [5659] Midway Arcade Treasures - Paperboy
- [5788] Digimon Battle Chronicle
- [5849] Nickelodeon Tak 2