### PR TITLE
Nt memory functions

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -177,6 +177,7 @@ typedef long                            NTSTATUS;
 #define STATUS_UNABLE_TO_FREE_VM         ((DWORD   )0xC000001AL)
 #define STATUS_FREE_VM_NOT_AT_BASE       ((DWORD   )0xC000009FL)
 #define STATUS_MEMORY_NOT_ALLOCATED      ((DWORD   )0xC00000A0L)
+#define STATUS_NOT_COMMITTED             ((DWORD   )0xC000002DL)
 
 // ******************************************************************
 // * Registry value types

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -175,6 +175,7 @@ typedef long                            NTSTATUS;
 #define STATUS_INVALID_PAGE_PROTECTION   ((DWORD   )0xC0000045L)
 #define STATUS_CONFLICTING_ADDRESSES     ((DWORD   )0xC0000018L)
 #define STATUS_UNABLE_TO_FREE_VM         ((DWORD   )0xC000001AL)
+#define STATUS_FREE_VM_NOT_AT_BASE       ((DWORD   )0xC000009FL)
 #define STATUS_MEMORY_NOT_ALLOCATED      ((DWORD   )0xC00000A0L)
 
 // ******************************************************************

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -74,7 +74,7 @@ extern "C" {
 #define PAGE_SIZE_LARGE             0x400000
 #define PAGE_MASK                   (PAGE_SIZE - 1)
 #define BYTES_IN_PHYSICAL_MAP       256 * ONE_MB // this refears to the system RAM physical window 0x80000000 - 0x8FFFFFFF
-#define MAXIMUM_ZERO_BITS           21 // for NtAllocateVirtualMemory
+#define MAXIMUM_ZERO_BITS           21 // for XbAllocateVirtualMemory
 
 /*! memory size per system */
 #define XBOX_MEMORY_SIZE (64 * ONE_MB)

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -74,6 +74,7 @@ extern "C" {
 #define PAGE_SIZE_LARGE             0x400000
 #define PAGE_MASK                   (PAGE_SIZE - 1)
 #define BYTES_IN_PHYSICAL_MAP       256 * ONE_MB // this refears to the system RAM physical window 0x80000000 - 0x8FFFFFFF
+#define MAXIMUM_ZERO_BITS           21 // for NtAllocateVirtualMemory
 
 /*! memory size per system */
 #define XBOX_MEMORY_SIZE (64 * ONE_MB)
@@ -155,7 +156,7 @@ extern "C" {
 
 #define LOWEST_USER_ADDRESS      0x00010000
 #define HIGHEST_USER_ADDRESS     0x7FFEFFFF
-#define HIGHEST_VAD_ADDRESS      HIGHEST_USER_ADDRESS - X64KB // for NtAllocateVirtualMemory
+#define HIGHEST_VMA_ADDRESS      HIGHEST_USER_ADDRESS - X64KB // for NtAllocateVirtualMemory
 #define USER_MEMORY_SIZE         HIGHEST_USER_ADDRESS - LOWEST_USER_ADDRESS + 1 // 0x7FFE0000 = 2 GiB - 128 KiB
 
 #define PAGE_DIRECTORY_BASE      0xC0300000

--- a/src/CxbxKrnl/EmuKrnlMm.cpp
+++ b/src/CxbxKrnl/EmuKrnlMm.cpp
@@ -408,7 +408,7 @@ XBSYSAPI EXPORTNUM(181) xboxkrnl::NTSTATUS NTAPI xboxkrnl::MmQueryStatistics
 	{
 		DbgPrintf("KNRL: MmQueryStatistics : PMM_STATISTICS MemoryStatistics is nullptr!\n");
 		LOG_IGNORED();
-		RETURN(STATUS_SUCCESS);
+		RETURN(STATUS_INVALID_PARAMETER);
 	}
 	#endif
 

--- a/src/CxbxKrnl/EmuKrnlMm.cpp
+++ b/src/CxbxKrnl/EmuKrnlMm.cpp
@@ -494,7 +494,7 @@ XBSYSAPI EXPORTNUM(374) xboxkrnl::PVOID NTAPI xboxkrnl::MmDbgAllocateMemory
 	assert(g_bIsDebug);
 
 	PVOID addr = (PVOID)g_VMManager.AllocateSystemMemory(DebuggerType, Protect, NumberOfBytes, false);
-	if (addr) { FillMemoryUlong((void*)addr, ROUND_UP_4K(NumberOfBytes), 0); } // debugger pages are zeroed
+	if (addr) { RtlFillMemoryUlong((void*)addr, ROUND_UP_4K(NumberOfBytes), 0); } // debugger pages are zeroed
 
 	RETURN(addr);
 }

--- a/src/CxbxKrnl/EmuKrnlMm.cpp
+++ b/src/CxbxKrnl/EmuKrnlMm.cpp
@@ -403,14 +403,12 @@ XBSYSAPI EXPORTNUM(181) xboxkrnl::NTSTATUS NTAPI xboxkrnl::MmQueryStatistics
 
 	NTSTATUS ret;
 
-	#ifdef _DEBUG_TRACE
-	 if (!MemoryStatistics)
+	if (!MemoryStatistics)
 	{
-		DbgPrintf("KNRL: MmQueryStatistics : PMM_STATISTICS MemoryStatistics is nullptr!\n");
+		EmuWarning("KNRL: MmQueryStatistics : PMM_STATISTICS MemoryStatistics is nullptr!\n");
 		LOG_IGNORED();
 		RETURN(STATUS_INVALID_PARAMETER);
 	}
-	#endif
 
 	if (MemoryStatistics->Length == sizeof(MM_STATISTICS))
 	{

--- a/src/CxbxKrnl/EmuKrnlMm.cpp
+++ b/src/CxbxKrnl/EmuKrnlMm.cpp
@@ -130,7 +130,7 @@ XBSYSAPI EXPORTNUM(167) xboxkrnl::PVOID NTAPI xboxkrnl::MmAllocateSystemMemory
 {
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(NumberOfBytes)
-		LOG_FUNC_ARG(Protect)
+		LOG_FUNC_ARG_TYPE(PROTECTION_TYPE, Protect)
 	LOG_FUNC_END;
 
 	PVOID addr = (PVOID)g_VMManager.AllocateSystemMemory(SystemMemoryType, Protect, NumberOfBytes, false);
@@ -334,7 +334,7 @@ XBSYSAPI EXPORTNUM(177) xboxkrnl::PVOID NTAPI xboxkrnl::MmMapIoSpace
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(PhysicalAddress)
 		LOG_FUNC_ARG(NumberOfBytes)
-		LOG_FUNC_ARG(ProtectionType)
+		LOG_FUNC_ARG_TYPE(PROTECTION_TYPE, ProtectionType)
 	LOG_FUNC_END;
 
 	PVOID pRet = (PVOID)g_VMManager.MapDeviceMemory(PhysicalAddress, NumberOfBytes, ProtectionType);
@@ -450,7 +450,7 @@ XBSYSAPI EXPORTNUM(182) xboxkrnl::VOID NTAPI xboxkrnl::MmSetAddressProtect
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(BaseAddress)
 		LOG_FUNC_ARG(NumberOfBytes)
-		LOG_FUNC_ARG(NewProtect)
+		LOG_FUNC_ARG_TYPE(PROTECTION_TYPE, NewProtect)
 	LOG_FUNC_END;
 
 	g_VMManager.Protect((VAddr)BaseAddress, NumberOfBytes, NewProtect);
@@ -487,7 +487,7 @@ XBSYSAPI EXPORTNUM(374) xboxkrnl::PVOID NTAPI xboxkrnl::MmDbgAllocateMemory
 {
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(NumberOfBytes)
-		LOG_FUNC_ARG(Protect)
+		LOG_FUNC_ARG_TYPE(PROTECTION_TYPE, Protect)
 	LOG_FUNC_END;
 
 	// This should only be called by debug xbe's

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -1357,16 +1357,31 @@ XBSYSAPI EXPORTNUM(217) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtQueryVirtualMemory
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(BaseAddress)
 		LOG_FUNC_ARG_OUT(Buffer)
-		LOG_FUNC_END;
+	LOG_FUNC_END;
 
-	NTSTATUS ret = NtDll::NtQueryVirtualMemory(
-		/*ProcessHandle=*/g_CurrentProcessHandle,
-		BaseAddress,
-		(NtDll::MEMORY_INFORMATION_CLASS)NtDll::MemoryBasicInformation,
-		(NtDll::PMEMORY_BASIC_INFORMATION)Buffer,
-		/*Length=*/sizeof(MEMORY_BASIC_INFORMATION),
-		/*ResultLength=*/nullptr);
+	#ifdef _DEBUG_TRACE
+		if (!Buffer)
+		{
+			DbgPrintf("KNRL: NtQueryVirtualMemory : PMEMORY_BASIC_INFORMATION Buffer is nullptr!\n");
+			LOG_IGNORED();
+			RETURN(STATUS_INVALID_PARAMETER);
+		}
+	#endif
 
+	NTSTATUS ret = g_VMManager.VirtualMemoryStatistics((VAddr)BaseAddress, Buffer);
+
+	if (ret == STATUS_SUCCESS)
+	{
+		DbgPrintf("   Buffer->AllocationBase    = 0x%.08X\n", Buffer->AllocationBase);
+		DbgPrintf("   Buffer->AllocationProtect = 0x%.08X\n", Buffer->AllocationProtect);
+		DbgPrintf("   Buffer->BaseAddress       = 0x%.08X\n", Buffer->BaseAddress);
+		DbgPrintf("   Buffer->RegionSize        = 0x%.08X\n", Buffer->RegionSize);
+		DbgPrintf("   Buffer->State             = 0x%.08X\n", Buffer->State);
+		DbgPrintf("   Buffer->Protect           = 0x%.08X\n", Buffer->Protect);
+		DbgPrintf("   Buffer->Type              = 0x%.08X\n", Buffer->Type);
+	}
+
+	#if 0
 	if (FAILED(ret)) {
 		EmuWarning("NtQueryVirtualMemory failed (%s)!", NtStatusToString(ret));
 
@@ -1390,6 +1405,7 @@ XBSYSAPI EXPORTNUM(217) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtQueryVirtualMemory
 			DbgPrintf("KRNL: NtQueryVirtualMemory: Applied fix for Forza Motorsport!\n");
 		}
 	}
+	#endif
 
 	RETURN(ret);
 }

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -82,7 +82,7 @@ XBSYSAPI EXPORTNUM(184) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtAllocateVirtualMemo
 		LOG_FUNC_ARG(ZeroBits)
 		LOG_FUNC_ARG(AllocationSize)
 		LOG_FUNC_ARG_TYPE(ALLOCATION_TYPE, AllocationType)
-		LOG_FUNC_ARG(Protect)
+		LOG_FUNC_ARG_TYPE(PROTECTION_TYPE, Protect)
 	LOG_FUNC_END;
 
 	NTSTATUS ret = g_VMManager.XbAllocateVirtualMemory((VAddr*)BaseAddress, ZeroBits, (size_t*)AllocationSize,
@@ -754,8 +754,8 @@ XBSYSAPI EXPORTNUM(199) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtFreeVirtualMemory
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(BaseAddress)
 		LOG_FUNC_ARG(FreeSize)
-		LOG_FUNC_ARG(FreeType)
-		LOG_FUNC_END;
+		LOG_FUNC_ARG_TYPE(ALLOCATION_TYPE, FreeType)
+	LOG_FUNC_END;
 
 	NTSTATUS ret = g_VMManager.XbFreeVirtualMemory((VAddr*)BaseAddress, (size_t*)FreeSize, FreeType);
 
@@ -907,7 +907,7 @@ XBSYSAPI EXPORTNUM(204) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtProtectVirtualMemor
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(BaseAddress)
 		LOG_FUNC_ARG(RegionSize)
-		LOG_FUNC_ARG(NewProtect)
+		LOG_FUNC_ARG_TYPE(PROTECTION_TYPE, NewProtect)
 		LOG_FUNC_ARG_OUT(OldProtect)
 	LOG_FUNC_END;
 

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -909,11 +909,14 @@ XBSYSAPI EXPORTNUM(204) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtProtectVirtualMemor
 		LOG_FUNC_ARG(RegionSize)
 		LOG_FUNC_ARG(NewProtect)
 		LOG_FUNC_ARG_OUT(OldProtect)
-		LOG_FUNC_END;
+	LOG_FUNC_END;
 
-	LOG_IGNORED();
 
-	RETURN(STATUS_SUCCESS);
+	DWORD Perms = NewProtect;
+	NTSTATUS ret = g_VMManager.XbProtect((VAddr*)BaseAddress, (size_t*)RegionSize, &Perms);
+	*OldProtect = Perms;
+
+	RETURN(ret);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -913,7 +913,7 @@ XBSYSAPI EXPORTNUM(204) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtProtectVirtualMemor
 
 
 	DWORD Perms = NewProtect;
-	NTSTATUS ret = g_VMManager.XbProtect((VAddr*)BaseAddress, (size_t*)RegionSize, &Perms);
+	NTSTATUS ret = g_VMManager.XbVirtualProtect((VAddr*)BaseAddress, (size_t*)RegionSize, &Perms);
 	*OldProtect = Perms;
 
 	RETURN(ret);

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -1359,16 +1359,14 @@ XBSYSAPI EXPORTNUM(217) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtQueryVirtualMemory
 		LOG_FUNC_ARG_OUT(Buffer)
 	LOG_FUNC_END;
 
-	#ifdef _DEBUG_TRACE
-		if (!Buffer)
-		{
-			DbgPrintf("KNRL: NtQueryVirtualMemory : PMEMORY_BASIC_INFORMATION Buffer is nullptr!\n");
-			LOG_IGNORED();
-			RETURN(STATUS_INVALID_PARAMETER);
-		}
-	#endif
+	if (!Buffer)
+	{
+		EmuWarning("KNRL: NtQueryVirtualMemory : PMEMORY_BASIC_INFORMATION Buffer is nullptr!\n");
+		LOG_IGNORED();
+		RETURN(STATUS_INVALID_PARAMETER);
+	}
 
-	NTSTATUS ret = g_VMManager.VirtualMemoryStatistics((VAddr)BaseAddress, Buffer);
+	NTSTATUS ret = g_VMManager.XbVirtualMemoryStatistics((VAddr)BaseAddress, Buffer);
 
 	if (ret == STATUS_SUCCESS)
 	{

--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -37,6 +37,7 @@
 #define _XBOXKRNL_DEFEXTRN_
 
 #define LOG_PREFIX "KRNL"
+#define CHECK_ALIGNMENT(size, alignment) (((size) % (alignment)) == 0) // For RtlFillMemoryUlong
 
 // prevent name collisions
 namespace xboxkrnl
@@ -55,6 +56,7 @@ namespace NtDll
 
 #include "CxbxKrnl.h" // For CxbxKrnlCleanup()
 #include "Emu.h" // For EmuWarning()
+#include <assert.h>
 
 #ifdef _WIN32
 
@@ -969,14 +971,21 @@ XBSYSAPI EXPORTNUM(285) xboxkrnl::VOID NTAPI xboxkrnl::RtlFillMemoryUlong
 		LOG_FUNC_ARG(Destination)
 		LOG_FUNC_ARG(Length)
 		LOG_FUNC_ARG(Pattern)
-		LOG_FUNC_END;
+	LOG_FUNC_END;
 
 	// Fill 32 bits at a time
 	// Any extra bytes are ignored
-	uint32_t numDwords = Length / sizeof(ULONG);
-	uint32_t *lastAddr = (uint32_t *)Destination + numDwords;
-	for (uint32_t *p = (uint32_t *)Destination; p < lastAddr; p++) {
-		*p = Pattern;
+
+	assert(Length != 0);
+	assert(CHECK_ALIGNMENT(Length, sizeof(ULONG)));                   // Length must be a multiple of ULONG
+	assert(CHECK_ALIGNMENT((uintptr_t)Destination, sizeof(ULONG)));   // Destination must be 4-byte aligned
+
+	int NumOfRepeats = Length / sizeof(ULONG);
+	ULONG* d = (ULONG*)Destination;
+
+	for (int i = 0; i < NumOfRepeats; ++i)
+	{
+		d[i] = Pattern; // copy an ULONG at a time
 	}
 }
 

--- a/src/CxbxKrnl/PhysicalMemory.cpp
+++ b/src/CxbxKrnl/PhysicalMemory.cpp
@@ -120,7 +120,7 @@ void PhysicalMemory::WritePfn(PFN pfn_start, PFN pfn_end, PMMPTE pPte, PageType 
 			TempPF.Default = 0;
 			TempPF.Busy.Busy = 1;
 			TempPF.Busy.BusyType = BusyType;
-			if (BusyType != PageType::VirtualPageTableType && BusyType != SystemPageTableType) {
+			if (BusyType != VirtualPageTableType && BusyType != SystemPageTableType) {
 				TempPF.Busy.PteIndex = GetPteOffset(GetVAddrMappedByPte(pPte));
 			}
 			else { TempPF.PTPageFrame.PtesUsed = 0; } // we are writing a pfn of a PT

--- a/src/CxbxKrnl/PhysicalMemory.cpp
+++ b/src/CxbxKrnl/PhysicalMemory.cpp
@@ -154,8 +154,11 @@ void PhysicalMemory::WritePte(PMMPTE pPteStart, PMMPTE pPteEnd, MMPTE Pte, PFN p
 			{
 				PTpfn = GetPfnOfPT(PointerPte);
 			}
-			WRITE_ZERO_PTE(PointerPte);
-			PTpfn->PTPageFrame.PtesUsed--;
+			if (PointerPte->Default != 0)
+			{
+				WRITE_ZERO_PTE(PointerPte);
+				PTpfn->PTPageFrame.PtesUsed--;
+			}
 			PointerPte++;
 		}
 	}
@@ -657,24 +660,6 @@ DWORD PhysicalMemory::ConvertXboxToWinProtection(DWORD Perms)
 	}
 	return Mask;
 }
-
-DWORD PhysicalMemory::ConvertXboxToWinAllocType(DWORD AllocType)
-{
-	// This function assumes that the supplied allocation mask has been sanitized already
-
-	DWORD Mask = 0;
-
-	if (AllocType & XBOX_MEM_COMMIT) { Mask |= MEM_COMMIT; }
-	else if(AllocType & XBOX_MEM_RESERVE) { Mask |= MEM_RESERVE; }
-	else if (AllocType & XBOX_MEM_DECOMMIT) { Mask |= MEM_DECOMMIT; }
-	else if (AllocType & XBOX_MEM_RELEASE) { Mask |= MEM_RELEASE; }
-	else if (AllocType & XBOX_MEM_RESET) { Mask |= MEM_RESET; }
-	else if (AllocType & XBOX_MEM_TOP_DOWN) { Mask |= MEM_TOP_DOWN; }
-	else if (AllocType & XBOX_MEM_NOZERO) { DbgPrintf("PMEM: XBOX_MEM_NOZERO flag is not supported!\n"); }
-
-	return Mask;
-}
-
 
 bool PhysicalMemory::AllocatePT(size_t Size, VAddr addr)
 {

--- a/src/CxbxKrnl/PhysicalMemory.cpp
+++ b/src/CxbxKrnl/PhysicalMemory.cpp
@@ -41,21 +41,6 @@
 #include <assert.h>
 
 
-void FillMemoryUlong(void* Destination, size_t Length, ULONG Long)
-{
-	assert(Length != 0);
-	assert(CHECK_ALIGNMENT(Length, sizeof(ULONG)));                   // Length must be a multiple of ULONG
-	assert(CHECK_ALIGNMENT((uintptr_t)Destination, sizeof(ULONG)));   // Destination must be 4-byte aligned
-
-	int NumOfRepeats = Length / sizeof(ULONG);
-	ULONG* d = (ULONG*)Destination;
-
-	for (int i = 0; i < NumOfRepeats; ++i)
-	{
-		d[i] = Long; // copy an ULONG at a time
-	}
-}
-
 void PhysicalMemory::InitializePageDirectory()
 {
 	PMMPTE pPde;

--- a/src/CxbxKrnl/PhysicalMemory.h
+++ b/src/CxbxKrnl/PhysicalMemory.h
@@ -261,7 +261,7 @@ class PhysicalMemory
 		// convert from Xbox to Windows permissions
 		DWORD ConvertXboxToWinProtection(DWORD Perms);
 		// convert from xbox to windows memory allocation type
-		DWORD ConvertXboxToWinAllocType(DWORD AllocType);
+		//DWORD ConvertXboxToWinAllocType(DWORD AllocType);
 		// add execute rights if the permission mask doesn't include it
 		DWORD PatchXboxPermissions(DWORD Perms);
 		// commit page tables (if necessary)

--- a/src/CxbxKrnl/PhysicalMemory.h
+++ b/src/CxbxKrnl/PhysicalMemory.h
@@ -208,10 +208,6 @@ typedef enum _PageType
 #define IS_USER_ADDRESS(Va) (((VAddr)(Va) - LOWEST_USER_ADDRESS) <= (HIGHEST_USER_ADDRESS - LOWEST_USER_ADDRESS))
 
 
-/* Global helper function used to copy an ULONG block of memory to another buffer. It mimics RtlFillMemoryUlong */
-void FillMemoryUlong(void* Destination, size_t Length, ULONG Long);
-
-
 /* PhysicalMemory class */
 class PhysicalMemory
 {

--- a/src/CxbxKrnl/PhysicalMemory.h
+++ b/src/CxbxKrnl/PhysicalMemory.h
@@ -260,8 +260,6 @@ class PhysicalMemory
 		DWORD ConvertPteToXboxProtection(ULONG PteMask);
 		// convert from Xbox to Windows permissions
 		DWORD ConvertXboxToWinProtection(DWORD Perms);
-		// convert from xbox to windows memory allocation type
-		//DWORD ConvertXboxToWinAllocType(DWORD AllocType);
 		// add execute rights if the permission mask doesn't include it
 		DWORD PatchXboxPermissions(DWORD Perms);
 		// commit page tables (if necessary)

--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -183,17 +183,17 @@ void VMManager::DestroyMemoryRegions()
 	// VirtualAlloc and MapViewOfFileEx cannot be used in the contiguous region so skip it
 	for (int i = 0; i < COUNTRegion - 1; ++i)
 	{
-		for (auto it = m_MemoryRegionArray[i].RegionMap.begin(); it != m_MemoryRegionArray[i].RegionMap.end(); ++it)
+		for (auto& it : m_MemoryRegionArray[i].RegionMap)
 		{
-			if (it->second.type != FreeVma && it->first >= XBE_MAX_VA)
+			if (it.second.type != FreeVma && it.first >= XBE_MAX_VA)
 			{
-				if (it->second.bFragmented)
+				if (it.second.bFragmented)
 				{
-					VirtualFree((void*)it->first, 0, MEM_RELEASE);
+					VirtualFree((void*)it.first, 0, MEM_RELEASE);
 				}
 				else
 				{
-					UnmapViewOfFile((void*)(ROUND_DOWN(it->first, m_AllocationGranularity)));
+					UnmapViewOfFile((void*)(ROUND_DOWN(it.first, m_AllocationGranularity)));
 				}
 			}
 		}
@@ -2014,7 +2014,7 @@ xboxkrnl::NTSTATUS VMManager::XbVirtualProtect(VAddr* addr, size_t* Size, DWORD*
 	RETURN(status);
 }
 
-xboxkrnl::NTSTATUS VMManager::VirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEMORY_BASIC_INFORMATION memory_statistics)
+xboxkrnl::NTSTATUS VMManager::XbVirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEMORY_BASIC_INFORMATION memory_statistics)
 {
 	VMAIter it;
 	PMMPTE PointerPte;
@@ -2122,12 +2122,12 @@ xboxkrnl::NTSTATUS VMManager::VirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEM
 		PointerPte++;
 	}
 
-	// This can happen if we reach EndingPte in loop above (and PointerPte will be EndingPte + 1) or if we are looking for reserved memory and
+	// This can happen if we reach EndingPte in the loop above (and PointerPte will be EndingPte + 1) or if we are looking for reserved memory and
 	// PointerPte/EndingPte are inside a single page: in this case, GetVAddrMappedByPte(PointerPde + 1) will make PointerPte much larger than
 	// EndingPte, hence this check
 	if (PointerPte > EndingPte) { PointerPte = EndingPte + 1; }
 
-	RegionSize = GetVAddrMappedByPte(EndingPte) - ROUND_DOWN_4K(addr);
+	RegionSize = GetVAddrMappedByPte(PointerPte) - ROUND_DOWN_4K(addr);
 
 	memory_statistics->AllocationBase = (void*)it->first;
 	memory_statistics->AllocationProtect = InitialProtect;

--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -136,7 +136,7 @@ dashboard from non-retail xbe?");
 
 	// Set up the pfn database
 	if ((QuickReboot & BOOT_QUICK_REBOOT) == 0) {
-		FillMemoryUlong((void*)PAGE_TABLES_BASE, PAGE_TABLES_SIZE, 0);
+		xboxkrnl::RtlFillMemoryUlong((void*)PAGE_TABLES_BASE, PAGE_TABLES_SIZE, 0);
 		InitializePfnDatabase();
 	}
 	else {
@@ -213,13 +213,13 @@ void VMManager::InitializePfnDatabase()
 
 	// Zero all the entries of the PFN database
 	if (g_bIsRetail) {
-		FillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB, 0); // Xbox: 64 KiB
+		xboxkrnl::RtlFillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB, 0); // Xbox: 64 KiB
 	}
 	else if (g_bIsChihiro) {
-		FillMemoryUlong((void*)CHIHIRO_PFN_ADDRESS, X64KB * 2, 0); // Chihiro: 128 KiB
+		xboxkrnl::RtlFillMemoryUlong((void*)CHIHIRO_PFN_ADDRESS, X64KB * 2, 0); // Chihiro: 128 KiB
 	}
 	else {
-		FillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB * 2, 0); // Debug: 128 KiB
+		xboxkrnl::RtlFillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB * 2, 0); // Debug: 128 KiB
 	}
 
 
@@ -692,18 +692,18 @@ void VMManager::RestorePersistentMemory()
 
 	// Zero all the remaining pte's
 	EndingPte += 1;
-	FillMemoryUlong((void*)PAGE_TABLES_BASE, (VAddr)GetPteAddress(CONTIGUOUS_MEMORY_BASE) - PAGE_TABLES_BASE, 0);
-	FillMemoryUlong((void*)EndingPte, PAGE_TABLES_END + 1 - (VAddr)EndingPte, 0);
+	xboxkrnl::RtlFillMemoryUlong((void*)PAGE_TABLES_BASE, (VAddr)GetPteAddress(CONTIGUOUS_MEMORY_BASE) - PAGE_TABLES_BASE, 0);
+	xboxkrnl::RtlFillMemoryUlong((void*)EndingPte, PAGE_TABLES_END + 1 - (VAddr)EndingPte, 0);
 
 	// Zero all the entries of the PFN database
 	if (g_bIsRetail) {
-		FillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB, 0); // Xbox: 64 KiB
+		xboxkrnl::RtlFillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB, 0); // Xbox: 64 KiB
 	}
 	else if (g_bIsChihiro) {
-		FillMemoryUlong((void*)CHIHIRO_PFN_ADDRESS, X64KB * 2, 0); // Chihiro: 128 KiB
+		xboxkrnl::RtlFillMemoryUlong((void*)CHIHIRO_PFN_ADDRESS, X64KB * 2, 0); // Chihiro: 128 KiB
 	}
 	else {
-		FillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB * 2, 0); // Debug: 128 KiB
+		xboxkrnl::RtlFillMemoryUlong((void*)XBOX_PFN_ADDRESS, X64KB * 2, 0); // Debug: 128 KiB
 	}
 
 	// Now we need to restore the launch data page and the frame buffer pointers to their correct values
