### PR TITLE
Centralized hardware devices

### DIFF
--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -255,6 +255,7 @@
     <ClInclude Include="..\..\src\devices\EEPROMDevice.h" />
     <ClInclude Include="..\..\src\devices\EmuNVNet.h" />
     <ClInclude Include="..\..\src\devices\LED.h" />
+    <ClInclude Include="..\..\src\devices\MCPXDevice.h" />
     <ClInclude Include="..\..\src\devices\PCIBus.h" />
     <ClInclude Include="..\..\src\devices\PCIDevice.h" />
     <ClInclude Include="..\..\src\devices\SMBus.h" />
@@ -598,6 +599,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\devices\EEPROMDevice.cpp" />
     <ClCompile Include="..\..\src\devices\EmuNVNet.cpp" />
+    <ClCompile Include="..\..\src\devices\MCPXDevice.cpp" />
     <ClCompile Include="..\..\src\devices\PCIBus.cpp" />
     <ClCompile Include="..\..\src\devices\PCIDevice.cpp" />
     <ClCompile Include="..\..\src\devices\SMBus.cpp" />

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -234,7 +234,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Common\Win32\Threads.cpp">
       <Filter>Shared</Filter>
-    </ClInclude>
+    </ClCompile>
     <ClCompile Include="..\..\src\devices\MCPXDevice.cpp">
       <Filter>Hardware</Filter>
     </ClCompile>

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -234,6 +234,8 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Common\Win32\Threads.cpp">
       <Filter>Shared</Filter>
+    <ClCompile Include="..\..\src\devices\MCPXDevice.cpp">
+      <Filter>Hardware</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -461,6 +463,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Common\Win32\Threads.h">
       <Filter>Shared</Filter>
+    <ClInclude Include="..\..\src\devices\MCPXDevice.h">
+      <Filter>Hardware</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -234,6 +234,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Common\Win32\Threads.cpp">
       <Filter>Shared</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\devices\MCPXDevice.cpp">
       <Filter>Hardware</Filter>
     </ClCompile>
@@ -463,6 +464,7 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Common\Win32\Threads.h">
       <Filter>Shared</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\devices\MCPXDevice.h">
       <Filter>Hardware</Filter>
     </ClInclude>

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -1040,7 +1040,7 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	SetupXboxDeviceTypes();
 
-	InitXboxHardware();
+	InitXboxHardware(HardwareModel::Revision1_5); // TODO : Make configurable
 
 	// Now the hardware devices exist, couple the EEPROM buffer to it's device
 	g_EEPROM->SetEEPROM((uint8_t*)EEPROM);

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -54,7 +54,7 @@ namespace xboxkrnl
 #include "EmuShared.h"
 #include "EmuFile.h" // For FindNtSymbolicLinkObjectByDriveLetter
 #include "Common\EmuEEPROM.h" // For EEPROM
-#include "devices\SMBus.h" // For g_SMBus
+#include "devices\Xbox.h" // For g_SMBus, SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER
 #include "devices\SMCDevice.h" // For SMC_COMMAND_SCRATCH
 
 #include <algorithm> // for std::replace
@@ -794,7 +794,7 @@ XBSYSAPI EXPORTNUM(360) xboxkrnl::NTSTATUS NTAPI xboxkrnl::HalInitiateShutdown
 	
 	ResetOrShutdownCommandCode = SMC_COMMAND_RESET;
 	ResetOrShutdownDataValue = SMC_RESET_ASSERT_SHUTDOWN;
-	xboxkrnl::HalWriteSMBusValue(SMBUS_SMC_SLAVE_ADDRESS, ResetOrShutdownCommandCode, 0, ResetOrShutdownDataValue);
+	xboxkrnl::HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, ResetOrShutdownCommandCode, 0, ResetOrShutdownDataValue);
 
 	RETURN(S_OK);
 }
@@ -829,7 +829,7 @@ XBSYSAPI EXPORTNUM(366) xboxkrnl::NTSTATUS NTAPI xboxkrnl::HalWriteSMCScratchReg
 
 //	HalpSMCScratchRegister = ScratchRegister;
 
