### PR TITLE
DSound fixes Part 1

### DIFF
--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -88,7 +88,7 @@ uint32_t GetAPUTime()
 	PerformanceCounter.QuadPart -= APUInitialPerformanceCounter.QuadPart;
 	// Apply a delta to make it appear to tick at 48khz
 	PerformanceCounter.QuadPart = (ULONGLONG)(NativeToXboxAPU_FactorForPerformanceFrequency * PerformanceCounter.QuadPart);
-	return PerformanceCounter.QuadPart;
+	return (DWORD)PerformanceCounter.QuadPart;
 }
 
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -178,11 +178,13 @@ XTL::X_XFileMediaObject::_vtbl XTL::X_XFileMediaObject::vtbl =
  */
 
 
+// TODO: Both buffer and stream cache size need to merge as one, there is no such thing as 4094 SGE
+
 // size of sound buffer cache (used for periodic sound buffer updates)
 #define SOUNDBUFFER_CACHE_SIZE 0x800 //Maximum is 2047 SGE overall
 
 // size of sound stream cache (used for periodic sound stream updates)
-#define SOUNDSTREAM_CACHE_SIZE 0x200
+#define SOUNDSTREAM_CACHE_SIZE 0x800
 
 //Currently disabled since below may not be needed since under -6,400 is just silence yet accepting up to -10,000
 // Xbox to PC volume ratio format (-10,000 / -6,400 )

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -518,8 +518,7 @@ VOID WINAPI XTL::EMUPATCH(DirectSoundDoWork)()
                 DSoundBufferWriteToBuffer(pThis->EmuDirectSoundBuffer8, buffer->rangeStart, buffer->pBuffer_data, buffer->xmp_data.dwMaxSize);
 
                 // Debug area begin
-                printf("DEBUG: next packet process | pThis = %08X | rangeStart = %08d | bufferSize - %08d | dwBufferBytes = %08d | dwWriteOffsetNext = %08d\n", pThis, buffer->rangeStart, buffer->xmp_data.dwMaxSize, pThis->EmuBufferDesc->dwBufferBytes, pThis->Host_dwWriteOffsetNext);
-                //printf("DEBUG: process next packet | pThis = %08X | packet capacity = %08d | packet size = %08d | playPos - %08d | writePos - %08d | dwTriggerRange = %08d | rangeStart = %08d | rangeEnd = %08d | dwWriteOffsetNext = %08d | bufferSize - %08d | nAvgBytesPerSec - %08d | nSamplesPerSec - %08d | wBitsPerSample - %08d | nBlockAlign - %08d\n", pThis, pThis->Host_BufferPacketArray.capacity(), pThis->Host_BufferPacketArray.size(), playPos, writePos, pThis->Host_dwTriggerRange, rangeStart, rangeEnd, pThis->Host_dwWriteOffsetNext, buffer->size, pThis->EmuBufferDesc->lpwfxFormat->nAvgBytesPerSec, pThis->EmuBufferDesc->lpwfxFormat->nSamplesPerSec, pThis->EmuBufferDesc->lpwfxFormat->wBitsPerSample, pThis->EmuBufferDesc->lpwfxFormat->nBlockAlign);
+                //printf("DEBUG: next packet process | pThis = %08X | rangeStart = %08d | bufferSize - %08d | dwBufferBytes = %08d | dwWriteOffsetNext = %08d\n", pThis, buffer->rangeStart, buffer->xmp_data.dwMaxSize, pThis->EmuBufferDesc->dwBufferBytes, pThis->Host_dwWriteOffsetNext);
                 // Debug area end
 
                 if (pThis->Host_isProcessing == false) {
@@ -528,51 +527,28 @@ VOID WINAPI XTL::EMUPATCH(DirectSoundDoWork)()
                     pThis->Host_isProcessing = true;
                 }
                 buffer->isWritten = true;
-                /*
-                // This is CORRECT, base on test cases: Battlestar Galactica and Rayman Arena
-                //free(buffer->pBuffer_data);
-                if (buffer->xmp_data.pdwStatus != xbnullptr) {
-                    (*buffer->xmp_data.pdwStatus) = XMP_STATUS_SUCCESS;
-                }
-                //pThis->Host_BufferPacketArray.erase(buffer);//*/
 
             } else {
                 DWORD writePos = 0, playPos = 0;
                 hRet = pThis->EmuDirectSoundBuffer8->GetCurrentPosition(&playPos, &writePos);
                 if (hRet == DS_OK) {
 
-                    // Buffer was not played, therefore ignore it.
-                    /*
-                    if (playPos == 0 && writePos == 0) {
-                        continue;
-                    }//*/
-
                     int bufPlayed = playPos - buffer->rangeStart;
-                    int bufNextOffset = writePos - (buffer->rangeStart + buffer->xmp_data.dwMaxSize);
 
                     // Correct it if buffer was playing and is at beginning.
                     if (bufPlayed < 0 && (buffer->isPlayed || (playPos + pThis->EmuBufferDesc->dwBufferBytes - buffer->rangeStart) < buffer->xmp_data.dwMaxSize)) {
                         bufPlayed = pThis->EmuBufferDesc->dwBufferBytes - (bufPlayed * -1);
                     }
 
-                    printf("DEBUG: test packet process | pThis = %08X | playPos - %08d | writePos - %08d | rangeStart = %08d | bufPlayed = %08d | bufferSize - %08d | dwBufferBytes = %08d | dwWriteOffsetNext = %08d\n", pThis, playPos, writePos, buffer->rangeStart, bufPlayed, buffer->xmp_data.dwMaxSize, pThis->EmuBufferDesc->dwBufferBytes, pThis->Host_dwWriteOffsetNext);
-
                     if (bufPlayed >= 0) {
                         if (buffer->isPlayed == false) {
                             buffer->isPlayed = true;
-                            /*
-                            if (buffer->xmp_data.pdwStatus != xbnullptr) {
-                            (*buffer->xmp_data.pdwStatus) = XMP_STATUS_SUCCESS;
-                            }
-                            //*/
                         }
                         if (bufPlayed >= (int)buffer->xmp_data.dwMaxSize) {
                             free(buffer->pBuffer_data);
-                            //*
                             if (buffer->xmp_data.pdwStatus != xbnullptr) {
                                 (*buffer->xmp_data.pdwStatus) = XMP_STATUS_SUCCESS;
                             }
-                            //*/
                             if (buffer->xmp_data.pdwCompletedSize != xbnullptr) {
                                 (*buffer->xmp_data.pdwCompletedSize) = DSoundBufferGetXboxBufferSize(pThis, buffer->xmp_data.dwMaxSize);
                             }
@@ -599,11 +575,6 @@ VOID WINAPI XTL::EMUPATCH(DirectSoundDoWork)()
                     }
                 }
             }
-
-                // Debug area begin
-                //printf("DEBUG: skip packet process | pThis = %08X | playPos - %08d | writePos - %08d | dwTriggerRange = %08d | rangeStart = %08d | rangeEnd = %08d | dwWriteOffsetNext = %08d | bufferSize - %08d | nAvgBytesPerSec - %08d | nSamplesPerSec - %08d | wBitsPerSample - %08d | nBlockAlign - %08d\n", pThis, playPos, writePos, pThis->Host_dwTriggerRange, buffer->rangeStart, buffer->rangeEnd, pThis->Host_dwWriteOffsetNext, buffer->size, pThis->EmuBufferDesc->lpwfxFormat->nAvgBytesPerSec, pThis->EmuBufferDesc->lpwfxFormat->nSamplesPerSec, pThis->EmuBufferDesc->lpwfxFormat->wBitsPerSample, pThis->EmuBufferDesc->lpwfxFormat->nBlockAlign);
-                // Debug area end
-            //}
         }
     }
 
