### PR TITLE
Cleanup of appveyor build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Cxbx-Reloaded is early in development and still pretty unstable, so don't expect
 ## Automated Builds
 Cxbx-Reloaded is not yet ready for general release, but the latest development builds can always be downloaded from our [AppVeyor](https://ci.appveyor.com/project/SoullessSentinel/cxbx-reloaded/branch/master) service:
 
-* [Latest build (Release-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Release.zip?branch=master&job=Configuration:%20Release;%20Platform:%20Win32)
-* [Latest build (Debug-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Debug.zip?branch=master&job=Configuration:%20Debug;%20Platform:%20Win32)
+* [Latest build (Release-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Release.zip?branch=master&job=Configuration:%20Release)
+* [Latest build (Debug-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Debug.zip?branch=master&job=Configuration:%20Debug)
 * [Full build history](https://ci.appveyor.com/project/SoullessSentinel/cxbx-reloaded/history)
 
 ## Compatibility

--- a/appveyor-build.bat
+++ b/appveyor-build.bat
@@ -1,0 +1,42 @@
+:: Cxbx-Reloaded build script
+
+@if "%1"=="" goto show_usage
+
+@set SLN="%cd%\build\win32\Cxbx.sln"
+@set VS_ENV="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
+
+:: Setup build environment
+@if not exist %VS_ENV% goto missing_env
+
+@call %VS_ENV%
+
+:: Build managed projects (debugger)
+@call MSBuild.exe %SLN% /p:Platform="Any CPU" /p:Configuration=%1% /m
+@if %errorlevel% neq 0 goto failure
+
+:: Build native projects (emulator, debugger dlls)
+@call MSBuild.exe %SLN% /p:Platform="Win32" /p:Configuration=%1% /m
+@if %errorlevel% neq 0 goto failure
+
+@goto success
+
+:missing_env
+@echo Unable to locate MSBuild environment command
+@set ERRORLEVEL=1
+@goto eof
+
+:show_usage
+@echo Usage: %~0% build_config
+@set ERRORLEVEL=1
+@goto eof
+
+:failure
+@echo Failed to build at least one configuration, exiting...
+@goto eof
+
+:success
+@echo All builds finished successfully
+@goto eof
+
+:eof
+

--- a/appveyor-gather.bat
+++ b/appveyor-gather.bat
@@ -1,6 +1,6 @@
-:: Cxbx-Reloaded artifact script
+:: Cxbx-Reloaded gather script
 
-@if "%1"=="" goto no_arg
+@if "%1"=="" goto show_usage
 
 @set ZIP_APP="%cd%\import\7za\7za.exe"
 @set BUILD_PATH="%cd%\build\win32\%1\"
@@ -24,13 +24,13 @@
 
 :missing_build
 @echo Missing build directory %BUILD_PATH%
+@set ERRORLEVEL=1
 @goto eof
 
-:no_arg
-@echo Usage: %0 build_configuration
+:show_usage
+@echo Usage: %~0% build_config
 @goto eof
 
 :eof
-@set ERRORLEVEL=0
 @echo Gather complete
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,32 +7,22 @@ branches:
   only:
     - master
 
-image: 
+image:
+  # If this is modified, please also update the build script
   - Visual Studio 2017
 
 configuration:
-  # The builds are run in this order
-  # Each configuration will compile all below platforms
+  # The builds will be run in this order
   - Release
   - Debug
 
-platform:
-  # Build the debugger and managed deps
-  # This must be done first!
-  - Any CPU
-  # Build native binaries
-  - Win32
-
-build:
-  project: build/win32/Cxbx.sln
-  parallel: true
-  verbosity: minimal
+build_script:
+  - cmd: appveyor-build.bat %CONFIGURATION%
 
 after_build:
-  - cmd: GatherArtifacts.bat %CONFIGURATION%
+  - cmd: appveyor-gather.bat %CONFIGURATION%
 
 artifacts:
-  # Note this publishes after building each platform, not after each configuration
   - path: export/*.zip
 
 install:


### PR DESCRIPTION
This should run just twice (once per configuration), meaning all artifacts are uploaded together