### PR TITLE
Fixed debug console output menu setting being ignored

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -153,6 +153,7 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 			lErrCodeKrnlDebugFilename = RegQueryValueEx(hKey, "KrnlDebugFilename", NULL, &dwType, (PBYTE)m_KrnlDebugFilename, &dwSize);
 
 			// Prevent using an incorrect path from the registry if the debug folders have been moved
+			if (m_CxbxDebug == DM_FILE)
 			{
 				if(lErrCodeCxbxDebugFilename == ERROR_FILE_NOT_FOUND || strlen(m_CxbxDebugFilename) == 0)
 				{
@@ -182,7 +183,10 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 					free(CxbxDebugPath);
 					free(CxbxDebugName);
 				}
-				
+			}
+
+			if (m_KrnlDebug == DM_FILE)
+			{
 				if(lErrCodeKrnlDebugFilename == ERROR_FILE_NOT_FOUND || strlen(m_KrnlDebugFilename) == 0)
 				{
 					m_KrnlDebug = DM_NONE;


### PR DESCRIPTION
Setting the debug console output (View -> Debug Output) for either GUI or Kernel would ignore the console setting if a debug file was not set.

It now checks that the `DM_FILE` mode is active before checking if the debug file is suitable.