### PR TITLE
Check for WoW64 and Wine version

### DIFF
--- a/src/Cxbx/WinMain.cpp
+++ b/src/Cxbx/WinMain.cpp
@@ -49,6 +49,20 @@ processorArchitecture = '*' publicKeyToken = '6595b64144ccf1df' language = '*'\"
 /*! program entry point */
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
+	// First detect if we are running on WoW64, if not, prevent Cxbx-Reloaded from starting
+	// Cxbx-Relaoded needs access to high memory, only exposed to WoW64.
+	typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS) (HANDLE, PBOOL);
+	BOOL bIsWow64 = FALSE;
+	LPFN_ISWOW64PROCESS fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
+	if (fnIsWow64Process != nullptr) {
+		fnIsWow64Process(GetCurrentProcess(), &bIsWow64);
+	}
+	
+	if (bIsWow64 == FALSE) {
+		MessageBox(NULL, "Cxbx-Reloaded can only run under WoW64\nThis means either a 64-bit version of Windows or Wine with a 64-bit prefix", "Cxbx-Reloaded", MB_OK);
+		return 1;
+	}
+
 	/*! verify Cxbx.exe is loaded to base address 0x00010000 */
 	if ((UINT_PTR)GetModuleHandle(nullptr) != CXBX_BASE_ADDR)
 	{

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -102,6 +102,7 @@ DWORD_PTR g_CPUXbox = 0;
 DWORD_PTR g_CPUOthers = 0;
 
 HANDLE g_CurrentProcessHandle = 0; // Set in CxbxKrnlMain
+bool g_IsWine = false;
 
 // Define function located in EmuXApi so we can call it from here
 void SetupXboxDeviceTypes();
@@ -237,6 +238,9 @@ void RestoreExeImageHeader()
 	ExeOptionalHeader->DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS] = NewOptionalHeader->DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS];
 }
 
+typedef const char* (CDECL *LPFN_WINEGETVERSION)(void);
+LPFN_WINEGETVERSION wine_get_version;
+
 // Returns the Win32 error in string format. Returns an empty string if there is no error.
 std::string CxbxGetErrorCodeAsString(DWORD errorCode)
 {
@@ -303,6 +307,10 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 		}
 	}
 
+	// Make sure memory.bin is at least 128 MB in size		
+	SetFilePointer(hFile, CHIHIRO_MEMORY_SIZE, nullptr, FILE_BEGIN);
+	SetEndOfFile(hFile);
+
 	HANDLE hFileMapping = CreateFileMapping(
 		hFile,
 		/* lpFileMappingAttributes */nullptr,
@@ -353,6 +361,31 @@ void *CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 	else
 		printf("[0x%.4X] INIT: Loaded contiguous memory.bin\n", GetCurrentThreadId());
 
+	size_t tiledMemorySize = TILED_MEMORY_CHIHIRO_SIZE;
+	if (g_IsWine) {
+		printf("Wine detected: Using 64MB Tiled Memory Size\n");
+		// TODO: Figure out why Wine needs this and Windows doesn't.
+		// Perhaps it's a Wine bug, or perhaps Wine reserves this memory for it's own usage?
+		tiledMemorySize = TILED_MEMORY_XBOX_SIZE;
+	}
+
+	// Map memory.bin contents into tiled memory too :
+	void *tiled_memory = (void *)MapViewOfFileEx(
+		hFileMapping,
+		FILE_MAP_READ | FILE_MAP_WRITE,
+				/* dwFileOffsetHigh */0,
+				/* dwFileOffsetLow */0,
+		tiledMemorySize,
+		(void *)TILED_MEMORY_BASE);
+
+	if (tiled_memory != (void *)TILED_MEMORY_BASE)
+	{
+		if (tiled_memory)
+			UnmapViewOfFile(tiled_memory);
+
+		CxbxKrnlCleanup("CxbxRestoreContiguousMemory: Couldn't map contiguous memory.bin into tiled memory at 0xF0000000!");
+		return nullptr;
+	}
 	
 	printf("[0x%.4X] INIT: Mapped contiguous memory to Xbox tiled memory at 0x%.8X to 0x%.8X\n",
 		GetCurrentThreadId(), TILED_MEMORY_BASE, TILED_MEMORY_BASE + TILED_MEMORY_CHIHIRO_SIZE - 1);
@@ -402,21 +435,8 @@ void PrintCurrentConfigurationLog()
 			dwBuild = (DWORD)(HIWORD(dwVersion));
 		}
 
-		// Detect Wine
-		bool isWine = false;
-		typedef const char* (CDECL *LPFN_WINEGETVERSION)(void);
-		LPFN_WINEGETVERSION wine_get_version;
-		HMODULE hNtDll = GetModuleHandle("ntdll.dll");
-		
-		if (hNtDll != nullptr) {
-			wine_get_version = (LPFN_WINEGETVERSION)GetProcAddress(hNtDll, "wine_get_version");
-			if (wine_get_version)	{
-				isWine = true;
-			}
-		}
-
 		printf("------------------------ENVIRONMENT DETAILS-------------------------\n");
-		if (isWine) {
+		if (g_IsWine) {
 			printf("Wine %s\n", wine_get_version());
 			printf("Presenting as Windows %d.%d (%d)\n", dwMajorVersion, dwMinorVersion, dwBuild);
 		} else {
@@ -559,6 +579,16 @@ void CxbxKrnlMain(int argc, char* argv[])
 #endif
 	}
 
+	// Detect Wine
+	g_IsWine = false;
+	HMODULE hNtDll = GetModuleHandle("ntdll.dll");
+
+	if (hNtDll != nullptr) {
+		wine_get_version = (LPFN_WINEGETVERSION)GetProcAddress(hNtDll, "wine_get_version");
+		if (wine_get_version) {
+			g_IsWine = true;
+		}
+	}
 	// Now we got the arguments, start by initializing the Xbox memory map :
 	// PrepareXBoxMemoryMap()
 	{

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -203,6 +203,8 @@ void ConnectWindowsTimersToThunkTable();
 /*! kernel thunk table */
 extern uint32 CxbxKrnl_KernelThunkTable[379];
 
+extern bool g_IsWine;
+
 void InitXboxThread(DWORD_PTR cores);
 
 /*! thread local storage structure */


### PR DESCRIPTION
This patch introduces a sanity check for WoW64 and prevents Cxbx-Reloaded from launching if not detected. Cxbx-Reloaded does not work under 32-bit Windows anyway, so we show a nice error rather than memory allocation errors.

Wine version detection is also included, and outputted in KrnlDebug.log.

The line-ending change was necessary to get it to compile: WinMain was using mixed line endings, and not it (correctly) uses Windows line endings.

Also fixed execution on Wine for real this time: By reducing the TILED memory region to 64MB. This has no effect for HLE, and for LLE, it could cause issues with Chihiro titles: But we don't have working LLE yet, this is fine for now, and only effects Wine. On Windows, the full 128MB is still used
  