### PR TITLE
Implement critical section and critical region kernel functions

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -983,10 +983,6 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	CxbxKrnlRegisterThread(GetCurrentThread());
 
-	// Clear critical section list
-	//extern void InitializeSectionStructures(void); 
-	InitializeSectionStructures();
-
 	// Make sure the Xbox1 code runs on one core (as the box itself has only 1 CPU,
 	// this will better aproximate the environment with regard to multi-threading) :
 	DbgPrintf("INIT: Determining CPU affinity.\n");

--- a/src/CxbxKrnl/Emu.h
+++ b/src/CxbxKrnl/Emu.h
@@ -98,8 +98,6 @@ g_pXInputSetStateStatus[XINPUT_SETSTATE_SLOTS];
 extern bool g_XInputEnabled;
 extern HANDLE g_hInputHandle[XINPUT_HANDLE_SLOTS];
 
-extern void InitializeSectionStructures(void);
-
 typedef struct DUMMY_KERNEL
 {
 	IMAGE_DOS_HEADER DosHeader;

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -563,18 +563,6 @@ XBSYSAPI EXPORTNUM(100) xboxkrnl::VOID NTAPI xboxkrnl::KeDisconnectInterrupt
 	KiUnlockDispatcherDatabase(OldIrql);
 }
 
-// From looking at the wine src code for Rtl*CriticalSection functions
-// and from seeing what the xbox kernel does with KeEnter/Leave CriticalRegion,
-// I can only conclude that is is accessing a Teb structure in Xbox memory.
-// Many Xbox Kernel functions load this pointer and make changes to fields
-// in it. More research will be needed to define all fields
-uint8_t* get_thread_Teb() {
-    return (uint8_t*)0x80047BF0;
-}
-#define CRITICAL_REGION_UNKNOWN1 (get_thread_Teb() + 0x34)
-#define CRITICAL_REGION_UNKNOWN2 (get_thread_Teb() + 0x49)
-#define CRITICAL_REGION_UNKNOWN3 (get_thread_Teb() + 0x68)
-
 // ******************************************************************
 // * 0x0065 - KeEnterCriticalRegion()
 // ******************************************************************
@@ -584,8 +572,8 @@ XBSYSAPI EXPORTNUM(101) xboxkrnl::VOID NTAPI xboxkrnl::KeEnterCriticalRegion
 )
 {
     LOG_FUNC();
-    uint32_t* critical_region_unk = (uint32_t*)CRITICAL_REGION_UNKNOWN3;
-    *critical_region_unk--;
+    PKTHREAD thread = KeGetCurrentThread();
+    thread->KernelApcDisable--;
 }
 
 // ******************************************************************
