### PR TITLE
Kernel test suite fixes

### DIFF
--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -825,16 +825,18 @@ XBSYSAPI EXPORTNUM(199) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtFreeVirtualMemory
 		LOG_FUNC_ARG(FreeType)
 		LOG_FUNC_END;
 
-	assert(BaseAddress); // Must be assigned
-	// FreeSize may be unassigned
+	NTSTATUS ret = STATUS_INVALID_PARAMETER;
 
-	ULONG RegionSize = (FreeSize) ? *FreeSize : 0;
+	if (BaseAddress) { // Must be assigned
+		// FreeSize may be unassigned
+		ULONG RegionSize = (FreeSize) ? *FreeSize : 0;
 
-	NTSTATUS ret = g_VMManager.XbFreeVirtualMemory((VAddr*)BaseAddress, (size_t*)&RegionSize, FreeType);
+		ret = g_VMManager.XbFreeVirtualMemory((VAddr*)BaseAddress, (size_t*)&RegionSize, FreeType);
 
-	if (SUCCEEDED(ret)) {
-		if (FreeSize != xbnullptr)
-			*FreeSize = RegionSize;
+		if (SUCCEEDED(ret)) {
+			if (FreeSize != xbnullptr)
+				*FreeSize = RegionSize;
+		}
 	}
 
 	RETURN(ret);

--- a/src/devices/video/EmuNV2A_PFIFO.cpp
+++ b/src/devices/video/EmuNV2A_PFIFO.cpp
@@ -280,7 +280,7 @@ static void pfifo_run_pusher(NV2AState *d) {
 			command->parameter = word;
 
 			{
-				std::unique_lock<std::mutex> cache_unique_lock(d->pfifo.cache1.cache_lock); // UNTESTED
+				std::unique_lock<std::mutex> cache_unique_lock(d->pfifo.cache1.cache_lock);
 				state->cache.push(command);
 				state->cache_cond.notify_all();
 			} // end of cache_unique_lock scope
@@ -393,9 +393,9 @@ int pfifo_puller_thread(NV2AState *d)
 			state->working_cache.push(state->cache.front());
 			state->cache.pop();
 		}
-		cache_unique_lock.unlock(); // UNTESTED
+		cache_unique_lock.unlock();
 
-		d->pgraph.pgraph_lock.lock(); // UNTESTED
+		d->pgraph.pgraph_lock.lock();
 
 		while (!state->working_cache.empty()) {
 			CacheEntry* command = state->working_cache.front();
@@ -421,10 +421,10 @@ int pfifo_puller_thread(NV2AState *d)
 				}
 
 				/* the engine is bound to the subchannel */
-				cache_unique_lock.lock(); // UNTESTED
+				cache_unique_lock.lock();
 				state->bound_engines[command->subchannel] = entry.engine;
 				state->last_engine = entry.engine;
-				cache_unique_lock.unlock(); // UNTESTED
+				cache_unique_lock.unlock();
 			} else if (command->method >= 0x100) {
 				/* method passed to engine */
 

--- a/src/devices/video/nv2a.h
+++ b/src/devices/video/nv2a.h
@@ -301,8 +301,7 @@ typedef struct GraphicsContext {
 
 
 typedef struct PGRAPHState {
-	std::mutex pgraph_mutex;
-	std::unique_lock<std::mutex> pgraph_lock;
+	std::mutex pgraph_lock;
 
 	uint32_t pending_interrupts;
 	uint32_t enabled_interrupts;


### PR DESCRIPTION
Fixes three issues that were hindering the kernel test suite by @Luca1991 (https://github.com/Luca1991/xbox_kernel_test_suite).

* NV2A : Fixed pgraph_lock'ing. With this, the nxdk-compiled "Xbox kernel test suite" runs through pb_init() and pb_show_debug_screen(), reaching the first print ("Kernel Test Suite")!
* MOVSX opcode handler
* NtFreeVirtualMemory when called on nullptr (actually a bug in the kernel test suite)