### PR TITLE
Use Chihiro memory size & Attempt recovery for missing KPCR

### DIFF
--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -115,7 +115,7 @@ std::string EIPToString(xbaddr EIP)
 {
 	char buffer[256];
 	
-	if (EIP < XBOX_MEMORY_SIZE) {
+	if (EIP < CHIHIRO_MEMORY_SIZE) {
 		int symbolOffset = 0;
 		std::string symbolName = GetDetectedSymbolName(EIP, &symbolOffset);
 		sprintf(buffer, "0x%.08X(=%s+0x%x)", EIP, symbolName.c_str(), symbolOffset);

--- a/src/CxbxKrnl/EmuFS.cpp
+++ b/src/CxbxKrnl/EmuFS.cpp
@@ -92,10 +92,7 @@ void EmuKeSetPcr(xboxkrnl::KPCR *Pcr)
 	// the user data-slot of each Windows thread Cxbx uses for an
 	// Xbox thread.
 	//
-	__asm {
-		mov eax, Pcr
-		mov fs : [TIB_ArbitraryDataSlot], eax
-	}
+	__writefsdword(TIB_ArbitraryDataSlot, (DWORD)Pcr);
 }
 
 __declspec(naked) void EmuFS_CmpEsiFs00()

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -138,12 +138,16 @@ BOOLEAN KiInsertTreeTimer(
 // ******************************************************************
 xboxkrnl::KPCR* KeGetPcr()
 {
-	xboxkrnl::KPCR* Pcr;
+	xboxkrnl::PKPCR Pcr;
 
 	// See EmuKeSetPcr()
-	__asm {
-		mov eax, fs : [TIB_ArbitraryDataSlot]
-		mov Pcr, eax
+	Pcr = (xboxkrnl::PKPCR)__readfsdword(TIB_ArbitraryDataSlot);
+
+	if (Pcr == nullptr) {
+		EmuWarning("KeGetPCR returned nullptr: Was this called from a non-xbox thread?");
+		// Attempt to salvage the situation by calling InitXboxThread to setup KPCR in place
+		InitXboxThread(g_CPUXbox);
+		Pcr = (xboxkrnl::PKPCR)__readfsdword(TIB_ArbitraryDataSlot);
 	}
 
 	return Pcr;

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -110,7 +110,7 @@ void SetupXboxDeviceTypes()
 			printf("DeviceTable Entires: %u\n", deviceTableEntryCount);
 
 			// Sanity check: Where all these device offsets within Xbox memory
-			if (deviceTableStartOffset >= XBOX_MEMORY_SIZE || deviceTableEndOffset >= XBOX_MEMORY_SIZE) {
+			if (deviceTableStartOffset >= CHIHIRO_MEMORY_SIZE || deviceTableEndOffset >= CHIHIRO_MEMORY_SIZE) {
 				CxbxKrnlCleanup("XAPI DeviceTable Location is outside of Xbox Memory range");
 			}
 

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -237,7 +237,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 					{
 						output << "\t*ADDRESS TOO LOW!*";
 					}
-					else if (location > XBOX_MEMORY_SIZE)
+					else if (location > CHIHIRO_MEMORY_SIZE)
 					{
 						output << "\t*ADDRESS TOO HIGH!*";
 					}

--- a/src/CxbxKrnl/PhysicalMemory.h
+++ b/src/CxbxKrnl/PhysicalMemory.h
@@ -92,7 +92,7 @@ class PhysicalMemory
 		// amount of physical memory in use
 		size_t m_PhysicalMemoryInUse = 0;
 		// max physical memory available on the Xbox/Chihiro
-		size_t m_MaxPhysicalMemory = XBOX_MEMORY_SIZE;
+		size_t m_MaxPhysicalMemory = CHIHIRO_MEMORY_SIZE;
 		// map tracking the physical memory currently in use
 		std::map<PAddr, size_t> m_Mem_map;
 		// map tracking the blocks allocated with VirtualAlloc
@@ -102,7 +102,7 @@ class PhysicalMemory
 		// current error status code of the PhysicalMemory class
 		PMEMORY_STATUS m_Status = PMEMORY_SUCCESS;
 		// highest address available for contiguous allocations
-		PAddr m_MaxContiguousAddress = XBOX_CONTIGUOUS_MEMORY_LIMIT;
+		PAddr m_MaxContiguousAddress = CHIHIRO_CONTIGUOUS_MEMORY_LIMIT;
 	
 		// protected constructor so PhysicalMemory can only be inherited from
 		PhysicalMemory() {};

--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -138,7 +138,7 @@ void VMManager::Initialize(HANDLE file_view)
 	upper_mem_vma.vma_type = VMAType::Allocated;
 	upper_mem_vma.page_type = PageType::SystemMemory;
 	upper_mem_vma.permissions = PAGE_READWRITE;
-	upper_mem_vma.backing_block = AllocatePhysicalMemoryRange(32 * PAGE_SIZE, upper_mem_vma.page_type, m_MaxContiguousAddress, XBOX_MEMORY_SIZE);
+	upper_mem_vma.backing_block = AllocatePhysicalMemoryRange(32 * PAGE_SIZE, upper_mem_vma.page_type, m_MaxContiguousAddress, CHIHIRO_MEMORY_SIZE);
 	UpdatePageTableForVMA(upper_mem_vma);
 
 	// Allocate memory for the dummy kernel

--- a/src/devices/video/nv2a.cpp
+++ b/src/devices/video/nv2a.cpp
@@ -58,7 +58,7 @@ void NV2ADevice::Init()
 
 	// Register physical memory on bar 1
 	r.Memory.address = 0;
-	RegisterBAR(1, XBOX_MEMORY_SIZE, r.value); // TODO : Read g_PhysicalMemory->Size
+	RegisterBAR(1, CHIHIRO_MEMORY_SIZE, r.value); // TODO : Read g_PhysicalMemory->Size
 	/* LukeUsher commented at https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/882#discussion_r162871029
 
 	This is not right: I should have done a better review ;)


### PR DESCRIPTION
This fixes a regression where Virtua Cop 3 crashes instead of booting.

Instead of crashing, it boots to an error screen, this isn't as good as previous, but is still much better than current master, where it immediately throws an exception
![image](https://user-images.githubusercontent.com/740003/35995244-acb1f35c-0d0a-11e8-92b8-22903b20ef6b.png)