@@ -844,7 +844,7 @@ VAddr VMManager::AllocateZeroed(size_t Size)
 	LOG_FORWARD("g_VMManager.Allocate");
 
 	VAddr addr = Allocate(Size);
-	if (addr) { FillMemoryUlong((void*)addr, ROUND_UP_4K(Size), 0); }
+	if (addr) { xboxkrnl::RtlFillMemoryUlong((void*)addr, ROUND_UP_4K(Size), 0); }
 
 	RETURN(addr);
 }

--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -185,7 +185,7 @@ void VMManager::DestroyMemoryRegions()
 	{
 		for (auto it = m_MemoryRegionArray[i].RegionMap.begin(); it != m_MemoryRegionArray[i].RegionMap.end(); ++it)
 		{
-			if (it->second.type != FreeVma)
+			if (it->second.type != FreeVma && it->first >= XBE_MAX_VA)
 			{
 				if (it->second.bFragmented)
 				{

--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -1715,7 +1715,7 @@ xboxkrnl::NTSTATUS VMManager::XbAllocateVirtualMemory(VAddr* addr, ULONG ZeroBit
 		VAddr TempAddr = AlignedCapturedBase;
 		size_t TempSize = AlignedCapturedSize;
 		DWORD TempProtect = Protect;
-		XbProtect(&TempAddr, &TempSize, &TempProtect);
+		XbVirtualProtect(&TempAddr, &TempSize, &TempProtect);
 	}
 
 	DbgPrintf("VMEM: XbAllocateVirtualMemory resulting range : 0x%.8X - 0x%.8X\n", AlignedCapturedBase,
@@ -1886,7 +1886,7 @@ xboxkrnl::NTSTATUS VMManager::XbFreeVirtualMemory(VAddr* addr, size_t* Size, DWO
 	RETURN(status);
 }
 
-xboxkrnl::NTSTATUS VMManager::XbProtect(VAddr* addr, size_t* Size, DWORD* Protect)
+xboxkrnl::NTSTATUS VMManager::XbVirtualProtect(VAddr* addr, size_t* Size, DWORD* Protect)
 {
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(*addr)

--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -1633,6 +1633,9 @@ xboxkrnl::NTSTATUS VMManager::XbAllocateVirtualMemory(VAddr* addr, ULONG ZeroBit
 	// If we reach here then XBOX_MEM_COMMIT was specified, so we will also have to allocate physical memory for the allocation and
 	// write the pte/pfn
 
+	AlignedCapturedBase = ROUND_DOWN_4K(CapturedBase);
+	AlignedCapturedSize = (PAGES_SPANNED(CapturedBase, CapturedSize)) << PAGE_SHIFT;
+
 	it = CheckConflictingVMA(AlignedCapturedBase, AlignedCapturedSize);
 
 	if (it == m_MemoryRegionArray[UserRegion].RegionMap.end() || it->second.type != ReservedVma)
@@ -1711,6 +1714,9 @@ xboxkrnl::NTSTATUS VMManager::XbAllocateVirtualMemory(VAddr* addr, ULONG ZeroBit
 	// If some pte's were detected to have different permissions in the above check, we need to update those as well
 
 	if (bUpdatePteProtections) {} // TODO
+
+	DbgPrintf("VMEM: XbAllocateVirtualMemory resulting range : 0x%.8X - 0x%.8X\n", AlignedCapturedBase,
+		AlignedCapturedBase + AlignedCapturedSize);
 
 	*addr = AlignedCapturedBase;
 	*Size = AlignedCapturedSize;

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -102,6 +102,8 @@ class VMManager : public PhysicalMemory
 		// destructor
 		~VMManager()
 		{
+			// DestroyMemoryRegions is not called when emulation ends, but only when the GUI process ends. This is probably because the emu
+			// process is killed with TerminateProcess and so it doesn't have a chance to perform a cleanup...
 			//DestroyMemoryRegions();
 			DeleteCriticalSection(&m_CriticalSection);
 			FlushViewOfFile((void*)CONTIGUOUS_MEMORY_BASE, CHIHIRO_MEMORY_SIZE);

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -200,7 +200,7 @@ class VMManager : public PhysicalMemory
 		// constructs a vma
 		void ConstructVMA(VAddr Start, size_t Size, MemoryRegionType Type, VMAType VmaType, bool bFragFlag, DWORD Perms = XBOX_PAGE_NOACCESS);
 		// destructs a vma
-		void DestructVMA(VMAIter it, MemoryRegionType Type, size_t Size);
+		void DestructVMA(VAddr addr, MemoryRegionType Type, size_t Size);
 		// checks if a vma exists at the supplied address. Also checks its size if specified
 		VMAIter CheckExistenceVMA(VAddr addr, MemoryRegionType Type, size_t Size = 0);
 		// removes a vma block from the mapped memory

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -62,7 +62,7 @@ struct VirtualMemoryArea
 	size_t size = 0;
 	// vma kind of memory
 	VMAType type = FreeVma;
-	// initial vma permissions of the allocation, only used by VirtualMemoryStatistics
+	// initial vma permissions of the allocation, only used by XbVirtualMemoryStatistics
 	DWORD permissions = XBOX_PAGE_NOACCESS;
 	// this allocation was served by VirtualAlloc
 	bool bFragmented = false;
@@ -164,7 +164,7 @@ class VMManager : public PhysicalMemory
 		// xbox implementation of NtProtectVirtualMemory
 		xboxkrnl::NTSTATUS XbVirtualProtect(VAddr* addr, size_t* Size, DWORD* Protect);
 		// xbox implementation of NtQueryVirtualMemory
-		xboxkrnl::NTSTATUS VirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEMORY_BASIC_INFORMATION memory_statistics);
+		xboxkrnl::NTSTATUS XbVirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEMORY_BASIC_INFORMATION memory_statistics);
 
 	
 	private:

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -177,6 +177,8 @@ class VMManager : public PhysicalMemory
 		DWORD m_AllocationGranularity = 0;
 		// number of bytes reserved with XBOX_MEM_RESERVE by XbAllocateVirtualMemory
 		size_t m_VirtualMemoryBytesReserved = 0;
+		// number of bytes reserved for the xbe image
+		size_t m_ReservedBytesOfXbeImage = 0;
 
 	
 		// set up the pfn database
@@ -198,7 +200,7 @@ class VMManager : public PhysicalMemory
 		// constructs a vma
 		void ConstructVMA(VAddr Start, size_t Size, MemoryRegionType Type, VMAType VmaType, bool bFragFlag, DWORD Perms = XBOX_PAGE_NOACCESS);
 		// destructs a vma
-		void DestructVMA(VMAIter it, MemoryRegionType Type, size_t Size, bool bSkipDestruction = false);
+		void DestructVMA(VMAIter it, MemoryRegionType Type, size_t Size);
 		// checks if a vma exists at the supplied address. Also checks its size if specified
 		VMAIter CheckExistenceVMA(VAddr addr, MemoryRegionType Type, size_t Size = 0);
 		// removes a vma block from the mapped memory
@@ -221,7 +223,7 @@ class VMManager : public PhysicalMemory
 		void RestorePersistentMemory();
 		// restores a persistent allocation
 		void RestorePersistentAllocation(VAddr addr, PFN StartingPfn, PFN EndingPfn, PageType Type);
-		// checks if any of the EXECUTE flags are set
+		// checks if any of the execute flags are set
 		bool HasPageExecutionFlag(DWORD protect);
 		// acquires the critical section
 		void Lock();

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -156,10 +156,11 @@ class VMManager : public PhysicalMemory
 		// retrieves the number of free debugger pages
 		PFN_COUNT QueryNumberOfFreeDebuggerPages();
 		// xbox implementation of NtAllocateVirtualMemory
-		xboxkrnl::NTSTATUS XbAllocateVirtualMemory(VAddr* addr, ULONG ZeroBits, size_t* Size, DWORD AllocationType,
-			DWORD Protect);
+		xboxkrnl::NTSTATUS XbAllocateVirtualMemory(VAddr* addr, ULONG ZeroBits, size_t* Size, DWORD AllocationType, DWORD Protect);
 		// xbox implementation of NtFreeVirtualMemory
 		xboxkrnl::NTSTATUS XbFreeVirtualMemory(VAddr* addr, size_t* Size, DWORD FreeType);
+		// xbox implementation of NtProtectVirtualMemory
+		xboxkrnl::NTSTATUS XbProtect(VAddr* addr, size_t* Size, DWORD* Protect);
 
 	
 	private:

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -160,7 +160,7 @@ class VMManager : public PhysicalMemory
 		// xbox implementation of NtFreeVirtualMemory
 		xboxkrnl::NTSTATUS XbFreeVirtualMemory(VAddr* addr, size_t* Size, DWORD FreeType);
 		// xbox implementation of NtProtectVirtualMemory
-		xboxkrnl::NTSTATUS XbProtect(VAddr* addr, size_t* Size, DWORD* Protect);
+		xboxkrnl::NTSTATUS XbVirtualProtect(VAddr* addr, size_t* Size, DWORD* Protect);
 		// xbox implementation of NtQueryVirtualMemory
 		xboxkrnl::NTSTATUS VirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEMORY_BASIC_INFORMATION memory_statistics);
 

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -62,7 +62,7 @@ struct VirtualMemoryArea
 	size_t size = 0;
 	// vma kind of memory
 	VMAType type = FreeVma;
-	// initial vma permissions for user allocations, only used by NtQueryVirtualMemory
+	// initial vma permissions of the allocation, only used by VirtualMemoryStatistics
 	DWORD permissions = XBOX_PAGE_NOACCESS;
 	// this allocation was served by VirtualAlloc
 	bool bFragmented = false;
@@ -161,6 +161,8 @@ class VMManager : public PhysicalMemory
 		xboxkrnl::NTSTATUS XbFreeVirtualMemory(VAddr* addr, size_t* Size, DWORD FreeType);
 		// xbox implementation of NtProtectVirtualMemory
 		xboxkrnl::NTSTATUS XbProtect(VAddr* addr, size_t* Size, DWORD* Protect);
+		// xbox implementation of NtQueryVirtualMemory
+		xboxkrnl::NTSTATUS VirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEMORY_BASIC_INFORMATION memory_statistics);
 
 	
 	private:
@@ -178,8 +180,8 @@ class VMManager : public PhysicalMemory
 		DWORD m_AllocationGranularity = 0;
 		// number of bytes reserved with XBOX_MEM_RESERVE by XbAllocateVirtualMemory
 		size_t m_VirtualMemoryBytesReserved = 0;
-		// number of bytes reserved for the xbe image
-		size_t m_ReservedBytesOfXbeImage = 0;
+		// number of bytes reserved for the memory placeholder after the xbe image
+		size_t m_ReservedBytesAfterXbeImage = 0;
 
 	
 		// set up the pfn database

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -180,8 +180,6 @@ class VMManager : public PhysicalMemory
 		DWORD m_AllocationGranularity = 0;
 		// number of bytes reserved with XBOX_MEM_RESERVE by XbAllocateVirtualMemory
 		size_t m_VirtualMemoryBytesReserved = 0;
-		// number of bytes reserved for the memory placeholder after the xbe image
-		size_t m_ReservedBytesAfterXbeImage = 0;
 
 	
 		// set up the pfn database

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -188,7 +188,7 @@ class VMManager : public PhysicalMemory
 		// clears all memory region structs
 		void DestroyMemoryRegions();
 		// map a memory block with the supplied allocation routine
-		VAddr MapMemoryBlock(MappingFn MappingRoutine, MemoryRegionType Type, PFN_COUNT PteNumber, PFN pfn);
+		VAddr MapMemoryBlock(MappingFn MappingRoutine, MemoryRegionType Type, PFN_COUNT PteNumber, PFN pfn, VAddr HighestAddress = 0);
 		// helper function which maps a block with VirtualAlloc
 		VAddr MapBlockWithVirtualAlloc(VAddr StartingAddr, size_t Size, size_t VmaEnd, DWORD Unused, PFN Unused2);
 		// helper function which reserves a block of virtual memory with VirtualAlloc


### PR DESCRIPTION
This extends the VMManager to support the kernel Nt memory functions (NtAllocateVirtualMemory, NtFreeVirtualMemory, NtProtectVirtualMemory, NtQueryVirtualMemory) and gets rid of the Ntdll calls previously present. One thing: I couldn't find any games/homebrews which call the last two or make use of the ZeroBits/MEM_TOP_DOWN parameters of NtAlloc, so testing for these cases is welcomed.