### PR TITLE
EEPROM improvements for issue #198

### DIFF
--- a/src/Common/EmuEEPROM.h
+++ b/src/Common/EmuEEPROM.h
@@ -99,6 +99,8 @@ extern xboxkrnl::XBOX_EEPROM *EEPROM;
 
 extern xboxkrnl::ULONG XboxFactoryGameRegion;
 
+void gen_section_CRCs(xboxkrnl::XBOX_EEPROM*);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
Calculate eeprom Section CRC checksum on write (Checksum2/3 in the User and Factory settings). Run data checksum on eeprom read to ensure section data is correct. Add plumbing for thread safety in eeprom reads/writes (throws an exception right now due to the current thread returning null). 