### PR TITLE
Introduce GetVertexBufferSize and use it to determine the size of buffers for patching

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -87,7 +87,7 @@ static DWORD WINAPI                 EmuRenderWindow(LPVOID);
 static DWORD WINAPI                 EmuCreateDeviceProxy(LPVOID);
 static LRESULT WINAPI               EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 static DWORD WINAPI                 EmuUpdateTickCount(LPVOID);
-static inline void                  EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource);
+static inline void                  EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD dwSize);
 static void                         EmuAdjustPower2(UINT *dwWidth, UINT *dwHeight);
 static void							UpdateCurrentMSpFAndFPS(); // Used for benchmarking/fps count
 
@@ -795,13 +795,13 @@ void ForceResourceRehash(XTL::X_D3DResource* pXboxResource)
 	}
 }
 
-XTL::IDirect3DResource8 *GetHostResource(XTL::X_D3DResource *pXboxResource, bool shouldRegister = true)
+XTL::IDirect3DResource8 *GetHostResource(XTL::X_D3DResource *pXboxResource, bool shouldRegister = true, DWORD dwSize = 0)
 {
 	if (pXboxResource == NULL || pXboxResource->Data == NULL)
 		return nullptr;
 
 	if (shouldRegister) {
-		EmuVerifyResourceIsRegistered(pXboxResource);
+		EmuVerifyResourceIsRegistered(pXboxResource, dwSize);
 	}
 
 	if (IsSpecialXboxResource(pXboxResource)) // Was X_D3DRESOURCE_DATA_YUV_SURFACE
@@ -859,7 +859,7 @@ size_t GetXboxResourceSize(XTL::X_D3DResource* pXboxResource)
 	
 }
 
