### PR TITLE
Kernel work on Ob*, Ke* and Nt* API's

### DIFF
--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -224,6 +224,7 @@
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlKe.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlKi.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlLogging.h" />
+    <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlOb.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuNtDll.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuSha.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuX86.h" />

--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -220,6 +220,7 @@
     <ClInclude Include="..\..\src\CxbxKrnl\EmuDSoundInline.hpp" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuFile.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuFS.h" />
+    <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnl.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlKi.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlLogging.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuNtDll.h" />

--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -221,6 +221,7 @@
     <ClInclude Include="..\..\src\CxbxKrnl\EmuFile.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuFS.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnl.h" />
+    <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlKe.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlKi.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlLogging.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\EmuNtDll.h" />

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -531,6 +531,9 @@
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnl.h">
       <Filter>Kernel</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlKe.h">
+      <Filter>Kernel</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\Splash.jpg">

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -534,6 +534,9 @@
     <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlKe.h">
       <Filter>Kernel</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnlOb.h">
+      <Filter>Kernel</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\Splash.jpg">

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -528,6 +528,9 @@
     <ClInclude Include="..\..\src\devices\video\queue.h">
       <Filter>Hardware\Video</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\CxbxKrnl\EmuKrnl.h">
+      <Filter>Kernel</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\Splash.jpg">

--- a/import/OpenXDK/include/xboxkrnl/kernel.h
+++ b/import/OpenXDK/include/xboxkrnl/kernel.h
@@ -434,10 +434,10 @@ XBSYSAPI EXPORTNUM(147) KPRIORITY NTAPI KeSetPriorityProcess
 // ******************************************************************
 // * 0x0094 - KeSetPriorityThread()
 // ******************************************************************
-XBSYSAPI EXPORTNUM(148) BOOLEAN NTAPI KeSetPriorityThread
+XBSYSAPI EXPORTNUM(148) KPRIORITY NTAPI KeSetPriorityThread
 (
     IN PKTHREAD  Thread,
-    IN LONG  Priority
+    IN KPRIORITY Priority
 );
 
 // ******************************************************************

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -170,12 +170,12 @@ typedef long                            NTSTATUS;
 // The SCSI input buffer was too large (not necessarily an error!)
 #define STATUS_DATA_OVERRUN              ((DWORD   )0xC000003CL)
 #define STATUS_MUTANT_NOT_OWNED          ((DWORD   )0xC0000046L)
+#define STATUS_SEMAPHORE_LIMIT_EXCEEDED  ((DWORD   )0xC0000047L)
 #define STATUS_INVALID_IMAGE_FORMAT      ((DWORD   )0xC000007BL)
 #define STATUS_INSUFFICIENT_RESOURCES    ((DWORD   )0xC000009AL)
 #define STATUS_TOO_MANY_SECRETS          ((DWORD   )0xC0000156L)
 #define STATUS_XBE_REGION_MISMATCH       ((DWORD   )0xC0050001L)
 #define STATUS_XBE_MEDIA_MISMATCH        ((DWORD   )0xC0050002L)
-
 
 
 

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -1651,6 +1651,7 @@ typedef enum _KOBJECTS
 	MutantObject = 2,
 	QueueObject = 4,
 	SemaphoreObject = 5,
