### PR TITLE
Documented vertex shader functions

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -74,7 +74,7 @@ HWND                                g_hEmuWindow   = NULL; // rendering window
 XTL::LPDIRECT3DDEVICE8              g_pD3DDevice8  = NULL; // Direct3D8 Device
 XTL::LPDIRECTDRAWSURFACE7           g_pDDSPrimary  = NULL; // DirectDraw7 Primary Surface
 XTL::LPDIRECTDRAWCLIPPER            g_pDDClipper   = nullptr; // DirectDraw7 Clipper
-DWORD                               g_CurrentVertexShader = 0;
+DWORD                               g_CurrentXboxVertexShaderHandle = 0;
 XTL::X_PixelShader*					g_D3DActivePixelShader = nullptr;
 BOOL                                g_bIsFauxFullscreen = FALSE;
 BOOL								g_bHackUpdateSoftwareOverlay = FALSE;
@@ -2643,7 +2643,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShader)
 
 	HRESULT hRet;
 	
-	g_CurrentVertexShader = Handle;
+	g_CurrentXboxVertexShaderHandle = Handle;
 
     if(VshHandleIsVertexShader(Handle))
     {
@@ -5901,7 +5901,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShader)
 
     HRESULT hRet = D3D_OK;
 
-    g_CurrentVertexShader = Handle;
+    g_CurrentXboxVertexShaderHandle = Handle;
 
     // Store viewport offset and scale in constant registers 58 (c-38) and
     // 59 (c-37) used for screen space transformation.
@@ -6041,7 +6041,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 		VPDesc.dwStartVertex = StartVertex;
 		VPDesc.pXboxVertexStreamZeroData = 0;
 		VPDesc.uiXboxVertexStreamZeroStride = 0;
-		VPDesc.hVertexShader = g_CurrentVertexShader;
+		VPDesc.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
 		VertexPatcher VertPatch;
 
@@ -6112,7 +6112,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVerticesUP)
 		VPDesc.dwStartVertex = 0;
 		VPDesc.pXboxVertexStreamZeroData = pVertexStreamZeroData;
 		VPDesc.uiXboxVertexStreamZeroStride = VertexStreamZeroStride;
-		VPDesc.hVertexShader = g_CurrentVertexShader;
+		VPDesc.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
 		VertexPatcher VertPatch;
 
@@ -6193,7 +6193,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 		VPDesc.dwStartVertex = 0;
 		VPDesc.pXboxVertexStreamZeroData = 0;
 		VPDesc.uiXboxVertexStreamZeroStride = 0;
-		VPDesc.hVertexShader = g_CurrentVertexShader;
+		VPDesc.hVertexShader = g_CurrentXboxVertexShaderHandle;
 		VPDesc.pIndexData = pIndexData;
 		VPDesc.dwIndexBase = indexBase;
 
@@ -6312,7 +6312,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 		VPDesc.dwStartVertex = 0;
 		VPDesc.pXboxVertexStreamZeroData = pVertexStreamZeroData;
 		VPDesc.uiXboxVertexStreamZeroStride = VertexStreamZeroStride;
-		VPDesc.hVertexShader = g_CurrentVertexShader;
+		VPDesc.hVertexShader = g_CurrentXboxVertexShaderHandle;
 		VPDesc.pIndexData = (PWORD)pIndexData;
 
 		VertexPatcher VertPatch;
@@ -6713,7 +6713,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShader)
 
     if(pHandle)
     {
-        (*pHandle) = g_CurrentVertexShader;
+        (*pHandle) = g_CurrentXboxVertexShaderHandle;
     }
 }
 
@@ -6853,7 +6853,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShaderProgram)
 		LOG_FUNC_ARG(Address)
 		LOG_FUNC_END;
 
-	DWORD hCurrentShader = g_CurrentVertexShader;
+	DWORD hCurrentShader = g_CurrentXboxVertexShaderHandle;
 
 
 	load_shader_program_key_t shaderCacheKey = ((load_shader_program_key_t)hCurrentShader << 32) | (DWORD)pFunction;

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -250,7 +250,7 @@ extern void XTL::EmuExecutePushBufferRaw
             pdwPushData += dwCount;
 
             // retrieve vertex shader
