### PR TITLE
Implement APU Time register

### DIFF
--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -51,6 +51,8 @@
 #include "EmuX86.h"
 #include "HLEIntercept.h" // for bLLE_GPU
 
+#include "EmuXTL.h"
+
 #include <assert.h>
 #include "devices\Xbox.h" // For g_PCIBus
 
@@ -177,6 +179,8 @@ uint32_t EmuX86_Read(xbaddr addr, int size)
 
 	if (addr >= XBOX_FLASH_ROM_BASE) { // 0xFFF00000 - 0xFFFFFFF
 		value = EmuFlash_Read32(addr - XBOX_FLASH_ROM_BASE); // TODO : Make flash access size-aware
+	} else if(addr == 0xFE80200C) {
+		return XTL::EMUPATCH(DirectSoundGetSampleTime)();
 	} else {
 		// Pass the Read to the PCI Bus, this will handle devices with BARs set to MMIO addresses
 		if (g_PCIBus->MMIORead(addr, &value, size)) {

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -51,10 +51,10 @@
 #include "EmuX86.h"
 #include "HLEIntercept.h" // for bLLE_GPU
 
-#include "EmuXTL.h"
-
 #include <assert.h>
 #include "devices\Xbox.h" // For g_PCIBus
+
+extern uint32_t GetAPUTime();
 
 //
 // Read & write handlers handlers for I/O
@@ -180,7 +180,8 @@ uint32_t EmuX86_Read(xbaddr addr, int size)
 	if (addr >= XBOX_FLASH_ROM_BASE) { // 0xFFF00000 - 0xFFFFFFF
 		value = EmuFlash_Read32(addr - XBOX_FLASH_ROM_BASE); // TODO : Make flash access size-aware
 	} else if(addr == 0xFE80200C) {
-		return XTL::EMUPATCH(DirectSoundGetSampleTime)();
+		// TODO: Remove this once we have an LLE APU Device
+		return GetAPUTime();
 	} else {
 		// Pass the Read to the PCI Bus, this will handle devices with BARs set to MMIO addresses
 		if (g_PCIBus->MMIORead(addr, &value, size)) {


### PR DESCRIPTION
XACT & others use this directly, so it's helpful for HLE even when we don't have a full APU Device yet.