### PR TITLE
D3DBegin/End Tweaks

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4678,11 +4678,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_Begin)
 
     g_IVBPrimitiveType = PrimitiveType;
 
-    if(g_IVBTable == nullptr)
-    {
-        g_IVBTable = (struct XTL::_D3DIVB*)g_VMManager.Allocate(sizeof(XTL::_D3DIVB)*IVB_TABLE_SIZE);
-    }
-
     g_IVBTblOffs = 0;
     g_IVBFVF = 0;
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4898,7 +4898,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f)
         }
 
         default:
-            CxbxKrnlCleanup("Unknown IVB Register : %d", Register);
+            EmuWarning("Unknown IVB Register : %d", Register);
     }   
 }
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -53,7 +53,7 @@
 XTL::DWORD                  *XTL::g_pIVBVertexBuffer = nullptr;
 XTL::X_D3DPRIMITIVETYPE      XTL::g_IVBPrimitiveType = XTL::X_D3DPT_INVALID;
 UINT                         XTL::g_IVBTblOffs = 0;
-struct XTL::_D3DIVB         *XTL::g_IVBTable = nullptr;
+struct XTL::_D3DIVB         XTL::g_IVBTable[IVB_TABLE_SIZE];
 extern DWORD                 XTL::g_IVBFVF = 0;
 extern XTL::X_D3DVertexBuffer      *g_pVertexBuffer = NULL;
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -130,7 +130,7 @@ extern DWORD                  *g_pIVBVertexBuffer;
 extern X_D3DPRIMITIVETYPE      g_IVBPrimitiveType;
 extern DWORD                   g_IVBFVF;
 
-#define IVB_TABLE_SIZE  ONE_MB // This should be more than enough.. Tweak as necessary if it overflows
+#define IVB_TABLE_SIZE  4096 // This should be more than enough. Tweak as necessary if it overflows or the resulting VertexBuffer fails to allocate
 #define IVB_BUFFER_SIZE sizeof(_D3DIVB) * IVB_TABLE_SIZE
 
 // TODO : Enlarge IVB_TABLE_SIZE and IVB_BUFFER_SIZE

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -130,12 +130,13 @@ extern DWORD                  *g_pIVBVertexBuffer;
 extern X_D3DPRIMITIVETYPE      g_IVBPrimitiveType;
 extern DWORD                   g_IVBFVF;
 
-#define IVB_TABLE_SIZE 1024
-#define IVB_BUFFER_SIZE sizeof(_D3DIVB)*1024
+#define IVB_TABLE_SIZE  ONE_MB // This should be more than enough.. Tweak as necessary if it overflows
+#define IVB_BUFFER_SIZE sizeof(_D3DIVB) * IVB_TABLE_SIZE
+
 // TODO : Enlarge IVB_TABLE_SIZE and IVB_BUFFER_SIZE
 // TODO : Calculate IVB_BUFFER_SIZE using sizeof(DWORD)
 
-extern struct _D3DIVB
+struct _D3DIVB
 {
     XTL::D3DXVECTOR3 Position;   // Position
     FLOAT            Rhw;        // Rhw
@@ -147,8 +148,9 @@ extern struct _D3DIVB
     XTL::D3DXVECTOR2 TexCoord2;  // TexCoord2
     XTL::D3DXVECTOR2 TexCoord3;  // TexCoord3
     XTL::D3DXVECTOR2 TexCoord4;  // TexCoord4
-}
-*g_IVBTable;
+};
+
+extern _D3DIVB g_IVBTable[IVB_TABLE_SIZE];
 
 extern UINT g_IVBTblOffs;
 


### PR DESCRIPTION
This fixes a crash in Silent Hill 2 where it overflows the IVB table. This very likely effects other titles too.
It still doesn't reach gameplay, but no longer crashes within SetVertexData4f.

A better long term solution would be to have this table and the resulting vertex buffer by dynamically sized, so overflow is not possible, but this works well as a short-term workaround, and is intended as a quick fix until we solve the problem better (by unpatching these functions, allowing push buffers to be created and parse them instead)