### PR TITLE
HalIsResetOrShutdownPending implementation

### DIFF
--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -684,9 +684,14 @@ XBSYSAPI EXPORTNUM(358) xboxkrnl::BOOLEAN NTAPI xboxkrnl::HalIsResetOrShutdownPe
 {
 	LOG_FUNC();
 
-	LOG_UNIMPLEMENTED();
+	BOOLEAN ret = FALSE;
+	uint8_t CommandCode;
+	uint32_t DataValue;
+	g_SMC->GetResetOrShutdownCode(&CommandCode, &DataValue);
 
-	RETURN(FALSE);
+	if (CommandCode != 0) { ret = TRUE; }
+
+	RETURN(ret);
 }
 
 // ******************************************************************
@@ -699,7 +704,10 @@ XBSYSAPI EXPORTNUM(360) xboxkrnl::NTSTATUS NTAPI xboxkrnl::HalInitiateShutdown
 {
 	LOG_FUNC();
 	
-	xboxkrnl::HalWriteSMBusValue(SMBUS_SMC_SLAVE_ADDRESS, SMC_COMMAND_RESET, 0, SMC_RESET_ASSERT_SHUTDOWN);
+	uint8_t CommandCode = SMC_COMMAND_RESET;
+	uint32_t DataValue = SMC_RESET_ASSERT_SHUTDOWN;
+	g_SMC->SetResetOrShutdownCode(&CommandCode, &DataValue);
+	xboxkrnl::HalWriteSMBusValue(SMBUS_SMC_SLAVE_ADDRESS, CommandCode, 0, DataValue);
 
 	RETURN(S_OK);
 }

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -70,6 +70,11 @@ namespace NtDll
 static DWORD EmuSoftwareInterrupRequestRegister = 0;
 HalSystemInterrupt HalSystemInterrupts[MAX_BUS_INTERRUPT_LEVEL + 1];
 
+// variables used by the SMC to know a reset / shutdown is pending
+uint8_t ResetOrShutdownCommandCode = 0;
+uint32_t ResetOrShutdownDataValue = 0;
+
+
 // ******************************************************************
 // * 0x0009 - HalReadSMCTrayState()
 // ******************************************************************
@@ -685,11 +690,8 @@ XBSYSAPI EXPORTNUM(358) xboxkrnl::BOOLEAN NTAPI xboxkrnl::HalIsResetOrShutdownPe
 	LOG_FUNC();
 
 	BOOLEAN ret = FALSE;
-	uint8_t CommandCode;
-	uint32_t DataValue;
-	g_SMC->GetResetOrShutdownCode(&CommandCode, &DataValue);
 
-	if (CommandCode != 0) { ret = TRUE; }
+	if (ResetOrShutdownCommandCode != 0) { ret = TRUE; }
 
 	RETURN(ret);
 }
@@ -704,10 +706,9 @@ XBSYSAPI EXPORTNUM(360) xboxkrnl::NTSTATUS NTAPI xboxkrnl::HalInitiateShutdown
 {
 	LOG_FUNC();
 	
-	uint8_t CommandCode = SMC_COMMAND_RESET;
-	uint32_t DataValue = SMC_RESET_ASSERT_SHUTDOWN;
-	g_SMC->SetResetOrShutdownCode(&CommandCode, &DataValue);
-	xboxkrnl::HalWriteSMBusValue(SMBUS_SMC_SLAVE_ADDRESS, CommandCode, 0, DataValue);
+	ResetOrShutdownCommandCode = SMC_COMMAND_RESET;
+	ResetOrShutdownDataValue = SMC_RESET_ASSERT_SHUTDOWN;
+	xboxkrnl::HalWriteSMBusValue(SMBUS_SMC_SLAVE_ADDRESS, ResetOrShutdownCommandCode, 0, ResetOrShutdownDataValue);
 
 	RETURN(S_OK);
 }

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -75,6 +75,8 @@ void SMCDevice::Init()
 	buffer[SMC_COMMAND_AV_PACK] = AV_PACK_HDTV; // see http://xboxdevwiki.net/PIC#The_AV_Pack
 	buffer[SMC_COMMAND_LED_SEQUENCE] = LED::GREEN;
 	buffer[SMC_COMMAND_SCRATCH] = 0; // http://xboxdevwiki.net/PIC#Scratch_register_values