-bool HostResourceRequiresUpdate(resource_key_t key)
+bool HostResourceRequiresUpdate(resource_key_t key, DWORD dwSize)
 {
 	auto it = g_HostResources.find(key);
 	if (it == g_HostResources.end()) {
@@ -871,6 +871,12 @@ bool HostResourceRequiresUpdate(resource_key_t key)
 	DWORD type = GetXboxCommonResourceType(it->second.pXboxResource);
 	if (type != X_D3DCOMMON_TYPE_SURFACE && type != X_D3DCOMMON_TYPE_TEXTURE && type != X_D3DCOMMON_TYPE_VERTEXBUFFER) {
 		return false;
+	}
+
+	// If the resource size got bigger, we need to re-create it
+	// if it got smaller, just hashing will suffice
+	if (dwSize > it->second.szXboxDataSize) {
+		return true;
 	}
 
 	bool modified = false;
@@ -902,7 +908,7 @@ bool HostResourceRequiresUpdate(resource_key_t key)
 	return modified;
 }
 
-void SetHostResource(XTL::X_D3DResource* pXboxResource, XTL::IDirect3DResource8* pHostResource)
+void SetHostResource(XTL::X_D3DResource* pXboxResource, XTL::IDirect3DResource8* pHostResource, DWORD dwSize = 0)
 {
 	auto key = GetHostResourceKey(pXboxResource);
 	auto it = g_HostResources.find(key);
@@ -914,7 +920,7 @@ void SetHostResource(XTL::X_D3DResource* pXboxResource, XTL::IDirect3DResource8*
 	hostResourceInfo.pHostResource = pHostResource;
 	hostResourceInfo.pXboxResource = pXboxResource;
 	hostResourceInfo.pXboxData = GetDataFromXboxResource(pXboxResource);
-	hostResourceInfo.szXboxDataSize = GetXboxResourceSize(pXboxResource);
+	hostResourceInfo.szXboxDataSize = dwSize > 0 ? dwSize : GetXboxResourceSize(pXboxResource);
 	hostResourceInfo.hash = XXHash32::hash(hostResourceInfo.pXboxData, hostResourceInfo.szXboxDataSize, 0);
 	hostResourceInfo.hashLifeTime = 1ms;
     hostResourceInfo.lastUpdate = std::chrono::high_resolution_clock::now();
@@ -978,14 +984,14 @@ XTL::IDirect3DIndexBuffer8 *GetHostIndexBuffer(XTL::X_D3DResource *pXboxResource
 	return (XTL::IDirect3DIndexBuffer8*)GetHostResource(pXboxResource);;
 }
 
-XTL::IDirect3DVertexBuffer8 *GetHostVertexBuffer(XTL::X_D3DResource *pXboxResource)
+XTL::IDirect3DVertexBuffer8 *GetHostVertexBuffer(XTL::X_D3DResource *pXboxResource, DWORD dwSize)
 {
 	if (pXboxResource == NULL)
 		return nullptr;
 
 	assert(GetXboxCommonResourceType(pXboxResource) == X_D3DCOMMON_TYPE_VERTEXBUFFER);
 
-	return (XTL::IDirect3DVertexBuffer8*)GetHostResource(pXboxResource);
+	return (XTL::IDirect3DVertexBuffer8*)GetHostResource(pXboxResource, true, dwSize);
 }
 
 void SetHostSurface(XTL::X_D3DResource *pXboxResource, XTL::IDirect3DSurface8 *pHostSurface)
@@ -1028,12 +1034,12 @@ void SetHostIndexBuffer(XTL::X_D3DResource *pXboxResource, XTL::IDirect3DIndexBu
 	SetHostResource(pXboxResource, (XTL::IDirect3DResource8*)pHostIndexBuffer);
 }
 
-void SetHostVertexBuffer(XTL::X_D3DResource *pXboxResource, XTL::IDirect3DVertexBuffer8 *pHostVertexBuffer)
+void SetHostVertexBuffer(XTL::X_D3DResource *pXboxResource, XTL::IDirect3DVertexBuffer8 *pHostVertexBuffer, DWORD dwSize)
 {
 	assert(pXboxResource != NULL);
 	assert(GetXboxCommonResourceType(pXboxResource) == X_D3DCOMMON_TYPE_VERTEXBUFFER);
 
-	SetHostResource(pXboxResource, (XTL::IDirect3DResource8*)pHostVertexBuffer);
+	SetHostResource(pXboxResource, (XTL::IDirect3DResource8*)pHostVertexBuffer, dwSize);
 }
 
 int XboxD3DPaletteSizeToBytes(const XTL::X_D3DPALETTESIZE Size)
@@ -2188,7 +2194,8 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 }
 
 // check if a resource has been registered yet (if not, register it)
-static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource)
+VOID WINAPI CreateHostResource(XTL::X_D3DResource *pThis, DWORD dwSize); // Forward declartion to prevent restructure of code
+static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD dwSize = 0)
 {
 	// Skip resources without data
 	if (pResource->Data == NULL)
@@ -2200,14 +2207,14 @@ static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource)
 
 	auto key = GetHostResourceKey(pResource);
 	if (std::find(g_RegisteredResources.begin(), g_RegisteredResources.end(), key) != g_RegisteredResources.end()) {
-		if (!HostResourceRequiresUpdate(key)) {
+		if (!HostResourceRequiresUpdate(key, dwSize)) {
 			return;
 		}
 
 		FreeHostResource(key);
 	}
 
-	XTL::EMUPATCH(D3DResource_Register)(pResource, /* Base = */NULL);
+	CreateHostResource(pResource, dwSize);
         
 	g_RegisteredResources.push_back(key);
 }
@@ -4682,12 +4689,13 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 // ******************************************************************
 // * patch: IDirect3DResource8_Register
 // ******************************************************************
-VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
+VOID WINAPI CreateHostResource
 (
-    X_D3DResource      *pThis,
-    PVOID               pBase
+    XTL::X_D3DResource      *pThis,
+    DWORD               dwSize
 )
 {
+	using namespace XTL;
 	//FUNC_EXPORTS
 
 	LOG_FUNC_BEGIN
@@ -4721,8 +4729,12 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
 
             // create vertex buffer
             {
-                DWORD dwSize = g_VMManager.QuerySize((VAddr)pVirtualAddr);
+				// If we didn't get a size passed in, use QuerySize
+				if (dwSize == 0) {
+					g_VMManager.QuerySize((VAddr)pVirtualAddr);
+				}
 
+				// If we still didn't get a valid size, make a wild guess
                 if(dwSize == 0)
                 {
                     // TODO: once this is known to be working, remove the warning
@@ -4731,17 +4743,6 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
 					/*hRet = E_FAIL;
 					goto fail;*/
                 }
-
-				// Dirty hack: Vetrex buffers shouldn't be this big... so cap the size
-				// TODO: Until we solve the root cause (which is the same memory region containing multiple smaller buffers,
-				// or Vertex buffers embedded in the XBE instead of allocated at runtime) this has to stay...
-				// This is one of two tweaks that prevents memory usage spiralling out of control  (the other is VertexPatcher changes)
-				// Some titles ended up allocating multiple > 50MB buffers because of this!
-				// Once VertexPatcher is updated to create it's own host buffers for unpatched resources (with VertexCount being known at that point)
-				// this will no longer be required, and we can create a correctly sized vertex buffer at that point.
-				if (dwSize > ONE_MB) {
-					dwSize = ONE_MB;
-				}
 
                 hRet = g_pD3DDevice8->CreateVertexBuffer
                 (
@@ -4759,7 +4760,7 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_Register)
 					EmuWarning( szString );
 				}
 
-				SetHostVertexBuffer(pResource, pNewHostVertexBuffer);
+				SetHostVertexBuffer(pResource, pNewHostVertexBuffer, dwSize);
 
                 #ifdef _DEBUG_TRACK_VB
                 g_VBTrackTotal.insert(pNewHostVertexBuffer);
@@ -6921,6 +6922,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
     VPDesc.pVertexStreamZeroData = 0;
     VPDesc.uiVertexStreamZeroStride = 0;
     VPDesc.hVertexShader = g_CurrentVertexShader;
+	VPDesc.pIndexData = pIndexData;
 
     VertexPatcher VertPatch;
 	bool FatalError = false;
@@ -7038,6 +7040,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
     VPDesc.pVertexStreamZeroData = pVertexStreamZeroData;
     VPDesc.uiVertexStreamZeroStride = VertexStreamZeroStride;
     VPDesc.hVertexShader = g_CurrentVertexShader;
+	VPDesc.pIndexData = (PWORD)pIndexData;
 
     VertexPatcher VertPatch;
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -731,14 +731,13 @@ void *GetDataFromXboxResource(XTL::X_D3DResource *pXboxResource)
 	DWORD Type = GetXboxCommonResourceType(pXboxResource);
 	switch (Type) {
 	case X_D3DCOMMON_TYPE_VERTEXBUFFER:
-	case X_D3DCOMMON_TYPE_INDEXBUFFER:
 	case X_D3DCOMMON_TYPE_PALETTE:
 	case X_D3DCOMMON_TYPE_TEXTURE:
 	case X_D3DCOMMON_TYPE_SURFACE:
-		pData |= MM_SYSTEM_PHYSICAL_MAP;
+			pData |= MM_SYSTEM_PHYSICAL_MAP;
 		break;
 	case X_D3DCOMMON_TYPE_PUSHBUFFER:
-		break;
+	case X_D3DCOMMON_TYPE_INDEXBUFFER:
 	case X_D3DCOMMON_TYPE_FIXUP:
 		break;
 	default:
@@ -4725,7 +4724,7 @@ VOID WINAPI CreateHostResource
 			XTL::IDirect3DVertexBuffer8  *pNewHostVertexBuffer = nullptr;
 
 			// Vertex buffers live in Physical Memory Region
-			void* pVirtualAddr = (void*)((xbaddr)pThis->Data | MM_SYSTEM_PHYSICAL_MAP);
+			void* pVirtualAddr = GetDataFromXboxResource(pResource);
 
             // create vertex buffer
             {
@@ -4821,7 +4820,7 @@ VOID WINAPI CreateHostResource
                 DbgPrintf("EmuIDirect3DResource8_Register :-> Texture...\n");
             }
 
-			void* pVirtualAddr = (void*)((xbaddr)pThis->Data | MM_SYSTEM_PHYSICAL_MAP);
+			void* pVirtualAddr = GetDataFromXboxResource(pResource);
 
 			X_D3DPixelContainer *pPixelContainer = (X_D3DPixelContainer*)pResource;
 
@@ -5127,7 +5126,7 @@ VOID WINAPI CreateHostResource
                             }
                         }
 
-                        BYTE *pSrc = (BYTE*)(pThis->Data | MM_SYSTEM_PHYSICAL_MAP); // TODO : Fix (look at Dxbx) this, as it gives cube textures identical sides
+						BYTE *pSrc = (BYTE*)GetDataFromXboxResource(pResource); // TODO : Fix (look at Dxbx) this, as it gives cube textures identical sides
 
                         if(( pResource->Data == X_D3DRESOURCE_DATA_BACK_BUFFER)
                          ||( (DWORD)pThis->Data == X_D3DRESOURCE_DATA_BACK_BUFFER))
