### PR TITLE
Enable all Audio Codecs by default

### DIFF
--- a/src/Common/Win32/XBAudio.cpp
+++ b/src/Common/Win32/XBAudio.cpp
@@ -40,7 +40,7 @@
 // ******************************************************************
 // * func: XBAudio::XBAudio
 // ******************************************************************
-XBAudio::XBAudio() : m_bLegacyAudioHack(false), m_bPCM(true), m_bXADPCM(false), m_bUnknownCodec(false)
+XBAudio::XBAudio() : m_bLegacyAudioHack(false), m_bPCM(true), m_bXADPCM(true), m_bUnknownCodec(true)
 {
     m_binAudioAdapter = { 0 };
 }


### PR DESCRIPTION
These codecs are required for audio in many titles, it doesn't make sense to keep them disabled by default.