### PR TITLE
Remove _CXBXKRNL_INTERNAL define for issue #820

### DIFF
--- a/src/Common/EmuEEPROM.cpp
+++ b/src/Common/EmuEEPROM.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 // prevent name collisions

--- a/src/Common/Win32/EmuShared.cpp
+++ b/src/Common/Win32/EmuShared.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "CxbxKrnl/CxbxKrnl.h"

--- a/src/Common/XDVDFS Tools/buffered_io.cpp
+++ b/src/Common/XDVDFS Tools/buffered_io.cpp
@@ -1,6 +1,5 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check it.
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 // prevent name collisions

--- a/src/Common/XDVDFS Tools/xdvdfs.cpp
+++ b/src/Common/XDVDFS Tools/xdvdfs.cpp
@@ -1,6 +1,5 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check it.
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include <stdlib.h>

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -34,7 +34,6 @@
 // *
 // ******************************************************************
 
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 /* prevent name collisions */

--- a/src/CxbxKrnl/DbgConsole.cpp
+++ b/src/CxbxKrnl/DbgConsole.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "CxbxKrnl.h"

--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 // prevent name collisions

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 #include "xxhash32.h"
 #include <condition_variable>

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "CxbxKrnl/Emu.h"

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_LOCAL_
 
 /*

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "CxbxKrnl/Emu.h"

--- a/src/CxbxKrnl/EmuD3D8/State.cpp
+++ b/src/CxbxKrnl/EmuD3D8/State.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "CxbxKrnl/Emu.h"

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "CxbxKrnl/VMManager.h"

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "CxbxKrnl/CxbxKrnl.h"

--- a/src/CxbxKrnl/EmuD3D8Logging.cpp
+++ b/src/CxbxKrnl/EmuD3D8Logging.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include "Logging.h"

--- a/src/CxbxKrnl/EmuDInput.cpp
+++ b/src/CxbxKrnl/EmuDInput.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "DINP"

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -35,7 +35,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 // prevent name collisions

--- a/src/CxbxKrnl/EmuFS.cpp
+++ b/src/CxbxKrnl/EmuFS.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuFile.cpp
+++ b/src/CxbxKrnl/EmuFile.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "FILE"

--- a/src/CxbxKrnl/EmuKrnl.cpp
+++ b/src/CxbxKrnl/EmuKrnl.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlAv.cpp
+++ b/src/CxbxKrnl/EmuKrnlAv.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlDbg.cpp
+++ b/src/CxbxKrnl/EmuKrnlDbg.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlEx.cpp
+++ b/src/CxbxKrnl/EmuKrnlEx.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlFs.cpp
+++ b/src/CxbxKrnl/EmuKrnlFs.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlIo.cpp
+++ b/src/CxbxKrnl/EmuKrnlIo.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlKd.cpp
+++ b/src/CxbxKrnl/EmuKrnlKd.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlLogging.cpp
+++ b/src/CxbxKrnl/EmuKrnlLogging.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlMm.cpp
+++ b/src/CxbxKrnl/EmuKrnlMm.cpp
@@ -35,7 +35,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlPs.cpp
+++ b/src/CxbxKrnl/EmuKrnlPs.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlXbox.cpp
+++ b/src/CxbxKrnl/EmuKrnlXbox.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlXc.cpp
+++ b/src/CxbxKrnl/EmuKrnlXc.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuKrnlXe.cpp
+++ b/src/CxbxKrnl/EmuKrnlXe.cpp
@@ -34,7 +34,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"

--- a/src/CxbxKrnl/EmuNV2A.cpp
+++ b/src/CxbxKrnl/EmuNV2A.cpp
@@ -39,7 +39,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "NV2A"

--- a/src/CxbxKrnl/EmuNVNet.cpp
+++ b/src/CxbxKrnl/EmuNVNet.cpp
@@ -37,7 +37,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "NET " // Intentional extra space to align on 4 characters

--- a/src/CxbxKrnl/EmuNtDll.cpp
+++ b/src/CxbxKrnl/EmuNtDll.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include <windows.h>

--- a/src/CxbxKrnl/EmuSha.cpp
+++ b/src/CxbxKrnl/EmuSha.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #include <Windows.h>

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "X86 " // Intentional extra space to align on 4 characters

--- a/src/CxbxKrnl/EmuXG.cpp
+++ b/src/CxbxKrnl/EmuXG.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "XGRP"

--- a/src/CxbxKrnl/EmuXInput.cpp
+++ b/src/CxbxKrnl/EmuXInput.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "XINP"

--- a/src/CxbxKrnl/EmuXOnline.cpp
+++ b/src/CxbxKrnl/EmuXOnline.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "XONL"

--- a/src/CxbxKrnl/EmuXactEng.cpp
+++ b/src/CxbxKrnl/EmuXactEng.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "XACT"

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "XAPI"

--- a/src/CxbxKrnl/HLEDataBase.cpp
+++ b/src/CxbxKrnl/HLEDataBase.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 #undef FIELD_OFFSET     // prevent macro redefinition warnings

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 
 #define LOG_PREFIX "HLE " // Intentional extra space to align on 4 characters
 

--- a/src/CxbxKrnl/KernelThunk.cpp
+++ b/src/CxbxKrnl/KernelThunk.cpp
@@ -33,7 +33,6 @@
 // *  All rights reserved
 // *
 // ******************************************************************
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 // prevent name collisions

--- a/src/CxbxKrnl/PhysicalMemory.h
+++ b/src/CxbxKrnl/PhysicalMemory.h
@@ -37,7 +37,6 @@
 #ifndef PHYSICAL_MEMORY_H
 #define PHYSICAL_MEMORY_H
 
-#define _CXBXKRNL_INTERNAL
 #define _XBOXKRNL_DEFEXTRN_
 
 namespace xboxkrnl


### PR DESCRIPTION
As stated in issue #820, this define is not used in any #ifdef statements. Build/run was not affected by removing this define.