@@ -2067,14 +2038,12 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Process)
                 packet_input.isWritten = false;
                 packet_input.isPlayed = false;
 
-                //TODO: will compressed audio be a problem?
                 DSoundBufferOutputXBtoHost(pThis->EmuFlags, pThis->EmuBufferDesc, pInputBuffer->pvBuffer, pInputBuffer->dwMaxSize, packet_input.pBuffer_data, packet_input.xmp_data.dwMaxSize);
                 pThis->Host_BufferPacketArray.push_back(packet_input);
 
-                //*
                 if (pInputBuffer->pdwStatus != xbnullptr) {
                     (*pInputBuffer->pdwStatus) = XMP_STATUS_PENDING;
-                }//*/
+                }
                 if (pInputBuffer->pdwCompletedSize != xbnullptr) {
                     (*pInputBuffer->pdwCompletedSize) = 0;
                 }
@@ -2137,21 +2106,18 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
 
     DSoundBufferRemoveSynchPlaybackFlag(pThis->EmuFlags);
 
-    /*host_voice_packet packetSilence;
-    packetSilence.size = pThis->Host_dwTriggerRange;
-    packetSilence.pBuffer_data = malloc(packetSilence.size);
-    memset(packetSilence.pBuffer_data, 0, packetSilence.size);
-    packetSilence.pdwStatus = nullptr;
-    pThis->Host_BufferPacketArray.push_back(packetSilence);*/
-    /*
+    host_voice_packet packetSilence;
+    packetSilence.xmp_data = { 0 };
+    packetSilence.xmp_data.dwMaxSize = pThis->Host_dwTriggerRange;
+    packetSilence.pBuffer_data = malloc(packetSilence.xmp_data.dwMaxSize);
+    memset(packetSilence.pBuffer_data, 0, packetSilence.xmp_data.dwMaxSize);
+    packetSilence.rangeStart = pThis->Host_dwWriteOffsetNext;
+    packetSilence.isPlayed = false;
+    packetSilence.isWritten = false;
+    pThis->Host_BufferPacketArray.push_back(packetSilence);
     do {
         XTL::EMUPATCH(DirectSoundDoWork)();
-    } while (pThis->Host_BufferPacketArray.size() > 0);*/
-    for (std::vector<host_voice_packet>::iterator buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end(); ) {
-        free(buffer->pBuffer_data);
-        (*buffer->xmp_data.pdwStatus) = XMP_STATUS_FLUSHED;
-        buffer = pThis->Host_BufferPacketArray.erase(buffer);
-    }
+    } while (pThis->Host_BufferPacketArray.size() > 0);
 
 
     pThis->EmuDirectSoundBuffer8->Stop();

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2707,13 +2707,11 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF)
 {
     FUNC_EXPORTS;
 
-    enterCriticalSection;
+    //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
 
     LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
 }
 
 // ******************************************************************
@@ -2725,13 +2723,11 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF)
 {
     FUNC_EXPORTS;
 
-    enterCriticalSection;
+    //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
 
     LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
 }
 
 // ******************************************************************
@@ -2743,13 +2739,11 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF4Channel)
 {
     FUNC_EXPORTS;
 
-    enterCriticalSection;
+    //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
 
     LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
 }
 
 // ******************************************************************
@@ -2761,13 +2755,11 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF4Channel)
 {
     FUNC_EXPORTS;
 
-    enterCriticalSection;
+    //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
 
     LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -508,7 +508,6 @@ VOID WINAPI XTL::EMUPATCH(DirectSoundDoWork)()
                 // Debug area end
 
                 if (pThis->Host_isProcessing == false) {
-                    pThis->EmuDirectSoundBuffer8->SetCurrentPosition(buffer->rangeStart);
                     pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
                     pThis->Host_isProcessing = true;
                 }
@@ -2034,6 +2033,10 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Process)
                 }
                 if (pInputBuffer->pdwCompletedSize != xbnullptr) {
                     (*pInputBuffer->pdwCompletedSize) = 0;
+                }
+
+                if (pThis->Host_isProcessing == false && pThis->Host_BufferPacketArray.size() == 1) {
+                    pThis->EmuDirectSoundBuffer8->SetCurrentPosition(packet_input.rangeStart);
                 }
             // Once full it needs to change status to flushed when cannot hold any more packets.
             } else {

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -48,7 +48,16 @@ namespace xboxkrnl {
 #include "EmuFS.h"
 #include "EmuShared.h"
 #include "EmuXTL.h"
+
+//*
+#ifndef _DEBUG_TRACE
+#define _DEBUG_TRACE
 #include "Logging.h"
+#undef _DEBUG_TRACE
+#else
+#include "Logging.h"
+#endif
+//*/
 
 #include <mmreg.h>
 #include <msacm.h>

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2117,7 +2117,9 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
     pThis->Host_BufferPacketArray.push_back(packetSilence);
     do {
         XTL::EMUPATCH(DirectSoundDoWork)();
-    } while (pThis->Host_BufferPacketArray.size() > 0);
+    } while (pThis->Host_BufferPacketArray.size() > 1);
+
+    pThis->Host_BufferPacketArray.clear();
 
 
     pThis->EmuDirectSoundBuffer8->Stop();

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2017,9 +2017,12 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
 
 	LOG_FUNC_ONE_ARG(pThis);
 
-    LOG_UNIMPLEMENTED_DSOUND();
-
     DSoundBufferRemoveSynchPlaybackFlag(pThis->EmuFlags);
+    pThis->EmuDirectSoundBuffer8->Play(0, 0, 0);
+    DWORD dwStatus;
+    do {
+        pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);
+    } while((dwStatus & DSBSTATUS_PLAYING) > 0);
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1213,7 +1213,8 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Unlock)
         LOG_FUNC_ARG(pdwAudioBytes2)
         LOG_FUNC_END;
 
