### PR TITLE
Prepare for unswizzling in 3D

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4482,7 +4482,7 @@ void CreateHostResource(XTL::X_D3DResource *pThis, int TextureStage, DWORD dwSiz
 									const DWORD dwSlicePitch = 0; // only needed for volume textures (dwDepth > 1)
 									// First we need to unswizzle the texture data
 									XTL::EmuUnswizzleBox(
-										pSrc + dwMipOffs, dwMipWidth, LockedRect.Pitch, dwMipHeight, dwSlicePitch, dwDepth, 
+										pSrc + dwMipOffs, dwMipWidth, dwMipPitch, dwMipHeight, dwSlicePitch, dwDepth, 
 										LockedRect.pBits, dwBPP
 									);
 								}

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4482,7 +4482,7 @@ void CreateHostResource(XTL::X_D3DResource *pThis, int TextureStage, DWORD dwSiz
 									const DWORD dwSlicePitch = 0; // only needed for volume textures (dwDepth > 1)
 									// First we need to unswizzle the texture data
 									XTL::EmuUnswizzleBox(
-										pSrc + dwMipOffs, dwMipWidth, dwMipPitch, dwMipHeight, dwSlicePitch, dwDepth, 
+										pSrc + dwMipOffs, dwMipWidth, LockedRect.Pitch, dwMipHeight, dwSlicePitch, dwDepth,
 										LockedRect.pBits, dwBPP
 									);
 								}

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4487,7 +4487,7 @@ void CreateHostResource(XTL::X_D3DResource *pThis, int TextureStage, DWORD dwSiz
 
 								uint8_t *pDst = (uint8_t *)LockedRect.pBits;
 								DWORD dwDstRowPitch = LockedRect.Pitch;
-								const DWORD dwDstSlicePitch = 0; // TODO : Set for volume texture support
+								const DWORD dwDstSlicePitch = dwSrcSlicePitch; // TODO : Set for volume texture support
 
 								// Convert a row at a time, using a libyuv-like callback approach :
 								if (!ConvertD3DTextureToARGBBuffer(

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -1338,14 +1338,14 @@ CONST DWORD XTL::EmuD3DRenderStateSimpleEncoded[174] =
 
 void XTL::EmuUnswizzleBox
 (
-	PVOID pSrcBuff,
-	DWORD dwWidth,
-	DWORD dwRowPitch,
-	DWORD dwHeight,
-	DWORD dwSlicePitch,
-	DWORD dwDepth,
-	PVOID pDstBuff,
-	DWORD dwBPP // expressed in Bytes Per Pixel
+	CONST PVOID pSrcBuff,
+	CONST DWORD dwWidth,
+	CONST DWORD dwRowPitch,
+	CONST DWORD dwHeight,
+	CONST DWORD dwSlicePitch,
+	CONST DWORD dwDepth,
+	CONST PVOID pDstBuff,
+	CONST DWORD dwBPP // expressed in Bytes Per Pixel
 ) // Source : Dxbx
 {
 	DWORD dwMaskX = 0, dwMaskY = 0, dwMaskZ = 0;
@@ -1366,9 +1366,6 @@ void XTL::EmuUnswizzleBox
 		}
 	}
 
-	DWORD dwRowPitchCorrection = dwWidth - (dwRowPitch / dwBPP);
-	DWORD dwSlicePitchCorrection = ((dwHeight * dwRowPitch) - dwSlicePitch) / dwBPP;
-
 	const DWORD dwStartX = 0;
 	const DWORD dwStartY = 0;
 	const DWORD dwStartZ = 0;
@@ -1376,73 +1373,76 @@ void XTL::EmuUnswizzleBox
 	DWORD dwZ = dwStartZ;
 	switch (dwBPP) {
 	case 1: {
-		uint8_t *pSrc = (uint8_t *)pSrcBuff;
-		uint8_t *pDest = (uint8_t *)pDstBuff;
+		const uint8_t *pSrc = (uint8_t *)pSrcBuff;
+		uint8_t *pDestSlice = (uint8_t *)pDstBuff;
 
 		for (uint z = 0; z < dwDepth; z++) {
+			uint8_t *pDestRow = pDestSlice;
 			DWORD dwY = dwStartY;
 			for (uint y = 0; y < dwHeight; y++) {
 				DWORD dwYZ = dwY | dwZ;
 				DWORD dwX = dwStartX;
 				for (uint x = 0; x < dwWidth; x++) {
 					uint delta = dwX | dwYZ;
-					*(pDest++) = pSrc[delta]; // copy one pixel
+					pDestRow[x] = pSrc[delta]; // copy one pixel
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDest += dwRowPitchCorrection; // step to next line in destination
+				pDestRow += dwRowPitch; // / 1; // = / dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDest += dwSlicePitchCorrection; // step to next level in destination
+			pDestSlice += dwSlicePitch; // / 1; // = / dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;
 	}
 	case 2: {
-		uint16_t *pSrc = (uint16_t *)pSrcBuff;
-		uint16_t *pDest = (uint16_t *)pDstBuff;
+		const uint16_t *pSrc = (uint16_t *)pSrcBuff;
+		uint16_t *pDestSlice = (uint16_t *)pDstBuff;
 
 		for (uint z = 0; z < dwDepth; z++) {
+			uint16_t *pDestRow = pDestSlice;
 			DWORD dwY = dwStartY;
 			for (uint y = 0; y < dwHeight; y++) {
 				DWORD dwYZ = dwY | dwZ;
 				DWORD dwX = dwStartX;
 				for (uint x = 0; x < dwWidth; x++) {
 					uint delta = dwX | dwYZ;
-					*(pDest++) = pSrc[delta]; // copy one pixel
+					pDestRow[x] = pSrc[delta]; // copy one pixel
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDest += dwRowPitchCorrection; // step to next line in destination
+				pDestRow += dwRowPitch / 2; // = dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDest += dwSlicePitchCorrection; // step to next level in destination
+			pDestSlice += dwSlicePitch / 2; // = dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;
 	}
 	case 4: {
-		uint32_t *pSrc = (uint32_t *)pSrcBuff;
-		uint32_t *pDest = (uint32_t *)pDstBuff;
+		const uint32_t *pSrc = (uint32_t *)pSrcBuff;
+		uint32_t *pDestSlice = (uint32_t *)pDstBuff;
 
 		for (uint z = 0; z < dwDepth; z++) {
+			uint32_t *pDestRow = pDestSlice;
 			DWORD dwY = dwStartY;
 			for (uint y = 0; y < dwHeight; y++) {
 				DWORD dwYZ = dwY | dwZ;
 				DWORD dwX = dwStartX;
 				for (uint x = 0; x < dwWidth; x++) {
 					uint delta = dwX | dwYZ;
-					*(pDest++) = pSrc[delta]; // copy one pixel
+					pDestRow[x] = pSrc[delta]; // copy one pixel
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDest += dwRowPitchCorrection; // step to next line in destination
+				pDestRow += dwRowPitch / 4; // = dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDest += dwSlicePitchCorrection; // step to next level in destination
+			pDestSlice += dwSlicePitch / 4; // = dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -931,7 +931,7 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
 	/* 0x34 undefined             */ {},
 	/* 0x35 X_D3DFMT_LIN_L16      */ { 16, Linear, _____L16, XTL::D3DFMT_A8L8      , Texture, "X_D3DFMT_LIN_L16 -> D3DFMT_A8L8" },
-	/* 0x36 X_D3DFMT_LIN_V16U16   */ { 32, Linear, NoCmpnts, XTL::D3DFMT_V16U16    },
+	/* 0x36 X_D3DFMT_LIN_V16U16   */ { 32, Linear, NoCmpnts, XTL::D3DFMT_V16U16    }, // Note : Seems ununsed on Xbox
 	/* 0x37 X_D3DFMT_LIN_L6V5U5   */ { 16, Linear, __R6G5B5, XTL::D3DFMT_L6V5U5    }, // Alias : X_D3DFMT_LIN_R6G5B5
 	/* 0x38 X_D3DFMT_R5G5B5A1     */ { 16, Swzzld, R5G5B5A1, XTL::D3DFMT_A1R5G5B5  , Texture, "X_D3DFMT_R5G5B5A1 -> D3DFMT_A1R5G5B5" },
 	/* 0x39 X_D3DFMT_R4G4B4A4     */ { 16, Swzzld, R4G4B4A4, XTL::D3DFMT_A4R4G4B4  , Texture, "X_D3DFMT_R4G4B4A4 -> D3DFMT_A4R4G4B4" },
@@ -1336,20 +1336,18 @@ CONST DWORD XTL::EmuD3DRenderStateSimpleEncoded[174] =
     X_D3DRSSE_UNK,  X_D3DRSSE_UNK,  // 172
 };
 
-void XTL::EmuUnswizzleRect
+void XTL::EmuUnswizzleBox
 (
 	PVOID pSrcBuff,
 	DWORD dwWidth,
+	DWORD dwRowPitch,
 	DWORD dwHeight,
+	DWORD dwSlicePitch,
 	DWORD dwDepth,
 	PVOID pDstBuff,
-	DWORD dwPitch,
-	RECT rSrc, // Unused
-	POINT poDst, // Unused
 	DWORD dwBPP // expressed in Bytes Per Pixel
 ) // Source : Dxbx
 {
-	// TODO : The following could be done using a lookup table :
 	DWORD dwMaskX = 0, dwMaskY = 0, dwMaskZ = 0;
 	for (uint i=1, j=1; (i <= dwWidth) || (i <= dwHeight) || (i <= dwDepth); i <<= 1) {
 		if (i < dwWidth) {
@@ -1368,64 +1366,89 @@ void XTL::EmuUnswizzleRect
 		}
 	}
 
-	// get the biggest mask
-	DWORD dwMaskMax;
-	if (dwMaskX > dwMaskY)
-		dwMaskMax = dwMaskX;
-	else
-		dwMaskMax = dwMaskY;
+	DWORD dwRowPitchCorrection = dwWidth - (dwRowPitch / dwBPP);
+	DWORD dwSlicePitchCorrection = ((dwHeight * dwRowPitch) - dwSlicePitch) / dwBPP;
 
-	if (dwMaskZ > dwMaskMax)
-		dwMaskMax = dwMaskZ;
-
-	DWORD dwStartX = 0, dwOffsetX = 0;
-	DWORD dwStartY = 0, dwOffsetY = 0;
-	DWORD dwStartZ = 0, dwOffsetW = 0;
-	/* TODO : Use values from poDst and rSrc to initialize above values, after which the following makes more sense:
-	for (uint i=1; i <= dwMaskMax; i <<= 1) {
-		if (i <= dwMaskX) {
-			if (dwMaskX & i)
-				dwStartX |= (dwOffsetX & i);
-			else
-				dwOffsetX <<= 1;
-		}
-
-		if (i <= dwMaskY) {
-			if (dwMaskY & i)
-				dwStartY |= dwOffsetY & i;
-			else
-				dwOffsetY <<= 1;
-		}
-
-		if (i <= dwMaskZ) {
-			if (dwMaskZ & i)
-				dwStartZ |= dwOffsetZ & i;
-			else
-				dwOffsetZ <<= 1;
-		}
-	}*/
+	const DWORD dwStartX = 0;
+	const DWORD dwStartY = 0;
+	const DWORD dwStartZ = 0;
 
 	DWORD dwZ = dwStartZ;
-	for (uint z = 0; z < dwDepth; z++) {
-		DWORD dwY = dwStartY;
-		for (uint y = 0; y < dwHeight; y++) {
-			DWORD dwX = dwStartX;
-			DWORD dwYZ = dwY | dwZ;
-			for (uint x = 0; x < dwWidth; x++) {
-				uint delta = (dwX | dwYZ) * dwBPP;
-				memcpy(pDstBuff, (PBYTE)pSrcBuff + delta, dwBPP); // copy one pixel
-				pDstBuff = (PBYTE)pDstBuff + dwBPP; // Step to next pixel in destination
-				dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
+	switch (dwBPP) {
+	case 1: {
+		uint8_t *pSrc = (uint8_t *)pSrcBuff;
+		uint8_t *pDest = (uint8_t *)pDstBuff;
+
+		for (uint z = 0; z < dwDepth; z++) {
+			DWORD dwY = dwStartY;
+			for (uint y = 0; y < dwHeight; y++) {
+				DWORD dwYZ = dwY | dwZ;
+				DWORD dwX = dwStartX;
+				for (uint x = 0; x < dwWidth; x++) {
+					uint delta = dwX | dwYZ;
+					*(pDest++) = pSrc[delta]; // copy one pixel
+					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
+				}
+
+				pDest += dwRowPitchCorrection; // step to next line in destination
+				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDstBuff = (PBYTE)pDstBuff + dwPitch - (dwWidth * dwBPP); // step to next line in destination
-			dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
+			pDest += dwSlicePitchCorrection; // step to next level in destination
+			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
-
-		// TODO : How to step to next level in destination? Should X and Y be recalculated per level?
-		dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
+		break;
 	}
-} // EmuUnswizzleRect NOPATCH
+	case 2: {
+		uint16_t *pSrc = (uint16_t *)pSrcBuff;
+		uint16_t *pDest = (uint16_t *)pDstBuff;
+
+		for (uint z = 0; z < dwDepth; z++) {
+			DWORD dwY = dwStartY;
+			for (uint y = 0; y < dwHeight; y++) {
+				DWORD dwYZ = dwY | dwZ;
+				DWORD dwX = dwStartX;
+				for (uint x = 0; x < dwWidth; x++) {
+					uint delta = dwX | dwYZ;
+					*(pDest++) = pSrc[delta]; // copy one pixel
+					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
+				}
+
+				pDest += dwRowPitchCorrection; // step to next line in destination
+				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
+			}
+
+			pDest += dwSlicePitchCorrection; // step to next level in destination
+			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
+		}
+		break;
+	}
+	case 4: {
+		uint32_t *pSrc = (uint32_t *)pSrcBuff;
+		uint32_t *pDest = (uint32_t *)pDstBuff;
+
+		for (uint z = 0; z < dwDepth; z++) {
+			DWORD dwY = dwStartY;
+			for (uint y = 0; y < dwHeight; y++) {
+				DWORD dwYZ = dwY | dwZ;
+				DWORD dwX = dwStartX;
+				for (uint x = 0; x < dwWidth; x++) {
+					uint delta = dwX | dwYZ;
+					*(pDest++) = pSrc[delta]; // copy one pixel
+					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
+				}
+
+				pDest += dwRowPitchCorrection; // step to next line in destination
+				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
+			}
+
+			pDest += dwSlicePitchCorrection; // step to next level in destination
+			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
+		}
+		break;
+	}
+	}
+} // EmuUnswizzleBox NOPATCH
 
 namespace XTL
 {

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -1345,7 +1345,7 @@ void XTL::EmuUnswizzleBox
 	CONST DWORD dwBytesPerPixel,
 	CONST PVOID pDstBuff,
 	CONST DWORD dwDstRowPitch,
-	CONST DWORD dwDstSlicePitch,
+	CONST DWORD dwDstSlicePitch
 ) // Source : Dxbx
 {
 	DWORD dwMaskX = 0, dwMaskY = 0, dwMaskZ = 0;

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -1349,19 +1349,19 @@ void XTL::EmuUnswizzleBox
 ) // Source : Dxbx
 {
 	DWORD dwMaskX = 0, dwMaskY = 0, dwMaskZ = 0;
-	for (uint i=1, j=1; (i <= dwWidth) || (i <= dwHeight) || (i <= dwDepth); i <<= 1) {
+	for (uint i=1, j=1; (i < dwWidth) || (i < dwHeight) || (i < dwDepth); i <<= 1) {
 		if (i < dwWidth) {
-			dwMaskX = dwMaskX | j;
+			dwMaskX |= j;
 			j <<= 1;
-		};
+		}
 
 		if (i < dwHeight) {
-			dwMaskY = dwMaskY | j;
+			dwMaskY |= j;
 			j <<= 1;
 		}
 
 		if (i < dwDepth) {
-			dwMaskZ = dwMaskZ | j;
+			dwMaskZ |= j;
 			j <<= 1;
 		}
 	}

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -1342,10 +1342,10 @@ void XTL::EmuUnswizzleBox
 	CONST DWORD dwWidth,
 	CONST DWORD dwHeight,
 	CONST DWORD dwDepth,
+	CONST DWORD dwRowPitch,
+	CONST DWORD dwSlicePitch,
 	CONST DWORD dwBytesPerPixel,
-	CONST PVOID pDstBuff,
-	CONST DWORD dwDstRowPitch,
-	CONST DWORD dwDstSlicePitch
+	CONST PVOID pDstBuff
 ) // Source : Dxbx
 {
 	DWORD dwMaskX = 0, dwMaskY = 0, dwMaskZ = 0;
@@ -1388,11 +1388,11 @@ void XTL::EmuUnswizzleBox
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDestRow += dwDstRowPitch; // / 1; // = / dwBPP; // step to next line in destination
+				pDestRow += dwRowPitch; // / 1; // = / dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDestSlice += dwDstSlicePitch; // / 1; // = / dwBPP; // step to next level in destination
+			pDestSlice += dwSlicePitch; // / 1; // = / dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;
@@ -1413,11 +1413,11 @@ void XTL::EmuUnswizzleBox
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDestRow += dwDstRowPitch / 2; // = dwBPP; // step to next line in destination
+				pDestRow += dwRowPitch / 2; // = dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDestSlice += dwDstSlicePitch / 2; // = dwBPP; // step to next level in destination
+			pDestSlice += dwSlicePitch / 2; // = dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;
@@ -1438,11 +1438,11 @@ void XTL::EmuUnswizzleBox
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDestRow += dwDstRowPitch / 4; // = dwBPP; // step to next line in destination
+				pDestRow += dwRowPitch / 4; // = dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDestSlice += dwDstSlicePitch / 4; // = dwBPP; // step to next level in destination
+			pDestSlice += dwSlicePitch / 4; // = dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -1340,12 +1340,12 @@ void XTL::EmuUnswizzleBox
 (
 	CONST PVOID pSrcBuff,
 	CONST DWORD dwWidth,
-	CONST DWORD dwRowPitch,
 	CONST DWORD dwHeight,
-	CONST DWORD dwSlicePitch,
 	CONST DWORD dwDepth,
+	CONST DWORD dwBytesPerPixel,
 	CONST PVOID pDstBuff,
-	CONST DWORD dwBPP // expressed in Bytes Per Pixel
+	CONST DWORD dwDstRowPitch,
+	CONST DWORD dwDstSlicePitch,
 ) // Source : Dxbx
 {
 	DWORD dwMaskX = 0, dwMaskY = 0, dwMaskZ = 0;
@@ -1371,7 +1371,7 @@ void XTL::EmuUnswizzleBox
 	const DWORD dwStartZ = 0;
 
 	DWORD dwZ = dwStartZ;
-	switch (dwBPP) {
+	switch (dwBytesPerPixel) {
 	case 1: {
 		const uint8_t *pSrc = (uint8_t *)pSrcBuff;
 		uint8_t *pDestSlice = (uint8_t *)pDstBuff;
@@ -1388,11 +1388,11 @@ void XTL::EmuUnswizzleBox
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDestRow += dwRowPitch; // / 1; // = / dwBPP; // step to next line in destination
+				pDestRow += dwDstRowPitch; // / 1; // = / dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDestSlice += dwSlicePitch; // / 1; // = / dwBPP; // step to next level in destination
+			pDestSlice += dwDstSlicePitch; // / 1; // = / dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;
@@ -1413,11 +1413,11 @@ void XTL::EmuUnswizzleBox
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDestRow += dwRowPitch / 2; // = dwBPP; // step to next line in destination
+				pDestRow += dwDstRowPitch / 2; // = dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDestSlice += dwSlicePitch / 2; // = dwBPP; // step to next level in destination
+			pDestSlice += dwDstSlicePitch / 2; // = dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;
@@ -1438,11 +1438,11 @@ void XTL::EmuUnswizzleBox
 					dwX = (dwX - dwMaskX) & dwMaskX; // step to next pixel in source
 				}
 
-				pDestRow += dwRowPitch / 4; // = dwBPP; // step to next line in destination
+				pDestRow += dwDstRowPitch / 4; // = dwBPP; // step to next line in destination
 				dwY = (dwY - dwMaskY) & dwMaskY; // step to next line in source
 			}
 
-			pDestSlice += dwSlicePitch / 4; // = dwBPP; // step to next level in destination
+			pDestSlice += dwDstSlicePitch / 4; // = dwBPP; // step to next level in destination
 			dwZ = (dwZ - dwMaskZ) & dwMaskZ; // step to next level in source
 		}
 		break;

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -239,7 +239,7 @@ inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(X_D3DPRIMITIVETYPE PrimitiveTy
     return EmuPrimitiveTypeLookup[PrimitiveType];
 }
 
-void XTL::EmuUnswizzleBox
+extern void EmuUnswizzleBox
 (
 	CONST PVOID pSrcBuff,
 	CONST DWORD dwWidth,
@@ -248,7 +248,7 @@ void XTL::EmuUnswizzleBox
 	CONST DWORD dwBytesPerPixel,
 	CONST PVOID pDstBuff,
 	CONST DWORD dwDstRowPitch,
-	CONST DWORD dwDstSlicePitch,
+	CONST DWORD dwDstSlicePitch
 ); // NOPATCH
 
 // From : https://www.virtualbox.org/svn/vbox/trunk/src/VBox/Additions/x11/x11include/libdrm-2.4.13/nouveau_class.h

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -241,14 +241,14 @@ inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(X_D3DPRIMITIVETYPE PrimitiveTy
 
 extern void EmuUnswizzleBox
 (
-	PVOID pSrcBuff,
-	DWORD dwWidth,
-	DWORD dwRowPitch,
-	DWORD dwHeight,
-	DWORD dwSlicePitch,
-	DWORD dwDepth,
-	PVOID pDstBuff,
-	DWORD dwBPP // expressed in Bytes Per Pixel
+	CONST PVOID pSrcBuff,
+	CONST DWORD dwWidth,
+	CONST DWORD dwRowPitch,
+	CONST DWORD dwHeight,
+	CONST DWORD dwSlicePitch,
+	CONST DWORD dwDepth,
+	CONST PVOID pDstBuff,
+	CONST DWORD dwBPP // expressed in Bytes Per Pixel
 ); // NOPATCH
 
 // From : https://www.virtualbox.org/svn/vbox/trunk/src/VBox/Additions/x11/x11include/libdrm-2.4.13/nouveau_class.h

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -239,16 +239,15 @@ inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(X_D3DPRIMITIVETYPE PrimitiveTy
     return EmuPrimitiveTypeLookup[PrimitiveType];
 }
 
-extern void EmuUnswizzleRect
+extern void EmuUnswizzleBox
 (
 	PVOID pSrcBuff,
 	DWORD dwWidth,
+	DWORD dwRowPitch,
 	DWORD dwHeight,
+	DWORD dwSlicePitch,
 	DWORD dwDepth,
 	PVOID pDstBuff,
-	DWORD dwPitch,
-	RECT rSrc, // Unused
-	POINT poDst, // Unused
 	DWORD dwBPP // expressed in Bytes Per Pixel
 ); // NOPATCH
 

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -245,10 +245,10 @@ extern void EmuUnswizzleBox
 	CONST DWORD dwWidth,
 	CONST DWORD dwHeight,
 	CONST DWORD dwDepth,
+	CONST DWORD dwRowPitch,
+	CONST DWORD dwSlicePitch,
 	CONST DWORD dwBytesPerPixel,
-	CONST PVOID pDstBuff,
-	CONST DWORD dwDstRowPitch,
-	CONST DWORD dwDstSlicePitch
+	CONST PVOID pDstBuff
 ); // NOPATCH
 
 // From : https://www.virtualbox.org/svn/vbox/trunk/src/VBox/Additions/x11/x11include/libdrm-2.4.13/nouveau_class.h

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -239,16 +239,16 @@ inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(X_D3DPRIMITIVETYPE PrimitiveTy
     return EmuPrimitiveTypeLookup[PrimitiveType];
 }
 
-extern void EmuUnswizzleBox
+void XTL::EmuUnswizzleBox
 (
 	CONST PVOID pSrcBuff,
 	CONST DWORD dwWidth,
-	CONST DWORD dwRowPitch,
 	CONST DWORD dwHeight,
-	CONST DWORD dwSlicePitch,
 	CONST DWORD dwDepth,
+	CONST DWORD dwBytesPerPixel,
 	CONST PVOID pDstBuff,
-	CONST DWORD dwBPP // expressed in Bytes Per Pixel
+	CONST DWORD dwDstRowPitch,
+	CONST DWORD dwDstSlicePitch,
 ); // NOPATCH
 
 // From : https://www.virtualbox.org/svn/vbox/trunk/src/VBox/Additions/x11/x11include/libdrm-2.4.13/nouveau_class.h


### PR DESCRIPTION
Currently, Cxbx-Reloaded lacks volume texture support, and is incorrect when dealing with cube textures and mipmap levels.

This PR contains preparations for volume texture support, by adding depth-awareness to functions that decode texture dimensions and our pixel unswizzle function.

I've tested this with the Swizzle XDK sample (and others) and a few titles (JSRF, Turok).

Please test if this work doesn't cause regressions other cases (like the below mentioned Frogger Ancient Shadow, Burnout, Antz Extreme Racing, WWE RAW 2)