### PR TITLE
Fix a crash when setting a debug filename for the first time

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -178,13 +178,13 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 			dwType = REG_SZ; dwSize = MAX_PATH; ULONG lErrCodeCxbxDebugFilename;
 			lErrCodeCxbxDebugFilename = RegQueryValueEx(hKey, "CxbxDebugFilename", NULL, &dwType, (PBYTE)m_CxbxDebugFilename, &dwSize);
 			if (lErrCodeCxbxDebugFilename != ERROR_SUCCESS) {
-				m_CxbxDebugFilename = "";
+				m_CxbxDebugFilename[0] = '\0';
 			}
 
 			dwType = REG_SZ; dwSize = MAX_PATH; LONG lErrCodeKrnlDebugFilename;
 			lErrCodeKrnlDebugFilename = RegQueryValueEx(hKey, "KrnlDebugFilename", NULL, &dwType, (PBYTE)m_KrnlDebugFilename, &dwSize);
 			if (lErrCodeKrnlDebugFilename != ERROR_SUCCESS) {
-				m_KrnlDebugFilename = "";
+				m_KrnlDebugFilename[0] = '\0';
 			}
 
 			// Prevent using an incorrect path from the registry if the debug folders have been moved


### PR DESCRIPTION
This was caused by doing = on a string that was not a std::string,
unintentially causing the pointer address to be changed.

This tweak instead causes the first character of the string to be set to
\0 (null) causing all string parsing functions to treat it as an empty
string, without trashing the pointer.