### PR TITLE
Force VSync on by default

### DIFF
--- a/src/Common/Win32/XBVideo.cpp
+++ b/src/Common/Win32/XBVideo.cpp
@@ -40,7 +40,7 @@
 // ******************************************************************
 // * func: XBVideo::XBVideo
 // ******************************************************************
-XBVideo::XBVideo() : m_bVSync(false), m_bFullscreen(false), m_bHardwareYUV(false)
+XBVideo::XBVideo() : m_bVSync(true), m_bFullscreen(false), m_bHardwareYUV(false)
 {
     strcpy(m_szVideoResolution, "Automatic (Default)");
 }


### PR DESCRIPTION
As discussed in #966, this PR enables V-sync by default when there is no related registry entry, also did confirm LLE options are disabled with a clean registry