+	ThreadObject = 6,
 	TimerNotificationObject = 8,
 	TimerSynchronizationObject = 9,
 	ApcObject = 0x12,

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -1640,6 +1640,8 @@ KFLOATING_SAVE, *PKFLOATING_SAVE;
 // ******************************************************************
 typedef enum _KOBJECTS
 {
+	EventNotificationObject = 0,
+	EventSynchronizationObject = 1, 
 	MutantObject = 2,
 	QueueObject = 4,
 	SemaphoreObject = 5,

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -148,30 +148,36 @@ typedef void* LPSECURITY_ATTRIBUTES;
 typedef long                            NTSTATUS;
 
 #define NT_SUCCESS(Status)              ((NTSTATUS) (Status) >= 0)
+
 #define STATUS_SUCCESS                   ((DWORD   )0x00000000L)
+#define STATUS_ABANDONED                 ((DWORD   )0x00000080L)
+#define STATUS_USER_APC                  ((DWORD   )0x000000C0L)
+#define STATUS_ALERTED                   ((DWORD   )0x00000101L)
 #ifndef STATUS_PENDING
 #define STATUS_PENDING                   ((DWORD   )0x00000103L)
 #endif
 #define STATUS_TIMER_RESUME_IGNORED      ((DWORD   )0x40000025L)
 #define STATUS_BUFFER_OVERFLOW           ((DWORD   )0x80000005L)
-#define STATUS_UNSUCCESSFUL              ((DWORD   )0xC0000001)
-#define STATUS_UNRECOGNIZED_MEDIA        ((DWORD   )0xC0000014)
+#define STATUS_UNSUCCESSFUL              ((DWORD   )0xC0000001L)
+#define STATUS_UNRECOGNIZED_MEDIA        ((DWORD   )0xC0000014L)
 #ifndef STATUS_NO_MEMORY
 #define STATUS_NO_MEMORY                 ((DWORD   )0xC0000017L)
 #endif
 #define STATUS_BUFFER_TOO_SMALL          ((DWORD   )0xC0000023L)
 #define STATUS_INVALID_PARAMETER_2       ((DWORD   )0xC00000F0L)
-#define STATUS_ALERTED                   ((DWORD   )0x00000101)
-#define STATUS_USER_APC                  ((DWORD   )0x000000C0L)
+#define STATUS_OBJECT_NAME_NOT_FOUND     ((DWORD   )0xC0000034L)
+#define STATUS_OBJECT_NAME_COLLISION     ((DWORD   )0xC0000035L)
 // The SCSI input buffer was too large (not necessarily an error!)
 #define STATUS_DATA_OVERRUN              ((DWORD   )0xC000003CL)
+#define STATUS_MUTANT_NOT_OWNED          ((DWORD   )0xC0000046L)
 #define STATUS_INVALID_IMAGE_FORMAT      ((DWORD   )0xC000007BL)
 #define STATUS_INSUFFICIENT_RESOURCES    ((DWORD   )0xC000009AL)
 #define STATUS_TOO_MANY_SECRETS          ((DWORD   )0xC0000156L)
 #define STATUS_XBE_REGION_MISMATCH       ((DWORD   )0xC0050001L)
 #define STATUS_XBE_MEDIA_MISMATCH        ((DWORD   )0xC0050002L)
-#define STATUS_OBJECT_NAME_NOT_FOUND     ((DWORD   )0xC0000034L)
-#define STATUS_OBJECT_NAME_COLLISION     ((DWORD   )0xC0000035L)
+
+
+
 
 // ******************************************************************
 // * Registry value types

--- a/src/CxbxKrnl/EmuKrnl.h
+++ b/src/CxbxKrnl/EmuKrnl.h
@@ -60,9 +60,6 @@ xboxkrnl::PLIST_ENTRY RemoveTailList(xboxkrnl::PLIST_ENTRY pListHead);
 
 xboxkrnl::NTSTATUS EmuObFindObjectByHandle(xboxkrnl::HANDLE Handle, PVOID *Object);
 
-enum class GetMode { Existing, ExistingOrNew, Erase }; // TODO : Move to EmuKrnlKe.h
-HANDLE GetHostEvent(xboxkrnl::PRKEVENT Event, GetMode getMode = GetMode::ExistingOrNew); // TODO : Move to EmuKrnlKe.h
-
 extern xboxkrnl::LAUNCH_DATA_PAGE DefaultLaunchDataPage;
 extern xboxkrnl::PKINTERRUPT EmuInterruptList[MAX_BUS_INTERRUPT_LEVEL + 1];
 

--- a/src/CxbxKrnl/EmuKrnl.h
+++ b/src/CxbxKrnl/EmuKrnl.h
@@ -56,6 +56,11 @@ void RemoveEntryList(xboxkrnl::PLIST_ENTRY pEntry);
 xboxkrnl::PLIST_ENTRY RemoveHeadList(xboxkrnl::PLIST_ENTRY pListHead);
 xboxkrnl::PLIST_ENTRY RemoveTailList(xboxkrnl::PLIST_ENTRY pListHead);
 
+xboxkrnl::NTSTATUS EmuObFindObjectByHandle(xboxkrnl::HANDLE Handle, PVOID *Object);
+
+enum class GetMode { Existing, ExistingOrNew, Erase }; // TODO : Move to EmuKrnlKe.h
+HANDLE GetHostEvent(xboxkrnl::PRKEVENT Event, GetMode getMode = GetMode::ExistingOrNew); // TODO : Move to EmuKrnlKe.h
+
 extern xboxkrnl::LAUNCH_DATA_PAGE DefaultLaunchDataPage;
 extern xboxkrnl::PKINTERRUPT EmuInterruptList[MAX_BUS_INTERRUPT_LEVEL + 1];
 

--- a/src/CxbxKrnl/EmuKrnl.h
+++ b/src/CxbxKrnl/EmuKrnl.h
@@ -48,6 +48,8 @@
 
 void InitializeListHead(xboxkrnl::PLIST_ENTRY pListHead);
 bool IsListEmpty(xboxkrnl::PLIST_ENTRY pListHead);
+#define NextListEntry(pListEntry) ((pListEntry)->Flink)
+#define PrevListEntry(pListEntry) ((pListEntry)->Blink)
 void InsertHeadList(xboxkrnl::PLIST_ENTRY pListHead, xboxkrnl::PLIST_ENTRY pEntry);
 void InsertTailList(xboxkrnl::PLIST_ENTRY pListHead, xboxkrnl::PLIST_ENTRY pEntry);
 //#define RemoveEntryList(e) do { PLIST_ENTRY f = (e)->Flink, b = (e)->Blink; f->Blink = b; b->Flink = f; (e)->Flink = (e)->Blink = NULL; } while (0)

--- a/src/CxbxKrnl/EmuKrnl.h
+++ b/src/CxbxKrnl/EmuKrnl.h
@@ -48,8 +48,7 @@
 
 void InitializeListHead(xboxkrnl::PLIST_ENTRY pListHead);
 bool IsListEmpty(xboxkrnl::PLIST_ENTRY pListHead);
-#define NextListEntry(pListEntry) ((pListEntry)->Flink)
-#define PrevListEntry(pListEntry) ((pListEntry)->Blink)
+
 void InsertHeadList(xboxkrnl::PLIST_ENTRY pListHead, xboxkrnl::PLIST_ENTRY pEntry);
 void InsertTailList(xboxkrnl::PLIST_ENTRY pListHead, xboxkrnl::PLIST_ENTRY pEntry);
 //#define RemoveEntryList(e) do { PLIST_ENTRY f = (e)->Flink, b = (e)->Blink; f->Blink = b; b->Flink = f; (e)->Flink = (e)->Blink = NULL; } while (0)

--- a/src/CxbxKrnl/EmuKrnlEx.cpp
+++ b/src/CxbxKrnl/EmuKrnlEx.cpp
@@ -341,6 +341,15 @@ XBSYSAPI EXPORTNUM(21) xboxkrnl::LONGLONG FASTCALL xboxkrnl::ExInterlockedCompar
 	RETURN(Result);
 }
 
+xboxkrnl::VOID NTAPI ExpDeleteMutant(IN xboxkrnl::PVOID Mutant)
+{
+	xboxkrnl::KeReleaseMutant(
+		/* Mutant =    */(xboxkrnl::PKMUTANT)Mutant,
+		/* Increment = */1,
+		/* Abandoned = */TRUE,
+		/* Wait =      */FALSE);
+}
+
 // ******************************************************************
 // * 0x0016 - ExMutantObjectType
 // ******************************************************************
@@ -349,7 +358,7 @@ XBSYSAPI EXPORTNUM(22) xboxkrnl::OBJECT_TYPE xboxkrnl::ExMutantObjectType =
 	xboxkrnl::ExAllocatePoolWithTag,
 	xboxkrnl::ExFreePool,
 	NULL,
-	NULL, // TODO : xboxkrnl::ExpDeleteMutant,
+	ExpDeleteMutant,
 	NULL,
 	(PVOID)offsetof(xboxkrnl::KMUTANT, Header),
 	'atuM' // = first four characters of "Mutant" in reverse

--- a/src/CxbxKrnl/EmuKrnlIo.cpp
+++ b/src/CxbxKrnl/EmuKrnlIo.cpp
@@ -188,6 +188,8 @@ XBSYSAPI EXPORTNUM(63) xboxkrnl::NTSTATUS NTAPI xboxkrnl::IoCheckShareAccess
 	RETURN(S_OK);
 }
 
+extern xboxkrnl::KEVENT ObpDefaultObject; // TODO : Move to EmuKrnlOb.h
+
 // ******************************************************************
 // * 0x0040 - IoCompletionObjectType
 // ******************************************************************
@@ -198,7 +200,7 @@ XBSYSAPI EXPORTNUM(64) xboxkrnl::OBJECT_TYPE xboxkrnl::IoCompletionObjectType =
 	NULL,
 	NULL, // TODO : xboxkrnl::IopDeleteIoCompletion,
 	NULL,
-	NULL, // &xboxkrnl::ObpDefaultObject,
+	&ObpDefaultObject,
 	'pmoC' // = first four characters of "Completion" in reverse
 };
 
@@ -376,7 +378,7 @@ XBSYSAPI EXPORTNUM(70) xboxkrnl::OBJECT_TYPE xboxkrnl::IoDeviceObjectType =
 	NULL,
 	NULL,
 	NULL, // TODO : xboxkrnl::IoParseDevice,
-	NULL, // TODO : &xboxkrnl::ObpDefaultObject,
+	&ObpDefaultObject,
 	'iveD' // = first four characters of "Device" in reverse
 };
 

