### PR TITLE
Implement RTLCriticalSection and KeCriticalRegion functions

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -990,10 +990,6 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	CxbxKrnlRegisterThread(GetCurrentThread());
 
-	// Clear critical section list
-	//extern void InitializeSectionStructures(void); 
-	InitializeSectionStructures();
-
 	// Make sure the Xbox1 code runs on one core (as the box itself has only 1 CPU,
 	// this will better aproximate the environment with regard to multi-threading) :
 	DbgPrintf("INIT: Determining CPU affinity.\n");

--- a/src/CxbxKrnl/Emu.h
+++ b/src/CxbxKrnl/Emu.h
@@ -98,8 +98,6 @@ g_pXInputSetStateStatus[XINPUT_SETSTATE_SLOTS];
 extern bool g_XInputEnabled;
 extern HANDLE g_hInputHandle[XINPUT_HANDLE_SLOTS];
 
-extern void InitializeSectionStructures(void);
-
 typedef struct DUMMY_KERNEL
 {
 	IMAGE_DOS_HEADER DosHeader;

--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -56,46 +56,6 @@ namespace NtDll
 #include "CxbxKrnl.h" // For CxbxKrnlCleanup()
 #include "Emu.h" // For EmuWarning()
 
-// A critical section containing the PC and Xbox equivalent
-struct INTERNAL_CRITICAL_SECTION
-{
-	xboxkrnl::PRTL_CRITICAL_SECTION XboxCriticalSection;
-	NtDll::_RTL_CRITICAL_SECTION NativeCriticalSection;
-};
-
-#define MAX_XBOX_CRITICAL_SECTIONS 1024
-INTERNAL_CRITICAL_SECTION GlobalCriticalSections[MAX_XBOX_CRITICAL_SECTIONS] = { 0 };
-
-void InitializeSectionStructures(void)
-{
-	ZeroMemory(GlobalCriticalSections, sizeof(GlobalCriticalSections));
-}
-
-int FindCriticalSection(xboxkrnl::PRTL_CRITICAL_SECTION CriticalSection)
-{
-	int FreeSection = -1;
-
-	int iSection = 0;
-	for (iSection = 0; iSection < MAX_XBOX_CRITICAL_SECTIONS; ++iSection)
-	{
-		if (GlobalCriticalSections[iSection].XboxCriticalSection == CriticalSection)
-		{
-			FreeSection = iSection;
-			break;
-		}
-		else if (FreeSection < 0 && GlobalCriticalSections[iSection].XboxCriticalSection == NULL)
-		{
-			FreeSection = iSection;
-		}
-	}
-
-	if (FreeSection < 0)
-	{
-		EmuWarning("Too many critical sections in use!\n");
-	}
-
-	return FreeSection;
-}
 extern uint8_t* get_thread_Teb();
 
 // ******************************************************************


### PR DESCRIPTION
Trying this again. Critical section functions use a map to implement the host OS critical sections while including the Xbox functionality.