-	NTSTATUS Res = HalWriteSMBusValue(SMBUS_SMC_SLAVE_ADDRESS, SMC_COMMAND_SCRATCH, /*WordFlag:*/false, ScratchRegister);
+	NTSTATUS Res = HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_SCRATCH, /*WordFlag:*/false, ScratchRegister);
 
 	RETURN(Res);
 }

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -568,7 +568,7 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 		// NOTE: the error code is displayed by ExDisplayFatalError by other code paths so we need to change our corresponding
 		// paths if we want to emulate all the possible fatal errors
 
-		xboxkrnl::HalWriteSMBusValue(SMBUS_SMC_SLAVE_ADDRESS, SMC_COMMAND_SCRATCH, 0, SMC_SCRATCH_DISPLAY_FATAL_ERROR);
+		xboxkrnl::HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_SCRATCH, 0, SMC_SCRATCH_DISPLAY_FATAL_ERROR);
 		char szArgsBuffer[4096];
 		char szWorkingDirectoy[MAX_PATH];
 		bool bQuickReboot = true;

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -1249,8 +1249,6 @@ XBSYSAPI EXPORTNUM(211) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtQueryInformationFil
 			// Bail out if the buffer gets too big
 			if (bufferSize > 65536)
 				return STATUS_INVALID_PARAMETER;   // TODO: what's the appropriate error code to return here?
-			
-			ntFileInfo = malloc(bufferSize);
 		}
 	} while (ret == STATUS_BUFFER_OVERFLOW);
 	

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -52,7 +52,7 @@
 #include "HLEIntercept.h" // for bLLE_GPU
 
 #include <assert.h>
-#include "devices\PCIBus.h"
+#include "devices\Xbox.h" // For g_PCIBus
 
 //
 // Read & write handlers handlers for I/O

--- a/src/devices/EEPROMDevice.h
+++ b/src/devices/EEPROMDevice.h
@@ -37,8 +37,6 @@
 
 #include "SMDevice.h"
 
-#define SMBUS_EEPROM_ADDRESS 0xA8 // = Write; Read = 0xA9
-
 class EEPROMDevice : public SMDevice {
 public:
 	// SMDevice functions
@@ -61,5 +59,3 @@ public:
 private:
 	uint8_t* m_pEEPROM;
 };
-
-extern EEPROMDevice* g_EEPROM;

--- a/src/devices/EmuNVNet.h
+++ b/src/devices/EmuNVNet.h
@@ -48,5 +48,3 @@ public:
 	uint32_t MMIORead(int barIndex, uint32_t addr, unsigned size);
 	void MMIOWrite(int barIndex, uint32_t addr, uint32_t value, unsigned size);
 };
-
-extern NVNetDevice* g_NVNet;

--- a/src/devices/MCPXDevice.cpp
+++ b/src/devices/MCPXDevice.cpp
@@ -1,3 +1,5 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 // ******************************************************************
 // *
 // *    .,-:::::    .,::      .::::::::.    .,::      .:
@@ -7,7 +9,7 @@
 // *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
 // *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
 // *
-// *   src->devices->video->nv2a.h
+// *   src->devices->video->MCPXDevice.cpp
 // *
 // *  This file is part of the Cxbx project.
 // *
@@ -26,27 +28,52 @@
 // *  If not, write to the Free Software Foundation, Inc.,
 // *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
 // *
-// *  (c) 2017-2018 Luke Usher <luke.usher@outlook.com>
 // *  (c) 2018 Patrick van Logchem <pvanlogchem@gmail.com>
 // *
 // *  All rights reserved
 // *
 // ******************************************************************
-#pragma once
+#define _XBOXKRNL_DEFEXTRN_
 
-#include "devices\PCIDevice.h" // For PCIDevice
+#define LOG_PREFIX "MCPX"
 
-#define NV2A_ADDR  0xFD000000
-#define NV2A_SIZE             0x01000000
 