--- a/src/CxbxKrnl/EmuKrnlIo.cpp
+++ b/src/CxbxKrnl/EmuKrnlIo.cpp
@@ -49,6 +49,7 @@ namespace xboxkrnl
 #include "CxbxKrnl.h" // For CxbxKrnlCleanup
 #include "Emu.h" // For EmuWarning()
 #include "EmuFile.h" // For CxbxCreateSymbolicLink(), etc.
+#include "EmuKrnlOb.h" // For ObpDefaultObject
 #include "CxbxDebugger.h"
 
 // ******************************************************************
@@ -187,8 +188,6 @@ XBSYSAPI EXPORTNUM(63) xboxkrnl::NTSTATUS NTAPI xboxkrnl::IoCheckShareAccess
 
 	RETURN(S_OK);
 }
-
-extern xboxkrnl::KEVENT ObpDefaultObject; // TODO : Move to EmuKrnlOb.h
 
 // ******************************************************************
 // * 0x0040 - IoCompletionObjectType

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -161,7 +161,7 @@ xboxkrnl::KPCR* KeGetPcr()
 	// See EmuKeSetPcr()
 	Pcr = (xboxkrnl::PKPCR)__readfsdword(TIB_ArbitraryDataSlot);
 
-	if (Pcr == nullptr) {
+	if (Pcr == nullptr || Pcr->SelfPcr != Pcr) {
 		EmuWarning("KeGetPCR returned nullptr: Was this called from a non-xbox thread?");
 		// Attempt to salvage the situation by calling InitXboxThread to setup KPCR in place
 		InitXboxThread(g_CPUXbox);
@@ -1446,7 +1446,7 @@ XBSYSAPI EXPORTNUM(138) xboxkrnl::LONG NTAPI xboxkrnl::KeResetEvent
 
 	// Fetch the host event and signal it
 	LONG PreviousState;
-	NtDll::NtResetEvent(GetNtEvent(Event), &PreviousState);
+	//NtDll::NtResetEvent(GetNtEvent(Event), &PreviousState);
 
 	RETURN(ret);
 }

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -57,6 +57,7 @@ namespace NtDll
 #include "Emu.h" // For EmuWarning()
 #include "EmuKrnl.h" // For InitializeListHead(), etc.
 #include "EmuKrnlKi.h" // For KiRemoveTreeTimer(), KiInsertTreeTimer()
+#include "EmuKrnlKe.h" // For KeClearEvent(), GetMode, GetHostEvent()
 #include "EmuFile.h" // For IsEmuHandle(), NtStatusToString()
 
 #include <chrono>
@@ -150,14 +151,6 @@ xboxkrnl::KPRCB *KeGetCurrentPrcb()
 {
 	return &(KeGetPcr()->PrcbData);
 }
-
-// Forward KeLowerIrql() to KfLowerIrql()
-#define KeLowerIrql(NewIrql) \
-	KfLowerIrql(NewIrql)
-
-// Forward KeRaiseIrql() to KfRaiseIrql()
-#define KeRaiseIrql(NewIrql, OldIrql) \
-	*(OldIrql) = KfRaiseIrql(NewIrql)
 
 ULONGLONG BootTickCount = 0;
 

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -1539,7 +1539,7 @@ XBSYSAPI EXPORTNUM(141) xboxkrnl::PLIST_ENTRY NTAPI xboxkrnl::KeRundownQueue
 	}
 
 	while (pQueue->ThreadListHead.Flink != &pQueue->ThreadListHead) {
-		auto pEntry = NextListEntry(&pQueue->ThreadListHead);
+		auto pEntry = pQueue->ThreadListHead.Flink;
 		KTHREAD *pThread = CONTAINING_RECORD(pEntry, xboxkrnl::KTHREAD, QueueListEntry);
 		pThread->Queue = NULL;
 		RemoveEntryList(pEntry);
@@ -1691,7 +1691,7 @@ XBSYSAPI EXPORTNUM(146) xboxkrnl::VOID NTAPI xboxkrnl::KeSetEventBoostPriority
 		pEvent->Header.SignalState = 1;
 	}
 	else {
-		PKTHREAD WaitThread = CONTAINING_RECORD(NextListEntry(&pEvent->Header.WaitListHead), xboxkrnl::KWAIT_BLOCK, WaitListEntry)->Thread;
+		PKTHREAD WaitThread = CONTAINING_RECORD(pEvent->Header.WaitListHead.Flink, xboxkrnl::KWAIT_BLOCK, WaitListEntry)->Thread;
 		auto pWaitThread = WaitThread;
 		auto pWaitThreadProcess = pWaitThread->ApcState.Process;
 

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -917,9 +917,14 @@ XBSYSAPI EXPORTNUM(116) xboxkrnl::LONG NTAPI xboxkrnl::KeInsertHeadQueue
 		LOG_FUNC_ARG(Entry)
 		LOG_FUNC_END;
 
-	LOG_UNIMPLEMENTED();
+	KIRQL oldIRQL;
+	KiLockDispatcherDatabase(&oldIRQL);
 
-	RETURN(0);
+	LONG prevState = KiInsertQueue(Queue, Entry, TRUE);
+
+	KiUnlockDispatcherDatabase(oldIRQL);
+
+	RETURN(prevState);
 }
 
 XBSYSAPI EXPORTNUM(117) xboxkrnl::LONG NTAPI xboxkrnl::KeInsertQueue
@@ -933,9 +938,14 @@ XBSYSAPI EXPORTNUM(117) xboxkrnl::LONG NTAPI xboxkrnl::KeInsertQueue
 		LOG_FUNC_ARG(Entry)
 		LOG_FUNC_END;
 
-	LOG_UNIMPLEMENTED();
+	KIRQL oldIRQL;
+	KiLockDispatcherDatabase(&oldIRQL);
 
-	RETURN(0);
+	LONG prevState = KiInsertQueue(Queue, Entry, FALSE);
+
+	KiUnlockDispatcherDatabase(oldIRQL);
+
+	RETURN(prevState);
 }
 
 XBSYSAPI EXPORTNUM(118) xboxkrnl::BOOLEAN NTAPI xboxkrnl::KeInsertQueueApc

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -1733,10 +1733,10 @@ XBSYSAPI EXPORTNUM(147) xboxkrnl::KPRIORITY NTAPI xboxkrnl::KeSetPriorityProcess
 // ******************************************************************
 // * 0x0094 - KeSetPriorityThread()
 // ******************************************************************
