### PR TITLE
Thread names

### DIFF
--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -190,6 +190,7 @@
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\Common\Win32\Threads.h" />
     <ClInclude Include="..\..\src\Common\Win32\XBAudio.h" />
     <ClInclude Include="..\..\src\Common\XADPCM.h" />
     <ClInclude Include="..\..\src\Common\XbePrinter.h" />
@@ -362,6 +363,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Common\Win32\Threads.cpp" />
     <ClCompile Include="..\..\src\Common\Win32\XBAudio.cpp" />
     <ClCompile Include="..\..\src\Common\XbePrinter.cpp" />
     <ClCompile Include="..\..\src\CxbxKrnl\EmuD3D8Logging.cpp" />

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -232,6 +232,9 @@
     <ClCompile Include="..\..\src\Common\XbePrinter.cpp">
       <Filter>Shared</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Common\Win32\Threads.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Cxbx\DlgControllerConfig.h">
@@ -454,6 +457,9 @@
       <Filter>Hardware</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Common\XbePrinter.h">
+      <Filter>Shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Common\Win32\Threads.h">
       <Filter>Shared</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Common/Win32/Threads.cpp
+++ b/src/Common/Win32/Threads.cpp
@@ -1,0 +1,73 @@
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->Win32->Threads.cpp
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+#include <windows.h>
+#include "Threads.h"
+
+// Exception structure and method from:
+// https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
+
+const DWORD MS_VC_EXCEPTION = 0x406D1388;
+
+#pragma pack(push,8)  
+typedef struct tagTHREADNAME_INFO
+{
+	DWORD dwType; // Must be 0x1000.  
+	LPCSTR szName; // Pointer to name (in user addr space).  
+	DWORD dwThreadID; // Thread ID (-1=caller thread).  
+	DWORD dwFlags; // Reserved for future use, must be zero.  
+} THREADNAME_INFO;
+#pragma pack(pop)  
+
+void SetThreadName(DWORD dwThreadID, const char* szThreadName)
+{
+	THREADNAME_INFO info;
+	info.dwType = 0x1000;
+	info.szName = szThreadName;
+	info.dwThreadID = dwThreadID;
+	info.dwFlags = 0;
+#pragma warning(push)  
+#pragma warning(disable: 6320 6322)  
+	__try {
+		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+	}
+#pragma warning(pop)  
+}
+
+void SetCurrentThreadName(const char* szThreadName)
+{
+	SetThreadName((DWORD)-1, szThreadName);
+}

