### PR TITLE
Fix a regression where some FMVs stopped rendering after D3D8to9 was introduced

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4864,8 +4864,11 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_UpdateOverlay)
 
 		// Update overlay if present was not called since the last call to
 		// EmuD3DDevice_UpdateOverlay.
-		if(g_bHackUpdateSoftwareOverlay)
+		if (g_bHackUpdateSoftwareOverlay) {
+			g_pD3DDevice8->EndScene();
 			g_pD3DDevice8->Present(0, 0, 0, 0);
+			g_pD3DDevice8->BeginScene();
+		}
 
 		g_bHackUpdateSoftwareOverlay = TRUE;
 	}   


### PR DESCRIPTION
Test case: xonlinedash 4920)