-XBSYSAPI EXPORTNUM(148) xboxkrnl::BOOLEAN NTAPI xboxkrnl::KeSetPriorityThread
+XBSYSAPI EXPORTNUM(148) xboxkrnl::KPRIORITY NTAPI xboxkrnl::KeSetPriorityThread
 (
     IN PKTHREAD  Thread,
-    IN LONG  Priority
+    IN KPRIORITY Priority
 )
 {
 	LOG_FUNC_BEGIN

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -1744,9 +1744,22 @@ XBSYSAPI EXPORTNUM(148) xboxkrnl::BOOLEAN NTAPI xboxkrnl::KeSetPriorityThread
 		LOG_FUNC_ARG_OUT(Priority)
 		LOG_FUNC_END;
 
-	LOG_UNIMPLEMENTED();
+	auto pThread = Thread;
 
-	RETURN(1);
+	KIRQL oldIRQL;
+	KiLockDispatcherDatabase(&oldIRQL);
+
+	KPRIORITY prevPriority = pThread->Priority;
+	PKPROCESS process = pThread->ApcState.Process;
+	auto pProcess = process;
+	pThread->Quantum = pProcess->ThreadQuantum;
+	pThread->DecrementCount = 0;
+	pThread->PriorityDecrement = 0;
+	// TODO : KiSetPriorityThread(Thread, Priority);
+
+	KiUnlockDispatcherDatabase(oldIRQL);
+
+	RETURN(prevPriority);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -1836,6 +1836,8 @@ XBSYSAPI EXPORTNUM(159) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForSingleObject
 {
 	LOG_FORWARD("KeWaitForMultipleObjects");
 
+	KWAIT_BLOCK WaitBlock;
+
 	return xboxkrnl::KeWaitForMultipleObjects(
 		/*Count=*/1,
 		&Object,
@@ -1844,6 +1846,6 @@ XBSYSAPI EXPORTNUM(159) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForSingleObject
 		WaitMode,
 		Alertable,
 		Timeout,
-		/*WaitBlockArray*/NULL
+		&WaitBlock
 	);
 }

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -1207,7 +1207,7 @@ XBSYSAPI EXPORTNUM(128) xboxkrnl::VOID NTAPI xboxkrnl::KeQuerySystemTime
 // ******************************************************************
 XBSYSAPI EXPORTNUM(129) xboxkrnl::UCHAR NTAPI xboxkrnl::KeRaiseIrqlToDpcLevel()
 {
-	LOG_FORWARD(KfRaiseIrql);
+	LOG_FORWARD("KfRaiseIrql");
 
 	return KfRaiseIrql(DISPATCH_LEVEL);
 }
@@ -1217,7 +1217,7 @@ XBSYSAPI EXPORTNUM(129) xboxkrnl::UCHAR NTAPI xboxkrnl::KeRaiseIrqlToDpcLevel()
 // ******************************************************************
 XBSYSAPI EXPORTNUM(130) xboxkrnl::UCHAR NTAPI xboxkrnl::KeRaiseIrqlToSynchLevel()
 {
-	LOG_FORWARD(KfRaiseIrql);
+	LOG_FORWARD("KfRaiseIrql");
 
 	return KfRaiseIrql(SYNC_LEVEL);
 }

--- a/src/CxbxKrnl/EmuKrnlKe.h
+++ b/src/CxbxKrnl/EmuKrnlKe.h
@@ -50,3 +50,16 @@ void KeClearEvent(IN xboxkrnl::PRKEVENT Event);
 
 void KeQueryMutant(xboxkrnl::PRKMUTANT pMutant, xboxkrnl::PMUTANT_BASIC_INFORMATION pMutantInformation);
 
+namespace XboxTypes = xboxkrnl;
+
+void KeInitializeThread
+(
+	XboxTypes::PKTHREAD Thread,
+	XboxTypes::PVOID KernelStack,
+	XboxTypes::SIZE_T KernelStackSize,
+	XboxTypes::SIZE_T TlsDataSize,
+	XboxTypes::PKSYSTEM_ROUTINE SystemRoutine,
+	XboxTypes::PKSTART_ROUTINE StartRoutine,
+	XboxTypes::PVOID StartContext,
+	XboxTypes::PKPROCESS Process
+);

--- a/src/CxbxKrnl/EmuKrnlKe.h
+++ b/src/CxbxKrnl/EmuKrnlKe.h
@@ -1,0 +1,51 @@
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->src->CxbxKrnl->EmuKrnlKe.h
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2018 Patrick van Logchem <pvanlogchem@gmail.com>
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+#pragma once
+
+// Forward KeLowerIrql() to KfLowerIrql()
+#define KeLowerIrql(NewIrql) \
+	KfLowerIrql(NewIrql)
+
+// Forward KeRaiseIrql() to KfRaiseIrql()
+#define KeRaiseIrql(NewIrql, OldIrql) \
+	*(OldIrql) = KfRaiseIrql(NewIrql)
+
+enum class GetMode { Existing, ExistingOrNew, Erase };
+
+HANDLE GetHostEvent(xboxkrnl::PRKEVENT Event, GetMode getMode = GetMode::ExistingOrNew);
+
+void KeClearEvent
+(
+	IN xboxkrnl::PRKEVENT Event
+);

--- a/src/CxbxKrnl/EmuKrnlKe.h
+++ b/src/CxbxKrnl/EmuKrnlKe.h
@@ -44,8 +44,9 @@
 enum class GetMode { Existing, ExistingOrNew, Erase };
 
 HANDLE GetHostEvent(xboxkrnl::PRKEVENT Event, GetMode getMode = GetMode::ExistingOrNew);
+HANDLE GetNtMutant(xboxkrnl::PRKMUTANT pMutant, GetMode getMode, BOOLEAN InitialOwner = FALSE);
 
-void KeClearEvent
-(
-	IN xboxkrnl::PRKEVENT Event
-);
+void KeClearEvent(IN xboxkrnl::PRKEVENT Event);
+
+void KeQueryMutant(xboxkrnl::PRKMUTANT pMutant, xboxkrnl::PMUTANT_BASIC_INFORMATION pMutantInformation);
+

--- a/src/CxbxKrnl/EmuKrnlKi.cpp
+++ b/src/CxbxKrnl/EmuKrnlKi.cpp
@@ -47,7 +47,8 @@ namespace xboxkrnl
 #include "Logging.h" // For LOG_FUNC()
 #include "EmuKrnlLogging.h"
 
-//#include "EmuKrnl.h" // For InitializeListHead(), etc.
+#include "EmuKrnl.h" // For CONTAINING_RECORD, InitializeListHead(), etc.
+#include "EmuKrnlKi.h" // For KiRemoveTreeTimer(), KiInsertTreeTimer()
 
 xboxkrnl::BOOLEAN KiInsertTimerTable(
 	IN xboxkrnl::LARGE_INTEGER Interval,
@@ -88,4 +89,47 @@ xboxkrnl::BOOLEAN KiInsertTreeTimer(
 
 	Timer->Header.Inserted = TRUE;
 	return KiInsertTimerTable(Interval, xboxkrnl::KeQueryInterruptTime(), Timer);
+}
+
+xboxkrnl::LONG KiInsertQueue
+(
+	xboxkrnl::PRKQUEUE pQueue, 
+	xboxkrnl::PLIST_ENTRY pEntry, 
+	xboxkrnl::BOOLEAN Head
+)
+{
+	xboxkrnl::LONG prevState = pQueue->Header.SignalState;
+	xboxkrnl::KTHREAD *pThread = xboxkrnl::KeGetCurrentThread();
+
+	auto pWaitEntry = PrevListEntry(&pQueue->Header.WaitListHead);
+	if (pWaitEntry != &pQueue->Header.WaitListHead && pQueue->CurrentCount < pQueue->MaximumCount &&
+		((xboxkrnl::PRKQUEUE)(pThread->Queue) != pQueue || pThread->WaitReason != xboxkrnl::WrQueue)) {
+
+		RemoveEntryList(pWaitEntry);
+		xboxkrnl::KWAIT_BLOCK *pWaitBlock = CONTAINING_RECORD(pWaitEntry, xboxkrnl::KWAIT_BLOCK, WaitListEntry);
+		pThread = (xboxkrnl::KTHREAD*)(pWaitBlock->Thread);
+
+		pThread->WaitStatus = (xboxkrnl::LONG_PTR)pEntry;
+		RemoveEntryList(&pThread->WaitListEntry);
+		pQueue->CurrentCount += 1;
+		pThread->WaitReason = 0;
+
+		xboxkrnl::KTIMER *Timer = &pThread->Timer;
+		if (Timer->Header.Inserted == TRUE) {
+			KiRemoveTreeTimer(Timer);
+		}
+
+		// TODO : KiReadyThread(pThread);
+	}
+	else {
+		pQueue->Header.SignalState += 1;
+		if (Head != FALSE) {
+			InsertHeadList(&pQueue->EntryListHead, pEntry);
+		}
+		else {
+			InsertTailList(&pQueue->EntryListHead, pEntry);
+		}
+	}
+
+	return prevState;
 }

--- a/src/CxbxKrnl/EmuKrnlKi.cpp
+++ b/src/CxbxKrnl/EmuKrnlKi.cpp
@@ -101,7 +101,7 @@ xboxkrnl::LONG KiInsertQueue
 	xboxkrnl::LONG prevState = pQueue->Header.SignalState;
 	xboxkrnl::KTHREAD *pThread = xboxkrnl::KeGetCurrentThread();
 
-	auto pWaitEntry = PrevListEntry(&pQueue->Header.WaitListHead);
+	auto pWaitEntry = pQueue->Header.WaitListHead.Blink;
 	if (pWaitEntry != &pQueue->Header.WaitListHead && pQueue->CurrentCount < pQueue->MaximumCount &&
 		((xboxkrnl::PRKQUEUE)(pThread->Queue) != pQueue || pThread->WaitReason != xboxkrnl::WrQueue)) {
 

--- a/src/CxbxKrnl/EmuKrnlKi.h
+++ b/src/CxbxKrnl/EmuKrnlKi.h
@@ -50,3 +50,10 @@ xboxkrnl::BOOLEAN KiInsertTreeTimer(
 	IN xboxkrnl::PKTIMER Timer,
 	IN xboxkrnl::LARGE_INTEGER Interval
 );
+
+xboxkrnl::LONG KiInsertQueue
+(
+	xboxkrnl::PRKQUEUE pQueue,
+	xboxkrnl::PLIST_ENTRY pEntry,
+	xboxkrnl::BOOLEAN Head
+);

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -227,11 +227,12 @@ XBSYSAPI EXPORTNUM(187) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtClose
 		// delete 'special' handles
 		EmuHandle *iEmuHandle = HandleToEmuHandle(Handle);
 		ret = iEmuHandle->NtClose();
-
-		LOG_UNIMPLEMENTED(); // TODO : Base this on the Ob* functions
 	}
     else
     {
+		KIRQL OldIrql = KeRaiseIrqlToDpcLevel();
+
+		LOG_INCOMPLETE(); // TODO : Base this on the Ob* functions, 
 		// Check if this is an event handle
 		PVOID KernelObject; // TODO : Use ObpDestroyObjectHandle()
 		if (SUCCEEDED(EmuObFindObjectByHandle(Handle, &KernelObject))) {			
@@ -250,6 +251,8 @@ XBSYSAPI EXPORTNUM(187) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtClose
 			// close normal handles
 			ret = NtDll::NtClose(Handle);
 		}
+
+		KeLowerIrql(OldIrql);
     }
 
 	RETURN(ret);

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -56,6 +56,7 @@ namespace NtDll
 #include "CxbxKrnl.h" // For CxbxKrnlCleanup
 #include "Emu.h" // For EmuWarning()
 #include "EmuFile.h" // For EmuNtSymbolicLinkObject, NtStatusToString(), etc.
+#include "EmuKrnl.h" // For OBJECT_TO_OBJECT_HEADER()
 #include "VMManager.h" // For g_VMManager
 #include "CxbxDebugger.h"
 
@@ -69,6 +70,12 @@ namespace NtDll
 #define MM_HIGHEST_USER_ADDRESS     0x7FFEFFFF
 #define X64K                        ((ULONG)64*1024)
 #define MM_HIGHEST_VAD_ADDRESS      (MM_HIGHEST_USER_ADDRESS - X64K)
+
+// external declaration, should reside in EmuKrnlKe.h
+void KeClearEvent
+(
+	IN xboxkrnl::PRKEVENT Event
+);
 
 // ******************************************************************
 // * 0x00B8 - NtAllocateVirtualMemory()
@@ -197,10 +204,13 @@ XBSYSAPI EXPORTNUM(186) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtClearEvent
 {
 	LOG_FUNC_ONE_ARG(EventHandle);
 
-	NTSTATUS ret = NtDll::NtClearEvent(EventHandle);
+	PVOID KernelEvent;
 
-	if (FAILED(ret))
-		EmuWarning("NtClearEvent Failed!");
+	NTSTATUS ret = ObReferenceObjectByHandle(EventHandle, &ExEventObjectType, &KernelEvent);
+	if (SUCCEEDED(ret)) {
+		KeClearEvent((PKEVENT)KernelEvent);
+		ObfDereferenceObject(KernelEvent);
+	}
 
 	RETURN(ret);
 }
@@ -296,7 +306,6 @@ XBSYSAPI EXPORTNUM(189) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtCreateEvent
 		LOG_FUNC_ARG(InitialState)
 		LOG_FUNC_END;
 
-/*
 	NTSTATUS Status;
 
 	if ((EventType != NotificationEvent) && (EventType != SynchronizationEvent)) {
@@ -313,49 +322,6 @@ XBSYSAPI EXPORTNUM(189) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtCreateEvent
 	}
 
 	RETURN(Status);
-*/
-	LOG_INCOMPLETE(); // TODO : Verify arguments, use ObCreateObject, KeInitializeEvent and ObInsertObject instead of this:
-
-	// initialize object attributes
-	NativeObjectAttributes nativeObjectAttributes;
-	CxbxObjectAttributesToNT(ObjectAttributes, /*var*/nativeObjectAttributes);
-
-	// TODO : Is this the correct ACCESS_MASK? :
-	const ACCESS_MASK DesiredAccess = EVENT_ALL_ACCESS;
-
-	// redirect to Win2k/XP
-	NTSTATUS ret = NtDll::NtCreateEvent(
-		/*OUT*/EventHandle,
-		DesiredAccess,
-		nativeObjectAttributes.NtObjAttrPtr,
-		(NtDll::EVENT_TYPE)EventType,
-		InitialState);
-
-	// TODO : Instead of the above, we should consider using the Ke*Event APIs, but
-	// that would require us to create the event's kernel object with the Ob* api's too!
-
-	if (FAILED(ret))
-	{
-		EmuWarning("Trying fallback (without object attributes)...\nError code 0x%X", ret);
-
-		// If it fails, try again but without the object attributes stucture
-		// This fixes Panzer Dragoon games on non-Vista OSes.
-		ret = NtDll::NtCreateEvent(
-			/*OUT*/EventHandle,
-			DesiredAccess,
-			/*nativeObjectAttributes.NtObjAttrPtr*/ NULL,
-			(NtDll::EVENT_TYPE)EventType,
-			InitialState);
-
-		if(FAILED(ret))
-			EmuWarning("NtCreateEvent Failed!");
-		else
-			DbgPrintf("KRNL: NtCreateEvent EventHandle = 0x%.8X\n", *EventHandle);
-	}
-	else
-		DbgPrintf("KRNL: NtCreateEvent EventHandle = 0x%.8X\n", *EventHandle);
-
-	RETURN(ret);
 }
 
 // ******************************************************************
@@ -1010,14 +976,17 @@ XBSYSAPI EXPORTNUM(205) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtPulseEvent
 		LOG_FUNC_ARG_OUT(PreviousState)
 		LOG_FUNC_END;
 
-	// redirect to Windows NT
-	// TODO : Untested
-	NTSTATUS ret = NtDll::NtPulseEvent(
-		EventHandle, 
-		/*OUT*/PreviousState);
+	PVOID KernelEvent;
 
-	if (FAILED(ret))
-		EmuWarning("NtPulseEvent failed!");
+	NTSTATUS ret = ObReferenceObjectByHandle(EventHandle, &ExEventObjectType, &KernelEvent);		
+	if (SUCCEEDED(ret)) {
+		ret = KePulseEvent((PKEVENT)KernelEvent, (KPRIORITY)1, FALSE);
+		if (PreviousState) {
+			*PreviousState = ret;
+		}
+
+		ObfDereferenceObject(KernelEvent);
+	}
 
 	RETURN(ret);
 }