-    if (pThis->X_BufferCache != xbnullptr) {
+    // TODO: Find out why pThis->EmuLockPtr1 is nullptr... (workaround atm is to check if it is not a nullptr.)
+    if (pThis->X_BufferCache != xbnullptr && pThis->EmuLockPtr1 != nullptr) {
         memcpy_s((PBYTE)pThis->X_BufferCache + pThis->EmuLockOffset,
                  pThis->EmuBufferDesc->dwBufferBytes - pThis->EmuLockOffset,
                  pThis->EmuLockPtr1,

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2019,9 +2019,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
 
     LOG_UNIMPLEMENTED_DSOUND();
 
-    if (pThis != NULL) {
-        DSoundBufferRemoveSynchPlaybackFlag(pThis->EmuFlags);
-    }
+    DSoundBufferRemoveSynchPlaybackFlag(pThis->EmuFlags);
 
     leaveCriticalSection;
 
@@ -2993,7 +2991,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_FlushEx)
 
     leaveCriticalSection;
 
-    return XTL::EMUPATCH(CDirectSoundStream_Flush)(NULL);
+    return XTL::EMUPATCH(CDirectSoundStream_Flush)(pThis);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -600,7 +600,17 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetOrientation)
 		LOG_FUNC_ARG(dwApply)
 		LOG_FUNC_END;
 
-    HRESULT hRet = g_pDSoundPrimary3DListener8->SetOrientation(xFront, yFront, zFront, xTop, yTop, zTop, dwApply);
+    HRESULT hRet = DS_OK;
+    // TODO: (DSound) Should we do restrictive or passive to return actual result back to titles?
+    // Test case: Jet Set Radio Future, ?
+    if (xFront == 0.0f && yFront == 0.0f && zFront == 0.0f) {
+        printf("WARNING: SetOrientation was called with xFront = 0, yFront = 0, and zFront = 0. Current action is ignore call to PC.\n");
+    }
+    if (xTop == 0.0f && yTop == 0.0f && zTop == 0.0f) {
+        printf("WARNING: SetOrientation was called with xTop = 0, yTop = 0, and zTop = 0. Current action is ignore call to PC.\n");
+    } else {
+        hRet = g_pDSoundPrimary3DListener8->SetOrientation(xFront, yFront, zFront, xTop, yTop, zTop, dwApply);
+    }
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -178,9 +178,9 @@ XTL::X_XFileMediaObject::_vtbl XTL::X_XFileMediaObject::vtbl =
  */
 
 
-
+// TODO: This is more of a hack(?) since certain titles won't go through. Find out why then revert it back to 0x200 as it should be.
 // size of sound buffer cache (used for periodic sound buffer updates)
-#define SOUNDBUFFER_CACHE_SIZE 0x200
+#define SOUNDBUFFER_CACHE_SIZE 0x800
 
 // size of sound stream cache (used for periodic sound stream updates)
 #define SOUNDSTREAM_CACHE_SIZE 0x200

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1685,7 +1685,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
 
     GeneratePCMFormat(pDSBufferDesc, pdssd->lpwfxFormat, dwEmuFlags);
 
-    DSoundBufferSetDefault((*ppStream), pDSBufferDesc, dwEmuFlags, DSBPLAY_LOOPING);
+    DSoundBufferSetDefault((*ppStream), pDSBufferDesc, dwEmuFlags, 0);
 
     DbgPrintf("EmuDSound: DirectSoundCreateStream, *ppStream := 0x%.08X\n", *ppStream);
 
@@ -2085,7 +2085,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Pause)
 		LOG_FUNC_ARG(dwPause)
 		LOG_FUNC_END;
 
-    return HybridDirectSoundBuffer_Pause(pThis->EmuDirectSoundBuffer8, dwPause, pThis->EmuFlags);
+    return HybridDirectSoundBuffer_Pause(pThis->EmuDirectSoundBuffer8, dwPause, pThis->EmuFlags, pThis->EmuPlayFlags);
 }
 
 // ******************************************************************
@@ -2879,7 +2879,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Pause)
                         pThis->EmuLockBytes2,
                         pThis->EmuLockFlags);
 
-    return HybridDirectSoundBuffer_Pause(DSoundBufferSelectionT(pThis), dwPause, pThis->EmuFlags);
+    return HybridDirectSoundBuffer_Pause(DSoundBufferSelectionT(pThis), dwPause, pThis->EmuFlags, pThis->EmuPlayFlags);
 }
 
 // ******************************************************************
@@ -2904,7 +2904,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_PauseEx)
     // This function wasn't part of the XDK until 4721.
     // TODO: Implement time stamp feature (a thread maybe?)
 
-    HRESULT hRet = HybridDirectSoundBuffer_Pause(DSoundBufferSelectionT(pThis), dwPause, pThis->EmuFlags);
+    HRESULT hRet = HybridDirectSoundBuffer_Pause(DSoundBufferSelectionT(pThis), dwPause, pThis->EmuFlags, pThis->EmuPlayFlags);
 
     leaveCriticalSection;
 
@@ -3919,7 +3919,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_PauseEx)
     // This function wasn't part of the XDK until 4721. (Same as IDirectSoundBuffer_PauseEx?)
     // TODO: Implement time stamp feature (a thread maybe?)
 
-    HRESULT hRet = HybridDirectSoundBuffer_Pause(pThis->EmuDirectSoundBuffer8, dwPause, pThis->EmuFlags);
+    HRESULT hRet = HybridDirectSoundBuffer_Pause(pThis->EmuDirectSoundBuffer8, dwPause, pThis->EmuFlags, pThis->EmuPlayFlags);
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -3394,6 +3394,8 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFormat)
 		LOG_FUNC_ARG(pwfxFormat)
 		LOG_FUNC_END;
 
