### PR TITLE
Support for controller vibration

### DIFF
--- a/src/CxbxKrnl/EmuXInput.cpp
+++ b/src/CxbxKrnl/EmuXInput.cpp
@@ -49,7 +49,6 @@
 // * Static Variable(s)
 // ******************************************************************
 static XINPUT_STATE		g_Controller;
-static XINPUT_VIBRATION g_Vibration;
 static BOOL				g_bXInputInitialized = FALSE;
 
 
@@ -132,4 +131,22 @@ void XTL::EmuXInputPCPoll( XTL::PXINPUT_STATE Controller )
 	} else {
 		Controller->Gamepad.wButtons &= ~XB_XINPUT_GAMEPAD_DPAD_RIGHT;
 	}
+}
+
+
+// ******************************************************************
+// * Native implementation of XInputSetState
+// ******************************************************************
+void XTL::EmuXInputSetState(XTL::PXINPUT_FEEDBACK Feedback)
+{
+	XINPUT_VIBRATION FrameVibration =
+	{
+		Feedback->Rumble.wLeftMotorSpeed,
+		Feedback->Rumble.wRightMotorSpeed
+	};
+	
+	//
+	// Set the PC XInput state
+
+	XInputSetState(0, &FrameVibration);
 }

--- a/src/CxbxKrnl/EmuXInput.h
+++ b/src/CxbxKrnl/EmuXInput.h
@@ -39,4 +39,9 @@
 // ******************************************************************
 void EmuXInputPCPoll( XTL::PXINPUT_STATE Controller );
 
+// ******************************************************************
+// * Native implementation of XInputSetState
+// ******************************************************************
+void EmuXInputSetState(XTL::PXINPUT_FEEDBACK Feedback);
+
 #endif

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -521,8 +521,8 @@ DWORD WINAPI XTL::EMUPATCH(XInputGetCapabilities)
         if(dwPort == 0)
         {
             pCapabilities->SubType = XINPUT_DEVSUBTYPE_GC_GAMEPAD;
-			ZeroMemory(&pCapabilities->Gamepad, sizeof(XINPUT_GAMEPAD));
-			ZeroMemory(&pCapabilities->Rumble, sizeof(XINPUT_RUMBLE));
+			pCapabilities->In.Gamepad = {};
+			pCapabilities->Out.Rumble = {};
 
             ret = ERROR_SUCCESS;
         }
@@ -611,14 +611,64 @@ DWORD WINAPI XTL::EMUPATCH(XInputSetState)
 
     if(pph != NULL)
     {
+        int v;
+
+        //
+        // Check if this device is already being polled
+        //
+
+        bool found = false;
+
+        for(v=0;v<XINPUT_SETSTATE_SLOTS;v++)
+        {
+            if(g_pXInputSetStateStatus[v].hDevice == hDevice)
+            {
+                found = true;
+
+                if(pFeedback->Header.dwStatus == ERROR_SUCCESS)
+                {
+                    ret = ERROR_SUCCESS;
+
+                    // remove from slot
+                    g_pXInputSetStateStatus[v].hDevice = NULL;
+                    g_pXInputSetStateStatus[v].pFeedback = NULL;
+                    g_pXInputSetStateStatus[v].dwLatency = 0;
+                }
+            }
+        }
+
+        //
+        // If device was not already slotted, queue it
+        //
+
+        if(!found)
+        {
+            for(v=0;v<XINPUT_SETSTATE_SLOTS;v++)
+            {
+                if(g_pXInputSetStateStatus[v].hDevice == 0)
+                {
+                    g_pXInputSetStateStatus[v].hDevice = hDevice;
+                    g_pXInputSetStateStatus[v].dwLatency = 0;
+                    g_pXInputSetStateStatus[v].pFeedback = pFeedback;
+
+                    pFeedback->Header.dwStatus = ERROR_IO_PENDING;
+
+                    break;
+                }
+            }
+
+            if(v == XINPUT_SETSTATE_SLOTS)
+            {
+                CxbxKrnlCleanup("Ran out of XInputSetStateStatus slots!");
+            }
+        }
+
 		if (pph->dwPort == 0)
 		{
 			if (g_XInputEnabled)
 			{
 				XTL::EmuXInputSetState(pFeedback);
 			}
-
-			ret = ERROR_SUCCESS;
 		}
     }
 

