### PR TITLE
Eeprom improvements

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -2106,6 +2106,14 @@ typedef enum _XC_VALUE_INDEX
 XC_VALUE_INDEX, *PXC_VALUE_INDEX;
 
 // ******************************************************************
+// * EEPROM game region codes
+// ******************************************************************
+#define XC_GAME_REGION_NA             0x00000001
+#define XC_GAME_REGION_JAPAN          0x00000002
+#define XC_GAME_REGION_RESTOFWORLD    0x00000004
+#define XC_GAME_REGION_MANUFACTURING  0x80000000
+
+// ******************************************************************
 // * XBOX_HARDWARE_INFO
 // ******************************************************************
 typedef struct _XBOX_HARDWARE_INFO

--- a/src/Common/EmuEEPROM.cpp
+++ b/src/Common/EmuEEPROM.cpp
@@ -56,7 +56,7 @@ xboxkrnl::XBOX_EEPROM *EEPROM = nullptr; // Set using CxbxRestoreEEPROM()
 xboxkrnl::ULONG XboxFactoryGameRegion = XC_GAME_REGION_NA;
 
 // Default eeprom key (all zeros). Used to calculate the checksum of the eeprom header and to encrypt it if desired
-UCHAR EepromKey[20] = { 0 };
+UCHAR EepromKey[16] = { 0 };
 
 const EEPROMInfo* EmuFindEEPROMInfo(xboxkrnl::XC_VALUE_INDEX index)
 {
@@ -230,7 +230,7 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 		if (memcmp(Checksum, pEEPROM->EncryptedSettings.Checksum, 20))
 		{
 			// The checksums do not match. Log this error and flash the LED (red, off, red, off)
-			EmuWarning("Stored and calculated checksums don't match: eeprom corrupted");
+			EmuWarning("Stored and calculated checksums don't match. Possible eeprom corruption");
 			SetLEDSequence(0xA0);
 		}
 	}

--- a/src/Common/EmuEEPROM.cpp
+++ b/src/Common/EmuEEPROM.cpp
@@ -46,11 +46,17 @@ namespace xboxkrnl
 
 #include "Cxbx.h" // For DbgPrintf
 #include "EmuEEPROM.h" // For EEPROMInfo, EEPROMInfos
+#include "..\CxbxKrnl\Emu.h" // For EmuWarning
+#include "..\..\src\devices\LED.h" // For SetLEDSequence
+#include "..\CxbxKrnl\CxbxKrnl.h"
 
 xboxkrnl::XBOX_EEPROM *EEPROM = nullptr; // Set using CxbxRestoreEEPROM()
 
 // Default value (NA), overwritten with the actual content in the eeprom by CxbxRestoreEEPROM
 xboxkrnl::ULONG XboxFactoryGameRegion = XC_GAME_REGION_NA;
+
+// Default eeprom key (all zeros). Used to calculate the checksum of the eeprom header and to encrypt it if desired
+UCHAR EepromKey[20] = { 0 };
 
 const EEPROMInfo* EmuFindEEPROMInfo(xboxkrnl::XC_VALUE_INDEX index)
 {
@@ -130,7 +136,9 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 		}
 	}
 
-	// TODO : Make sure EEPROM.bin is at least 256 bytes in size - FileSeek(hFileEEPROM, EEPROM_SIZE, soFromBeginning);
+	// Make sure EEPROM.bin is at least 256 bytes in size
+	SetFilePointer(hFileEEPROM, 256, nullptr, FILE_BEGIN);
+	SetEndOfFile(hFileEEPROM);
 
 	HANDLE hFileMappingEEPROM = CreateFileMapping(
 		hFileEEPROM,
@@ -142,6 +150,15 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 	if (hFileMappingEEPROM == NULL)
 	{
 		DbgPrintf("INIT: Couldn't create EEPROM.bin file mapping!\n");
+		return nullptr;
+	}
+
+	LARGE_INTEGER  len_li;
+	GetFileSizeEx(hFileEEPROM, &len_li);
+	unsigned int FileSize = len_li.u.LowPart;
+	if (FileSize != 256)
+	{
+		CxbxKrnlCleanup("CxbxRestoreEEPROM : EEPROM.bin file is not 256 bytes large!\n");
 		return nullptr;
 	}
 
@@ -161,8 +178,6 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
     // so that users do not need to delete their EEPROM.bin from older versions
     gen_section_CRCs(pEEPROM);
 
-	// TODO : Verify checksums
-
 	// Check for (and fix) invalid fields that were set by previous versions of Cxbx-Reloaded
 	// Without this, all users would have to delete their EEPROM.bin
 	// The issue was that the AV_FLAG_XXhz was set in the wrong field, we fix it by
@@ -173,12 +188,6 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 		pEEPROM->UserSettings.VideoFlags = 0;
 		pEEPROM->FactorySettings.AVRegion = AV_STANDARD_NTSC_M | AV_FLAGS_60Hz;
 	}