-class NV2ADevice : public PCIDevice {
-public:
-	// PCI Device functions
-	void Init();
-	void Reset();
+#include "MCPXDevice.h"
 
-	uint32_t IORead(int barIndex, uint32_t port, unsigned size);
-	void IOWrite(int barIndex, uint32_t port, uint32_t value, unsigned size);
-	uint32_t MMIORead(int barIndex, uint32_t addr, unsigned size);
-	void MMIOWrite(int barIndex, uint32_t addr, uint32_t value, unsigned size);
-};
+/* MCPXDevice */
+
+MCPXDevice::MCPXDevice(MCPXRevision revision)
+{
+	m_revision = revision;
+}
+
+// PCI Device functions
+
+void MCPXDevice::Init()
+{
+//	m_DeviceId = ?;
+//	m_VendorId = PCI_VENDOR_ID_NVIDIA;
+}
+
+void MCPXDevice::Reset()
+{
+}
+
+uint32_t MCPXDevice::IORead(int barIndex, uint32_t port, unsigned size)
+{
+	return 0;
+}
+
+void MCPXDevice::IOWrite(int barIndex, uint32_t port, uint32_t value, unsigned size)
+{
+}
+
+uint32_t MCPXDevice::MMIORead(int barIndex, uint32_t addr, unsigned size)
+{
+	return 0;
+}
+
+void MCPXDevice::MMIOWrite(int barIndex, uint32_t addr, uint32_t value, unsigned size)
+{
+	// TODO : Log unexpected bar access
+}

--- a/src/devices/MCPXDevice.h
+++ b/src/devices/MCPXDevice.h
@@ -7,7 +7,7 @@
 // *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
 // *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
 // *
-// *   src->devices->video->nv2a.h
+// *   src->devices->video->MCPXDevice.h
 // *
 // *  This file is part of the Cxbx project.
 // *
@@ -26,7 +26,6 @@
 // *  If not, write to the Free Software Foundation, Inc.,
 // *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
 // *
-// *  (c) 2017-2018 Luke Usher <luke.usher@outlook.com>
 // *  (c) 2018 Patrick van Logchem <pvanlogchem@gmail.com>
 // *
 // *  All rights reserved
@@ -36,11 +35,21 @@
 
 #include "devices\PCIDevice.h" // For PCIDevice
 
-#define NV2A_ADDR  0xFD000000
-#define NV2A_SIZE             0x01000000
+typedef enum {
+	MCPX_1_0,
+	MCPX_1_1,
+} MCPXROMVersion;
 
