### PR TITLE
Hotfix for SetBufferData when dwBufferBytes is 0

### DIFF
--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -424,6 +424,17 @@ inline void DSoundBufferRegionRelease(XTL::X_CDirectSoundBuffer *pThis)
     // NOTE: DSB Buffer8Region and 3DBuffer8Region are set
     // to nullptr inside DSoundBufferRegionSetDefault function.
     if (pThis->EmuDirectSoundBuffer8Region != nullptr) {
+        if (pThis->EmuLockPtr1 != xbnullptr) {
+            DSoundGenericUnlock(pThis->EmuFlags,
+                                pThis->EmuDirectSoundBuffer8Region,
+                                pThis->EmuBufferDesc,
+                                pThis->EmuLockOffset,
+                                pThis->EmuLockPtr1,
+                                pThis->EmuLockBytes1,
+                                pThis->EmuLockPtr2,
+                                pThis->EmuLockBytes2,
+                                pThis->EmuLockFlags);
+        }
         pThis->EmuDirectSoundBuffer8Region->Release();
 
         if (pThis->EmuDirectSound3DBuffer8Region != nullptr) {


### PR DESCRIPTION
Fixed Crazy Taxi 3 title and some other titles crashing due to switching between SetBufferData and Lock calls.