### PR TITLE
Less debug file clutter

### DIFF
--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -72,6 +72,7 @@ typedef u32              xbaddr;
 /*! xbnull is the type of null address or value*/
 #define xbnull  0
 
+#ifdef _DEBUG
 /*! define this to track vertex buffers */
 #define _DEBUG_TRACK_VB
 /*! define this to track vertex shaders */
@@ -81,7 +82,6 @@ typedef u32              xbaddr;
 /*! define this to track push buffers */
 #define _DEBUG_TRACK_PB
 /*! define this to track memory allocations */
-#ifdef _DEBUG
 //#define _DEBUG_ALLOC
 #endif
 /*! define this to trace intercepted function calls */

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -4892,7 +4892,7 @@ HRESULT XTL::CreatePixelShaderFunction(X_D3DPIXELSHADERDEF *pPSD, LPD3DXBUFFER* 
 	printf("*** PIXEL SHADER CREATION FINISHED!\n");
 	pCodeBuffer = NULL;
 
-	#ifdef _DEBUG
+	#ifdef _DEBUG_TRACK_PS
 		DumpPixelShaderDefToFile(pPSD, szCode);
 	#endif
 

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -4892,7 +4892,9 @@ HRESULT XTL::CreatePixelShaderFunction(X_D3DPIXELSHADERDEF *pPSD, LPD3DXBUFFER* 
 	printf("*** PIXEL SHADER CREATION FINISHED!\n");
 	pCodeBuffer = NULL;
 
-	DumpPixelShaderDefToFile(pPSD, szCode);
+	#ifdef _DEBUG
+		DumpPixelShaderDefToFile(pPSD, szCode);
+	#endif
 
 	//if(bR1WAccess || bR1AWAccess || bR1RGBWAccess)
 	//	Sleep(3000);


### PR DESCRIPTION
This changes the pixel and vertex shader file dumping to only occur on debug builds. I'm not sure whether this should be the default behavior, but it does reduce clutter in the working folder on release builds significantly. (after playing a few games I had ~200 PsDef.txt and ~20 failed.xvu files)

Unless these are enabled on release for getting useful information from release builds (for example when someone uploads a log on the game-compatibility repository) I think this is a reasonable change but I'm open to feedback as I'm not fully aware if there are any implications from removing these.