### PR TITLE
D3D : Added YUY2 and UYVY conversions, derived from libyuv. 

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4450,6 +4450,22 @@ VOID WINAPI CreateHostResource
                     );
 					DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->CreateTexture");
 
+					// If the above failed, we might be able to use an ARGB texture instead
+					if((hRet != D3D_OK) && (PCFormat != D3DFMT_A8R8G8B8) && EmuXBFormatCanBeConvertedToARGB(X_Format))
+					{
+						hRet = g_pD3DDevice8->CreateTexture
+						(
+							dwWidth, dwHeight, dwMipMapLevels, 0, D3DFMT_A8R8G8B8,
+							D3DPOOL_MANAGED, &pNewHostTexture
+						);
+						DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->CreateTexture(D3DFMT_A8R8G8B8)");
+						if (hRet == D3D_OK) {
+							// Okay, now this works, make sure the texture gets converted
+							CacheFormat = PCFormat;
+							PCFormat = D3DFMT_A8R8G8B8;
+						}
+					}
+
 					/*if(FAILED(hRet))
 					{
 						hRet = g_pD3DDevice8->CreateTexture


### PR DESCRIPTION
Also, added a fallback to ARGB when a first CreateTexture attempt doesn't work.

This might help user with nvidia cards that fail YUY2 and/or UYVY textures.
Users that didn't have problems with YUY2 and UYVY textures aren't affected