@@ -7027,7 +7026,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 
 
 	CxbxUpdateNativeD3DResources();
-	CxbxUpdateActiveIndexBuffer((PWORD)pIndexData, VertexCount);
 
     if( (PrimitiveType == X_D3DPT_LINELOOP) || (PrimitiveType == X_D3DPT_QUADLIST) )
         EmuWarning("Unsupported PrimitiveType! (%d)", (DWORD)PrimitiveType);

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4699,7 +4699,7 @@ VOID WINAPI CreateHostResource
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
-		LOG_FUNC_ARG(pBase)
+		LOG_FUNC_ARG(dwSize)
 		LOG_FUNC_END;
 
     HRESULT hRet = D3D_OK;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2109,7 +2109,7 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
                 );
 				DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->CreateVertexBuffer");
 
-                for(int Streams = 0; Streams < 8; Streams++)
+                for(int Streams = 0; Streams < 16; Streams++)
                 {
                     hRet = g_pD3DDevice8->SetStreamSource(Streams, g_pDummyBuffer, 1);
 					DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->SetStreamSource");

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -259,7 +259,7 @@ bool XTL::VertexPatcher::ApplyCachedStream(VertexPatchDesc *pPatchDesc,
 
         uiStride  = pPatchDesc->uiVertexStreamZeroStride;
         pCalculateData = (uint08 *)pPatchDesc->pVertexStreamZeroData;
-        uiLength = GetVertexBufferSize(pPatchDesc->dwPrimitiveCount, uiStride, pPatchDesc->pIndexData);
+        uiLength = GetVertexBufferSize(pPatchDesc->dwVertexCount, uiStride, pPatchDesc->pIndexData);
         uiKey = (uint32)pCalculateData;
         //pCachedStream->bIsUP = true;
         //pCachedStream->pStreamUP = pCalculateData;

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -418,7 +418,7 @@ bool XTL::VertexPatcher::PatchStream(VertexPatchDesc *pPatchDesc,
 		uiLength = GetVertexBufferSize(pPatchDesc->dwVertexCount, uiStride, pPatchDesc->pIndexData);
 
         // Set a new (exact) vertex count
-		uiVertexCount = pPatchDesc->dwVertexCount;
+		uiVertexCount = uiLength / uiStride;
 
 		// Dxbx addition : Don't update pPatchDesc.dwVertexCount because an indexed draw
 		// can (and will) use less vertices than the supplied nr of indexes. Thix fixes
@@ -448,9 +448,9 @@ bool XTL::VertexPatcher::PatchStream(VertexPatchDesc *pPatchDesc,
         uiStride  = pPatchDesc->uiVertexStreamZeroStride;
 		pStreamPatch->ConvertedStride = max(pStreamPatch->ConvertedStride, uiStride); // ??
 		pOrigData = (uint08 *)pPatchDesc->pVertexStreamZeroData;
-        // TODO: This is sometimes the number of indices, which isn't too good
-		uiVertexCount = pPatchDesc->dwVertexCount;
-        dwNewSize = GetVertexBufferSize(uiVertexCount, pStreamPatch->ConvertedStride, pPatchDesc->pIndexData);
+		uiLength = GetVertexBufferSize(pPatchDesc->dwVertexCount, uiStride, pPatchDesc->pIndexData);
+		uiVertexCount = uiLength / uiStride;
+		dwNewSize = uiVertexCount * pStreamPatch->ConvertedStride;
         pNewVertexBuffer = NULL;
         pNewData = (uint08*)g_VMManager.Allocate(dwNewSize);
         if(!pNewData)
@@ -653,7 +653,8 @@ bool XTL::VertexPatcher::NormalizeTexCoords(VertexPatchDesc *pPatchDesc, UINT ui
         pNewVertexBuffer = 0;
         pData = (uint08 *)pPatchDesc->pVertexStreamZeroData;
         uiStride = pPatchDesc->uiVertexStreamZeroStride;
-        uiVertexCount = pPatchDesc->dwVertexCount;
+		DWORD uiLength = GetVertexBufferSize(pPatchDesc->dwVertexCount, uiStride, pPatchDesc->pIndexData);
+        uiVertexCount = uiLength / uiStride;
     }
     else
     {
@@ -662,7 +663,7 @@ bool XTL::VertexPatcher::NormalizeTexCoords(VertexPatchDesc *pPatchDesc, UINT ui
 		uiStride = g_D3DStreamStrides[uiStream];
 		UINT uiLength = GetVertexBufferSize(pPatchDesc->dwVertexCount, uiStride, pPatchDesc->pIndexData);
 
-		uiVertexCount = pPatchDesc->dwVertexCount;
+		uiVertexCount = uiLength / uiLength;
 
 		uint08 *pOrigData = (uint08*)GetDataFromXboxResource(pOrigVertexBuffer);
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -120,7 +120,7 @@ size_t GetVertexBufferSize(DWORD dwVertexCount, DWORD dwStride, PWORD pIndexData
 	}
 
 	// Vertex Buffer Size must be a multiple of PAGE_SIZE
-	vertexBufferSize = (((vertexBufferSize + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE);
+	//vertexBufferSize = (((vertexBufferSize + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE);
 	return vertexBufferSize;
 }
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -283,9 +283,13 @@ bool XTL::VertexPatcher::ApplyCachedStream(VertexPatchDesc *pPatchDesc,
 				pCalculateData = (void*)GetDataFromXboxResource(pOrigVertexBuffer);
             }
 
-            uint32_t uiHash = XXHash32::hash((void *)pCalculateData, uiLength, HASH_SEED);
+            uint32_t uiHash = XXHash32::hash((void *)pCalculateData, pCachedStream->uiLength, HASH_SEED);
 			*pHash = uiHash;
-            if(uiHash == pCachedStream->uiHash)
+			
+			// If the hash didn't change and the length didn't increase, use the cached stream
+			// If the length increased,we have more data then before and we must re-create the
+			// vertex buffer
+            if(uiHash == pCachedStream->uiHash && uiLength <= pCachedStream->uiLength)
             {
                 // Take a while longer to check
                 if(pCachedStream->uiCheckFrequency < 32*1024)

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -663,7 +663,7 @@ bool XTL::VertexPatcher::NormalizeTexCoords(VertexPatchDesc *pPatchDesc, UINT ui
 		uiStride = g_D3DStreamStrides[uiStream];
 		UINT uiLength = GetVertexBufferSize(pPatchDesc->dwVertexCount, uiStride, pPatchDesc->pIndexData);
 
-		uiVertexCount = uiLength / uiLength;
+		uiVertexCount = uiLength / uiStride;
 
 		uint08 *pOrigData = (uint08*)GetDataFromXboxResource(pOrigVertexBuffer);
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -102,7 +102,7 @@ void XTL::VertexPatcher::DumpCache(void)
 }
 
 size_t GetVertexBufferSize(DWORD dwVertexCount, DWORD dwStride, PWORD pIndexData)
-{
+{	
 	// If this is not an indexed draw, the size is simply VertexCount * Stride
 	if (pIndexData == nullptr) {
 		return dwVertexCount * dwStride;
@@ -349,6 +349,11 @@ UINT XTL::VertexPatcher::GetNbrStreams(VertexPatchDesc *pPatchDesc)
         }
         else
         {
+			// Draw..Up always have one stream
+			if (pPatchDesc->pVertexStreamZeroData != nullptr) {
+				return 1;
+			}
+
 			int lastStreamIndex;
 			for (int i = 0; i < 16; i++) {
 				if (g_D3DStreams[i] != nullptr) {

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -283,13 +283,10 @@ bool XTL::VertexPatcher::ApplyCachedStream(VertexPatchDesc *pPatchDesc,
 				pCalculateData = (void*)GetDataFromXboxResource(pOrigVertexBuffer);
             }
 
-            uint32_t uiHash = XXHash32::hash((void *)pCalculateData, pCachedStream->uiLength, HASH_SEED);
+            uint32_t uiHash = XXHash32::hash((void *)pCalculateData, uiLength, HASH_SEED);
 			*pHash = uiHash;
 			
-			// If the hash didn't change and the length didn't increase, use the cached stream
-			// If the length increased,we have more data then before and we must re-create the
-			// vertex buffer
-            if(uiHash == pCachedStream->uiHash && uiLength <= pCachedStream->uiLength)
+            if(uiHash == pCachedStream->uiHash)
             {
                 // Take a while longer to check
                 if(pCachedStream->uiCheckFrequency < 32*1024)

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -50,6 +50,7 @@ typedef struct _VertexPatchDesc
     IN     UINT                  uiVertexStreamZeroStride;
     // The current vertex shader, used to identify the streams
     IN     DWORD                 hVertexShader;
+	IN	   PWORD				 pIndexData = nullptr;
 }
 VertexPatchDesc;
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -106,7 +106,8 @@ class VertexPatcher
 
         // Caches a patched stream
         void CacheStream(VertexPatchDesc *pPatchDesc,
-                         UINT             uiStream);
+                         UINT             uiStream,
+						 uint32_t		  uiHash);
 
         // Frees a cached, patched stream
         void FreeCachedStream(void *pStream);
@@ -114,7 +115,8 @@ class VertexPatcher
         // Tries to apply a previously patched stream from the cache
         bool ApplyCachedStream(VertexPatchDesc *pPatchDesc,
                                UINT             uiStream,
-							   bool			   *pbFatalError);
+							   bool			   *pbFatalError,
+							   uint32_t        *uiHash);
 
         // Patches the types of the stream
         bool PatchStream(VertexPatchDesc *pPatchDesc, UINT uiStream);

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1780,7 +1780,7 @@ static void VshConverToken_TESSELATOR(DWORD   *pToken,
 
 static boolean VshAddStreamPatch(VSH_PATCH_DATA *pPatchData)
 {
-    int CurrentStream = pPatchData->StreamPatchData.NbrStreams - 1; // TODO : Should we use pPatchData->CurrentStreamNumber?
+    int CurrentStream = pPatchData->CurrentStreamNumber;
 
     if(CurrentStream >= 0)
     {
@@ -1816,6 +1816,7 @@ static void VshConvertToken_STREAM(DWORD          *pToken,
     {
         XTL::DWORD StreamNumber = VshGetVertexStream(*pToken);
         DbgVshPrintf("\tD3DVSD_STREAM(%d),\n", StreamNumber);
+		pPatchData->CurrentStreamNumber = (WORD)StreamNumber;
 
         // new stream
         // copy current data to structure
@@ -1829,9 +1830,9 @@ static void VshConvertToken_STREAM(DWORD          *pToken,
 			pPatchData->StreamPatchData.NbrStreams = 0; // Dxbx addition
 		}
 
-		pPatchData->CurrentStreamNumber = (WORD)StreamNumber;
-		
-		pPatchData->StreamPatchData.NbrStreams++;
+		if (StreamNumber >= pPatchData->StreamPatchData.NbrStreams) {
+			pPatchData->StreamPatchData.NbrStreams = StreamNumber + 1;
+		}	
     }
 }
 

--- a/src/CxbxKrnl/EmuKrnlMm.cpp
+++ b/src/CxbxKrnl/EmuKrnlMm.cpp
@@ -260,7 +260,12 @@ XBSYSAPI EXPORTNUM(170) xboxkrnl::VOID NTAPI xboxkrnl::MmDeleteKernelStack
 
 	VAddr StackBottom = (VAddr)StackBase - ActualSize;
 
-	g_VMManager.DeallocateStack(StackBottom);
+	// TODO: Why does this end up trying to deallocate a non-VMManager page
+	// Could be that we don't properly emulate the KPCR? 
+	// The KPCRs stack base / stack limit never get updated by push/pop
+	// as the host stack ends up being used...
+	EmuWarning("xboxkrnl::MmDeleteKernelStack Ignored");
+	//g_VMManager.DeallocateStack(StackBottom);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/xxhash32.h
+++ b/src/CxbxKrnl/xxhash32.h
@@ -121,18 +121,6 @@ public:
 	@return 32 bit XXHash **/
 	static uint32_t hash(const void* input, uint64_t length, uint32_t seed)
 	{
-		// TODO: This is the same hack as vertex buffer size
-		// but here it prevents hashing from destroying performance
-		// in titles like Zapper and Shemnue II.
-		// Like the other occurance of this hack, this could be solved
-		// by properly calculating vertex buffer size at draw time.
-		// But because of index buffers, it's not as easy as using
-		// the vertex count.
-		#define ONE_MB (1024 * 1024)
-		if (length > ONE_MB) {
-			length = ONE_MB;
-		}
-
 		// Some modern CPUs support hardware accellerated CRC32
 		// This is significantly faster than xxHash, in some cases, by more than double
 		// So now we check for this capability and use it if it exists.


### PR DESCRIPTION
The end result is less missing polygons/better rendering in many titles.

With this, the dashboard runs a little slower, but renders much better.

Many other titles render better with no performance impact, and in some cases, perform much faster than before, due to better caching/reducing the amount of hashing required.