@@ -1924,19 +1893,13 @@ XBSYSAPI EXPORTNUM(233) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
     IN  PLARGE_INTEGER   Timeout
 )
 {
-	LOG_FORWARD("KeWaitForMultipleObjects");
+	LOG_FORWARD("NtWaitForSingleObjectEx");
 
-	KWAIT_BLOCK WaitBlock;
-
-	return xboxkrnl::KeWaitForMultipleObjects(
-		/*Count=*/1,
-		&Handle,
-		/*WaitType=*/WaitAll,
-		/*WaitReason=*/WrUserRequest,
+	return NtWaitForSingleObjectEx(
+		Handle,
 		/*WaitMode=*/KernelMode,
 		Alertable,
-		Timeout,
-		&WaitBlock
+		Timeout
 	);
 }
 
@@ -1953,18 +1916,38 @@ XBSYSAPI EXPORTNUM(234) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
 {
 	LOG_FORWARD("KeWaitForMultipleObjects");
 
-	KWAIT_BLOCK WaitBlock;
+	PVOID Object;
+	NTSTATUS Status = ObReferenceObjectByHandle(Handle, NULL, &Object);
 
-	return xboxkrnl::KeWaitForMultipleObjects(
-		/*Count=*/1,
-		&Handle,
-		/*WaitType=*/WaitAll,
-		/*WaitReason=*/WrUserRequest,
-		WaitMode,
-		Alertable,
-		Timeout,
-		&WaitBlock
-	);
+	if (NT_SUCCESS(Status)) {
+		POBJECT_HEADER ObjectHeader = OBJECT_TO_OBJECT_HEADER(Object);
+		PVOID WaitObject = ObjectHeader->Type->DefaultObject;
+
+		if ((intptr_t)WaitObject >= 0) {
+			WaitObject = (PVOID)((PCHAR)Object + (ULONG_PTR)WaitObject);
+		}
+
+		//try {
+			KWAIT_BLOCK WaitBlock;
+
+			Status = xboxkrnl::KeWaitForMultipleObjects(
+				/*Count=*/1,
+				&WaitObject,
+				/*WaitType=*/WaitAll,
+				/*WaitReason=*/WrUserRequest,
+				WaitMode,
+				Alertable,
+				Timeout,
+				&WaitBlock
+			);
+		//} except(EXCEPTION_EXECUTE_HANDLER) {
+		//	Status = GetExceptionCode();
+		//}
+
+		ObfDereferenceObject(Object);
+	}
+
+	return Status;
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -237,13 +237,24 @@ XBSYSAPI EXPORTNUM(187) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtClose
 	}
     else
     {
-        if (CxbxDebugger::CanReport())
-        {
-            CxbxDebugger::ReportFileClosed(Handle);
-        }
+		// Check if this is an event handle
+		PVOID KernelObject; // TODO : Use ObpDestroyObjectHandle()
+		if (SUCCEEDED(EmuObFindObjectByHandle(Handle, &KernelObject))) {			
+			// For now, retrieve the host couterpart event and close that handle
+			HANDLE hostEvent = GetHostEvent((PKEVENT)KernelObject, GetMode::Erase);
+			if (hostEvent) {
+				CloseHandle(hostEvent);
+			}
+		}
+		else {
+			if (CxbxDebugger::CanReport())
+			{
+				CxbxDebugger::ReportFileClosed(Handle);
+			}
 
-        // close normal handles
-        ret = NtDll::NtClose(Handle);
+			// close normal handles
+			ret = NtDll::NtClose(Handle);
+		}
     }
 
 	RETURN(ret);
@@ -981,11 +992,10 @@ XBSYSAPI EXPORTNUM(205) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtPulseEvent
 	NTSTATUS ret = ObReferenceObjectByHandle(EventHandle, &ExEventObjectType, &KernelEvent);		
 	if (SUCCEEDED(ret)) {
 		ret = KePulseEvent((PKEVENT)KernelEvent, (KPRIORITY)1, FALSE);
+		ObfDereferenceObject(KernelEvent);
 		if (PreviousState) {
 			*PreviousState = ret;
 		}
-
-		ObfDereferenceObject(KernelEvent);
 	}
 
 	RETURN(ret);
@@ -1893,7 +1903,7 @@ XBSYSAPI EXPORTNUM(233) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
     IN  PLARGE_INTEGER   Timeout
 )
 {
-	LOG_FORWARD("NtWaitForSingleObjectEx");
+	// LOG_FORWARD("NtWaitForSingleObjectEx");
 
 	return NtWaitForSingleObjectEx(
 		Handle,

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -1926,6 +1926,8 @@ XBSYSAPI EXPORTNUM(233) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
 {
 	LOG_FORWARD("KeWaitForMultipleObjects");
 
+	KWAIT_BLOCK WaitBlock;
+
 	return xboxkrnl::KeWaitForMultipleObjects(
 		/*Count=*/1,
 		&Handle,
@@ -1934,7 +1936,7 @@ XBSYSAPI EXPORTNUM(233) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
 		/*WaitMode=*/KernelMode,
 		Alertable,
 		Timeout,
-		/*WaitBlockArray*/NULL
+		&WaitBlock
 	);
 }
 
@@ -1951,6 +1953,8 @@ XBSYSAPI EXPORTNUM(234) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
 {
 	LOG_FORWARD("KeWaitForMultipleObjects");
 
+	KWAIT_BLOCK WaitBlock;
+
 	return xboxkrnl::KeWaitForMultipleObjects(
 		/*Count=*/1,
 		&Handle,
@@ -1959,7 +1963,7 @@ XBSYSAPI EXPORTNUM(234) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
 		WaitMode,
 		Alertable,
 		Timeout,
-		/*WaitBlockArray*/NULL
+		&WaitBlock
 	);
 }
 
@@ -1978,6 +1982,8 @@ XBSYSAPI EXPORTNUM(235) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForMultipleObje
 {
 	LOG_FORWARD("KeWaitForMultipleObjects");
 
+	KWAIT_BLOCK WaitBlockArray[9];
+
 	return xboxkrnl::KeWaitForMultipleObjects(
 		Count,
 		Handles,
@@ -1986,7 +1992,7 @@ XBSYSAPI EXPORTNUM(235) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForMultipleObje
 		WaitMode,
 		Alertable,
 		Timeout,
-		/*WaitBlockArray*/NULL);
+		WaitBlockArray);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -57,6 +57,7 @@ namespace NtDll
 #include "Emu.h" // For EmuWarning()
 #include "EmuFile.h" // For EmuNtSymbolicLinkObject, NtStatusToString(), etc.
 #include "EmuKrnl.h" // For OBJECT_TO_OBJECT_HEADER()
+#include "EmuKrnlKe.h" // For KeClearEvent(), GetMode, GetHostEvent()
 #include "VMManager.h" // For g_VMManager
 #include "CxbxDebugger.h"
 
@@ -70,12 +71,6 @@ namespace NtDll
 #define MM_HIGHEST_USER_ADDRESS     0x7FFEFFFF
 #define X64K                        ((ULONG)64*1024)
 #define MM_HIGHEST_VAD_ADDRESS      (MM_HIGHEST_USER_ADDRESS - X64K)
-
-// external declaration, should reside in EmuKrnlKe.h
-void KeClearEvent
-(
-	IN xboxkrnl::PRKEVENT Event
-);
 
 // ******************************************************************
 // * 0x00B8 - NtAllocateVirtualMemory()

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -550,7 +550,7 @@ XBSYSAPI EXPORTNUM(249) xboxkrnl::OBJECT_TYPE xboxkrnl::ObSymbolicLinkObjectType
 	NULL,
 	NULL, // TODO : xboxkrnl::ObpDeleteSymbolicLink,
 	NULL,
-	NULL, // TODO : &xboxkrnl::ObpDefaultObject,
+	&ObpDefaultObject,
 	'bmyS' // = first four characters of "SymbolicLink" in reverse
 };
 

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -277,6 +277,18 @@ XBSYSAPI EXPORTNUM(239) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ObCreateObject
 	RETURN(Status);
 }
 
