### PR TITLE
IVB : Renames and refactorings, copied over from WIP_LessVertexPatching.

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3551,18 +3551,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_Begin)
 
 	LOG_FUNC_ONE_ARG(PrimitiveType);
 
-    g_IVBPrimitiveType = PrimitiveType;
-
-    g_IVBTblOffs = 0;
-    g_IVBFVF = 0;
-
-    // default values
-    ZeroMemory(g_IVBTable, sizeof(XTL::_D3DIVB)*IVB_TABLE_SIZE);
-
-    if(g_pIVBVertexBuffer == nullptr)
-    {
-        g_pIVBVertexBuffer = (DWORD*)g_VMManager.Allocate(IVB_BUFFER_SIZE);
-    }
+    g_InlineVertexBuffer_PrimitiveType = PrimitiveType;
+    g_InlineVertexBuffer_TableOffset = 0;
+    g_InlineVertexBuffer_FVF = 0;
 }
 
 // ******************************************************************
@@ -3628,51 +3619,75 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f)
 
     HRESULT hRet = D3D_OK;
 
-	int o = g_IVBTblOffs;
+	// Grow g_InlineVertexBuffer_Table to contain at least current, and a potentially next vertex
+	if (g_InlineVertexBuffer_TableLength <= g_InlineVertexBuffer_TableOffset + 1) {
+		if (g_InlineVertexBuffer_TableLength == 0) {
+			g_InlineVertexBuffer_TableLength = PAGE_SIZE / sizeof(struct _D3DIVB);
+		} else {
+			g_InlineVertexBuffer_TableLength *= 2;
+		}
 
-	if (o >= IVB_TABLE_SIZE) {
-		CxbxKrnlCleanup("Overflow g_IVBTblOffs : %d", o);
+		g_InlineVertexBuffer_Table = (struct _D3DIVB*)realloc(g_InlineVertexBuffer_Table, sizeof(struct _D3DIVB) * g_InlineVertexBuffer_TableLength);
+		DbgPrintf("Reallocated g_InlineVertexBuffer_Table to %d entries\n", g_InlineVertexBuffer_TableLength);
 	}
+
+	// Is this the initial call after D3DDevice_Begin() ?
+	if (g_InlineVertexBuffer_FVF == 0) {
+		// Set first vertex to zero (preventing leaks from prior Begin/End calls)
+		g_InlineVertexBuffer_Table[0] = {};
+	}
+
+	int o = g_InlineVertexBuffer_TableOffset;
 
     switch(Register)
     {
-        // TODO: Blend weight.
-
+        case X_D3DVSDE_VERTEX:
         case X_D3DVSDE_POSITION:
         {
-            g_IVBTable[o].Position.x = a;
-            g_IVBTable[o].Position.y = b;
-            g_IVBTable[o].Position.z = c;
-            g_IVBTable[o].Rhw = 1.0f;
+            g_InlineVertexBuffer_Table[o].Position.x = a;
+            g_InlineVertexBuffer_Table[o].Position.y = b;
+			g_InlineVertexBuffer_Table[o].Position.z = c;
+			g_InlineVertexBuffer_Table[o].Rhw = d; // Was : 1.0f; // Dxbx note : Why set Rhw to 1.0? And why ignore d?
 
-            g_IVBTblOffs++;
+			if ((g_InlineVertexBuffer_FVF & D3DFVF_POSITION_MASK) == 0) {
+				g_InlineVertexBuffer_FVF = D3DFVF_XYZRHW;
+			}
 
-            g_IVBFVF |= D3DFVF_XYZRHW;
-	        break;
+			// Start a new vertex
+			g_InlineVertexBuffer_TableOffset++;
+			// Copy all attributes of the previous vertex (if any) to the new vertex
+			static UINT uiPreviousOffset = ~0; // Can't use 0, as that may be copied too
+			if (uiPreviousOffset != ~0) {
+				g_InlineVertexBuffer_Table[g_InlineVertexBuffer_TableOffset] = g_InlineVertexBuffer_Table[uiPreviousOffset];
+			}
+			uiPreviousOffset = g_InlineVertexBuffer_TableOffset;
+	
+			break;
         }
 
 		case X_D3DVSDE_BLENDWEIGHT:
 		{
-            g_IVBTable[o].Position.x = a;
-            g_IVBTable[o].Position.y = b;
-            g_IVBTable[o].Position.z = c;
-			g_IVBTable[o].Blend1 = d;
+            g_InlineVertexBuffer_Table[o].Blend[0] = a;
+            g_InlineVertexBuffer_Table[o].Blend[1] = b;
+            g_InlineVertexBuffer_Table[o].Blend[2] = c;
+			g_InlineVertexBuffer_Table[o].Blend[3] = d;
+			// TODO: Test the above. 
+			// TODO: Does or doesn't Xbox support five blendweights? And if so, how is the fifth set?
 
-            g_IVBTblOffs++;
+			if ((g_InlineVertexBuffer_FVF & D3DFVF_POSITION_MASK) == 0) {
+				g_InlineVertexBuffer_FVF = D3DFVF_XYZB1;
+				// TODO: How to select blendweight D3DFVF_XYZB2 or up?
+			}
 
-            g_IVBFVF |= D3DFVF_XYZB1;
-		    break;
+			break;
         }
 
 		case X_D3DVSDE_NORMAL:
         {
-            g_IVBTable[o].Normal.x = a;
-            g_IVBTable[o].Normal.y = b;
-            g_IVBTable[o].Normal.z = c;
-
-            g_IVBTblOffs++;
-
-            g_IVBFVF |= D3DFVF_NORMAL;
+            g_InlineVertexBuffer_Table[o].Normal.x = a;
+            g_InlineVertexBuffer_Table[o].Normal.y = b;
+			g_InlineVertexBuffer_Table[o].Normal.z = c;
+            g_InlineVertexBuffer_FVF |= D3DFVF_NORMAL;
 			break;
         }
 
@@ -3683,9 +3698,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f)
             DWORD cg = FtoDW(b) << 8;
             DWORD cb = FtoDW(c) << 0;
 
-            g_IVBTable[o].dwDiffuse = ca | cr | cg | cb;
-
-            g_IVBFVF |= D3DFVF_DIFFUSE;
+            g_InlineVertexBuffer_Table[o].Diffuse = ca | cr | cg | cb;
+            g_InlineVertexBuffer_FVF |= D3DFVF_DIFFUSE;
 			break;
         }
 