+    XTL::EMUPATCH(CDirectSoundStream_Flush)(pThis);
+
     return HybridDirectSoundBuffer_SetFormat(pThis->EmuDirectSoundBuffer8, pwfxFormat, pThis->EmuBufferDesc,
                                              pThis->EmuFlags, pThis->EmuPlayFlags, pThis->EmuDirectSound3DBuffer8,
                                              0, pThis->X_BufferCache, pThis->X_BufferCacheSize);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1949,29 +1949,15 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Process)
         HRESULT hRet;
 
 
-        //NOTE : XADPCM audio has occurred in Rayman Arena first intro video, all other title's intro videos are PCM so far.
-        if (pThis->EmuFlags & DSB_FLAG_XADPCM) {
+        hRet = pThis->EmuDirectSoundBuffer8->Lock(0, DSoundBufferGetPCMBufferSize(pThis, pInputBuffer->dwMaxSize), &pAudioPtr, &dwAudioBytes,
+                                                    nullptr, nullptr, 0);
 
-            DSoundBufferXboxAdpcmDecoder(pThis->EmuDirectSoundBuffer8,
-                                         pThis->EmuBufferDesc,
-                                         0,
-                                         pThis->X_BufferCache,
-                                         pInputBuffer->dwMaxSize,
-                                         0,
-                                         0,
-                                         false);
+        if (hRet == DS_OK) {
 
-        } else {
-            hRet = pThis->EmuDirectSoundBuffer8->Lock(0, pThis->EmuBufferDesc->dwBufferBytes, &pAudioPtr, &dwAudioBytes,
-                                                      nullptr, nullptr, 0);
-
-            if (hRet == DS_OK) {
-
-                if (pAudioPtr != 0) {
-                    DSoundBufferOutputXBtoPC(pThis->EmuFlags, pThis->EmuBufferDesc, pThis->X_BufferCache, pInputBuffer->dwMaxSize, pAudioPtr, dwAudioBytes);
-                }
-                pThis->EmuDirectSoundBuffer8->Unlock(pAudioPtr, dwAudioBytes, nullptr, 0);
+            if (pAudioPtr != 0) {
+                DSoundBufferOutputXBtoHost(pThis->EmuFlags, pThis->EmuBufferDesc, pThis->X_BufferCache, pInputBuffer->dwMaxSize, pAudioPtr, dwAudioBytes);
             }
+            pThis->EmuDirectSoundBuffer8->Unlock(pAudioPtr, dwAudioBytes, nullptr, 0);
         }
         //TODO: RadWolfie - If remove this part, XADPCM audio will stay running, Rayman Arena, except...
         //...PCM audio does not for rest of titles. However it should not be here, so this is currently a workaround fix for now.

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -86,10 +86,10 @@ uint32_t GetAPUTime()
 // TODO: Tasks need to do for DirectSound HLE
 // * Need create patches
 //   * Ac97CreateMediaObject (Need OOVPA)
-//   * WmaCreateDecoder (Need OOVPA)
-//   * WmaCreateDecoderEx (Is just a forward to WmaCreateDecoder, nothing else)
-//   * WmaCreateInMemoryDecoder (Need OOVPA)
-//   * WmaCreateInMemoryDecoderEx (Is just a forward to WmaCreateInMemoryDecoder, nothing else)
+//   - WmaCreateDecoder (Need OOVPA, not require) Test case: WMAStream sample
+//   - WmaCreateDecoderEx (Is just a forward to WmaCreateDecoder, nothing else)
+//   - WmaCreateInMemoryDecoder (Need OOVPA, not require) Test case: WMAInMemory sample
+//   - WmaCreateInMemoryDecoderEx (Is just a forward to WmaCreateInMemoryDecoder, nothing else)
 //   * XWmaDecoderCreateMediaObject (Need OOVPA)
 // * Missing CDirectSoundStream patch
 //   * CDirectSoundStream_Set3DVoiceData (new, undocument)

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -957,11 +957,16 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
 
         DSBUFFERDESC *pDSBufferDesc = (DSBUFFERDESC*)malloc(sizeof(DSBUFFERDESC));
 
-        //DWORD dwAcceptableMask = 0x00000010 | 0x00000020 | 0x00000080 | 0x00000100 | 0x00002000 | 0x00040000 | 0x00080000;
+        //TODO: Find out the cause for DSBCAPS_MUTE3DATMAXDISTANCE to have invalid arg.
         DWORD dwAcceptableMask = 0x00000010 | 0x00000020 | 0x00000080 | 0x00000100 | 0x00020000 | 0x00040000 /*| 0x00080000*/;
 
         if (pdsbd->dwFlags & (~dwAcceptableMask)) {
             EmuWarning("Use of unsupported pdsbd->dwFlags mask(s) (0x%.08X)", pdsbd->dwFlags & (~dwAcceptableMask));
+        }
+
+        // HACK: Hot fix for titles not giving CTRL3D flag. Xbox might accept it, however the host does not.
+        if ((pdsbd->dwFlags & DSBCAPS_MUTE3DATMAXDISTANCE) > 0 && (pdsbd->dwFlags & DSBCAPS_CTRL3D) == 0) {
+            pdsbd->dwFlags &= ~DSBCAPS_MUTE3DATMAXDISTANCE;
         }
 
         pDSBufferDesc->dwSize = sizeof(DSBUFFERDESC);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -515,7 +515,7 @@ VOID WINAPI XTL::EMUPATCH(DirectSoundDoWork)()
             if (buffer->isWritten == false) {
 
             prepareNextBufferPacket:
-                DSoundBufferWriteToBuffer(pThis->EmuDirectSoundBuffer8, pThis->Host_dwWriteOffsetNext, buffer->pBuffer_data, buffer->xmp_data.dwMaxSize);
+                DSoundBufferWriteToBuffer(pThis->EmuDirectSoundBuffer8, buffer->rangeStart, buffer->pBuffer_data, buffer->xmp_data.dwMaxSize);
 
                 // Debug area begin
                 printf("DEBUG: next packet process | pThis = %08X | rangeStart = %08d | bufferSize - %08d | dwBufferBytes = %08d | dwWriteOffsetNext = %08d\n", pThis, buffer->rangeStart, buffer->xmp_data.dwMaxSize, pThis->EmuBufferDesc->dwBufferBytes, pThis->Host_dwWriteOffsetNext);

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -305,7 +305,7 @@ struct X_CDirectSoundBuffer
     };
 
     BYTE                    UnknownB[0x0C];     // Offset: 0x24
-    PVOID                   EmuBuffer;          // Offset: 0x28
+    PVOID                   X_BufferCache;      // Offset: 0x28
     DSBUFFERDESC*           EmuBufferDesc;      // Offset: 0x2C
     PVOID                   EmuLockPtr1;        // Offset: 0x30
     DWORD                   EmuLockBytes1;      // Offset: 0x34
@@ -324,6 +324,7 @@ struct X_CDirectSoundBuffer
     DWORD                   EmuRegionPlayLength;
     LPDIRECTSOUNDBUFFER8    EmuDirectSoundBuffer8Region;
     LPDIRECTSOUND3DBUFFER8  EmuDirectSound3DBuffer8Region;
+    DWORD                   X_BufferCacheSize;
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069
@@ -439,7 +440,7 @@ class X_CDirectSoundStream
         // cached data
         LPDIRECTSOUNDBUFFER8        EmuDirectSoundBuffer8;
         LPDIRECTSOUND3DBUFFER8      EmuDirectSound3DBuffer8;
-        PVOID                       EmuBuffer;
+        PVOID                       X_BufferCache;
         LPDSBUFFERDESC              EmuBufferDesc;
         PVOID                       EmuLockPtr1;
         DWORD                       EmuLockBytes1;
@@ -447,6 +448,7 @@ class X_CDirectSoundStream
         DWORD                       EmuLockBytes2;
         DWORD                       EmuPlayFlags;
         DWORD                       EmuFlags;
+        DWORD                       X_BufferCacheSize;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -333,13 +333,13 @@ struct X_CDirectSoundBuffer
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069
-//Custom flags?
+//Custom flags (4 bytes support up to 31 shifts,starting from 0)
 #define DSB_FLAG_PCM                    (1 << 0)
 #define DSB_FLAG_XADPCM                 (1 << 1)
 #define DSB_FLAG_PCM_UNKNOWN            (1 << 2)
-#define DSB_FLAG_SYNCHPLAYBACK_CONTROL  (2 << 0)
-#define DSB_FLAG_PAUSE                  (2 << 1)
-#define DSB_FLAG_RECIEVEDATA            (5 << 0)
+#define DSB_FLAG_SYNCHPLAYBACK_CONTROL  (1 << 10)
+#define DSB_FLAG_PAUSE                  (1 << 11)
+#define DSB_FLAG_RECIEVEDATA            (1 << 20)
 #define DSB_FLAG_AUDIO_CODECS           (DSB_FLAG_PCM | DSB_FLAG_XADPCM | DSB_FLAG_PCM_UNKNOWN)
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -383,9 +383,11 @@ class X_CMcpxStream
 
 // host_voice_packet is needed for DirectSoundStream packet handling internally.
 struct host_voice_packet {
-    DWORD   size;
-    PDWORD  pdwStatus;
+    XTL::XMEDIAPACKET xmp_data;
     PVOID   pBuffer_data;
+    DWORD   rangeStart;
+    bool    isWritten;
+    bool    isPlayed;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -463,6 +463,9 @@ class X_CDirectSoundStream
         DWORD                                   X_BufferCacheSize; // Not really needed...
         DWORD                                   X_MaxAttachedPackets;
         std::vector<struct host_voice_packet>   Host_BufferPacketArray;
+        LPDIRECTSOUNDBUFFER8                    EmuDirectSoundBuffer8Next;
+        HANDLE                                  Host_PacketEventHandle;
+        DSBPOSITIONNOTIFY                       Host_NotifyPosition;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -87,6 +87,8 @@ struct X_DSBUFFERDESC
     DWORD           dwInputMixBin;
 };
 
+typedef VOID(CALLBACK *LPFNXMOCALLBACK)(LPVOID pStreamContext, LPVOID pPacketContext, DWORD dwStatus);
+
 // ******************************************************************
 // * X_DSSTREAMDESC
 // ******************************************************************
@@ -95,9 +97,9 @@ struct X_DSSTREAMDESC
     DWORD                       dwFlags;
     DWORD                       dwMaxAttachedPackets;
     LPWAVEFORMATEX              lpwfxFormat;
-    PVOID                       lpfnCallback;   // TODO: Correct Parameter
+    LPFNXMOCALLBACK             lpfnCallback;
     LPVOID                      lpvContext;
-    PVOID                       lpMixBins;      // TODO: Correct Parameter
+    PVOID                       lpMixBins;      // TODO: Implement
 };
 
 // ******************************************************************
@@ -481,6 +483,8 @@ class X_CDirectSoundStream
         DWORD                                   Host_dwWriteOffsetNext;
         DWORD                                   Host_dwTriggerRange;
         bool                                    Host_isProcessing;
+        LPFNXMOCALLBACK                         Xb_lpfnCallback;
+        LPVOID                                  Xb_lpvContext;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -334,11 +334,12 @@ struct X_CDirectSoundBuffer
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069
 //Custom flags?
-#define DSB_FLAG_PCM                    0x00000001
-#define DSB_FLAG_XADPCM                 0x00000002
-#define DSB_FLAG_PCM_UNKNOWN            0x00000010
-#define DSB_FLAG_SYNCHPLAYBACK_CONTROL  0x00000100
-#define DSB_FLAG_RECIEVEDATA            0x00001000
+#define DSB_FLAG_PCM                    (1 << 0)
+#define DSB_FLAG_XADPCM                 (1 << 1)
+#define DSB_FLAG_PCM_UNKNOWN            (1 << 2)
+#define DSB_FLAG_SYNCHPLAYBACK_CONTROL  (2 << 0)
+#define DSB_FLAG_PAUSE                  (2 << 1)
+#define DSB_FLAG_RECIEVEDATA            (5 << 0)
 #define DSB_FLAG_AUDIO_CODECS           (DSB_FLAG_PCM | DSB_FLAG_XADPCM | DSB_FLAG_PCM_UNKNOWN)
 
 // ******************************************************************
@@ -464,6 +465,8 @@ class X_CDirectSoundStream
         DWORD                                   X_MaxAttachedPackets;
         std::vector<struct host_voice_packet>   Host_BufferPacketArray;
         DWORD                                   Host_dwWriteOffsetNext;
+        DWORD                                   Host_dwTriggerRange;
+        bool                                    Host_isProcessing;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -463,9 +463,7 @@ class X_CDirectSoundStream
         DWORD                                   X_BufferCacheSize; // Not really needed...
         DWORD                                   X_MaxAttachedPackets;
         std::vector<struct host_voice_packet>   Host_BufferPacketArray;
-        LPDIRECTSOUNDBUFFER8                    EmuDirectSoundBuffer8Next;
-        HANDLE                                  Host_PacketEventHandle;
-        DSBPOSITIONNOTIFY                       Host_NotifyPosition;
+        DWORD                                   Host_dwWriteOffsetNext;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -71,6 +71,7 @@ void CxbxInitAudio();
 #define X_DSBSTOPEX_IMMEDIATE         0x00000000
 #define X_DSBSTOPEX_ENVELOPE          0x00000001
 #define X_DSBSTOPEX_RELEASEWAVEFORM   0x00000002
+#define X_DSBSTOPEX_ALL               (X_DSBSTOPEX_ENVELOPE | X_DSBSTOPEX_RELEASEWAVEFORM)
 
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -121,6 +121,11 @@ typedef struct _XMEDIAPACKET
 }
 XMEDIAPACKET, *PXMEDIAPACKET, *LPXMEDIAPACKET;
 
