### PR TITLE
Xbe flags are now dumped correctly

### DIFF
--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -585,7 +585,7 @@ void Xbe::DumpInformation(FILE *x_file)
 
     // print init flags
     {
-        fprintf(x_file, "Init Flags                       : 0x%.08X ", m_Header.dwInitFlags.bMountUtilityDrive);
+        fprintf(x_file, "Init Flags                       : 0x%.08X ", m_Header.dwInitFlags_value);
 
         if(m_Header.dwInitFlags.bMountUtilityDrive)
             fprintf(x_file, "[Mount Utility Drive] ");
@@ -703,7 +703,7 @@ void Xbe::DumpInformation(FILE *x_file)
 
             // print flags
             {
-                fprintf(x_file, "Flags                            : 0x%.08X ", m_SectionHeader[v].dwFlags.bWritable);
+                fprintf(x_file, "Flags                            : 0x%.08X ", m_SectionHeader[v].dwFlags_value);
 
                 if(m_SectionHeader[v].dwFlags.bWritable)
                     fprintf(x_file, "(Writable) ");
@@ -773,16 +773,16 @@ void Xbe::DumpInformation(FILE *x_file)
 
                 // print flags
                 {
-                    fprintf(x_file, "Flags                            : ");
+                    fprintf(x_file, "Flags                            : 0x%.04X ", m_LibraryVersion[v].wFlags_value);
 
-                    fprintf(x_file, "QFEVersion : 0x%.04X, ", m_LibraryVersion[v].dwFlags.QFEVersion);
+                    fprintf(x_file, "QFEVersion : 0x%.04X, ", m_LibraryVersion[v].wFlags.QFEVersion);
 
-                    if(m_LibraryVersion[v].dwFlags.bDebugBuild)
+                    if(m_LibraryVersion[v].wFlags.bDebugBuild)
                         fprintf(x_file, "Debug, ");
                     else
                         fprintf(x_file, "Retail, ");
 
-                    switch(m_LibraryVersion[v].dwFlags.Approved)
+                    switch(m_LibraryVersion[v].wFlags.Approved)
                     {
                         case 0:
                             fprintf(x_file, "Unapproved");

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -92,7 +92,7 @@ class Xbe : public Error
             uint32 dwSections;                      // 0x011C - number of sections
             uint32 dwSectionHeadersAddr;            // 0x0120 - section headers address
 
-            struct InitFlags                        // 0x0124 - initialization flags
+			typedef struct                         
             {
                 uint32 bMountUtilityDrive   : 1;    // mount utility drive flag
                 uint32 bFormatUtilityDrive  : 1;    // format utility drive flag
@@ -102,8 +102,12 @@ class Xbe : public Error
                 uint32 Unused_b1            : 8;    // unused (or unknown)
                 uint32 Unused_b2            : 8;    // unused (or unknown)
                 uint32 Unused_b3            : 8;    // unused (or unknown)
-            }
-            dwInitFlags;
+			} InitFlags;
+
+			union {                                 // 0x0124 - initialization flags
+				InitFlags dwInitFlags;
+				uint32 dwInitFlags_value;
+			};
 
             uint32 dwEntryAddr;                     // 0x0128 - entry point address
             uint32 dwTLSAddr;                       // 0x012C - thread local storage directory address
@@ -162,7 +166,7 @@ class Xbe : public Error
         #include "AlignPrefix1.h"
         struct SectionHeader
         {
-            struct _Flags
+            typedef struct 
             {
                 uint32 bWritable        : 1;    // writable flag
                 uint32 bPreload         : 1;    // preload flag
@@ -175,8 +179,12 @@ class Xbe : public Error
                 uint32 Unused_b1        : 8;    // unused (or unknown)
                 uint32 Unused_b2        : 8;    // unused (or unknown)
                 uint32 Unused_b3        : 8;    // unused (or unknown)
-            }
-            dwFlags;
+			} _Flags;
+
+			union {
+				_Flags dwFlags;
+				uint32 dwFlags_value;
+			};
 
             uint32 dwVirtualAddr;               // virtual address
             uint32 dwVirtualSize;               // virtual size
@@ -200,13 +208,17 @@ class Xbe : public Error
             uint16 wMinorVersion;               // minor version
             uint16 wBuildVersion;               // build version
 
-            struct Flags
+            typedef struct 
             {
                 uint16 QFEVersion       : 13;   // QFE Version
                 uint16 Approved         : 2;    // Approved? (0:no, 1:possibly, 2:yes)
                 uint16 bDebugBuild      : 1;    // Is this a debug build?
-            }
-            dwFlags;
+			} Flags;
+
+			union {
+				Flags wFlags;
+				uint16 wFlags_value;
+			};
         }
         #include "AlignPosfix1.h"
         *m_LibraryVersion, *m_KernelLibraryVersion, *m_XAPILibraryVersion;


### PR DESCRIPTION
 Before this, only the first bitfield was shown, now the entire value.

This fixes issue https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/850