### PR TITLE
Move persistent memory restore to after contiguous memory is restored 

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -650,6 +650,7 @@ void CxbxKrnlMain(int argc, char* argv[])
 	}
 
 	CxbxRestoreContiguousMemory(szFilePath_memory_bin);
+	CxbxRestorePersistentMemoryRegions();
 
 	EEPROM = CxbxRestoreEEPROM(szFilePath_EEPROM_bin);
 	if (EEPROM == nullptr)
@@ -685,8 +686,6 @@ void CxbxKrnlMain(int argc, char* argv[])
 			// Initialize the Chihiro/Debug - specific memory ranges
 			g_VMManager.InitializeChihiroDebug();
 		}
-
-		CxbxRestorePersistentMemoryRegions();
 
 		// Copy over loaded Xbe Headers to specified base address
 		memcpy((void*)CxbxKrnl_Xbe->m_Header.dwBaseAddr, &CxbxKrnl_Xbe->m_Header, sizeof(Xbe::Header));

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -1111,7 +1111,7 @@ void CxbxRestoreLaunchDataPage()
 
 	if (LaunchDataPAddr)
 	{
-		xboxkrnl::LaunchDataPage = (xboxkrnl::LAUNCH_DATA_PAGE*)CONTIGUOUS_MEMORY_BASE + LaunchDataPAddr;
+		xboxkrnl::LaunchDataPage = (xboxkrnl::LAUNCH_DATA_PAGE*)(CONTIGUOUS_MEMORY_BASE + LaunchDataPAddr);
 		// Mark the launch page as allocated to prevent other allocations from overwriting it
 		xboxkrnl::MmAllocateContiguousMemoryEx(PAGE_SIZE, LaunchDataPAddr, LaunchDataPAddr + PAGE_SIZE - 1, PAGE_SIZE, PAGE_READWRITE);
 		LaunchDataPAddr = NULL;


### PR DESCRIPTION
Potential fix for (at least part of) #861.

If some mutli-xbe titles could be tested and the results fed back to me before merging, that would be appreciated. 

Sorry about the merge-commit in here, just do a squash or rebase merge to fix it ;)