-
-	// Initialize XboxFactoryGameRegion from the value stored in the eeprom
-	/*const EEPROMInfo* info = EmuFindEEPROMInfo(xboxkrnl::XC_ENCRYPTED_SECTION);
-	if (info != nullptr) {
-		XboxFactoryGameRegion = (*((xboxkrnl::XBOX_ENCRYPTED_SETTINGS*)((PBYTE)pEEPROM + info->value_offset))).GameRegion;
-	}*/
 
 	if (NeedsInitialization)
 	{
@@ -205,6 +214,25 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 	{
 		XboxFactoryGameRegion = pEEPROM->EncryptedSettings.GameRegion;
 		DbgPrintf("INIT: Loaded EEPROM.bin\n");
+	}
+
+	// Update the existing Checksum if it is all zeros. Without this, all users would have to delete their EEPROM.bin
+	UCHAR Checksum[20] = { 0 };
+	if (!memcmp(Checksum, pEEPROM->EncryptedSettings.Checksum, 20))
+	{
+		xboxkrnl::XcHMAC(EepromKey, 16, pEEPROM->EncryptedSettings.Confounder, 8, pEEPROM->EncryptedSettings.HDKey, 20,
+			pEEPROM->EncryptedSettings.Checksum);
+	}
+	else
+	{
+		// Verify the checksum of the eeprom header
+		xboxkrnl::XcHMAC(EepromKey, 16, pEEPROM->EncryptedSettings.Confounder, 8, pEEPROM->EncryptedSettings.HDKey, 20, Checksum);
+		if (memcmp(Checksum, pEEPROM->EncryptedSettings.Checksum, 20))
+		{
+			// The checksums do not match. Log this error and flash the LED (red, off, red, off)
+			EmuWarning("Stored and calculated checksums don't match: eeprom corrupted");
+			SetLEDSequence(0xA0);
+		}
 	}
 
 	return pEEPROM;

--- a/src/Common/EmuEEPROM.h
+++ b/src/Common/EmuEEPROM.h
@@ -86,6 +86,7 @@ static const EEPROMInfo EEPROMInfos[] = {
 	EEPROM_INFO_ENTRY(XC_FACTORY_ONLINE_KEY,    FactorySettings.OnlineKey,                REG_BINARY),
 	EEPROM_INFO_ENTRY(XC_FACTORY_AV_REGION,     FactorySettings.AVRegion,                 REG_DWORD),
 	// Note : XC_FACTORY_GAME_REGION is linked to a separate ULONG XboxFactoryGameRegion (of type REG_DWORD)
+	EEPROM_INFO_ENTRY(XC_FACTORY_GAME_REGION,   EncryptedSettings.GameRegion,             REG_DWORD),
 	EEPROM_INFO_ENTRY(XC_ENCRYPTED_SECTION,     EncryptedSettings,                        REG_BINARY),
 	{ xboxkrnl::XC_MAX_ALL,                     0,                                        REG_BINARY, sizeof(xboxkrnl::XBOX_EEPROM) },
 	{ XC_END_MARKER }

--- a/src/Common/EmuEEPROM.h
+++ b/src/Common/EmuEEPROM.h
@@ -102,6 +102,8 @@ extern xboxkrnl::ULONG XboxFactoryGameRegion;
 
 void gen_section_CRCs(xboxkrnl::XBOX_EEPROM*);
 
+extern UCHAR EepromKey[20];
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/Common/EmuEEPROM.h
+++ b/src/Common/EmuEEPROM.h
@@ -102,7 +102,7 @@ extern xboxkrnl::ULONG XboxFactoryGameRegion;
 
 void gen_section_CRCs(xboxkrnl::XBOX_EEPROM*);
 
-extern UCHAR EepromKey[20];
+extern UCHAR EepromKey[16];
 
 #if defined(__cplusplus)
 }

--- a/src/CxbxKrnl/EmuKrnlEx.cpp
+++ b/src/CxbxKrnl/EmuKrnlEx.cpp
@@ -427,6 +427,7 @@ XBSYSAPI EXPORTNUM(24) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ExQueryNonVolatileSett
 			// FIXME - Entering the critical region causes an exception because
 			// the current thread returns as 0.
 			// We temporarily bypass the problem of above we a host critical section
+			//RtlEnterCriticalSectionAndRegion(get_eeprom_crit_section());
 			LockEeprom();
 			if(eeprom_data_is_valid(index)) {
 				// Set the output value type :
@@ -439,6 +440,7 @@ XBSYSAPI EXPORTNUM(24) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ExQueryNonVolatileSett
 			else {
 				Status = STATUS_DEVICE_DATA_ERROR;
 			}
+			//RtlLeaveCriticalSectionAndRegion(get_eeprom_crit_section());
 			UnlockEeprom();
 		}
 		else {
@@ -599,7 +601,7 @@ XBSYSAPI EXPORTNUM(29) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ExSaveNonVolatileSetti
 	DWORD result_length;
 
 	// handle eeprom write
-	if (ValueIndex == XC_FACTORY_GAME_REGION) {
+	if (g_bIsDebug && ValueIndex == XC_FACTORY_GAME_REGION) {
 		value_addr = &XboxFactoryGameRegion;
 		result_length = sizeof(ULONG);
 	}
@@ -619,6 +621,7 @@ XBSYSAPI EXPORTNUM(29) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ExSaveNonVolatileSetti
 			// FIXME - Entering the critical region causes an exception because
 			// the current thread returns as 0.
 			// We temporarily bypass the problem of above we a host critical section
+			//RtlEnterCriticalSectionAndRegion(get_eeprom_crit_section());
 			LockEeprom();
 
 			// Clear the emulated EEMPROM value :
@@ -631,6 +634,7 @@ XBSYSAPI EXPORTNUM(29) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ExSaveNonVolatileSetti
 			// so XC_FACTORY_GAME_REGION will reflect the factory settings.
 
 			gen_section_CRCs(EEPROM);
+			//RtlLeaveCriticalSectionAndRegion(get_eeprom_crit_section());
 			UnlockEeprom();
 		}
 		else {

--- a/src/CxbxKrnl/EmuKrnlEx.cpp
+++ b/src/CxbxKrnl/EmuKrnlEx.cpp
@@ -600,6 +600,10 @@ XBSYSAPI EXPORTNUM(29) xboxkrnl::NTSTATUS NTAPI xboxkrnl::ExSaveNonVolatileSetti
 	void * value_addr = nullptr;
 	DWORD result_length;
 
+	// Don't allow writing to the eeprom encrypted area
+	if (ValueIndex == XC_ENCRYPTED_SECTION)
+		RETURN(STATUS_OBJECT_NAME_NOT_FOUND);
+
 	// handle eeprom write
 	if (g_bIsDebug || ValueIndex <= XC_MAX_OS || ValueIndex > XC_MAX_FACTORY)
 	{


### PR DESCRIPTION
This improves issue #198 (it 's just missing the gui now). From my tests: this seems to work fine however, more testing is welcome. One thing: with the new hash that is calculated, if that fails an error is logged and the LED flashes. As an alternative to this, we could just delete the existing eeprom.bin and regenerate a new one, so let me know what you think.