### PR TITLE
CxbxKrnlRegisterThread refactoring

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -471,14 +471,7 @@ VOID XTL::CxbxInitWindow(Xbe::Header *XbeHeader, uint32 XbeHeaderSize)
         // We set the priority of this thread a bit higher, to assure reliable timing :
         SetThreadPriority(hThread, THREAD_PRIORITY_ABOVE_NORMAL);
 
-        // we must duplicate this handle in order to retain Suspend/Resume thread rights from a remote thread
-        {
-            HANDLE hDupHandle = NULL;
-
-            DuplicateHandle(g_CurrentProcessHandle, hThread, g_CurrentProcessHandle, &hDupHandle, 0, FALSE, DUPLICATE_SAME_ACCESS);
-
-            CxbxKrnlRegisterThread(hDupHandle);
-        }
+        CxbxKrnlRegisterThread(hThread);
     }
 
 /* TODO : Port this Dxbx code :

--- a/src/CxbxKrnl/EmuKrnlPs.cpp
+++ b/src/CxbxKrnl/EmuKrnlPs.cpp
@@ -353,14 +353,7 @@ XBSYSAPI EXPORTNUM(255) xboxkrnl::NTSTATUS NTAPI xboxkrnl::PsCreateSystemThreadE
 		// Log ThreadID identical to how GetCurrentThreadID() is rendered :
 		EmuWarning("KRNL: Created Xbox proxy thread. Handle : 0x%X, ThreadId : [0x%.4X]\n", *ThreadHandle, dwThreadId);
 
-		// we must duplicate this handle in order to retain Suspend/Resume thread rights from a remote thread
-		{
-			HANDLE hDupHandle = NULL;
-
-			DuplicateHandle(g_CurrentProcessHandle, *ThreadHandle, g_CurrentProcessHandle, &hDupHandle, 0, FALSE, DUPLICATE_SAME_ACCESS);
-
-			CxbxKrnlRegisterThread(hDupHandle);
-		}
+		CxbxKrnlRegisterThread(*ThreadHandle);
 
 		if (ThreadId != NULL)
 			*ThreadId = (xboxkrnl::HANDLE)dwThreadId;


### PR DESCRIPTION
All callers first called DuplicateHandle. Now this is part of CxbxKrnlRegisterThread itself. Also, a possible failure of DuplicateHandle is logged.

This reduces the number of occurrences of DuplicateHandle to two, which reduces the amount of work needed for issue #679