### PR TITLE
Fix an assert on VMManager in Fable

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -1869,7 +1869,7 @@ void WndMain::OpenXbe(const char *x_filename)
     if(m_Xbe->HasError())
     {
 		// Save the error message as a separate string. This fixes a corruption in the message "Disclaimer: Cxbx-Reloaded has no
-		// affiliation with Microsoft" that would occour if loading an xbe and then launching the dashboard with the "Load dashboard"
+		// affiliation with Microsoft" that would occur if loading an xbe and then launching the dashboard with the "Open dashboard"
 		// option but it's not installed
 
 		std::string ErrorMessage = m_Xbe->GetError();


### PR DESCRIPTION
This fixes the assert in Fable in https://github.com/Cxbx-Reloaded/game-compatibility/issues/389
BTY, it will still assert shortly after but this ones comes from EmuX86. In particular, looking at the eip when the assert triggers I see the offending instruction is 0f 20 d8, which disassembles as mov    eax,cr3 

![capture](https://user-images.githubusercontent.com/30000751/38193286-97b8bc8e-3671-11e8-8ada-60e3101c7c54.PNG)
![capture2](https://user-images.githubusercontent.com/30000751/38193287-97dfefb6-3671-11e8-9a2c-0653790cffe2.PNG)
