### PR TITLE
Print String Representations of GameRegion and AllowedMedia

### DIFF
--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -658,7 +658,7 @@ void Xbe::DumpInformation(FILE *x_file)
     }
 
     fprintf(x_file, "Allowed Media                    : 0x%.08X\n", m_Certificate.dwAllowedMedia);
-    fprintf(x_file, "Game Region                      : 0x%.08X\n", m_Certificate.dwGameRegion);
+    fprintf(x_file, "Game Region                      : 0x%.08X (%s)\n", m_Certificate.dwGameRegion, GameRegionToString());
     fprintf(x_file, "Game Ratings                     : 0x%.08X\n", m_Certificate.dwGameRatings);
     fprintf(x_file, "Disk Number                      : 0x%.08X\n", m_Certificate.dwDiskNumber);
     fprintf(x_file, "Version                          : 0x%.08X\n", m_Certificate.dwVersion);
@@ -1012,4 +1012,26 @@ void Xbe::PurgeBadChar(std::string& s, const std::string& illegalChars)
 		bool found = illegalChars.find(*it) != std::string::npos;
 		if (found) { *it = '_'; }
 	}
+}
+
+const char *Xbe::GameRegionToString()
+{
+    const char *Region_text[] = {
+        "Unknown", "NTSC", "JAP", "NTSC+JAP",
+        "PAL", "PAL+NTSC", "PAL+JAP", "Region Free",
+        "DEBUG", "NTSC (DEBUG)", "JAP (DEBUG)", "NTSC+JAP (DEBUG)",
+        "PAL (DEBUG)", "PAL+NTSC (DEBUG)", "PAL+JAP (DEBUG)", "Region Free (DEBUG)"
+    };
+    const uint32 all_regions = XBEIMAGE_GAME_REGION_NA |
+                               XBEIMAGE_GAME_REGION_JAPAN |
+                               XBEIMAGE_GAME_REGION_RESTOFWORLD |
+                               XBEIMAGE_GAME_REGION_MANUFACTURING;
+
+    if(m_Certificate.dwGameRegion & ~all_regions) {
+        return "REGION ERROR";
+    }
+
+    uint8 index = (m_Certificate.dwGameRegion & XBEIMAGE_GAME_REGION_MANUFACTURING) ? 0x8 : 0;
+    index |= (m_Certificate.dwGameRegion & 0x7);
+    return Region_text[index];
 }

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -657,7 +657,7 @@ void Xbe::DumpInformation(FILE *x_file)
         fprintf(x_file, "\n");
     }
 
-    fprintf(x_file, "Allowed Media                    : 0x%.08X\n", m_Certificate.dwAllowedMedia);
+    fprintf(x_file, "Allowed Media                    : 0x%.08X (%s)\n", m_Certificate.dwAllowedMedia, AllowedMediaToString().c_str());
     fprintf(x_file, "Game Region                      : 0x%.08X (%s)\n", m_Certificate.dwGameRegion, GameRegionToString());
     fprintf(x_file, "Game Ratings                     : 0x%.08X\n", m_Certificate.dwGameRatings);
     fprintf(x_file, "Disk Number                      : 0x%.08X\n", m_Certificate.dwDiskNumber);
@@ -992,6 +992,7 @@ uint08 *Xbe::GetLogoBitmap(uint32 x_dwSize)
     return 0;
 }
 
+
 void *Xbe::FindSection(char *zsSectionName)
 {
 	for (uint32 v = 0; v < m_Header.dwSections; v++) {
@@ -1034,4 +1035,44 @@ const char *Xbe::GameRegionToString()
     uint8 index = (m_Certificate.dwGameRegion & XBEIMAGE_GAME_REGION_MANUFACTURING) ? 0x8 : 0;
     index |= (m_Certificate.dwGameRegion & 0x7);
     return Region_text[index];
+}
+
+std::string Xbe::AllowedMediaToString()
+{
+    const uint32 dwAllowedMedia = m_Certificate.dwAllowedMedia;
+    std::string text = "Media Types:";
+
+    if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_MEDIA_MASK) {
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_HARD_DISK)
+            text.append(" HARD_DISK");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_DVD_X2)
+            text.append(" DVD_X2");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_DVD_CD)
+            text.append(" DVD_CD");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_CD)
+            text.append(" CD");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_DVD_5_RO)
+            text.append(" DVD_5_RO");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_DVD_9_RO)
+            text.append(" DVD_9_RO");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_DVD_5_RW)
+            text.append(" DVD_5_RW");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_DVD_9_RW)
+            text.append(" DVD_9_RW");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_DONGLE)
+            text.append(" DONGLE");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_MEDIA_BOARD)
+            text.append(" BOARD");
+        if((dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_MEDIA_MASK) >= (XBEIMAGE_MEDIA_TYPE_MEDIA_BOARD * 2))
+            text.append(" UNKNOWN");
+    }
+
+    if(dwAllowedMedia & ~XBEIMAGE_MEDIA_TYPE_MEDIA_MASK) {
+        text.append(" NONSECURE");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_NONSECURE_HARD_DISK)
+            text.append(" HARD_DISK");
+        if(dwAllowedMedia & XBEIMAGE_MEDIA_TYPE_NONSECURE_MODE)
+            text.append(" MODE");
+    }
+    return text;
 }

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -74,6 +74,9 @@ class Xbe : public Error
 		// purge illegal characters in Windows filenames or other OS's
 		void PurgeBadChar(std::string& s, const std::string& illegalChars = "\\/:?\"<>|");
 