+#define XMP_STATUS_SUCCESS             S_OK
+#define XMP_STATUS_PENDING             E_PENDING
+#define XMP_STATUS_FLUSHED             E_ABORT
+#define XMP_STATUS_FAILURE             E_FAIL
+
 // ******************************************************************
 // * XMEDIAINFO
 // ******************************************************************
@@ -375,6 +380,13 @@ class X_CMcpxStream
         class X_CDirectSoundStream *pParentStream;
 };
 
+// host_voice_packet is needed for DirectSoundStream packet handling internally.
+struct host_voice_packet {
+    DWORD   size;
+    PDWORD  pdwStatus;
+    PVOID   pBuffer_data;
+};
+
 // ******************************************************************
 // * X_CDirectSoundStream
 // ******************************************************************
@@ -438,17 +450,19 @@ class X_CDirectSoundStream
 
     public:
         // cached data
-        LPDIRECTSOUNDBUFFER8        EmuDirectSoundBuffer8;
-        LPDIRECTSOUND3DBUFFER8      EmuDirectSound3DBuffer8;
-        PVOID                       X_BufferCache;
-        LPDSBUFFERDESC              EmuBufferDesc;
-        PVOID                       EmuLockPtr1;
-        DWORD                       EmuLockBytes1;
-        PVOID                       EmuLockPtr2;
-        DWORD                       EmuLockBytes2;
-        DWORD                       EmuPlayFlags;
-        DWORD                       EmuFlags;
-        DWORD                       X_BufferCacheSize;
+        LPDIRECTSOUNDBUFFER8                    EmuDirectSoundBuffer8;
+        LPDIRECTSOUND3DBUFFER8                  EmuDirectSound3DBuffer8;
+        PVOID                                   X_BufferCache; // Not really needed...
+        LPDSBUFFERDESC                          EmuBufferDesc;
+        PVOID                                   EmuLockPtr1;
+        DWORD                                   EmuLockBytes1;
+        PVOID                                   EmuLockPtr2;
+        DWORD                                   EmuLockBytes2;
+        DWORD                                   EmuPlayFlags;
+        DWORD                                   EmuFlags;
+        DWORD                                   X_BufferCacheSize; // Not really needed...
+        DWORD                                   X_MaxAttachedPackets;
+        std::vector<struct host_voice_packet>   Host_BufferPacketArray;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -296,6 +296,15 @@ enum X_DSB_TOGGLE {
     X_DSB_TOGGLE_LOOP
 };
 
