### PR TITLE
Download from the last successful non-PR builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Cxbx-Reloaded is early in development, however it is progressing almost daily: W
 ## Automated Builds
 Cxbx-Reloaded is not yet ready for general release, but the latest development builds can always be downloaded from our [AppVeyor](https://ci.appveyor.com/project/SoullessSentinel/cxbx-reloaded/branch/master) service:
 
-* [Latest build (Release-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Release.zip?branch=master&job=Configuration:%20Release)
-* [Latest build (Debug-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Debug.zip?branch=master&job=Configuration:%20Debug)
+* [Latest build (Release-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Release.zip?branch=master&job=Configuration:%20Release&pr=false)
+* [Latest build (Debug-mode)](https://ci.appveyor.com/api/projects/SoullessSentinel/cxbx-reloaded/artifacts/export/Debug.zip?branch=master&job=Configuration:%20Debug&pr=false)
 * [Full build history](https://ci.appveyor.com/project/SoullessSentinel/cxbx-reloaded/history)
 
 ## Compatibility


### PR DESCRIPTION
Currently, the permalinks are to the last build - which includes PR builds which have not been merged...

This fixed that!