### PR TITLE
Restore unknown vertex buffer/push buffer size checks 

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5211,7 +5211,7 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
             {
                 DWORD dwSize = g_VMManager.QuerySize((VAddr)pBase);
 
-                if(dwSize == -1)
+                if(dwSize == 0)
                 {
                     // TODO: once this is known to be working, remove the warning
                     EmuWarning("Vertex buffer allocation size unknown");
@@ -5275,7 +5275,7 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
             {
                 DWORD dwSize = g_VMManager.QuerySize((VAddr)pBase);
 
-                if(dwSize == -1)
+                if(dwSize == 0)
                 {
                     // TODO: once this is known to be working, remove the warning
                     EmuWarning("Push buffer allocation size unknown");


### PR DESCRIPTION
These were broken by the new VMManager, as it expected QueryMemorySize to return -1 on failure, now it returns 0.