+typedef struct _DSoundBuffer_Lock {
+    PVOID   pLockPtr1;
+    DWORD   dwLockBytes1;
+    PVOID   pLockPtr2;
+    DWORD   dwLockBytes2;
+    DWORD   dwLockOffset;
+    DWORD   dwLockFlags;
+} DSoundBuffer_Lock;
+
 // ******************************************************************
 // * X_CDirectSoundBuffer
 // ******************************************************************
@@ -310,17 +319,17 @@ struct X_CDirectSoundBuffer
     };
 
     BYTE                    UnknownB[0x0C];     // Offset: 0x24
-    PVOID                   X_BufferCache;      // Offset: 0x28
+    LPVOID                  X_BufferCache;      // Offset: 0x28
     DSBUFFERDESC*           EmuBufferDesc;      // Offset: 0x2C
-    PVOID                   EmuLockPtr1;        // Offset: 0x30
+    /*LPVOID                  EmuLockPtr1;        // Offset: 0x30
     DWORD                   EmuLockBytes1;      // Offset: 0x34
-    PVOID                   EmuLockPtr2;        // Offset: 0x38
-    DWORD                   EmuLockBytes2;      // Offset: 0x3C
+    LPVOID                  EmuLockPtr2;        // Offset: 0x38
+    DWORD                   EmuLockBytes2;      // Offset: 0x3C*/
     DWORD                   EmuPlayFlags;       // Offset: 0x40
     DWORD                   EmuFlags;           // Offset: 0x44
     LPDIRECTSOUND3DBUFFER8  EmuDirectSound3DBuffer8;
-    DWORD                   EmuLockOffset;
-    DWORD                   EmuLockFlags;
+    //DWORD                   EmuLockOffset;
+    //DWORD                   EmuLockFlags;
     // Play/Loop Region Section
     X_DSB_TOGGLE            EmuBufferToggle;
     DWORD                   EmuRegionLoopStartOffset;
@@ -330,6 +339,8 @@ struct X_CDirectSoundBuffer
     LPDIRECTSOUNDBUFFER8    EmuDirectSoundBuffer8Region;
     LPDIRECTSOUND3DBUFFER8  EmuDirectSound3DBuffer8Region;
     DWORD                   X_BufferCacheSize;
+    DSoundBuffer_Lock       Host_lock;
+    DSoundBuffer_Lock       X_lock;
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -575,6 +575,38 @@ inline void ResizeIDirectSoundBuffer(
     DSoundBufferReplace(pDSBuffer, pDSBufferDesc, PlayFlags, pDS3DBuffer);
 }
 
