### PR TITLE
FileFsSizeInformation should return number of allocation units

### DIFF
--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -1510,8 +1510,8 @@ XBSYSAPI EXPORTNUM(218) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtQueryVolumeInformat
 			XboxSizeInfo->SectorsPerAllocationUnit = superBlock.ClusterSize;
 		}
 
-		XboxSizeInfo->TotalAllocationUnits.QuadPart = partitionTable.TableEntries[partitionNumber - 1].LBASize * XboxSizeInfo->BytesPerSector;
-		XboxSizeInfo->AvailableAllocationUnits.QuadPart = partitionTable.TableEntries[partitionNumber - 1].LBASize  * XboxSizeInfo->BytesPerSector;
+		XboxSizeInfo->TotalAllocationUnits.QuadPart = partitionTable.TableEntries[partitionNumber - 1].LBASize / XboxSizeInfo->SectorsPerAllocationUnit;
+		XboxSizeInfo->AvailableAllocationUnits.QuadPart = partitionTable.TableEntries[partitionNumber - 1].LBASize / XboxSizeInfo->SectorsPerAllocationUnit;
 
 		RETURN(STATUS_SUCCESS);
 	}


### PR DESCRIPTION
It was returning the size in bytes before, which is not correct