@@ -1052,14 +1040,11 @@ XBSYSAPI EXPORTNUM(122) xboxkrnl::VOID NTAPI xboxkrnl::KeLeaveCriticalRegion
 {
     LOG_FUNC();
 
-    uint32_t* critcal_region_unk1 = (uint32_t*)CRITICAL_REGION_UNKNOWN1;
-    uint8_t* critcal_region_unk2 = CRITICAL_REGION_UNKNOWN2;
-    uint32_t* critical_region_unk3 = (uint32_t*)CRITICAL_REGION_UNKNOWN3;
-
-    *critical_region_unk3++;
-    if(*critical_region_unk3 == 0) {
-        if(*critcal_region_unk1 != (uint32_t)critcal_region_unk1) {
-            *critcal_region_unk2 = 1;
+    PKTHREAD thread = KeGetCurrentThread();
+    thread->KernelApcDisable++;
+    if(thread->KernelApcDisable == 0) {
+        if(thread->ApcState.ApcListHead[0].Flink != &thread->ApcState.ApcListHead[0]) {
+            thread->ApcState.KernelApcPending = 1;
             HalRequestSoftwareInterrupt(1);
         }
     }

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -563,19 +563,29 @@ XBSYSAPI EXPORTNUM(100) xboxkrnl::VOID NTAPI xboxkrnl::KeDisconnectInterrupt
 	KiUnlockDispatcherDatabase(OldIrql);
 }
 
+// From looking at the wine src code for Rtl*CriticalSection functions
+// and from seeing what the xbox kernel does with KeEnter/Leave CriticalRegion,
+// I can only conclude that is is accessing a Teb structure in Xbox memory.
+// Many Xbox Kernel functions load this pointer and make changes to fields
+// in it. More research will be needed to define all fields
+uint8_t* get_thread_Teb() {
+    return (uint8_t*)0x80047BF0;
+}
+#define CRITICAL_REGION_UNKNOWN1 (get_thread_Teb() + 0x34)
+#define CRITICAL_REGION_UNKNOWN2 (get_thread_Teb() + 0x49)
+#define CRITICAL_REGION_UNKNOWN3 (get_thread_Teb() + 0x68)
+
 // ******************************************************************
 // * 0x0065 - KeEnterCriticalRegion()
 // ******************************************************************
 XBSYSAPI EXPORTNUM(101) xboxkrnl::VOID NTAPI xboxkrnl::KeEnterCriticalRegion
 (
-	VOID
+    VOID
 )
 {
-	LOG_FUNC();
-
-	// TODO : Disable kernel APCs
-
-	LOG_UNIMPLEMENTED();
+    LOG_FUNC();
+    uint32_t* critical_region_unk = (uint32_t*)CRITICAL_REGION_UNKNOWN3;
+    *critical_region_unk--;
 }
 
 // ******************************************************************
@@ -1037,14 +1047,22 @@ void ConnectKeInterruptTimeToThunkTable()
 // ******************************************************************
 XBSYSAPI EXPORTNUM(122) xboxkrnl::VOID NTAPI xboxkrnl::KeLeaveCriticalRegion
 (
-	VOID
+    VOID
 )
 {
-	LOG_FUNC();
+    LOG_FUNC();
 
-	// TODO : Enable kernel APCs
+    uint32_t* critcal_region_unk1 = (uint32_t*)CRITICAL_REGION_UNKNOWN1;
+    uint8_t* critcal_region_unk2 = CRITICAL_REGION_UNKNOWN2;
+    uint32_t* critical_region_unk3 = (uint32_t*)CRITICAL_REGION_UNKNOWN3;
 
-	LOG_UNIMPLEMENTED();
+    *critical_region_unk3++;
+    if(*critical_region_unk3 == 0) {
+        if(*critcal_region_unk1 != (uint32_t)critcal_region_unk1) {
+            *critcal_region_unk2 = 1;
+            HalRequestSoftwareInterrupt(1);
+        }
+    }
 }
 
 XBSYSAPI EXPORTNUM(123) xboxkrnl::LONG NTAPI xboxkrnl::KePulseEvent

--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -56,46 +56,6 @@ namespace NtDll
 #include "CxbxKrnl.h" // For CxbxKrnlCleanup()
 #include "Emu.h" // For EmuWarning()
 
-// A critical section containing the PC and Xbox equivalent
-struct INTERNAL_CRITICAL_SECTION
-{
-	xboxkrnl::PRTL_CRITICAL_SECTION XboxCriticalSection;
-	NtDll::_RTL_CRITICAL_SECTION NativeCriticalSection;
-};
-
-#define MAX_XBOX_CRITICAL_SECTIONS 1024
-INTERNAL_CRITICAL_SECTION GlobalCriticalSections[MAX_XBOX_CRITICAL_SECTIONS] = { 0 };
-
-void InitializeSectionStructures(void)
-{
-	ZeroMemory(GlobalCriticalSections, sizeof(GlobalCriticalSections));
-}
-
-int FindCriticalSection(xboxkrnl::PRTL_CRITICAL_SECTION CriticalSection)
-{
-	int FreeSection = -1;
-
-	int iSection = 0;
-	for (iSection = 0; iSection < MAX_XBOX_CRITICAL_SECTIONS; ++iSection)
-	{
-		if (GlobalCriticalSections[iSection].XboxCriticalSection == CriticalSection)
-		{
-			FreeSection = iSection;
-			break;
-		}
-		else if (FreeSection < 0 && GlobalCriticalSections[iSection].XboxCriticalSection == NULL)
-		{
-			FreeSection = iSection;
-		}
-	}
-
-	if (FreeSection < 0)
-	{
-		EmuWarning("Too many critical sections in use!\n");
-	}
-
-	return FreeSection;
-}
 extern uint8_t* get_thread_Teb();
 
 // ******************************************************************


### PR DESCRIPTION
Reverse engineered from the disassembled kernel functions dumped from my Xbox, these kernel functions should now match the original functionality found on the Xbox:

KeEnterCriticalRegion
KeLeaveCriticalRegion
RtlEnterCriticalSectionAndRegion
RtlEnterCriticalSection
RtlInitializeCriticalSection
RtlLeaveCriticalSectionAndRegion
RtlLeaveCriticalSection
RtlTryEnterCriticalSection