-			DWORD dwVertexShader = g_CurrentVertexShader;
+			DWORD dwVertexShader = g_CurrentXboxVertexShaderHandle;
 
 			if (VshHandleIsVertexShader(dwVertexShader)) 
 			{
@@ -411,7 +411,7 @@ extern void XTL::EmuExecutePushBufferRaw
                     VPDesc.pXboxVertexStreamZeroData = 0;
                     VPDesc.uiXboxVertexStreamZeroStride = 0;
                     // TODO: Set the current shader and let the patcher handle it..
-                    VPDesc.hVertexShader = g_CurrentVertexShader;
+                    VPDesc.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
                     VertexPatcher VertPatch;
 
@@ -574,7 +574,7 @@ extern void XTL::EmuExecutePushBufferRaw
                     VPDesc.pXboxVertexStreamZeroData = 0;
                     VPDesc.uiXboxVertexStreamZeroStride = 0;
                     // TODO: Set the current shader and let the patcher handle it..
-                    VPDesc.hVertexShader = g_CurrentVertexShader;
+                    VPDesc.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
                     VertexPatcher VertPatch;
 
@@ -795,7 +795,7 @@ void XTL::DbgDumpPushBuffer( DWORD* PBData, DWORD dwSize )
 	// Write pushbuffer data to the file.
 	// TODO: Cache the 32-bit XXHash32::hash() of each pushbuffer to ensure that the same
 	// pushbuffer is not written twice within a given emulation session.
-	WriteFile( hFile, &g_CurrentVertexShader, sizeof( DWORD ), &dwBytesWritten, NULL );
+	WriteFile( hFile, &g_CurrentXboxVertexShaderHandle, sizeof( DWORD ), &dwBytesWritten, NULL );
 	WriteFile( hFile, PBData, dwSize, &dwBytesWritten, NULL );
 
 	// Close handle

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -203,7 +203,7 @@ bool XTL::VertexPatcher::PatchStream(VertexPatchDesc *pPatchDesc,
 {
     // FVF buffers doesn't have Xbox extensions, but texture coordinates may
     // need normalization if used with linear textures.
-    if(!VshHandleIsVertexShader(pPatchDesc->hVertexShader))
+    if(VshHandleIsFVF(pPatchDesc->hVertexShader))
     {
         if(pPatchDesc->hVertexShader & D3DFVF_TEXCOUNT_MASK)
         {
@@ -834,8 +834,8 @@ VOID XTL::EmuFlushIVB()
 	EmuUpdateActiveTextureStages();
 
     // Parse IVB table with current FVF shader if possible.
-    bool bFVF = VshHandleIsFVF(g_CurrentVertexShader);
-    DWORD dwCurFVF = (bFVF) ? g_CurrentVertexShader : g_InlineVertexBuffer_FVF;
+    bool bFVF = VshHandleIsFVF(g_CurrentXboxVertexShaderHandle);
+    DWORD dwCurFVF = (bFVF) ? g_CurrentXboxVertexShaderHandle : g_InlineVertexBuffer_FVF;
 
     DbgPrintf("g_InlineVertexBuffer_TableOffset := %d\n", g_InlineVertexBuffer_TableOffset);
 
@@ -990,7 +990,7 @@ VOID XTL::EmuFlushIVB()
     VPDesc.dwVertexCount = g_InlineVertexBuffer_TableOffset;
     VPDesc.pXboxVertexStreamZeroData = g_InlineVertexBuffer_pData;
     VPDesc.uiXboxVertexStreamZeroStride = uiStride;
-    VPDesc.hVertexShader = g_CurrentVertexShader;
+    VPDesc.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
     VertexPatcher VertPatch;
 
@@ -1011,7 +1011,7 @@ VOID XTL::EmuFlushIVB()
 
     if(bFVF)
     {
-        g_pD3DDevice8->SetVertexShader(g_CurrentVertexShader);
+        g_pD3DDevice8->SetVertexShader(g_CurrentXboxVertexShaderHandle);
     }
 
     g_InlineVertexBuffer_TableOffset = 0;

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2315,7 +2315,7 @@ extern boolean XTL::IsValidCurrentShader(void)
 {
 	// Dxbx addition : There's no need to call
 	// XTL_EmuIDirect3DDevice_GetVertexShader, just check g_CurrentVertexShader :
-	return VshHandleIsValidShader(g_CurrentVertexShader);
+	return VshHandleIsValidShader(g_CurrentXboxVertexShaderHandle);
 }
 
 // Checks for failed vertex shaders, and shaders that would need patching

--- a/src/CxbxKrnl/EmuXTL.h
+++ b/src/CxbxKrnl/EmuXTL.h
@@ -53,7 +53,7 @@ namespace XTL
 }
 
 extern XTL::LPDIRECT3DDEVICE8   g_pD3DDevice8;
-extern DWORD                    g_CurrentVertexShader;
+extern DWORD                    g_CurrentXboxVertexShaderHandle;
 extern XTL::X_PixelShader*		g_D3DActivePixelShader;
 extern BOOL                     g_bIsFauxFullscreen;
 


### PR DESCRIPTION
This is no functional change, it merely adds a load documentation on vertex shader functions, and two small changes (renamed `g_CurrentVertexShader` into `g_CurrentXboxVertexShaderHandle` and using `VshHandleIsFVF` instead of `!VshHandleIsVertexShader`).

