### PR TITLE
Various fixes

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -789,6 +789,7 @@ void SetLEDSequence(LED::Sequence aLEDSequence)
 {
 	// TODO : Move to best suited location & implement
 	// See http://xboxdevwiki.net/PIC#The_LED
+	DbgPrintf("SMC : SetLEDSequence : %u\n", (byte)aLEDSequence);
 }
 
 __declspec(noreturn) void CxbxKrnlInit

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3114,7 +3114,7 @@ XTL::X_D3DSurface* WINAPI XTL::EMUPATCH(D3DDevice_GetBackBuffer2)
     pBackBuffer->Data = X_D3DRESOURCE_DATA_BACK_BUFFER;
 	
 	// Increment reference count
-	pBackBuffer->Common++;
+	pBackBuffer->Common++; // EMUPATCH(D3DResource_AddRef)(pBackBuffer);
 
     return pBackBuffer;
 }
@@ -3323,7 +3323,7 @@ XTL::X_D3DSurface * WINAPI XTL::EMUPATCH(D3DDevice_GetRenderTarget2)()
 	X_D3DSurface *result = g_pCachedRenderTarget;
 
 	if (result)
-		EMUPATCH(D3DResource_AddRef)(result);
+		result->Common++; // EMUPATCH(D3DResource_AddRef)(result);
 
     RETURN(result);
 }
@@ -3357,7 +3357,7 @@ XTL::X_D3DSurface * WINAPI XTL::EMUPATCH(D3DDevice_GetDepthStencilSurface2)()
 	X_D3DSurface *result = g_pCachedDepthStencil;
 
 	if (result)
-		EMUPATCH(D3DResource_AddRef)(result);
+		result->Common++; // EMUPATCH(D3DResource_AddRef)(result);
 		
 	RETURN(result);
 }
@@ -5952,7 +5952,7 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_AddRef)
     X_D3DResource      *pThis
 )
 {
-	FUNC_EXPORTS
+	// FUNC_EXPORTS
 
 	LOG_FUNC_ONE_ARG(pThis);
 
@@ -7936,7 +7936,7 @@ XTL::X_D3DVertexBuffer* WINAPI XTL::EMUPATCH(D3DDevice_GetStreamSource2)
 		pVertexBuffer = g_D3DStreams[StreamNumber];
 		if (pVertexBuffer)
 		{
-			EMUPATCH(D3DResource_AddRef)(pVertexBuffer);
+			pVertexBuffer->Common++; // EMUPATCH(D3DResource_AddRef)(pVertexBuffer);
 			*pStride = g_D3DStreamStrides[StreamNumber];
 		}
 	}
@@ -9682,7 +9682,7 @@ XTL::X_D3DBaseTexture* WINAPI XTL::EMUPATCH(D3DDevice_GetTexture2)(DWORD Stage)
 	X_D3DBaseTexture* pRet = EmuD3DActiveTexture[Stage];
 
 	if (pRet) {
-		pRet->Common++;
+		pRet->Common++; // EMUPATCH(D3DResource_AddRef)(pRet);
 	}
 
 	return pRet;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5829,7 +5829,6 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
 												w += dwMipWidth * (sizeof(DWORD) - dwBPP);
 											}
 										}
-#endif // !OLD_COLOR_CONVERSION
 									}
 
 									//__asm int 3;
@@ -5839,6 +5838,7 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
 									// Flush unused data buffers
 									free(pExpandedTexture);
 								}
+#endif // !OLD_COLOR_CONVERSION
 							}
 						}
 

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -36,7 +36,7 @@
 
 #include "CxbxKrnl.h"
 
-#define OLD_COLOR_CONVERSION
+//#define OLD_COLOR_CONVERSION
 
 // simple render state encoding lookup table
 #define X_D3DRSSE_UNK 0x7fffffff

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -539,7 +539,7 @@ XBSYSAPI EXPORTNUM(50) xboxkrnl::NTSTATUS NTAPI xboxkrnl::HalWriteSMBusValue
 		// Note : GE_HOST_STC triggers ExecuteTransaction, which writes the command to the specified address
 
 	// Check if the command was executed successfully
-	if (g_SMBus->IORead(1, SMB_GLOBAL_STATUS) | GS_PRERR_STS) {
+	if (g_SMBus->IORead(1, SMB_GLOBAL_STATUS) & GS_PRERR_STS) {
 		Status = STATUS_UNSUCCESSFUL;
 	}
 

--- a/src/CxbxKrnl/SMBus.cpp
+++ b/src/CxbxKrnl/SMBus.cpp
@@ -24,13 +24,14 @@ void SMBus::Reset()
 
 void SMBus::ConnectDevice(uint8_t addr, SMDevice *pDevice)
 {
+	uint8_t dev_addr = (addr >> 1) & 0x7f;
 
-	if (m_Devices.find(addr) != m_Devices.end()) {
+	if (m_Devices.find(dev_addr) != m_Devices.end()) {
 		printf("PCIBus: Attempting to connect two devices to the same device address\n");
 		return;
 	}
 
-	m_Devices[addr] = pDevice;
+	m_Devices[dev_addr] = pDevice;
 	pDevice->Init();
 }
 


### PR DESCRIPTION
SMBus now actually forwards calls to SMC (initial connection used the wrong address).
HalWriteSMBusValue now actually returns success when a device responded.
No more EMUPATCH(D3DResource_AddRef) - it's entirely bypassed without discernable downsides.
Texture-conversion now uses new row-based (libyuv-like) color conversion callbacks.