+	ResetOrShutdownCommandCode.store(0);
+	ResetOrShutdownDataValue.store(0);
 }
 
 void SMCDevice::Reset()
@@ -208,4 +210,16 @@ void SMCDevice::WriteWord(uint8_t command, uint16_t value)
 void SMCDevice::WriteBlock(uint8_t command, uint8_t* data, int length)
 {
 	// TODO
+}
+
+void SMCDevice::GetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue)
+{
+	*CommandCode = ResetOrShutdownCommandCode.load();
+	*DataValue = ResetOrShutdownDataValue.load();
+}
+
+void SMCDevice::SetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue)
+{
+	ResetOrShutdownCommandCode.store(*CommandCode);
+	ResetOrShutdownDataValue.store(*DataValue);
 }

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -75,8 +75,6 @@ void SMCDevice::Init()
 	buffer[SMC_COMMAND_AV_PACK] = AV_PACK_HDTV; // see http://xboxdevwiki.net/PIC#The_AV_Pack
 	buffer[SMC_COMMAND_LED_SEQUENCE] = LED::GREEN;
 	buffer[SMC_COMMAND_SCRATCH] = 0; // http://xboxdevwiki.net/PIC#Scratch_register_values
-	ResetOrShutdownCommandCode.store(0);
-	ResetOrShutdownDataValue.store(0);
 }
 
 void SMCDevice::Reset()
@@ -212,14 +210,3 @@ void SMCDevice::WriteBlock(uint8_t command, uint8_t* data, int length)
 	// TODO
 }
 
-void SMCDevice::GetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue)
-{
-	*CommandCode = ResetOrShutdownCommandCode.load();
-	*DataValue = ResetOrShutdownDataValue.load();
-}
-
-void SMCDevice::SetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue)
-{
-	ResetOrShutdownCommandCode.store(*CommandCode);
-	ResetOrShutdownDataValue.store(*DataValue);
-}

--- a/src/devices/SMCDevice.h
+++ b/src/devices/SMCDevice.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include "SMDevice.h"
+#include <atomic>
 
 // This https://upload.wikimedia.org/wikipedia/commons/9/94/Xbox-Motherboard-FR.jpg shows :
 // PIC16LC63A-04/SO
@@ -119,10 +120,15 @@ public:
 	void WriteByte(uint8_t command, uint8_t value);
 	void WriteWord(uint8_t command, uint16_t value);
 	void WriteBlock(uint8_t command, uint8_t* data, int length);
+	void GetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue);
+	void SetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue);
 private:
 	HardwareModel m_HardwareModel;
 	int m_PICVersionStringIndex = 0;
 	uint8_t buffer[256] = {};
+	// variables used by the SMC to know a reset / shutdown is pending
+	std::atomic<uint8_t> ResetOrShutdownCommandCode;
+	std::atomic<uint32_t> ResetOrShutdownDataValue;
 };
 
 extern SMCDevice* g_SMC;

--- a/src/devices/SMCDevice.h
+++ b/src/devices/SMCDevice.h
@@ -36,7 +36,6 @@
 #pragma once
 
 #include "SMDevice.h"
-#include <atomic>
 
 // This https://upload.wikimedia.org/wikipedia/commons/9/94/Xbox-Motherboard-FR.jpg shows :
 // PIC16LC63A-04/SO
@@ -120,15 +119,11 @@ public:
 	void WriteByte(uint8_t command, uint8_t value);
 	void WriteWord(uint8_t command, uint16_t value);
 	void WriteBlock(uint8_t command, uint8_t* data, int length);
-	void GetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue);
-	void SetResetOrShutdownCode(uint8_t* CommandCode, uint32_t* DataValue);
+
 private:
 	HardwareModel m_HardwareModel;
 	int m_PICVersionStringIndex = 0;
 	uint8_t buffer[256] = {};
-	// variables used by the SMC to know a reset / shutdown is pending
-	std::atomic<uint8_t> ResetOrShutdownCommandCode;
-	std::atomic<uint32_t> ResetOrShutdownDataValue;
 };
 
 extern SMCDevice* g_SMC;


### PR DESCRIPTION
Very easy to implement, it just checks for a global variable. HalInitiateShutdown still works in Avalaunch, however, I don't have any titles that call HalIsResetOrShutdownPending so I don't know if there are problems. It's so simple that there shouldn't be though