### PR TITLE
CxbxCreatePartitionHeaderFile : Prevent NULL-pointer error

### DIFF
--- a/src/CxbxKrnl/EmuFile.cpp
+++ b/src/CxbxKrnl/EmuFile.cpp
@@ -100,7 +100,8 @@ void CxbxCreatePartitionHeaderFile(std::string filename, bool partition0 = false
 
 	// If this is partition 0, install the partiton table
 	if (partition0) {
-		WriteFile(hf, &BackupPartTbl, sizeof(XboxPartitionTable), NULL, 0);
+		DWORD NumberOfBytesWritten = 0;
+		WriteFile(hf, &BackupPartTbl, sizeof(XboxPartitionTable), &NumberOfBytesWritten, 0);
 	}
 
 	SetFilePointer(hf, 512 * ONE_KB, 0, FILE_BEGIN);


### PR DESCRIPTION
This PR is an attempt to fix a problem that seems occur only on Windows 7 (not Windows 10), somehow resulting in Cxbx no longer being able to load Xbe's...