+inline void DSoundBufferPrepare(
+    LPDIRECTSOUNDBUFFER8       &pDSBuffer,
+    LPDSBUFFERDESC              pDSBufferDesc,
+    DWORD                       dwPlayFlags,
+    PVOID                       pBufferData,
+    DWORD                       dwBufferSize) {
+
+
+    DWORD dwTempHolder = pDSBufferDesc->dwBufferBytes;
+
+    DSoundBufferCreate(pDSBufferDesc, pDSBuffer);
+
+    LPDIRECTSOUND3DBUFFER8 pDummy3DBuffer = nullptr;
+
+    ResizeIDirectSoundBuffer(pDSBuffer, pDSBufferDesc,
+                             dwPlayFlags, dwBufferSize, pDummy3DBuffer);
+
+    PVOID pAudioPtr;
+    DWORD dwAudioBytes;
+
+    HRESULT hRet = pDSBuffer->Lock(0, 0, &pAudioPtr, &dwAudioBytes,
+                                              nullptr, nullptr, DSBLOCK_ENTIREBUFFER);
+
+    if (hRet == DS_OK) {
+
+        if (pAudioPtr != 0) {
+            memcpy_s(pAudioPtr, dwAudioBytes, pBufferData, dwBufferSize);
+            pDSBuffer->Unlock(pAudioPtr, dwAudioBytes, nullptr, 0);
+        }
+    }
+}
+
 inline void DSoundBufferUpdate(
     LPDIRECTSOUNDBUFFER8    pThis,
     LPDSBUFFERDESC          pDSBufferDesc,

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -151,6 +151,7 @@ inline void GenerateXboxBufferCache(
                 X_BufferCacheSize = X_BufferSizeRequest;
             }
             memcpy_s(*X_BufferCache, X_BufferSizeRequest, tempBuffer, X_BufferCacheSize);
+            free(tempBuffer);
         } else {
             *X_BufferCache = malloc(X_BufferSizeRequest);
         }

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -936,6 +936,7 @@ inline HRESULT HybridDirectSound3DBuffer_SetConeOrientation(
 
     HRESULT hRet = DS_OK;
     if (pDS3DBuffer != nullptr) {
+        // TODO: (DSound) Should we do restrictive or passive to return actual result back to titles?
         // Test case: Turok Evolution, Jet Set Radio Future, ?
         if (x == 0.0f && y == 0.0f && z == 0.0f) {
             printf("WARNING: SetConeOrientation was called with x = 0, y = 0, and z = 0. Current action is ignore call to PC.\n");

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -575,34 +575,26 @@ inline void ResizeIDirectSoundBuffer(
     DSoundBufferReplace(pDSBuffer, pDSBufferDesc, PlayFlags, pDS3DBuffer);
 }
 
-inline void DSoundBufferPrepare(
+inline void DSoundBufferWriteToBuffer(
     LPDIRECTSOUNDBUFFER8       &pDSBuffer,
-    LPDSBUFFERDESC              pDSBufferDesc,
-    DWORD                       dwPlayFlags,
+    DWORD                       dwOffset,
     PVOID                       pBufferData,
     DWORD                       dwBufferSize) {
 
+    LPVOID pAudioPtr, pAudioPtr2;
+    DWORD dwAudioBytes, dwAudioBytes2;
 
-    DWORD dwTempHolder = pDSBufferDesc->dwBufferBytes;
-
-    DSoundBufferCreate(pDSBufferDesc, pDSBuffer);
-
-    LPDIRECTSOUND3DBUFFER8 pDummy3DBuffer = nullptr;
-
-    ResizeIDirectSoundBuffer(pDSBuffer, pDSBufferDesc,
-                             dwPlayFlags, dwBufferSize, pDummy3DBuffer);
-
-    PVOID pAudioPtr;
-    DWORD dwAudioBytes;
-
-    HRESULT hRet = pDSBuffer->Lock(0, 0, &pAudioPtr, &dwAudioBytes,
-                                              nullptr, nullptr, DSBLOCK_ENTIREBUFFER);
+    HRESULT hRet = pDSBuffer->Lock(dwOffset, dwBufferSize, &pAudioPtr, &dwAudioBytes,
+                                   &pAudioPtr2, &dwAudioBytes2, 0);
 
     if (hRet == DS_OK) {
 
-        if (pAudioPtr != 0) {
-            memcpy_s(pAudioPtr, dwAudioBytes, pBufferData, dwBufferSize);
-            pDSBuffer->Unlock(pAudioPtr, dwAudioBytes, nullptr, 0);
+        if (pAudioPtr != nullptr) {
+            memcpy_s(pAudioPtr, dwAudioBytes, pBufferData, dwAudioBytes);
+            if (pAudioPtr2 != nullptr) {
+                memcpy_s(pAudioPtr2, dwAudioBytes2, (PUCHAR)pBufferData + dwAudioBytes, dwAudioBytes2);
+            }
+            pDSBuffer->Unlock(pAudioPtr, dwAudioBytes, pAudioPtr2, dwAudioBytes2);
         }
     }
 }

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -302,13 +302,13 @@ inline void DSoundBufferCreate(LPDSBUFFERDESC &pDSBufferDesc, LPDIRECTSOUNDBUFFE
     LPDIRECTSOUNDBUFFER pTempBuffer;
     HRESULT hRetDS = g_pDSound8->CreateSoundBuffer(pDSBufferDesc, &pTempBuffer, NULL);
     if (hRetDS != DS_OK) {
-        CxbxKrnlCleanup("CreateSoundBuffer Failed!");
+        CxbxKrnlCleanup("CreateSoundBuffer error: 0x%08X", hRetDS);
         pDSBufferDesc = xbnullptr;
     } else {
         hRetDS = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&(pDSBuffer));
         pTempBuffer->Release();
         if (hRetDS != DS_OK) {
-            CxbxKrnlCleanup("Create IDirectSoundBuffer8 Failed!");
+            CxbxKrnlCleanup("Create IDirectSoundBuffer8 error: 0x%08X", hRetDS);
         }
     }
 }

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -135,6 +135,7 @@ void DSoundBufferXboxAdpcmDecoder(
 }
 
 #define DSoundBufferGetPCMBufferSize(pThis, size) (pThis->EmuFlags & DSB_FLAG_XADPCM) > 0 ? TXboxAdpcmDecoder_guess_output_size(size) : size
+#define DSoundBufferGetXboxBufferSize(pThis, size) (pThis->EmuFlags & DSB_FLAG_XADPCM) > 0 ? ((size / XBOX_ADPCM_DSTSIZE) * XBOX_ADPCM_SRCSIZE) : size
 
 void DSoundBufferOutputXBtoHost(DWORD emuFlags, DSBUFFERDESC* pDSBufferDesc, LPVOID pXBaudioPtr, DWORD dwXBAudioBytes, LPVOID pPCaudioPtr, DWORD dwPCMAudioBytes) {
     if ((emuFlags & DSB_FLAG_XADPCM) > 0) {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -802,6 +802,7 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
         case X_DSSPAUSE_RESUME:
             pDSBuffer->Play(0, 0, dwEmuPlayFlags);
             DSoundBufferRemoveSynchPlaybackFlag(dwEmuFlags);
+            dwEmuFlags ^= DSB_FLAG_PAUSE;
             break;
         case X_DSSPAUSE_PAUSE:
             hStatus = pDSBuffer->GetStatus(&dwStatus);
@@ -809,6 +810,7 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
                 pDSBuffer->Stop();
             }
             DSoundBufferRemoveSynchPlaybackFlag(dwEmuFlags);
+            dwEmuFlags |= DSB_FLAG_PAUSE;
             break;
         case X_DSSPAUSE_SYNCHPLAYBACK:
             //TODO: Test case Rayman 3 - Hoodlum Havoc, Battlestar Galactica, Miami Vice, and... ?

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -766,7 +766,8 @@ inline HRESULT HybridDirectSoundBuffer_Lock(
 inline HRESULT HybridDirectSoundBuffer_Pause(
     LPDIRECTSOUNDBUFFER8    pDSBuffer,
     DWORD                   dwPause,
-    DWORD                  &dwEmuFlags)
+    DWORD                  &dwEmuFlags,
+    DWORD                   dwEmuPlayFlags)
 {
 
     enterCriticalSection;
@@ -775,7 +776,7 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
     HRESULT hRet = DS_OK, hStatus;
     switch (dwPause) {
         case X_DSSPAUSE_RESUME:
-            pDSBuffer->Play(0, 0, DSBPLAY_LOOPING);
+            pDSBuffer->Play(0, 0, dwEmuPlayFlags);
             DSoundBufferRemoveSynchPlaybackFlag(dwEmuFlags);
             break;
         case X_DSSPAUSE_PAUSE:

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -136,13 +136,10 @@ void DSoundBufferXboxAdpcmDecoder(
 
 #define DSoundBufferGetPCMBufferSize(pThis, size) (pThis->EmuFlags & DSB_FLAG_XADPCM) > 0 ? TXboxAdpcmDecoder_guess_output_size(size) : size
 
-void DSoundBufferOutputXBtoPC(DWORD emuFlags, DSBUFFERDESC* pDSBufferDesc, LPVOID pXBaudioPtr, DWORD dwXBAudioBytes, LPVOID pPCaudioPtr, DWORD dwPCMAudioBytes) {
+void DSoundBufferOutputXBtoHost(DWORD emuFlags, DSBUFFERDESC* pDSBufferDesc, LPVOID pXBaudioPtr, DWORD dwXBAudioBytes, LPVOID pPCaudioPtr, DWORD dwPCMAudioBytes) {
     if ((emuFlags & DSB_FLAG_XADPCM) > 0) {
-        DWORD dwDecodedAudioBytes = TXboxAdpcmDecoder_guess_output_size(dwXBAudioBytes) * pDSBufferDesc->lpwfxFormat->nChannels;
 
-        if (dwDecodedAudioBytes > dwPCMAudioBytes) dwDecodedAudioBytes = dwPCMAudioBytes;
-
-        TXboxAdpcmDecoder_Decode_Memory((uint8_t*)pXBaudioPtr, dwXBAudioBytes / pDSBufferDesc->lpwfxFormat->nChannels, (uint8_t*)pPCaudioPtr, pDSBufferDesc->lpwfxFormat->nChannels);
+        TXboxAdpcmDecoder_Decode_Memory((uint8_t*)pXBaudioPtr, dwXBAudioBytes, (uint8_t*)pPCaudioPtr, pDSBufferDesc->lpwfxFormat->nChannels);
 
     // PCM format, no changes requirement.
     } else {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -286,7 +286,10 @@ inline void GeneratePCMFormat(
         GenerateXboxBufferCache(pDSBufferDesc, dwEmuFlags, X_BufferSizeRequest, X_BufferCache, X_BufferCacheSize);
     }
 
-    pDSBufferDesc->dwBufferBytes = DSoundBufferGetPCMBufferSize(dwEmuFlags, X_BufferCacheSize);
+    // Handle DSound Buffer only
+    if (X_BufferCacheSize > 0) {
+        pDSBufferDesc->dwBufferBytes = DSoundBufferGetPCMBufferSize(dwEmuFlags, X_BufferCacheSize);
+    }
 }
 
 inline void DSoundGenericUnlock(
@@ -1060,6 +1063,11 @@ inline HRESULT HybridDirectSoundBuffer_SetFormat(
     if (g_pDSoundPrimaryBuffer == pDSBuffer) {
         hRet = pDSBuffer->SetFormat(pBufferDesc->lpwfxFormat);
     } else {
+        // DSound Stream only
+        if (X_BufferCacheSize == 0) {
+            // Allocate at least 5 second worth of bytes in PCM format.
+            pBufferDesc->dwBufferBytes = pBufferDesc->lpwfxFormat->nAvgBytesPerSec * 5;
+        }
         DSoundBufferReplace(pDSBuffer, pBufferDesc, dwPlayFlags, pDS3DBuffer);
     }
 

--- a/src/CxbxKrnl/EmuXTL.h
+++ b/src/CxbxKrnl/EmuXTL.h
@@ -34,6 +34,8 @@
 #ifndef EMUXTL_H
 #define EMUXTL_H
 
+#include <vector>  // Needed for EmuDSound.h file, must be outside of XTL namespace.
+
 namespace XTL
 {
     #include "EmuXapi.h"


### PR DESCRIPTION

Tasks
- DirectSoundStream improvement (95% completed)
  - **Only affecting most of the FMVs and possible background music.**
  - Discontinuity function is not implemented yet. **Still not implemented yet, not sure "how" to implement or might not be even possible to include support.**
  - ~~Undetermined Flush function is correct way to do it base on doc.~~ Sample was nice enough to tell me the problems.
  - ~~Need RE runtime debug info for pInputBuffer's pass down optional values. (During DirectSoundDoWork calls btw.)~~
- DirectSoundBuffer improvement (Incomplete, only small improvement)
  - **Only affecting menu, in-game, and certain FMVs.**
  - ~~Tweaks currently cause titles to crash. It's a known issue until I have complete buffer size + give title allocated memory pointer instead of host's memory pointer.~~ Most are done, seem to be missing one more location.