+// Declare ObpDefaultObject identical to KeInitializeEvent(&ObpDefaultObject, SynchronizationEvent, TRUE);
+xboxkrnl::KEVENT ObpDefaultObject =
+{
+	/* Header.Type = */ xboxkrnl::EVENT_TYPE::SynchronizationEvent,
+	/* Header.Absolute = */ FALSE,
+	/* Header.Size = */ sizeof(xboxkrnl::KEVENT) / sizeof(xboxkrnl::LONG),
+	/* Header.Inserted = */ FALSE,
+	/* Header.SignalState = */ TRUE,
+	/* Header.WaitListHead.Flink= */ &ObpDefaultObject.Header.WaitListHead,
+	/* Header.WaitListHead.Blink= */ &ObpDefaultObject.Header.WaitListHead // See InitializeListHead()
+};
+
 // ******************************************************************
 // * 0x00F0 - ObDirectoryObjectType
 // ******************************************************************
@@ -287,7 +299,7 @@ XBSYSAPI EXPORTNUM(240) xboxkrnl::OBJECT_TYPE xboxkrnl::ObDirectoryObjectType =
 	NULL,
 	NULL,
 	NULL,
-	NULL, // TODO : &xboxkrnl::ObpDefaultObject,
+	&ObpDefaultObject,
 	'eriD' // = first four characters of "Directory" in reverse
 };
 

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -339,21 +339,19 @@ XBSYSAPI EXPORTNUM(242) xboxkrnl::VOID NTAPI xboxkrnl::ObMakeTemporaryObject
 {
 	LOG_FUNC_ONE_ARG(Object);
 
+	KIRQL OldIrql = KeRaiseIrqlToDpcLevel();
+
 	/* Get the header */
 	POBJECT_HEADER ObjectHeader = OBJECT_TO_OBJECT_HEADER(Object);
-
-	/* Acquire object lock */
-	//ObpAcquireObjectLock(ObjectHeader);
-	LOG_INCOMPLETE(); // TODO : Lock, etc.
 
 	/* Remove the flag */
 	ObjectHeader->Flags &= ~OB_FLAG_PERMANENT_OBJECT;
 
-	/* Release the lock */
-	// ObpReleaseObjectLock(ObjectHeader);
-
 	/* Check if we should delete the object now */
 	//ObpDeleteNameCheck(ObjectBody);
+	LOG_INCOMPLETE();
+
+	KeLowerIrql(OldIrql);
 }
 
 // ******************************************************************