--- a/src/CxbxKrnl/EmuXapi.h
+++ b/src/CxbxKrnl/EmuXapi.h
@@ -202,8 +202,18 @@ typedef struct _XINPUT_CAPABILITIES
 {
     BYTE SubType;
     WORD Reserved;
-	XINPUT_GAMEPAD Gamepad;
-	XINPUT_RUMBLE Rumble;
+
+    union
+    {
+        XINPUT_GAMEPAD Gamepad;
+    }
+    In;
+
+    union
+    {
+        XINPUT_RUMBLE Rumble;
+    }
+    Out;
 }
 XINPUT_CAPABILITIES, *PXINPUT_CAPABILITIES;
 
@@ -259,23 +269,27 @@ XINPUT_STATE, *PXINPUT_STATE;
 // ******************************************************************
 // * XINPUT_FEEDBACK_HEADER
 // ******************************************************************
-#pragma pack(1)
+#include "AlignPrefix1.h"
 typedef struct _XINPUT_FEEDBACK_HEADER
 {
     DWORD           dwStatus;
     HANDLE OPTIONAL hEvent;
     BYTE            Reserved[58];
 }
+#include "AlignPosfix1.h"
 XINPUT_FEEDBACK_HEADER, *PXINPUT_FEEDBACK_HEADER;
-#pragma pack()
 
 // ******************************************************************
 // * XINPUT_FEEDBACK
 // ******************************************************************
 typedef struct _XINPUT_FEEDBACK
 {
-	XINPUT_FEEDBACK_HEADER Header;
-	XINPUT_RUMBLE Rumble;
+    XINPUT_FEEDBACK_HEADER Header;
+
+    union
+    {
+        XINPUT_RUMBLE Rumble;
+    };
 }
 XINPUT_FEEDBACK, *PXINPUT_FEEDBACK;
 

--- a/src/CxbxKrnl/EmuXapi.h
+++ b/src/CxbxKrnl/EmuXapi.h
@@ -202,18 +202,8 @@ typedef struct _XINPUT_CAPABILITIES
 {
     BYTE SubType;
     WORD Reserved;
-
-    union
-    {
-        XINPUT_GAMEPAD Gamepad;
-    }
-    In;
-
-    union
-    {
-        XINPUT_RUMBLE Rumble;
-    }
-    Out;
+	XINPUT_GAMEPAD Gamepad;
+	XINPUT_RUMBLE Rumble;
 }
 XINPUT_CAPABILITIES, *PXINPUT_CAPABILITIES;
 
@@ -269,6 +259,7 @@ XINPUT_STATE, *PXINPUT_STATE;
 // ******************************************************************
 // * XINPUT_FEEDBACK_HEADER
 // ******************************************************************
+#pragma pack(1)
 typedef struct _XINPUT_FEEDBACK_HEADER
 {
     DWORD           dwStatus;
@@ -276,18 +267,15 @@ typedef struct _XINPUT_FEEDBACK_HEADER
     BYTE            Reserved[58];
 }
 XINPUT_FEEDBACK_HEADER, *PXINPUT_FEEDBACK_HEADER;
+#pragma pack()
 
 // ******************************************************************
 // * XINPUT_FEEDBACK
 // ******************************************************************
 typedef struct _XINPUT_FEEDBACK
 {
-    XINPUT_FEEDBACK_HEADER Header;
-
-    union
-    {
-        XINPUT_RUMBLE Rumble;
-    };
+	XINPUT_FEEDBACK_HEADER Header;
+	XINPUT_RUMBLE Rumble;
 }
 XINPUT_FEEDBACK, *PXINPUT_FEEDBACK;
 


### PR DESCRIPTION
Requires "Use XInput" to be checked from the settings menu

I've also removed logic which updates `g_pXInputSetStateStatus`, but any info on why it needs to poll there is welcomed!