### PR TITLE
Fixed crash when the debug filename is empty

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -669,7 +669,9 @@ void CxbxKrnlMain(int argc, char* argv[])
 	// Get KernelDebugFileName :
 	std::string DebugFileName = "";
 	if (argc > 4) {
-		DebugFileName = argv[5];
+		if (argv[5] != nullptr) {
+			DebugFileName = argv[5];
+		}
 	}
 
 	// debug console allocation (if configured)


### PR DESCRIPTION
`m_KrnlDebugFilename` can be null if the registry value "KrnlDebugFilename" is empty.

When launching CxbxDebugger, the argument is passed in a null which crashes when converting to an `std::string`.