### PR TITLE
Fix an issue where Xbox Dashboard could not successfully launch XOnlineDash

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -83,7 +83,7 @@ Xbe::Header *CxbxKrnl_XbeHeader = NULL;
 
 HWND CxbxKrnl_hEmuParent = NULL;
 DebugMode CxbxKrnl_DebugMode = DebugMode::DM_NONE;
-char* CxbxKrnl_DebugFileName = NULL;
+std::string CxbxKrnl_DebugFileName = "";
 Xbe::Certificate *g_pCertificate = NULL;
 
 /*! thread handles */
@@ -533,7 +533,7 @@ void CxbxKrnlMain(int argc, char* argv[])
 	}
 
 	// Get KernelDebugFileName :
-	std::string DebugFileName;
+	std::string DebugFileName = "";
 	if (argc > 4) {
 		DebugFileName = argv[5];
 	}

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -221,7 +221,7 @@ extern Xbe *CxbxKrnl_Xbe;
 /*! parent window handle */
 extern HWND CxbxKrnl_hEmuParent;
 extern DebugMode CxbxKrnl_DebugMode;
-extern char* CxbxKrnl_DebugFileName;
+extern std::string CxbxKrnl_DebugFileName;
 
 /*! file paths */
 extern char szFilePath_CxbxReloaded_Exe[MAX_PATH];

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -57,6 +57,7 @@ namespace xboxkrnl
 #include "EmuShared.h"
 #include "EmuFile.h" // For FindNtSymbolicLinkObjectByDriveLetter
 
+#include <algorithm> // for std::replace
 #include <locale>
 #include <codecvt>
 
@@ -472,7 +473,11 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 
 				char szArgsBuffer[4096];
 
-				snprintf(szArgsBuffer, 4096, "/load \"%s\" %u %d \"%s\"", XbePath.c_str(), CxbxKrnl_hEmuParent, CxbxKrnl_DebugMode, CxbxKrnl_DebugFileName);
+				// Some titles (Xbox Dashboard) use ";" as a final path seperator
+				// This allows the Xbox Live option on the dashboard to properly launch XOnlinedash.xbe
+				std::replace(XbePath.begin(), XbePath.end(), ';', '\\');
+
+				snprintf(szArgsBuffer, 4096, "/load \"%s\" %u %d \"%s\"", XbePath.c_str(), CxbxKrnl_hEmuParent, CxbxKrnl_DebugMode, CxbxKrnl_DebugFileName.c_str());
 				if ((int)ShellExecute(NULL, "open", szFilePath_CxbxReloaded_Exe, szArgsBuffer, szWorkingDirectoy, SW_SHOWDEFAULT) <= 32)
 					CxbxKrnlCleanup("Could not launch %s", XbePath.c_str());
 			}


### PR DESCRIPTION
This has been tested and confirmed working with Dashboard version 4920 (the latest available that doesn't use LTCG)