-class NV2ADevice : public PCIDevice {
+typedef enum {
+	MCPX_X2,
+	MCPX_X3,
+} MCPXRevision;
+
+class MCPXDevice : public PCIDevice {
 public:
+	// constructor
+	MCPXDevice(MCPXRevision revision);
+
 	// PCI Device functions
 	void Init();
 	void Reset();
@@ -49,4 +58,6 @@ public:
 	void IOWrite(int barIndex, uint32_t port, uint32_t value, unsigned size);
 	uint32_t MMIORead(int barIndex, uint32_t addr, unsigned size);
 	void MMIOWrite(int barIndex, uint32_t addr, uint32_t value, unsigned size);
+private:
+	MCPXRevision m_revision;
 };

--- a/src/devices/PCIBus.cpp
+++ b/src/devices/PCIBus.cpp
@@ -47,7 +47,7 @@ void PCIBus::IOWriteConfigData(uint32_t pData) {
 bool PCIBus::IORead(uint32_t addr, uint32_t* data, unsigned size)
 {
 	switch (addr) {
-	case PORT_PCI_CONFIG_DATA:
+	case PORT_PCI_CONFIG_DATA: // 0xCFC
 		if (size == sizeof(uint32_t)) {
 			*data = IOReadConfigData();
 			return true;
@@ -69,13 +69,13 @@ bool PCIBus::IORead(uint32_t addr, uint32_t* data, unsigned size)
 bool PCIBus::IOWrite(uint32_t addr, uint32_t value, unsigned size)
 {
 	switch (addr) {
-	case PORT_PCI_CONFIG_ADDRESS:
+	case PORT_PCI_CONFIG_ADDRESS: // 0xCF8
 		if (size == sizeof(uint32_t)) {
 			IOWriteConfigAddress(value);
 			return true;
 		} // TODO : else log wrong size-access?
 		break;
-	case PORT_PCI_CONFIG_DATA:
+	case PORT_PCI_CONFIG_DATA: // 0xCFC
 		if (size == sizeof(uint32_t)) {
 			IOWriteConfigData(value);
 			return true; // TODO : Should IOWriteConfigData() success/failure be returned?

--- a/src/devices/PCIBus.h
+++ b/src/devices/PCIBus.h
@@ -11,16 +11,19 @@
 #define PCI_CONFIG_REGISTER_MASK 0xFC
 
 #define PCI_DEVFN(slot, func) ((((slot) & 0x1f) << 3) | ((func) & 0x07))
-#define PCI_SLOT(devfn)	(((devfn) >> 3) & 0x1f)
-#define PCI_FUNC(devfn)	((devfn) & 0x07)
+
+#define PCI_SLOT(devfn)	(((devfn) >> 3) & 0x1f) // 5 bits (PCIConfigAddressRegister.deviceNumber)
+#define PCI_FUNC(devfn)	((devfn) & 0x07) // 3 bits (PCIConfigAddressRegister.functionNumber)
+
 #define PCI_DEVID(bus, devfn)  ((((uint16_t)(bus)) << 8) | (devfn))
+
 #define PCI_BUS_NUM(x) (((x) >> 8) & 0xff)
 
 typedef struct {
 	uint8_t registerNumber : 8;
-	uint8_t functionNumber : 3;
-	uint8_t deviceNumber : 5;
-	uint8_t busNumber : 8;
+	uint8_t functionNumber : 3; // PCI_FUNC
+	uint8_t deviceNumber : 5; // PCI_SLOT
+	uint8_t busNumber : 8; // PCI_BUS_NUM
 	uint8_t reserved : 7;
 	uint8_t enable : 1;
 } PCIConfigAddressRegister;
@@ -44,7 +47,5 @@ private:
 	std::map<uint32_t, PCIDevice*> m_Devices;
 	PCIConfigAddressRegister m_configAddressRegister;
 };
-
-extern PCIBus* g_PCIBus;
 
 #endif

--- a/src/devices/SMBus.h
+++ b/src/devices/SMBus.h
@@ -78,6 +78,4 @@ class SMBus : public PCIDevice {
 		std::map<uint8_t, SMDevice*> m_Devices;
 };
 
-extern SMBus* g_SMBus;
-
 #endif

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -102,6 +102,7 @@ uint8_t SMCDevice::ReadByte(uint8_t command)
 		case SCMRevision::P2L: buffer[0] = "P05"[m_PICVersionStringIndex]; break; // ??
 		case SCMRevision::D01: buffer[0] = "DXB"[m_PICVersionStringIndex]; break;
 		case SCMRevision::D05: buffer[0] = "D05"[m_PICVersionStringIndex]; break; // ??
+		// default: UNREACHABLE(m_revision);
 		}
 
 		m_PICVersionStringIndex = (m_PICVersionStringIndex + 1) % 3;

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -64,9 +64,9 @@ void SetLEDSequence(LED::Sequence aLEDSequence)
 
 /* SMCDevice */
 
-SMCDevice::SMCDevice(HardwareModel hardwareModel)
+SMCDevice::SMCDevice(SCMRevision revision)
 {
-	m_HardwareModel = hardwareModel;
+	m_revision = revision;
 }
 
 void SMCDevice::Init()
@@ -97,30 +97,30 @@ uint8_t SMCDevice::ReadByte(uint8_t command)
 	switch (command) {
 	case SMC_COMMAND_VERSION: // 0x01 PIC version string
 		// See http://xboxdevwiki.net/PIC#PIC_version_string
-		switch (m_HardwareModel) {
-		case Revision1_0: buffer[0] = "P01"[m_PICVersionStringIndex]; break;
-		case Revision1_1: buffer[0] = "P05"[m_PICVersionStringIndex]; break;
-		case DebugKit: buffer[0] = "DXB"[m_PICVersionStringIndex]; break;
-		// default: UNREACHABLE(hardwareModel);
+		switch (m_revision) {
+		case SCMRevision::P01: buffer[0] = "P01"[m_PICVersionStringIndex]; break;
+		case SCMRevision::P2L: buffer[0] = "P05"[m_PICVersionStringIndex]; break; // ??
+		case SCMRevision::D01: buffer[0] = "DXB"[m_PICVersionStringIndex]; break;
+		case SCMRevision::D05: buffer[0] = "D05"[m_PICVersionStringIndex]; break; // ??
 		}
 
 		m_PICVersionStringIndex = (m_PICVersionStringIndex + 1) % 3;
 		break;
-	//0x03	tray state
-	//#define SMC_COMMAND_AV_PACK 0x04	// A / V Pack state
-	//0x09	CPU temperature(°C)
-	//0x0A	board temperature(°C)
+	//case 0x03: // tray state
+	//case SMC_COMMAND_AV_PACK: // 0x04	// A / V Pack state
+	//case SMC_COMMAND_CPU_TEMP: // 0x09 // CPU temperature (°C)
+	//case SMC_COMMAND_GPU_TEMP: // 0x0A // GPU (board?) temperature (°C)
 	case 0x0F: // reads scratch register written with 0x0E
 		return buffer[0x0E];
-	//0x10	current fan speed(0~50)
-	//0x11	interrupt reason
-	//0x18	reading this reg locks up xbox in "overheated" state
-	//#define SMC_COMMAND_SCRATCH 0x1B	// scratch register for the original kernel
+	//case SMC_COMMAND_POWER_FAN_READBACK: // 0x10 // Current power fan speed (0-50)
+	//case 0x11: // interrupt reason
+	//case 0x18: // reading this reg locks up xbox in "overheated" state
+	//case SMC_COMMAND_SCRATCH: // 0x1B	// scratch register for the original kernel
 	case SMC_COMMAND_CHALLENGE_1C: // random number for boot challenge
 	case SMC_COMMAND_CHALLENGE_1D: // random number for boot challenge
 	case SMC_COMMAND_CHALLENGE_1E: // random number for boot challenge
 	case SMC_COMMAND_CHALLENGE_1F: // random number for boot challenge
-		if (m_HardwareModel == DebugKit)
+		if (m_revision == SCMRevision::D01)
 			// See http://xboxdevwiki.net/PIC#PIC_Challenge_.28regs_0x1C.7E0x21.29
 			return 0;
 
@@ -160,8 +160,8 @@ void SMCDevice::WriteByte(uint8_t command, uint8_t value)
 		case SMC_RESET_ASSERT_POWERCYCLE: return; // TODO
 		case SMC_RESET_ASSERT_SHUTDOWN: CxbxKrnlShutDown(); return; // Power off, terminating the emulation
 		}
-	//0x05	power fan mode(0 = automatic; 1 = custom speed from reg 0x06)
-	//0x06	power fan speed(0..~50)
+	//case SMC_COMMAND_POWER_FAN_MODE: // 0x05 // power fan mode(0 = automatic; 1 = custom speed from reg 0x06)
+	//case SMC_COMMAND_POWER_FAN_REGISTER: // 0x06 // Set custom power fan speed (0-50)
 	case SMC_COMMAND_LED_MODE: // 0x07 LED mode(0 = automatic; 1 = custom sequence from reg 0x08)
 		switch (value) {
 		case 0: SetLEDSequence(LED::GREEN); return; // Automatic LED management: we set it to solid green
@@ -182,10 +182,10 @@ void SMCDevice::WriteByte(uint8_t command, uint8_t value)
 		// STATUS_IO_DEVICE_ERROR, however WriteWord is not accessible from here
 		// The LED flashing sequence is stored in the buffer of the SMCDevice class, so there's nothing to do here
 		break;
-	//0x0C	tray eject(0 = eject; 1 = load)
-	//0x0E	another scratch register ? seems like an error code.
-	//0x19	reset on eject(0 = enable; 1 = disable)
-	//0x1A	interrupt enable(write 0x01 to enable; can't disable once enabled)
+	//case 0x0C: // tray eject(0 = eject; 1 = load)
+	//case 0x0E: // another scratch register ? seems like an error code.
+	//case 0x19: // reset on eject(0 = enable; 1 = disable)
+	//case 0x1A: // interrupt enable(write 0x01 to enable; can't disable once enabled)
 	case SMC_COMMAND_SCRATCH: //0x1B	scratch register for the original kernel
 		// See http://xboxdevwiki.net/PIC#Scratch_register_values
 		switch (value) {
@@ -201,8 +201,9 @@ void SMCDevice::WriteByte(uint8_t command, uint8_t value)
 		case SMC_SCRATCH_SHORT_ANIMATION: return; // TODO
 		case SMC_SCRATCH_DASHBOARD_BOOT: return;  // TODO
 		}
-	//0x20	response to PIC challenge(written first)
-	//0x21	response to PIC challenge(written second)
+		break;
+	//case 0x20: // response to PIC challenge(written first)
+	//case 0x21: // response to PIC challenge(written second)
 	}
 
 	buffer[command] = value;

--- a/src/devices/Xbox.cpp
+++ b/src/devices/Xbox.cpp
@@ -99,8 +99,9 @@ TVEncoder TVEncoderFromHardwareModel(HardwareModel hardwareModel)
 	case Revision1_6:
 		return TVEncoder::XCalibur;
 	case DebugKit:
-		// EmuWarning("Guessing TvEncoder");
-		return TVEncoder::Focus;
+		// LukeUsher : My debug kit and at least most of them (maybe all?)
+		// are equivalent to v1.0 and have Conexant encoders.
+		return TVEncoder::Conexant;
 	default: 
 		// UNREACHABLE(hardwareModel);
 		return TVEncoder::Focus;

--- a/src/devices/Xbox.h
+++ b/src/devices/Xbox.h
@@ -33,5 +33,49 @@
 // *  All rights reserved
 // *
 // ******************************************************************#pragma once
+#pragma once
 
-extern void InitXboxHardware();
+#include "PCIBus.h" // For PCIBus
+#include "SMBus.h" // For SMBus
+#include "MCPXDevice.h" // For MCPXDevice
+#include "SMCDevice.h" // For SMCDevice
+#include "EEPROMDevice.h" // For EEPROMDevice
+#include "EmuNVNet.h" // For NVNetDevice
+#include "devices\video\nv2a.h" // For NV2ADevice
+
+#define SMBUS_ADDRESS_MCPX 0x10 // = Write; Read = 0x11
+#define SMBUS_ADDRESS_TV_ENCODER 0x88 // = Write; Read = 0x89
+#define SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER 0x20 // = Write; Read = 0x21
+#define SMBUS_ADDRESS_TV_ENCODER_ID_CONEXANT 0x8A // = Write; Read = 0x8B
+#define SMBUS_ADDRESS_TEMPERATURE_MEASUREMENT 0x98 // = Write; Read = 0x99
+#define SMBUS_ADDRESS_EEPROM 0xA8 // = Write; Read = 0xA9
+#define SMBUS_ADDRESS_TV_ENCODER_ID_FOCUS 0xD4 // = Write; Read = 0xD5
+#define SMBUS_ADDRESS_TV_ENCODER_ID_XCALIBUR 0xE0 // = Write; Read = 0xE1
+
+typedef enum {
+	Revision1_0,
+	Revision1_1,
+	Revision1_2,
+	Revision1_3,
+	Revision1_4,
+	Revision1_5,
+	Revision1_6,
+	DebugKit
+} HardwareModel;
+
+typedef enum { // TODO : Move to it's own file
+	// http://xboxdevwiki.net/Hardware_Revisions#Video_encoder
+	Conexant,
+	Focus,
+	XCalibur
+} TVEncoder;
+
+extern PCIBus* g_PCIBus;
+extern SMBus* g_SMBus;
+extern MCPXDevice* g_MCPX;
+extern SMCDevice* g_SMC;
+extern EEPROMDevice* g_EEPROM;
+extern NVNetDevice* g_NVNet;
+extern NV2ADevice* g_NV2A;
+
+extern void InitXboxHardware(HardwareModel hardwareModel);


### PR DESCRIPTION
Centralized hardware devices around Xbox sytem, (revisions of) components chosen based on hardware revision.

Most is not yet implemented, but more will surely follow.
Moved SMBUS-address defines and global device variables towards Xbox.h