### PR TITLE
Various Fixes from patch-removal-experiment

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -9938,7 +9938,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_PersistDisplay)()
 // ******************************************************************
 DWORD WINAPI XTL::EMUPATCH(D3D_CMiniport_GetDisplayCapabilities)()
 {
-	FUNC_EXPORTS
+	//FUNC_EXPORTS
 
 	LOG_FUNC();
 

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2194,6 +2194,12 @@ extern HRESULT XTL::EmuRecompileVshFunction
         // The size of the shader is
         *pOriginalSize = (DWORD)pToken - (DWORD)pFunction;
 
+		// Do not attempt to compile empty shaders
+		if (pShader->IntermediateCount == 0) {
+			EmuWarning("Skipped empty Pixel Shader");
+			return STATUS_INVALID_PARAMETER;
+		}
+
         char* pShaderDisassembly = (char*)malloc(pShader->IntermediateCount * 100); // Should be plenty
         DbgVshPrintf("-- Before conversion --\n");
         VshWriteShader(pShader, pShaderDisassembly, FALSE);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -135,7 +135,6 @@ XTL::X_XFileMediaObject::_vtbl XTL::X_XFileMediaObject::vtbl =
     &XTL::EMUPATCH(XFileMediaObject_DoWork),            // 0x24
 };
 
-
 /* NOTE: SUCCEEDED define is only checking for is equal or greater than zero value.
     And FAILED check for less than zero value. Since DS_OK is only 0 base on DirectSound documentation,
     there is chance of failure which contain value greater than 0.
@@ -3590,7 +3589,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileCreateMediaObjectAsync)
     DWORD       dwMaxPackets,
     OUT void**      ppMediaObject)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3619,7 +3618,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Seek)
     DWORD               dwOrigin,
     LPDWORD             pdwAbsolute)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3642,7 +3641,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Seek)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(XFileMediaObject_DoWork)(X_XFileMediaObject* pThis)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3661,7 +3660,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_GetStatus)
     X_XFileMediaObject* pThis,
     OUT LPDWORD             pdwStatus)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3685,7 +3684,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_GetInfo)
     X_XFileMediaObject* pThis,
     OUT XMEDIAINFO*         pInfo)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3710,7 +3709,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Process)
     LPXMEDIAPACKET      pInputBuffer,
     LPXMEDIAPACKET      pOutputBuffer)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3734,7 +3733,7 @@ ULONG WINAPI XTL::EMUPATCH(XFileMediaObject_AddRef)
 (
 	X_XFileMediaObject* pThis)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3758,7 +3757,7 @@ ULONG WINAPI XTL::EMUPATCH(XFileMediaObject_Release)
 (
 	X_XFileMediaObject* pThis)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3785,7 +3784,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Discontinuity)
 (
 	X_XFileMediaObject *pThis)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -3370,7 +3370,7 @@ HRESULT WINAPI XTL::EMUPATCH(XWaveFileCreateMediaObject)
     LPCWAVEFORMATEX*        ppwfxFormat,
     OUT void**              ppMediaObject) //XFileMediaObject, include XMediaObject interface
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3937,7 +3937,7 @@ HRESULT WINAPI XTL::EMUPATCH(XWaveFileCreateMediaObjectEx)
     HANDLE              hFile,
     OUT void**          ppMediaObject) //XWaveFileMediaObject, include XFileMediaObject and XMediaObject interfaces
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -3344,7 +3344,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileCreateMediaObjectEx)
     HANDLE      hFile,
     OUT void**      ppMediaObject)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 
@@ -3907,7 +3907,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileCreateMediaObject)
     DWORD           dwFlagsAndAttributes,
     OUT void**      ppMediaObject)
 {
-    FUNC_EXPORTS;
+    //FUNC_EXPORTS;
 
     enterCriticalSection;
 


### PR DESCRIPTION
This is just a few of the modifications/tweaks from my patch-removal-experiment branch that are low impact/are safe to merge into master right now.

Nothing that impressive, but with this titles that use XFileMediaObject functionality of DSOUND are much less likely to freeze, hang or crash.