### PR TITLE
Hash the HLE database so OOVPA changes force a rescan

### DIFF
--- a/src/CxbxKrnl/HLEDataBase.cpp
+++ b/src/CxbxKrnl/HLEDataBase.cpp
@@ -81,51 +81,51 @@ const char *Sec_XNET = "XNET";
 
 const HLEData HLEDataBase[] = {
     // Support inline functions in .text section
-    { Lib_D3D8,{ Sec_text, Sec_D3D }, D3D8_OOVPAV2, D3D8_OOVPA_COUNTV2 },
+    { Lib_D3D8,{ Sec_text, Sec_D3D }, D3D8_OOVPAV2, D3D8_OOVPA_COUNT },
 
     // Cannot support LTCG in HLE
-    //{ Lib_D3D8LTCG,{ Sec_D3D }, _OOVPAV2, _OOVPA_COUNTV2 },
+    //{ Lib_D3D8LTCG,{ Sec_D3D }, _OOVPAV2, _OOVPA_COUNT },
 
     // Jarupxx mention this is not a requirement?
-    //{ Lib_D3DX8,{ Sec_D3DX }, _OOVPAV2, _OOVPA_COUNTV2 },
+    //{ Lib_D3DX8,{ Sec_D3DX }, _OOVPAV2, _OOVPA_COUNT },
 
     //
-    { Lib_DSOUND,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_COUNTV2 },
+    { Lib_DSOUND,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_COUNT },
 
     // DSOUNDH is just meant to define hot fix, there is no seperate section
-    //{ Lib_DSOUNDH,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_COUNTV2 },
+    //{ Lib_DSOUNDH,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_COUNT },
 
     //
-    { Lib_XACTENG, { Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_COUNTV2 },
+    { Lib_XACTENG, { Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_COUNT },
 
     // test case: Power Drome (Unluckily, it use LTCG version of the library.)
-    //{ Lib_XACTENLT,{ Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_COUNTV2 },
+    //{ Lib_XACTENLT,{ Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_COUNT },
 
     //
-    { Lib_XAPILIB,{ Sec_text, Sec_XPP }, XAPILIB_OOVPAV2, XAPILIB_OOVPA_COUNTV2 },
+    { Lib_XAPILIB,{ Sec_text, Sec_XPP }, XAPILIB_OOVPAV2, XAPILIB_OOVPA_COUNT },
 
     // Support inline functions in .text section
-    { Lib_XGRAPHC,{ Sec_text, Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_COUNTV2 },
+    { Lib_XGRAPHC,{ Sec_text, Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_COUNT },
 
     // Cannot support LTCG in HLE
-    //{ Lib_XGRAPHCL,{ Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_COUNTV2 },
+    //{ Lib_XGRAPHCL,{ Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_COUNT },
 
     // Added Sec_text and Sec_XNET just in case.
     // TODO: Need to find out which function is only part of XOnlines.
-    { Lib_XONLINE,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_COUNTV2 },
+    { Lib_XONLINE,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_COUNT },
 
     // Fun fact, XONLINES are split into 2 header sections.
-    { Lib_XONLINES,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_COUNTV2 },
+    { Lib_XONLINES,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_COUNT },
 
     // Added Sec_text just in case.
     // TODO: Need to find out which function is only part of XNets.
-    { Lib_XNET,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNTV2 },
+    { Lib_XNET,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNT },
 
     // XNETS only has XNET, might be true.
-    { Lib_XNETS,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNTV2 },
+    { Lib_XNETS,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNT },
 
     // test case: Stake
-    { Lib_XNETN,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNTV2 },
+    { Lib_XNETN,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNT },
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/HLEDataBase.cpp
+++ b/src/CxbxKrnl/HLEDataBase.cpp
@@ -83,57 +83,57 @@ const char *Sec_XNET = "XNET";
 
 const HLEData HLEDataBase[] = {
     // Support inline functions in .text section
-    { Lib_D3D8,{ Sec_text, Sec_D3D }, D3D8_OOVPAV2, D3D8_OOVPA_SIZEV2 },
+    { Lib_D3D8,{ Sec_text, Sec_D3D }, D3D8_OOVPAV2, D3D8_OOVPA_COUNTV2 },
 
     // Cannot support LTCG in HLE
-    //{ Lib_D3D8LTCG,{ Sec_D3D }, _OOVPAV2, _OOVPA_SIZEV2 },
+    //{ Lib_D3D8LTCG,{ Sec_D3D }, _OOVPAV2, _OOVPA_COUNTV2 },
 
     // Jarupxx mention this is not a requirement?
-    //{ Lib_D3DX8,{ Sec_D3DX }, _OOVPAV2, _OOVPA_SIZEV2 },
+    //{ Lib_D3DX8,{ Sec_D3DX }, _OOVPAV2, _OOVPA_COUNTV2 },
 
     //
-    { Lib_DSOUND,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_SIZEV2 },
+    { Lib_DSOUND,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_COUNTV2 },
 
     // DSOUNDH is just meant to define hot fix, there is no seperate section
-    //{ Lib_DSOUNDH,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_SIZEV2 },
+    //{ Lib_DSOUNDH,{ Sec_DSOUND }, DSound_OOVPAV2, DSound_OOVPA_COUNTV2 },
 
     //
-    { Lib_XACTENG, { Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_SIZEV2 },
+    { Lib_XACTENG, { Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_COUNTV2 },
 
     // test case: Power Drome (Unluckily, it use LTCG version of the library.)
-    //{ Lib_XACTENLT,{ Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_SIZEV2 },
+    //{ Lib_XACTENLT,{ Sec_XACTENG }, XACTENG_OOVPAV2, XACTENG_OOVPA_COUNTV2 },
 
     //
-    { Lib_XAPILIB,{ Sec_text, Sec_XPP }, XAPILIB_OOVPAV2, XAPILIB_OOVPA_SIZEV2 },
+    { Lib_XAPILIB,{ Sec_text, Sec_XPP }, XAPILIB_OOVPAV2, XAPILIB_OOVPA_COUNTV2 },
 
     // Support inline functions in .text section
-    { Lib_XGRAPHC,{ Sec_text, Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_SIZEV2 },
+    { Lib_XGRAPHC,{ Sec_text, Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_COUNTV2 },
 
     // Cannot support LTCG in HLE
-    //{ Lib_XGRAPHCL,{ Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_SIZEV2 },
+    //{ Lib_XGRAPHCL,{ Sec_XGRPH }, XGRAPHC_OOVPAV2, XGRAPHC_OOVPA_COUNTV2 },
 
     // Added Sec_text and Sec_XNET just in case.
     // TODO: Need to find out which function is only part of XOnlines.
-    { Lib_XONLINE,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_SIZEV2 },
+    { Lib_XONLINE,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_COUNTV2 },
 
     // Fun fact, XONLINES are split into 2 header sections.
-    { Lib_XONLINES,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_SIZEV2 },
+    { Lib_XONLINES,{ Sec_text, Sec_XONLINE, Sec_XNET }, XONLINES_OOVPAV2, XONLINES_OOVPA_COUNTV2 },
 
     // Added Sec_text just in case.
     // TODO: Need to find out which function is only part of XNets.
-    { Lib_XNET,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_SIZEV2 },
+    { Lib_XNET,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNTV2 },
 
     // XNETS only has XNET, might be true.
-    { Lib_XNETS,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_SIZEV2 },
+    { Lib_XNETS,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNTV2 },
 
     // test case: Stake
-    { Lib_XNETN,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_SIZEV2 },
+    { Lib_XNETN,{ Sec_text, Sec_XNET }, XNET_OOVPAV2, XNET_OOVPA_COUNTV2 },
 };
 
 // ******************************************************************
 // * HLEDataBaseCount
 // ******************************************************************
-const uint32 HLEDataBaseCount = sizeof(HLEDataBase) / sizeof(HLEData);
+const uint32 HLEDataBaseCount = sizeof(HLEDataBase) / sizeof(HLEDataBase[0]);
 
 // ******************************************************************
 // * XRefDataBase

--- a/src/CxbxKrnl/HLEDataBase.h
+++ b/src/CxbxKrnl/HLEDataBase.h
@@ -78,6 +78,7 @@ extern const uint32 HLEDataBaseCount;
 // ****************************************************************** 
 // Note: The returned hash is a 32-bit FNV-1a checksum
 // This checksum was chosen as the hash should approximate the database integrity - and run as fast as possible!
+// In future this should be a compile-time expression - not calculated at run-time
 // ******************************************************************
 extern uint32 GetHLEDataBaseHash();
 

--- a/src/CxbxKrnl/HLEDataBase.h
+++ b/src/CxbxKrnl/HLEDataBase.h
@@ -69,7 +69,7 @@ extern const struct HLEData
     const PairScanLibSec LibSec;
 
     OOVPATable     *OovpaTable;
-    uint32          OovpaTableSize;
+    uint32          OovpaTableCount;
 }
 HLEDataBase[];
 

--- a/src/CxbxKrnl/HLEDataBase.h
+++ b/src/CxbxKrnl/HLEDataBase.h
@@ -36,11 +36,6 @@
 
 #include "HLEDataBase\D3D8.OOVPA.h"
 
-// ******************************************************************
-// * szHLELastCompileTime
-// ******************************************************************
-extern "C" const char *szHLELastCompileTime;
-
 //TODO: Need to remove these externs as v2 is no longer require it.
 extern const char *Lib_D3D8;
 extern const char *Lib_D3D8LTCG;
@@ -77,6 +72,11 @@ HLEDataBase[];
 // * HLEDataBaseCount
 // ******************************************************************
 extern const uint32 HLEDataBaseCount;
+
+// ******************************************************************
+// * GetHLEDataBaseHash
+// ******************************************************************
+extern uint32 GetHLEDataBaseHash();
 
 // ******************************************************************
 // * XRefDataBaseOffset

--- a/src/CxbxKrnl/HLEDataBase.h
+++ b/src/CxbxKrnl/HLEDataBase.h
@@ -75,6 +75,9 @@ extern const uint32 HLEDataBaseCount;
 
 // ******************************************************************
 // * GetHLEDataBaseHash
+// ****************************************************************** 
+// Note: The returned hash is a 32-bit FNV-1a checksum
+// This checksum was chosen as the hash should approximate the database integrity - and run as fast as possible!
 // ******************************************************************
 extern uint32 GetHLEDataBaseHash();
 

--- a/src/CxbxKrnl/HLEDataBase/D3D8.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.OOVPA.inl
@@ -434,8 +434,8 @@ OOVPATable D3D8_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * D3D8_OOVPA_COUNTV2
+// * D3D8_OOVPA_COUNT
 // ******************************************************************
-const uint32 D3D8_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(D3D8_OOVPAV2);
+const uint32 D3D8_OOVPA_COUNT = OOVPA_TABLE_COUNT(D3D8_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/D3D8.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/D3D8.OOVPA.inl
@@ -434,8 +434,8 @@ OOVPATable D3D8_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * D3D8_OOVPA_SIZE
+// * D3D8_OOVPA_COUNTV2
 // ******************************************************************
-uint32 D3D8_OOVPA_SIZEV2 = sizeof(D3D8_OOVPAV2);
+const uint32 D3D8_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(D3D8_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
@@ -520,8 +520,8 @@ OOVPATable DSound_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * DSound_OOVPA_COUNTV2
+// * DSound_OOVPA_COUNT
 // ******************************************************************
-const uint32 DSound_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(DSound_OOVPAV2);
+const uint32 DSound_OOVPA_COUNT = OOVPA_TABLE_COUNT(DSound_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
@@ -520,8 +520,8 @@ OOVPATable DSound_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * DSOUND_OOVPA_SIZE
+// * DSound_OOVPA_COUNTV2
 // ******************************************************************
-uint32 DSound_OOVPA_SIZEV2 = sizeof(DSound_OOVPAV2);
+const uint32 DSound_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(DSound_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XG.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.OOVPA.inl
@@ -100,8 +100,8 @@ OOVPATable XGRAPHC_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XGRAPHC_OOVPA_SIZE
+// * XGRAPHC_OOVPA_COUNTV2
 // ******************************************************************
-uint32 XGRAPHC_OOVPA_SIZEV2 = sizeof(XGRAPHC_OOVPAV2);
+const uint32 XGRAPHC_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XGRAPHC_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XG.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XG.OOVPA.inl
@@ -100,8 +100,8 @@ OOVPATable XGRAPHC_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XGRAPHC_OOVPA_COUNTV2
+// * XGRAPHC_OOVPA_COUNT
 // ******************************************************************
-const uint32 XGRAPHC_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XGRAPHC_OOVPAV2);
+const uint32 XGRAPHC_OOVPA_COUNT = OOVPA_TABLE_COUNT(XGRAPHC_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XNet.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XNet.OOVPA.inl
@@ -79,8 +79,8 @@ OOVPATable XNET_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XNET_OOVPA_SIZE
+// * XNET_OOVPA_COUNTV2
 // ******************************************************************
-uint32 XNET_OOVPA_SIZEV2 = sizeof(XNET_OOVPAV2);
+const uint32 XNET_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XNET_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XNet.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XNet.OOVPA.inl
@@ -79,8 +79,8 @@ OOVPATable XNET_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XNET_OOVPA_COUNTV2
+// * XNET_OOVPA_COUNT
 // ******************************************************************
-const uint32 XNET_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XNET_OOVPAV2);
+const uint32 XNET_OOVPA_COUNT = OOVPA_TABLE_COUNT(XNET_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XOnline.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XOnline.OOVPA.inl
@@ -93,8 +93,8 @@ OOVPATable XONLINES_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XONLINES_OOVPA_COUNTV2
+// * XONLINES_OOVPA_COUNT
 // ******************************************************************
-const uint32 XONLINES_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XONLINES_OOVPAV2);
+const uint32 XONLINES_OOVPA_COUNT = OOVPA_TABLE_COUNT(XONLINES_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XOnline.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XOnline.OOVPA.inl
@@ -93,8 +93,8 @@ OOVPATable XONLINES_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XONLINES_OOVPA_SIZE
+// * XONLINES_OOVPA_COUNTV2
 // ******************************************************************
-uint32 XONLINES_OOVPA_SIZEV2 = sizeof(XONLINES_OOVPAV2);
+const uint32 XONLINES_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XONLINES_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XactEng.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XactEng.OOVPA.inl
@@ -105,8 +105,8 @@ OOVPATable XACTENG_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XACTENG_OOVPA_COUNTV2
+// * XACTENG_OOVPA_COUNT
 // ******************************************************************
-const uint32 XACTENG_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XACTENG_OOVPAV2);
+const uint32 XACTENG_OOVPA_COUNT = OOVPA_TABLE_COUNT(XACTENG_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/XactEng.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/XactEng.OOVPA.inl
@@ -105,8 +105,8 @@ OOVPATable XACTENG_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XACTENG_OOVPA_SIZE
+// * XACTENG_OOVPA_COUNTV2
 // ******************************************************************
-uint32 XACTENG_OOVPA_SIZEV2 = sizeof(XACTENG_OOVPAV2);
+const uint32 XACTENG_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XACTENG_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/Xapi.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.OOVPA.inl
@@ -186,8 +186,8 @@ OOVPATable XAPILIB_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XAPILIB_OOVPA_COUNTV2
+// * XAPILIB_OOVPA_COUNT
 // ******************************************************************
-const uint32 XAPILIB_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XAPILIB_OOVPAV2);
+const uint32 XAPILIB_OOVPA_COUNT = OOVPA_TABLE_COUNT(XAPILIB_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEDataBase/Xapi.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/Xapi.OOVPA.inl
@@ -186,8 +186,8 @@ OOVPATable XAPILIB_OOVPAV2[] = {
 };
 
 // ******************************************************************
-// * XAPILIB_OOVPA_SIZE
+// * XAPILIB_OOVPA_COUNTV2
 // ******************************************************************
-uint32 XAPILIB_OOVPA_SIZEV2 = sizeof(XAPILIB_OOVPAV2);
+const uint32 XAPILIB_OOVPA_COUNTV2 = OOVPA_TABLE_COUNT(XAPILIB_OOVPAV2);
 
 #endif

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -597,7 +597,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
                                     if (bPrintSkip) printf("Found\n");
                                     bPrintSkip = false;
 
-                                    EmuInstallPatches(HLEDataBase[d2].OovpaTable, HLEDataBase[d2].OovpaTableSize, pSectionScan, BuildVersion);
+                                    EmuInstallPatches(HLEDataBase[d2].OovpaTable, HLEDataBase[d2].OovpaTableCount, pSectionScan, BuildVersion);
                                     break;
                                 }
                             }
@@ -887,7 +887,7 @@ xbaddr EmuLocateFunction(OOVPA *Oovpa, xbaddr lower, xbaddr upper)
 }
 
 // install function interception wrappers
-void EmuInstallPatches(OOVPATable *OovpaTable, uint32 OovpaTableSize, Xbe::SectionHeader *pSectionHeader, uint16_t buildVersion)
+void EmuInstallPatches(OOVPATable *OovpaTable, uint32 OovpaTableCount, Xbe::SectionHeader *pSectionHeader, uint16_t buildVersion)
 {
     xbaddr lower = pSectionHeader->dwVirtualAddr;
 
@@ -895,7 +895,7 @@ void EmuInstallPatches(OOVPATable *OovpaTable, uint32 OovpaTableSize, Xbe::Secti
     xbaddr upper = pSectionHeader->dwVirtualAddr + pSectionHeader->dwVirtualSize;
 
     // traverse the full OOVPA table
-    OOVPATable *pLoopEnd = &OovpaTable[OovpaTableSize / sizeof(OOVPATable)];
+    OOVPATable *pLoopEnd = &OovpaTable[OovpaTableCount];
     OOVPATable *pLoop = OovpaTable;
     OOVPATable *pLastKnownSymbol = nullptr;
     xbaddr pLastKnownFunc = 0;
@@ -1087,7 +1087,7 @@ void VerifyHLEOOVPA(HLEVerifyContext *context, uint16_t buildVersion, OOVPA *oov
     }
 }
 
-void VerifyHLEDataEntry(HLEVerifyContext *context, const OOVPATable *table, uint32 index, uint32 count)
+void VerifyHLEDataEntry(HLEVerifyContext *context, const OOVPATable *table, uint32 index)
 {
     if (context->against == nullptr) {
         context->main_index = index;
@@ -1134,9 +1134,8 @@ void VerifyHLEData(HLEVerifyContext *context, const HLEData *data)
     }
 
     // verify each entry in this HLEData
-    uint32 count = data->OovpaTableSize / sizeof(OOVPATable);
-    for (uint32 e = 0; e < count; e++) {
-        VerifyHLEDataEntry(context, data->OovpaTable, e, count);
+    for (uint32 e = 0; e < data->OovpaTableCount; e++) {
+        VerifyHLEDataEntry(context, data->OovpaTable, e);
     }
 }
 

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -165,7 +165,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 
     printf("\n");
 	printf("*******************************************************************************\n");
-	printf("* Cxbx-Reloaded High Level Emulation database last modified %s\n", szHLELastCompileTime);
+	printf("* Cxbx-Reloaded High Level Emulation database\n");
 	printf("*******************************************************************************\n");
 	printf("\n");
 
@@ -190,15 +190,17 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	if (PathFileExists(filename.c_str())) {
 		printf("Found HLE Cache File: %08X.ini\n", uiHash);
 
-		// Verify the version of the cache file against the HLE Database
-		char buffer[SHRT_MAX] = { 0 };
-		char* bufferPtr = buffer;
-
-		GetPrivateProfileString("Info", "HLEDatabaseVersion", NULL, buffer, sizeof(buffer), filename.c_str());
 		g_BuildVersion = GetPrivateProfileInt("Libs", "D3D8_BuildVersion", 0, filename.c_str());
 
-		if (strcmp(buffer, szHLELastCompileTime) == 0) {
+		// Verify the version of the cache file against the HLE Database	
+		const uint32 HLECacheHash = GetPrivateProfileInt("Info", "HLECacheHash", 0, filename.c_str());
+
+		if (HLECacheHash == GetHLEDataBaseHash()) {
+			char buffer[SHRT_MAX] = { 0 };
+			char* bufferPtr = buffer;
+
 			printf("Using HLE Cache\n");
+
 			GetPrivateProfileSection("Symbols", buffer, sizeof(buffer), filename.c_str());
 
 			// Parse the .INI file into the map of symbol addresses
@@ -624,7 +626,10 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	printf("\n");
 
 	// Write the HLE Database version string
-	WritePrivateProfileString("Info", "HLEDatabaseVersion", szHLELastCompileTime, filename.c_str());
+	{
+		std::string HLECacheHashString = std::to_string(GetHLEDataBaseHash());
+		WritePrivateProfileString("Info", "HLECacheHash", HLECacheHashString.c_str(), filename.c_str());
+	}
 
 	// Write the Certificate Details to the cache file
 	WritePrivateProfileString("Certificate", "Name", tAsciiTitle, filename.c_str());

--- a/src/CxbxKrnl/OOVPA.h
+++ b/src/CxbxKrnl/OOVPA.h
@@ -43,7 +43,10 @@
 #define STRINGIZEX(x) #x
 #define STRINGIZE(x) STRINGIZEX(x)
 
-#define OOVPA_TABLE_COUNT(x) (sizeof(x) / sizeof(OOVPATable))
+#include <iterator>
+
+// http://en.cppreference.com/w/cpp/iterator/size
+#define OOVPA_TABLE_COUNT(x) std::size(x)
 
 #pragma pack(1)
 

--- a/src/CxbxKrnl/OOVPA.h
+++ b/src/CxbxKrnl/OOVPA.h
@@ -43,6 +43,8 @@
 #define STRINGIZEX(x) #x
 #define STRINGIZE(x) STRINGIZEX(x)
 
+#define OOVPA_TABLE_COUNT(x) (sizeof(x) / sizeof(OOVPATable))
+
 #pragma pack(1)
 
 // ******************************************************************


### PR DESCRIPTION
As per #836, the old timestamp check doesn't work if the cpp file isn't touched after editing OOVPA sigantures. This requires the cache to be cleaned - which defeats the point of auto-detecting it 😉 

This change introduces a new INI value `HLECacheHash` which stores the a FNV-1a checksum of the HLEDataTable.

The downside to this change is that **any** differences (between existing cache files and Cxbx build) will force a rescan. In future a contextual hash would be better suited! Phew!