### PR TITLE
Separate presentation parameters

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -1037,7 +1037,7 @@ XTL::D3DFORMAT XTL::EmuXB2PC_D3DFormat(X_D3DFORMAT Format)
 	{
 		const FormatInfo *info = &FormatInfos[Format];
 		if (info->warning != nullptr) {
-			DbgPrintf("%s", info->warning);
+			DbgPrintf("EmuXB2PC_D3DFormat %s\n", info->warning);
 		}
 
 		return info->pc;

--- a/src/devices/video/nv2a.cpp
+++ b/src/devices/video/nv2a.cpp
@@ -483,8 +483,8 @@ void InitOpenGLContext()
 										  // Initialize the viewport :
 										  //Viewport.X = 0;
 										  //Viewport.Y = 0;
-										  //Viewport.Width = g_EmuCDPD.pPresentationParameters.BackBufferWidth;
-										  //Viewport.Height = g_EmuCDPD.pPresentationParameters.BackBufferHeight;
+										  //Viewport.Width = g_EmuCDPD.pXboxPresentationParameters.BackBufferWidth;
+										  //Viewport.Height = g_EmuCDPD.pXboxPresentationParameters.BackBufferHeight;
 										  //Viewport.MinZ = -1.0;
 										  //Viewport.MaxZ = 1.0;
 


### PR DESCRIPTION
This PR separates the Host from the Xbox PresentationParameters, in order to prevent spilling host-required changes back to the Xbox code.