### PR TITLE
Shikigami no Shiro Tweaks

### DIFF
--- a/src/CxbxKrnl/EmuKrnlPs.cpp
+++ b/src/CxbxKrnl/EmuKrnlPs.cpp
@@ -322,7 +322,8 @@ XBSYSAPI EXPORTNUM(255) xboxkrnl::NTSTATUS NTAPI xboxkrnl::PsCreateSystemThreadE
 		// Note : DO NOT use iPCSTProxyParam anymore, since ownership is transferred to the proxy (which frees it too)
 
 		// Give the thread chance to start
-		Sleep(100);
+		// Note: Shikigami no Shiro will be able to wait until 10 ms
+		Sleep(10);
 
         EmuWarning("KRNL: Waiting for Xbox proxy thread to start...\n");
 


### PR DESCRIPTION
Fix no boot in Shikigami no Shiro https://github.com/Cxbx-Reloaded/game-compatibility/issues/468
Title wait for more than 10 ms to cause KeWaitForMultipleObjects failed! (STATUS_INVALID_HANDLE)

Also fix freezes on release build in Shikigami no Shiro Evolution https://github.com/Cxbx-Reloaded/game-compatibility/issues/473
