### PR TITLE
pixel shader conversion enhancement

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -2164,8 +2164,11 @@ PSH_RECOMPILED_SHADER PSH_XBOX_SHADER::Decode(XTL::X_D3DPIXELSHADERDEF *pPSDef)
   if (RemoveNops())
     Log("RemoveNops");
 
-  while (RemoveUselessWrites())
+  while (RemoveUselessWrites()) {
     Log("RemoveUselessWrites");
+    if (RemoveNops())
+      Log("RemoveNops");
+  }
 
   if (ConvertConstantsToNative(pPSDef, /*Recompiled=*/&Result))
     Log("ConvertConstantsToNative");
@@ -2173,8 +2176,11 @@ PSH_RECOMPILED_SHADER PSH_XBOX_SHADER::Decode(XTL::X_D3DPIXELSHADERDEF *pPSDef)
   ConvertXboxOpcodesToNative(pPSDef);
   Log("ConvertXboxOpcodesToNative");
 
-  while (RemoveUselessWrites()) // again
+  while (RemoveUselessWrites()) { // again
     Log("RemoveUselessWrites");
+    if (RemoveNops())
+      Log("RemoveNops");
+  }
 
   // Resolve all differences :
   if (FixupPixelShader())


### PR DESCRIPTION
This quick PR improves pixel shader conversion, by repeating cleanup steps (removing useless writes and no-ops) until no more modifications are done.

This can lead to smaller shaders and less conversion failures, improving visuals for some titles.

Test-case : Turok, when entering in-game, when the camera starts panning sideways while walking towards the first door. (This PR fixes issue #1053)