@@ -435,8 +433,7 @@ XBSYSAPI EXPORTNUM(244) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ObOpenObjectByPointer
 
 		new_handle = ObpCreateObjectHandle(Object);
 		KeLowerIrql(OldIrql);
-		if(new_handle == NULL)
-		{
+		if(new_handle == NULL) {
 			// Detected out of memory
 			ObfDereferenceObject(Object);
 			Status = STATUS_INSUFFICIENT_RESOURCES;

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -63,11 +63,9 @@ xboxkrnl::HANDLE EmuObCreateObjectHandle
 	IN xboxkrnl::PVOID Object
 )
 {
-	LOG_FUNC_ONE_ARG(Object);
-
 	HANDLE Handle = (HANDLE)Object; // Fake it for now
 
-	LOG_INCOMPLETE(); // TODO : Create an actual handle
+	// LOG_INCOMPLETE(); // TODO : Create an actual handle
 
 	return Handle;
 }
@@ -78,16 +76,11 @@ xboxkrnl::NTSTATUS EmuObFindObjectByHandle
 	OUT PVOID *Object
 )
 {
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(Handle)
-		LOG_FUNC_ARG_OUT(Object)
-		LOG_FUNC_END;
-
 	NTSTATUS Status = STATUS_SUCCESS;
 
 	*Object = (PVOID)Handle; // Fake it for now
 	
-	LOG_INCOMPLETE(); // TODO : Lookup an actual handle
+	// LOG_INCOMPLETE(); // TODO : Lookup an actual handle
 
 	if (*Object == NULL)
 		Status = STATUS_INVALID_HANDLE;

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -218,6 +218,9 @@ XBSYSAPI EXPORTNUM(239) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ObCreateObject
 	NTSTATUS Status = STATUS_SUCCESS;
 	int NameBufferSize = 0;
 
+//	NativeObjectAttributes nativeObjectAttributes;
+//	CxbxObjectAttributesToNT(ObjectAttributes, /*var*/nativeObjectAttributes);
+
 	if (ObjectAttributes != NULL && ObjectAttributes->ObjectName != NULL) {
 		if (ObjectAttributes->ObjectName->Length == 0) {
 			Status = STATUS_OBJECT_NAME_INVALID;

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -586,5 +586,7 @@ XBSYSAPI EXPORTNUM(251) xboxkrnl::VOID FASTCALL xboxkrnl::ObfReferenceObject
 {
 	LOG_FUNC_ONE_ARG_OUT(Object);
 
-	/*ignore result*/ObReferenceObjectByPointer(Object, /*ObjectType=*/NULL);
+	// Extract from ObReferenceObjectByPointer :
+	POBJECT_HEADER ObjectHeader = OBJECT_TO_OBJECT_HEADER(Object);
+	InterlockedIncrement(&ObjectHeader->PointerCount);
 }

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -50,6 +50,7 @@ namespace xboxkrnl
 #include "Emu.h" // For EmuWarning()
 #include "EmuKrnl.h" // For OBJECT_TO_OBJECT_HEADER()
 #include "EmuKrnlKe.h" // For KeLowerIrql()
+#include "EmuKrnlOb.h" // For ObpDefaultObject
 #include "EmuFile.h" // For EmuNtSymbolicLinkObject, NtStatusToString(), etc.
 
 #pragma warning(disable:4005) // Ignore redefined status values

--- a/src/CxbxKrnl/EmuKrnlOb.cpp
+++ b/src/CxbxKrnl/EmuKrnlOb.cpp
@@ -313,7 +313,9 @@ XBSYSAPI EXPORTNUM(241) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ObInsertObject
 		LOG_FUNC_ARG_OUT(Handle)
 		LOG_FUNC_END;
 
-	LOG_UNIMPLEMENTED();
+	*Handle = EmuObCreateObjectHandle(Object);
+
+	LOG_INCOMPLETE();
 
 	RETURN(S_OK);
 }
@@ -463,8 +465,12 @@ XBSYSAPI EXPORTNUM(246) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ObReferenceObjectByHa
 
 	NTSTATUS Status = EmuObFindObjectByHandle(Handle, ReturnedObject);
 
-	if (NT_SUCCESS(Status))
-		Status = ObReferenceObjectByPointer(ReturnedObject, ObjectType);
+	if (NT_SUCCESS(Status)) {
+		Status = ObReferenceObjectByPointer(*ReturnedObject, ObjectType);
+		if (Status == STATUS_OBJECT_TYPE_MISMATCH) {
+			ObfDereferenceObject(*ReturnedObject);
+		}
+	}
 
 	RETURN(Status);
 }
@@ -491,8 +497,12 @@ XBSYSAPI EXPORTNUM(247) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ObReferenceObjectByNa
 
 	NTSTATUS Status = EmuObFindObjectByName(ObjectName, Object); 
 
-	if (NT_SUCCESS(Status))
-		Status = ObReferenceObjectByPointer(Object, ObjectType);
+	if (NT_SUCCESS(Status)) {
+		Status = ObReferenceObjectByPointer(*Object, ObjectType);
+		if (Status == STATUS_OBJECT_TYPE_MISMATCH) {
+			ObfDereferenceObject(*Object);
+		}
+	}
 
 	RETURN(Status);
 }