--- a/src/Common/Win32/Threads.cpp
+++ b/src/Common/Win32/Threads.cpp
@@ -52,6 +52,9 @@ typedef struct tagTHREADNAME_INFO
 
 void SetThreadName(DWORD dwThreadID, const char* szThreadName)
 {
+	if (!IsDebuggerPresent())
+		return;
+
 	THREADNAME_INFO info;
 	info.dwType = 0x1000;
 	info.szName = szThreadName;
@@ -69,5 +72,5 @@ void SetThreadName(DWORD dwThreadID, const char* szThreadName)
 
 void SetCurrentThreadName(const char* szThreadName)
 {
-	SetThreadName((DWORD)-1, szThreadName);
+	SetThreadName(GetCurrentThreadId(), szThreadName);
 }

--- a/src/Common/Win32/Threads.h
+++ b/src/Common/Win32/Threads.h
@@ -1,0 +1,37 @@
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->Win32->Threads.h
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+#pragma once
+
+void SetCurrentThreadName(const char* szThreadName);

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -143,4 +143,11 @@ extern volatile bool g_bPrintfOn;
 	#define DbgPrintf null_func
 #endif
 
+#if WIN32
+#include "Win32\Threads.h"
+#define CxbxSetThreadName(Name) SetCurrentThreadName(Name)
+#else
+#define CxbxSetThreadName(Name)
+#endif
+
 #endif

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2044,6 +2044,8 @@ void WndMain::StopEmulation()
 // wrapper function to call CrashMonitor
 DWORD WINAPI WndMain::CrashMonitorWrapper(LPVOID lpVoid)
 {
+	CxbxSetThreadName("Cxbx Crash Monitor");
+
 	static_cast<WndMain*>(lpVoid)->CrashMonitor();
 	return 0;
 }

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -500,6 +500,8 @@ void PrintCurrentConfigurationLog()
 
 static unsigned int WINAPI CxbxKrnlInterruptThread(PVOID param)
 {
+	CxbxSetThreadName("CxbxKrnl Interrupts");
+
 	// Make sure Xbox1 code runs on one core :
 	InitXboxThread(g_CPUXbox);
 
@@ -519,6 +521,11 @@ static unsigned int WINAPI CxbxKrnlInterruptThread(PVOID param)
 
 void CxbxKrnlMain(int argc, char* argv[])
 {
+	// Treat this instance as the Xbox runtime entry point XBOXStartup()
+	// This is defined in OpenXDK:
+	//   import/OpenXDK/include/xhal/xhal.h
+	CxbxSetThreadName("Cxbx XBOXStartup");
+
 	// Skip '/load' switch
 	// Get XBE Name :
 	std::string xbePath = argv[2];

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1230,6 +1230,8 @@ static BOOL WINAPI EmuEnumDisplayDevices(GUID FAR *lpGUID, LPSTR lpDriverDescrip
 // window message processing thread
 static DWORD WINAPI EmuRenderWindow(LPVOID lpVoid)
 {
+	CxbxSetThreadName("Cxbx Render Window");
+
     // register window class
     {
         LOGBRUSH logBrush = {BS_SOLID, RGB(0,0,0)};
@@ -1572,6 +1574,8 @@ std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double,
 // timing thread procedure
 static DWORD WINAPI EmuUpdateTickCount(LPVOID)
 {
+	CxbxSetThreadName("Cxbx Timing Thread");
+
     // since callbacks come from here
 	InitXboxThread(g_CPUOthers); // avoid Xbox1 core for lowest possible latency
 
@@ -1671,6 +1675,8 @@ static DWORD WINAPI EmuUpdateTickCount(LPVOID)
 static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 {
 	LOG_FUNC();
+
+	CxbxSetThreadName("Cxbx CreateDevice Proxy");
 
     DbgPrintf("EmuD3D8: CreateDevice proxy thread is running.\n");
 

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -271,6 +271,8 @@ DWORD ExecuteDpcQueue()
 
 DWORD __stdcall EmuThreadDpcHandler(LPVOID lpVoid)
 {
+	CxbxSetThreadName("DPC Handler");
+
 	DbgPrintf("KRNL: DPC thread is running\n");
 
 	// Make sure DPC callbacks run on the same core as the one that runs Xbox1 code :

--- a/src/CxbxKrnl/EmuKrnlPs.cpp
+++ b/src/CxbxKrnl/EmuKrnlPs.cpp
@@ -114,6 +114,8 @@ static unsigned int WINAPI PCSTProxy
 	IN PVOID Parameter
 )
 {
+	CxbxSetThreadName("PsCreateSystemThread Proxy");
+
 	PCSTProxyParam *iPCSTProxyParam = (PCSTProxyParam*)Parameter;
 
 	PVOID StartRoutine = iPCSTProxyParam->StartRoutine;

--- a/src/devices/video/EmuNV2A.cpp
+++ b/src/devices/video/EmuNV2A.cpp
@@ -2297,6 +2297,8 @@ static void pgraph_method(unsigned int subchannel, unsigned int method, uint32_t
 
 static void* pfifo_puller_thread()
 {
+	CxbxSetThreadName("Cxbx NV2A FIFO");
+
 	Cache1State *state = &pfifo.cache1;
 
 	while (true) {
@@ -3893,6 +3895,8 @@ std::thread vblank_thread;
 extern std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double, std::nano>> GetNextVBlankTime();
 static void nv2a_vblank_thread()
 {
+	CxbxSetThreadName("Cxbx NV2A VBlank");
+
 	auto nextVBlankTime = GetNextVBlankTime();
 
 	while (true) {


### PR DESCRIPTION
This is to help debugging under Visual Studio.

Visual Studio uses a special interrupt to set the thread name, and auto-generates thread name using `__FUNCTION__` to set a reasonable default name. However for `std::thread` the inferred thread name is mangled due to anonymous functions which makes it hard to pick out threads from a glance.

Going forwards, naming thread manually like this allows other debuggers to use correct names without any symbol files 😆 

Please feel free to correct any names I've given!