@@ -3696,20 +3710,35 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f)
             DWORD cg = FtoDW(b) << 8;
             DWORD cb = FtoDW(c) << 0;
 
-            g_IVBTable[o].dwSpecular = ca | cr | cg | cb;
-
-            g_IVBFVF |= D3DFVF_SPECULAR;
+            g_InlineVertexBuffer_Table[o].Specular = ca | cr | cg | cb;
+            g_InlineVertexBuffer_FVF |= D3DFVF_SPECULAR;
 			break;
         }
 
+		// TODO case X_D3DVSDE_FOG: ; // Xbox extension
+
+		case X_D3DVSDE_POINTSIZE: {
+			g_InlineVertexBuffer_Table[o].PointSize = a;
+			g_InlineVertexBuffer_FVF |= D3DFVF_PSIZE;
+			break;
+		}
+
+		// TODO case X_D3DVSDE_BACKDIFFUSE: ; // Xbox extension
+
+		// TODO case X_D3DVSDE_BACKSPECULAR: ; // Xbox extension
+
 		case X_D3DVSDE_TEXCOORD0:
         {
-            g_IVBTable[o].TexCoord1.x = a;
-            g_IVBTable[o].TexCoord1.y = b;
-
-            if( (g_IVBFVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX1)
-            {
-                g_IVBFVF |= D3DFVF_TEX1;
+            g_InlineVertexBuffer_Table[o].TexCoord[0].x = a;
+			g_InlineVertexBuffer_Table[o].TexCoord[0].y = b;
+			g_InlineVertexBuffer_Table[o].TexCoord[0].z = c;
+			g_InlineVertexBuffer_Table[o].TexCoord[0].w = d;
+            if ((g_InlineVertexBuffer_FVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX1) {
+				// Dxbx fix : Use mask, else the format might get expanded incorrectly :
+				g_InlineVertexBuffer_FVF &= ~D3DFVF_TEXCOUNT_MASK;
+				g_InlineVertexBuffer_FVF |= D3DFVF_TEX1;
+				// Dxbx note : Correct usage of D3DFVF_TEX1 (and the other cases below)
+				// can be tested with "Daphne Xbox" (the Laserdisc Arcade Game Emulator).
             }
 
 			break;
@@ -3717,59 +3746,44 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f)
 
 		case X_D3DVSDE_TEXCOORD1:
         {
-            g_IVBTable[o].TexCoord2.x = a;
-            g_IVBTable[o].TexCoord2.y = b;
-
-            if( (g_IVBFVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX2)
-            {
-                g_IVBFVF |= D3DFVF_TEX2;
-            }
+            g_InlineVertexBuffer_Table[o].TexCoord[1].x = a;
+			g_InlineVertexBuffer_Table[o].TexCoord[1].y = b;
+			g_InlineVertexBuffer_Table[o].TexCoord[1].z = c;
+			g_InlineVertexBuffer_Table[o].TexCoord[1].w = d;
+			if ((g_InlineVertexBuffer_FVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX2) {
+				g_InlineVertexBuffer_FVF &= ~D3DFVF_TEXCOUNT_MASK;
+				g_InlineVertexBuffer_FVF |= D3DFVF_TEX2;
+			}
 
 			break;
         }
 
 		case X_D3DVSDE_TEXCOORD2:
         {
-            g_IVBTable[o].TexCoord3.x = a;
-            g_IVBTable[o].TexCoord3.y = b;
-
-            if( (g_IVBFVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX3)
-            {
-                g_IVBFVF |= D3DFVF_TEX3;
-            }
+            g_InlineVertexBuffer_Table[o].TexCoord[2].x = a;
+			g_InlineVertexBuffer_Table[o].TexCoord[2].y = b;
+			g_InlineVertexBuffer_Table[o].TexCoord[2].z = c;
+			g_InlineVertexBuffer_Table[o].TexCoord[2].w = d;
+			if ((g_InlineVertexBuffer_FVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX3) {
+				g_InlineVertexBuffer_FVF &= ~D3DFVF_TEXCOUNT_MASK;
+				g_InlineVertexBuffer_FVF |= D3DFVF_TEX3;
+			}
 
 			break;
         }
 
 		case X_D3DVSDE_TEXCOORD3:
         {
-            g_IVBTable[o].TexCoord4.x = a;
-            g_IVBTable[o].TexCoord4.y = b;
-
-            if( (g_IVBFVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX4)
-            {
-                g_IVBFVF |= D3DFVF_TEX4;
-            }
+            g_InlineVertexBuffer_Table[o].TexCoord[3].x = a;
+			g_InlineVertexBuffer_Table[o].TexCoord[3].y = b;
+			g_InlineVertexBuffer_Table[o].TexCoord[3].z = c;
+			g_InlineVertexBuffer_Table[o].TexCoord[3].w = d;
+			if ((g_InlineVertexBuffer_FVF & D3DFVF_TEXCOUNT_MASK) < D3DFVF_TEX4) {
+				g_InlineVertexBuffer_FVF &= ~D3DFVF_TEXCOUNT_MASK;
+				g_InlineVertexBuffer_FVF |= D3DFVF_TEX4;
+			}
 
 	        break;
-        }
-
-        case X_D3DVSDE_VERTEX:
-        {
-            g_IVBTable[o].Position.x = a;
-            g_IVBTable[o].Position.y = b;
-            g_IVBTable[o].Position.z = c;
-            g_IVBTable[o].Rhw = d;
-
-            // Copy current color to next vertex
-            g_IVBTable[o+1].dwDiffuse  = g_IVBTable[o].dwDiffuse;
-            g_IVBTable[o+1].dwSpecular = g_IVBTable[o].dwSpecular;
-
-            g_IVBTblOffs++;
-
-            g_IVBFVF |= D3DFVF_XYZRHW;
-
-			break;
         }
 
         default:
@@ -3849,12 +3863,12 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_End)()
 
 	LOG_FUNC();
 
-    if(g_IVBTblOffs != 0)
+    if(g_InlineVertexBuffer_TableOffset > 0)
         EmuFlushIVB();
 
     // TODO: Should technically clean this up at some point..but on XP doesnt matter much
-//    g_VMManager.Deallocate((VAddr)g_pIVBVertexBuffer);
-//    g_VMManager.Deallocate((VAddr)g_IVBTable);
+//    g_VMManager.Deallocate((VAddr)g_InlineVertexBuffer_pData);
+//    g_VMManager.Deallocate((VAddr)g_InlineVertexBuffer_Table);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.h
@@ -34,6 +34,10 @@
 #ifndef PUSHBUFFER_H
 #define PUSHBUFFER_H
 
+extern int DxbxFVF_GetTextureSize(DWORD dwFVF, int aTextureIndex);
+
+extern UINT DxbxFVFToVertexSizeInBytes(DWORD dwFVF, BOOL bIncludeTextures);
+
 extern void EmuExecutePushBuffer
 (
     X_D3DPushBuffer       *pPushBuffer,

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -52,12 +52,16 @@ extern void EmuUpdateActiveTextureStages();
 #define VERTEX_BUFFER_CACHE_SIZE 256
 #define MAX_STREAM_NOT_USED_TIME (2 * CLOCKS_PER_SEC) // TODO: Trim the not used time
 
-// inline vertex buffer emulation
-XTL::DWORD                  *XTL::g_pIVBVertexBuffer = nullptr;
-XTL::X_D3DPRIMITIVETYPE      XTL::g_IVBPrimitiveType = XTL::X_D3DPT_INVALID;
-UINT                         XTL::g_IVBTblOffs = 0;
-struct XTL::_D3DIVB         XTL::g_IVBTable[IVB_TABLE_SIZE];
-extern DWORD                 XTL::g_IVBFVF = 0;
+// Inline vertex buffer emulation
+extern XTL::X_D3DPRIMITIVETYPE XTL::g_InlineVertexBuffer_PrimitiveType = XTL::X_D3DPT_INVALID;
+extern DWORD                   XTL::g_InlineVertexBuffer_FVF = 0;
+extern struct XTL::_D3DIVB    *XTL::g_InlineVertexBuffer_Table = nullptr;
+extern UINT                    XTL::g_InlineVertexBuffer_TableLength = 0;
+extern UINT                    XTL::g_InlineVertexBuffer_TableOffset = 0;
+
+FLOAT *g_InlineVertexBuffer_pData = nullptr;
+UINT   g_InlineVertexBuffer_DataSize = 0;
+
 extern XTL::X_D3DVertexBuffer      *g_pVertexBuffer = NULL;
 
 extern DWORD				XTL::g_dwPrimPerFrame = 0;
@@ -1052,10 +1056,6 @@ VOID XTL::EmuFlushIVB()
     XTL::EmuUpdateDeferredStates();
 	EmuUpdateActiveTextureStages();
 
-    DWORD *pdwVB = (DWORD*)g_pIVBVertexBuffer;
-
-    UINT uiStride = 0;
-
     // Parse IVB table with current FVF shader if possible.
     bool bFVF = !VshHandleIsVertexShader(g_CurrentVertexShader);
     DWORD dwCurFVF;
@@ -1066,129 +1066,163 @@ VOID XTL::EmuFlushIVB()
 		// HACK: Halo...
 		if(dwCurFVF == 0)
 		{
-			EmuWarning("EmuFlushIVB(): using g_IVBFVF instead of current FVF!");
-			dwCurFVF = g_IVBFVF;
+			EmuWarning("EmuFlushIVB(): using g_InlineVertexBuffer_FVF instead of current FVF!");
+			dwCurFVF = g_InlineVertexBuffer_FVF;
 		}
     }
     else
     {
-        dwCurFVF = g_IVBFVF;
+        dwCurFVF = g_InlineVertexBuffer_FVF;
     }
 
-    DbgPrintf("g_IVBTblOffs := %d\n", g_IVBTblOffs);
+    DbgPrintf("g_InlineVertexBuffer_TableOffset := %d\n", g_InlineVertexBuffer_TableOffset);
 
     DWORD dwPos = dwCurFVF & D3DFVF_POSITION_MASK;
 	DWORD dwTexN = (dwCurFVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+	size_t TexSize[4];
 
-	for(uint v=0;v<g_IVBTblOffs;v++)
-    {
-        if(dwPos == D3DFVF_XYZ)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.y;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.z;
+	for (uint i = 0; i < dwTexN; i++) {
+		TexSize[i] = DxbxFVF_GetTextureSize(dwCurFVF, i);
+	}
 
-            DbgPrintf("IVB Position := {%f, %f, %f}\n", g_IVBTable[v].Position.x, g_IVBTable[v].Position.y, g_IVBTable[v].Position.z);
-        }
-        else if(dwPos == D3DFVF_XYZRHW)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.y;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.z;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Rhw;
-
-            DbgPrintf("IVB Position := {%f, %f, %f, %f, %f}\n", g_IVBTable[v].Position.x, g_IVBTable[v].Position.y, g_IVBTable[v].Position.z, g_IVBTable[v].Position.z, g_IVBTable[v].Rhw);
-        }
-		else if(dwPos == D3DFVF_XYZB1)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.y;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Position.z;
-			*(FLOAT*)pdwVB++ = g_IVBTable[v].Blend1;
-
-			DbgPrintf("IVB Position := {%f, %f, %f, %f}\n", g_IVBTable[v].Position.x, g_IVBTable[v].Position.y, g_IVBTable[v].Position.z, g_IVBTable[v].Blend1);
-        }
-        else
-        {
-			CxbxKrnlCleanup("Unsupported Position Mask (FVF := 0x%.08X dwPos := 0x%.08X)", dwCurFVF, dwPos);
-        }
-
-//      if(dwPos == D3DFVF_NORMAL)	// <- This didn't look right but if it is, change it back...
-		if(dwCurFVF & D3DFVF_NORMAL)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Normal.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Normal.y;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].Normal.z;
-
-            DbgPrintf("IVB Normal := {%f, %f, %f}\n", g_IVBTable[v].Normal.x, g_IVBTable[v].Normal.y, g_IVBTable[v].Normal.z);
-        }
-
-        if(dwCurFVF & D3DFVF_DIFFUSE)
-        {
-            *(DWORD*)pdwVB++ = g_IVBTable[v].dwDiffuse;
-
-            DbgPrintf("IVB Diffuse := 0x%.08X\n", g_IVBTable[v].dwDiffuse);
-        }
-
-        if(dwCurFVF & D3DFVF_SPECULAR)
-        {
-            *(DWORD*)pdwVB++ = g_IVBTable[v].dwSpecular;
-
-            DbgPrintf("IVB Specular := 0x%.08X\n", g_IVBTable[v].dwSpecular);
-        }
-
-        if(dwTexN >= 1)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord1.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord1.y;
-
-            DbgPrintf("IVB TexCoord1 := {%f, %f}\n", g_IVBTable[v].TexCoord1.x, g_IVBTable[v].TexCoord1.y);
-        }
-
-        if(dwTexN >= 2)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord2.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord2.y;
-
-            DbgPrintf("IVB TexCoord2 := {%f, %f}\n", g_IVBTable[v].TexCoord2.x, g_IVBTable[v].TexCoord2.y);
-        }
-
-        if(dwTexN >= 3)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord3.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord3.y;
-
-            DbgPrintf("IVB TexCoord3 := {%f, %f}\n", g_IVBTable[v].TexCoord3.x, g_IVBTable[v].TexCoord3.y);
-        }
-
-        if(dwTexN >= 4)
-        {
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord4.x;
-            *(FLOAT*)pdwVB++ = g_IVBTable[v].TexCoord4.y;
-
-            DbgPrintf("IVB TexCoord4 := {%f, %f}\n", g_IVBTable[v].TexCoord4.x, g_IVBTable[v].TexCoord4.y);
-        }
-
-		uint VertexBufferUsage = (BYTE *)pdwVB - (BYTE *)g_pIVBVertexBuffer;
-
-		if (v == 0)
-		{
-			// Stride is equal to the delta of the first vertex
-			uiStride = VertexBufferUsage;
+	// Use a tooling function to determine the vertex stride :
+	UINT uiStride = DxbxFVFToVertexSizeInBytes(dwCurFVF, /*bIncludeTextures=*/true);
+	// Make sure the output buffer is big enough 
+	UINT NeededSize = g_InlineVertexBuffer_TableOffset * uiStride;
+	if (g_InlineVertexBuffer_DataSize < NeededSize) {
+		g_InlineVertexBuffer_DataSize = NeededSize;
+		if (g_InlineVertexBuffer_pData != nullptr) {
+			free(g_InlineVertexBuffer_pData);
 		}
 
-		if (VertexBufferUsage >= IVB_BUFFER_SIZE)
-		{
-			CxbxKrnlCleanup("Overflow g_pIVBVertexBuffer  : %d", v);
+		g_InlineVertexBuffer_pData = (FLOAT*)malloc(g_InlineVertexBuffer_DataSize);
+	}
+
+    DWORD *pdwVB = (DWORD*)g_InlineVertexBuffer_pData;
+	for(uint v=0;v<g_InlineVertexBuffer_TableOffset;v++)
+    {
+		switch (dwPos) {
+        case D3DFVF_XYZ:
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
+            DbgPrintf("IVB Position := {%f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z);
+			break;
+		case D3DFVF_XYZRHW:
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Rhw;
+            DbgPrintf("IVB Position := {%f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Rhw);
+			break;
+		case D3DFVF_XYZB1:
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
+			DbgPrintf("IVB Position := {%f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0]);
+			break;
+		case D3DFVF_XYZB2:
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[1];
+			DbgPrintf("IVB Position := {%f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1]);
+			break;
+		case D3DFVF_XYZB3:
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[1];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[2];
+			DbgPrintf("IVB Position := {%f, %f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1], g_InlineVertexBuffer_Table[v].Blend[2]);
+			break;
+		case D3DFVF_XYZB4:
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[1];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[2];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[3];
+			DbgPrintf("IVB Position := {%f, %f, %f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1], g_InlineVertexBuffer_Table[v].Blend[2], g_InlineVertexBuffer_Table[v].Blend[3]);
+			break;
+#if 0 // TODO : Does or doesn't Xbox support five blendweights?
+		case D3DFVF_XYZB5:
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[1];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[2];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[3];
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[4];
+			DbgPrintf("IVB Position := {%f, %f, %f, %f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1], g_InlineVertexBuffer_Table[v].Blend[2], g_InlineVertexBuffer_Table[v].Blend[3], g_InlineVertexBuffer_Table[v].Blend[4]);
+			break;
+#endif
+		default:
+			CxbxKrnlCleanup("Unsupported Position Mask (FVF := 0x%.08X dwPos := 0x%.08X)", dwCurFVF, dwPos);
+			break;
+		}
+
+		if (dwCurFVF & D3DFVF_NORMAL) {
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Normal.x;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Normal.y;
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Normal.z;
+            DbgPrintf("IVB Normal := {%f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Normal.x, g_InlineVertexBuffer_Table[v].Normal.y, g_InlineVertexBuffer_Table[v].Normal.z);
+        }
+
+		if (dwCurFVF & D3DFVF_PSIZE) {
+			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].PointSize;
+			DbgPrintf("IVB PointSize := %f\n", g_InlineVertexBuffer_Table[v].PointSize);
+		}
+
+		if (dwCurFVF & D3DFVF_DIFFUSE) {
+            *(DWORD*)pdwVB++ = g_InlineVertexBuffer_Table[v].Diffuse;
+            DbgPrintf("IVB Diffuse := 0x%.08X\n", g_InlineVertexBuffer_Table[v].Diffuse);
+        }
+
+        if (dwCurFVF & D3DFVF_SPECULAR) {
+            *(DWORD*)pdwVB++ = g_InlineVertexBuffer_Table[v].Specular;
+            DbgPrintf("IVB Specular := 0x%.08X\n", g_InlineVertexBuffer_Table[v].Specular);
+        }
+
+		for (uint i = 0; i < dwTexN; i++) {
+            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].x;
+			if (TexSize[i] >= 2) {
+				*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].y;
+				if (TexSize[i] >= 3) {
+					*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].z;
+					if (TexSize[i] >= 4) {
+						*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].w;
+					}
+				}
+			}
+
+			if (g_bPrintfOn) {
+				switch (TexSize[i]) {
+				case 1: DbgPrintf("IVB TexCoord%d := {%f}\n", i + 1, g_InlineVertexBuffer_Table[v].TexCoord[i].x); break;
+				case 2: DbgPrintf("IVB TexCoord%d := {%f, %f}\n", i + 1, g_InlineVertexBuffer_Table[v].TexCoord[i].x, g_InlineVertexBuffer_Table[v].TexCoord[i].y); break;
+				case 3: DbgPrintf("IVB TexCoord%d := {%f, %f, %f}\n", i + 1, g_InlineVertexBuffer_Table[v].TexCoord[i].x, g_InlineVertexBuffer_Table[v].TexCoord[i].y, g_InlineVertexBuffer_Table[v].TexCoord[i].z); break;
+				case 4: DbgPrintf("IVB TexCoord%d := {%f, %f, %f, %f}\n", i + 1, g_InlineVertexBuffer_Table[v].TexCoord[i].x, g_InlineVertexBuffer_Table[v].TexCoord[i].y, g_InlineVertexBuffer_Table[v].TexCoord[i].z, g_InlineVertexBuffer_Table[v].TexCoord[i].w); break;
+				}
+			}
+        }
+
+		if (v == 0) {
+			uint VertexBufferUsage = (uintptr_t)pdwVB - (uintptr_t)g_InlineVertexBuffer_pData;
+			if (VertexBufferUsage != uiStride) {
+				CxbxKrnlCleanup("EmuFlushIVB uses wrong stride!");
+			}
 		}
 	}
 
-    VertexPatchDesc VPDesc;
-
-    VPDesc.XboxPrimitiveType = g_IVBPrimitiveType;
-    VPDesc.dwVertexCount = g_IVBTblOffs;
-    VPDesc.dwStartVertex = 0;
-    VPDesc.pXboxVertexStreamZeroData = g_pIVBVertexBuffer;
+	VertexPatchDesc VPDesc = {};
+    VPDesc.XboxPrimitiveType = g_InlineVertexBuffer_PrimitiveType;
+    VPDesc.dwVertexCount = g_InlineVertexBuffer_TableOffset;
+    VPDesc.pXboxVertexStreamZeroData = g_InlineVertexBuffer_pData;
     VPDesc.uiXboxVertexStreamZeroStride = uiStride;
     VPDesc.hVertexShader = g_CurrentVertexShader;
 
@@ -1216,7 +1250,7 @@ VOID XTL::EmuFlushIVB()
 
     VertPatch.Restore();
 
-    g_IVBTblOffs = 0;
+    g_InlineVertexBuffer_TableOffset = 0;
 
     return;
 }

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -131,33 +131,29 @@ class VertexPatcher
 };
 
 // inline vertex buffer emulation
-extern DWORD                  *g_pIVBVertexBuffer;
-extern X_D3DPRIMITIVETYPE      g_IVBPrimitiveType;
-extern DWORD                   g_IVBFVF;
+extern X_D3DPRIMITIVETYPE      g_InlineVertexBuffer_PrimitiveType;
+extern DWORD                   g_InlineVertexBuffer_FVF;
 
-#define IVB_TABLE_SIZE  4096 // This should be more than enough. Tweak as necessary if it overflows or the resulting VertexBuffer fails to allocate
-#define IVB_BUFFER_SIZE sizeof(_D3DIVB) * IVB_TABLE_SIZE
-
-// TODO : Enlarge IVB_TABLE_SIZE and IVB_BUFFER_SIZE
-// TODO : Calculate IVB_BUFFER_SIZE using sizeof(DWORD)
-
-struct _D3DIVB
+extern struct _D3DIVB
 {
-    XTL::D3DXVECTOR3 Position;   // Position
-    FLOAT            Rhw;        // Rhw
-	FLOAT			 Blend1;	 // Blend1		
-    XTL::DWORD       dwSpecular; // Specular
-    XTL::DWORD       dwDiffuse;  // Diffuse
-    XTL::D3DXVECTOR3 Normal;     // Normal
-    XTL::D3DXVECTOR2 TexCoord1;  // TexCoord1
-    XTL::D3DXVECTOR2 TexCoord2;  // TexCoord2
-    XTL::D3DXVECTOR2 TexCoord3;  // TexCoord3
-    XTL::D3DXVECTOR2 TexCoord4;  // TexCoord4
-};
+    XTL::D3DXVECTOR3 Position;
+    FLOAT            Rhw;
+	FLOAT			 Blend[4];	 // Blend1, Blend2, Blend3, Blend4 (TODO : Blend5 ?)
+    XTL::D3DXVECTOR3 Normal;
+	FLOAT            PointSize;
+	D3DCOLOR         Diffuse;
+	D3DCOLOR         Specular;
+#if 0
+	FLOAT            Fog; // TODO : Handle
+	XTL::D3DCOLOR	BackDiffuse; // TODO : Handle
+	XTL::D3DCOLOR	BackSpecular; // TODO  : Handle
+#endif
+    XTL::D3DXVECTOR4 TexCoord[4];  // TexCoord1, TexCoord2, TexCoord3, TexCoord4
+}
+*g_InlineVertexBuffer_Table;
 
-extern _D3DIVB g_IVBTable[IVB_TABLE_SIZE];
-
-extern UINT g_IVBTblOffs;
+extern UINT g_InlineVertexBuffer_TableLength;
+extern UINT g_InlineVertexBuffer_TableOffset;
 
 extern VOID EmuFlushIVB();
 


### PR DESCRIPTION
This stops the inline vertex buffer from overflowing, and improves the support for flexible vertex formats.

As always, this should be well tested before merging it in!