### PR TITLE
GetTexture and GetBackBuffer should increment the reference count

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3090,6 +3090,9 @@ XTL::X_D3DSurface* WINAPI XTL::EMUPATCH(D3DDevice_GetBackBuffer2)
 	SetHostSurface(pBackBuffer, pNewHostSurface);
     // update data pointer
     pBackBuffer->Data = X_D3DRESOURCE_DATA_BACK_BUFFER;
+	
+	// Increment reference count
+	pBackBuffer->Common++;
 
     return pBackBuffer;
 }
@@ -9624,6 +9627,10 @@ XTL::X_D3DResource* WINAPI XTL::EMUPATCH(D3DDevice_GetTexture2)(DWORD Stage)
 	
 	// Get the active texture from this stage
 	X_D3DPixelContainer* pRet = EmuD3DActiveTexture[Stage];
+
+	if (pRet) {
+		pRet->Common++;
+	}
 
 	return pRet;
 }


### PR DESCRIPTION
Missing reference counts were identified by Dartht33bagger on Discord:

> The assertion for Rainbow Six 3 is firing in the Cxbx code.  Line 726 in EmuD3D8.cpp. The pXboxResouce-Common variable is expected as type  X_D3DCOMMON_TYPE_SURFACE. After some debug, I found that D3DDevice_GetBackBuffer2 is patched and the third call to D3DDevice_GetBackBuffer2 causes the the assertion to fire when it calls SetHostSurface.  D3DDevice_GetBackBuffer2 creates a static X_D3DSurface pointer named pBackBuffer which initially has the value pBackBuffer->Common = 0x01050001. On the second call to D3DDevice_GetBackBuffer2, pBackBuffer->Common = 0x01050000. On the third call to D3DDevice_GetBackBuffer2, pBackBuffer->Common = 0x0104FFFF. What I found is that D3DRelease_Resource is being called inbetween D3DDevice_GetBackBuffer2, which is causing the pBackBuffer->Common variable to decrement by 1. Once pBackBuffer->Common = 0x0104FFFF, the return type of GetXboxCommonResourceType is no longer X_D3DCOMMON_TYPE_SURFACE, and is now of type X_D3DCOMMON_TYPE_TEXTURE, causing the assertion to fire.


Comparing our patches with the Xbox implementations revealed these two areas in which we are missing reference counts, this adds them in. 