--- a/src/CxbxKrnl/EmuKrnlOb.h
+++ b/src/CxbxKrnl/EmuKrnlOb.h
@@ -1,0 +1,36 @@
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->src->CxbxKrnl->EmuKrnlOb.h
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2018 Patrick van Logchem <pvanlogchem@gmail.com>
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+#pragma once
+
+extern xboxkrnl::KEVENT ObpDefaultObject;

--- a/src/CxbxKrnl/EmuNtDll.h
+++ b/src/CxbxKrnl/EmuNtDll.h
@@ -1484,6 +1484,15 @@ typedef NTSTATUS(NTAPI *FPTR_NtPulseEvent)
 );
 
 // ******************************************************************
+// * NtResetEvent
+// ******************************************************************
+typedef NTSTATUS(NTAPI *FPTR_NtResetEvent)
+(
+	IN HANDLE	EventHandle,
+	OUT PLONG	PreviousState OPTIONAL
+);
+
+// ******************************************************************
 // * NtCreateMutant
 // ******************************************************************
 typedef NTSTATUS (NTAPI *FPTR_NtCreateMutant)
@@ -1955,6 +1964,7 @@ EXTERN(NtQueueApcThread);
 EXTERN(NtReadFile);
 EXTERN(NtReleaseMutant);
 EXTERN(NtReleaseSemaphore);
+EXTERN(NtResetEvent);
 EXTERN(NtResumeThread);
 EXTERN(NtSetEvent);
 EXTERN(NtSetInformationFile);

--- a/src/CxbxKrnl/EmuNtDll.h
+++ b/src/CxbxKrnl/EmuNtDll.h
@@ -1484,15 +1484,6 @@ typedef NTSTATUS(NTAPI *FPTR_NtPulseEvent)
 );
 
 // ******************************************************************
-// * NtResetEvent
-// ******************************************************************
-typedef NTSTATUS(NTAPI *FPTR_NtResetEvent)
-(
-	IN HANDLE	EventHandle,
-	OUT PLONG	PreviousState OPTIONAL
-);
-
-// ******************************************************************
 // * NtCreateMutant
 // ******************************************************************
 typedef NTSTATUS (NTAPI *FPTR_NtCreateMutant)
@@ -1964,7 +1955,6 @@ EXTERN(NtQueueApcThread);
 EXTERN(NtReadFile);
 EXTERN(NtReleaseMutant);
 EXTERN(NtReleaseSemaphore);
-EXTERN(NtResetEvent);
 EXTERN(NtResumeThread);
 EXTERN(NtSetEvent);
 EXTERN(NtSetInformationFile);


### PR DESCRIPTION

### It's possible this PR causes regressions, so DON'T MERGE this without solid testing! 
(If any regression occurs, add a comment with enough details, so it can be investigated properly.)


This pull request stops using NtDll for Events, but instead, uses public Windows API's (`CreateEvent`, `PulseEvent`, etc).
This is also reflected in the various `WaitFor` functions and even `NtClose`.

Also, a lot of API's are copied over from OpenXbox and various symbol declarations are put in their own headers files.

One of the positive effects of this work is, that the https://github.com/Luca1991/xbox_kernel_test_suite can run to completion, passing all tests (even the ones added by https://github.com/Fisherman166/xbox_kernel_test_suite/commits/CriticalSection_tests).

Homebrew build using NXDK and/or pbkit will run further too (although we need proper LLE GPU to let these show anything).