+        // Convert game region field to string
+        const char *GameRegionToString();
+
         // Xbe header
         #include "AlignPrefix1.h"
         struct Header

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -253,6 +253,8 @@ class Xbe : public Error
         // return a modifiable pointer to logo bitmap data
         uint08 *GetLogoBitmap(uint32 x_dwSize);
 
+        std::string AllowedMediaToString();
+
         // used to encode/decode logo bitmap data
         union LogoRLE
         {

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -777,31 +777,6 @@ void LoadXboxKeys(std::string path)
 	EmuWarning("Failed to load Keys.bin. Cxbx-Reloaded will be unable to read Save Data from a real Xbox");
 }
 
-// game region flags for Xbe certificate
-#define XBEIMAGE_GAME_REGION_US_CANADA  XBEIMAGE_GAME_REGION_NA
-#define XBEIMAGE_GAME_REGION_ALL (XBEIMAGE_GAME_REGION_US_CANADA | XBEIMAGE_GAME_REGION_JAPAN | XBEIMAGE_GAME_REGION_RESTOFWORLD)
-#define XBEIMAGE_GAME_REGION_KNOWN (XBEIMAGE_GAME_REGION_ALL | XBEIMAGE_GAME_REGION_MANUFACTURING)
-
-const char *GameRegionToString(DWORD aGameRegion)
-{
-	const char *Regions[] = {
-		"UNKNOWN", "NTSC", "JAP", "NTSC+JAP",
-		"PAL", "PAL+NTSC", "PAL+JAP", "ALL",
-
-		"DEBUG", "NTSC (DEBUG)", "JAP (DEBUG)", "NTSC+JAP (DEBUG)",
-		"PAL (DEBUG)", "PAL+NTSC (DEBUG)", "PAL+JAP (DEBUG)", "ALL (DEBUG)"
-	};
-
-    if ((aGameRegion & ~XBEIMAGE_GAME_REGION_KNOWN) > 0) {
-        // Just in case we need this if a certificate structure data is corrupted again.
-        DbgPrintf("REGION ERROR! (0x%X)\n", aGameRegion);
-        return "REGION ERROR";
-    }
-
-	DWORD index = (aGameRegion & 7) | (aGameRegion & XBEIMAGE_GAME_REGION_MANUFACTURING ? 8 : 0);
-	return Regions[index];
-}
-
 __declspec(noreturn) void CxbxKrnlInit
 (
 	HWND                    hwndParent,
@@ -974,7 +949,7 @@ __declspec(noreturn) void CxbxKrnlInit
 		if (g_pCertificate != NULL) {
 			printf("[0x%.4X] INIT: XBE TitleID : %.8X\n", GetCurrentThreadId(), g_pCertificate->dwTitleId);
 			printf("[0x%.4X] INIT: XBE TitleName : %ls\n", GetCurrentThreadId(), g_pCertificate->wszTitleName);
-			printf("[0x%.4X] INIT: XBE Region : %s\n", GetCurrentThreadId(), GameRegionToString(g_pCertificate->dwGameRegion));
+			printf("[0x%.4X] INIT: XBE Region : %s\n", GetCurrentThreadId(), CxbxKrnl_Xbe->GameRegionToString());
 		}
 
 		// Dump Xbe library build numbers


### PR DESCRIPTION
Xbe fields GameRegion and AllowedMedia now print their string representation in the Xbe dump file for issue #686. A diff of a Xbe dump of RainbowSix 3 with new the feature:

![xbe_dump_diff](https://user-images.githubusercontent.com/5300468/34659713-dcb80740-f3f0-11e7-9ced-b3859d9aeae8.PNG)

While implementing the GameRegionToString function, I noticed that a duplicate implementation existed in CxbxKrnl.cpp. Heavily leveraging the code from that function, the function was moved into the Xbe class. Doing so allowed both the Kernal and Xbe::DumpInformation to use the same function. A diff of KrnlDebug on RainbowSix 3:

![krnldebug_diff](https://user-images.githubusercontent.com/5300468/34659751-4f924276-f3f1-11e7-80c7-afdff6e01ba9.PNG)