### PR TITLE
Dsound fixes part2

### DIFF
--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1394,7 +1394,21 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetStatus)
 		LOG_FUNC_ARG_OUT(pdwStatus)
 		LOG_FUNC_END;
 
-    HRESULT hRet = pThis->EmuDirectSoundBuffer8->GetStatus(pdwStatus);
+    DWORD dwStatusXbox = 0, dwStatusHost;
+    HRESULT hRet = pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatusHost);
+
+    // Conversion is a requirement to xbox.
+    if (hRet == DS_OK) {
+        if ((pThis->EmuFlags & DSE_FLAG_PAUSE) > 0) {
+            dwStatusXbox = X_DSBSTATUS_PAUSED;
+        } else if ((dwStatusHost & DSBSTATUS_PLAYING) > 0) {
+            dwStatusXbox = X_DSBSTATUS_PLAYING;
+        }
+        if ((dwStatusHost & DSBSTATUS_LOOPING) > 0) {
+            dwStatusXbox |= X_DSBSTATUS_LOOPING;
+        }
+        *pdwStatus = dwStatusXbox;
+    }
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2015,8 +2015,12 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetStatus)
             dwStatusXbox |= X_DSSSTATUS_PLAYING;
 
         } else {
-            // TODO: Might not be accurate. Doc state this flag is set when data is queued and paused.
+
             if ((pThis->EmuFlags & DSE_FLAG_PAUSE) > 0) {
+                dwStatusXbox |= X_DSSSTATUS_PAUSED;
+
+            // Set to paused when has packet(s) queued and is not processing.
+            } else if (pThis->Host_BufferPacketArray.size() != 0 && pThis->Host_isProcessing == false) {
                 dwStatusXbox |= X_DSSSTATUS_PAUSED;
             }
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1898,7 +1898,11 @@ ULONG WINAPI XTL::EMUPATCH(CDirectSoundStream_Release)
                     g_pDSoundStreamCache[v] = 0;
                 }
             }
-            EMUPATCH(CDirectSoundStream_Discontinuity)(pThis);
+
+            for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
+                DSoundStreamClearPacket(buffer._Ptr, XMP_STATUS_RELEASE_CXBXR, nullptr, nullptr, pThis->EmuFlags);
+                buffer = pThis->Host_BufferPacketArray.erase(buffer);
+            }
 
             if (pThis->EmuBufferDesc.lpwfxFormat != nullptr) {
                 free(pThis->EmuBufferDesc.lpwfxFormat);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -3308,8 +3308,8 @@ DWORD WINAPI XTL::EMUPATCH(DirectSoundGetSampleTime)()
 
 // ******************************************************************
 // * patch: CDirectSoundStream_SetMixBinVolumes_12
+// This revision API was used in XDK 3911 until API had changed in XDK 4039.
 // ******************************************************************
-// This revision API is only used in XDK 4039 and higher.
 HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12)
 (
     X_CDirectSoundStream*   pThis,
@@ -3339,7 +3339,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12)
 // ******************************************************************
 // * patch: CDirectSoundStream_SetMixBinVolumes_8
 // ******************************************************************
-// This revision API was used in XDK 3911 until API had changed in XDK 4039.
+// This revision API is only used in XDK 4039 and higher.
 HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
 (
     X_CDirectSoundStream*   pThis,

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1069,7 +1069,8 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
 
         DSoundDebugMuteFlag(pThis->X_BufferCacheSize, pThis->EmuFlags);
 
-        DSoundBufferUpdate(pThis, pThis->EmuPlayFlags, hRet);
+        // Only perform a resize, for lock emulation purpose.
+        DSoundBufferResizeSetSize(pThis, hRet, dwBufferBytes);
 
     }
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2045,8 +2045,9 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Process)
         }
 
         //TODO: What to do with output buffer audio variable? Need test case or functional source code.
+        // NOTE: pOutputBuffer is reserved, must be set to NULL from titles.
         if (pOutputBuffer != xbnullptr) {
-
+            LOG_TEST_CASE("pOutputBuffer is not nullptr, please report title test case to issue tracker. Thanks!");
         }
 
     } else {

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2744,7 +2744,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF)
 
 	LOG_FUNC();
 
-    LOG_UNIMPLEMENTED_DSOUND();
+    LOG_IGNORED();
 }
 
 // ******************************************************************
@@ -2760,7 +2760,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF)
 
 	LOG_FUNC();
 
-    LOG_UNIMPLEMENTED_DSOUND();
+    LOG_IGNORED();
 }
 
 // ******************************************************************
@@ -2776,7 +2776,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF4Channel)
 
 	LOG_FUNC();
 
-    LOG_UNIMPLEMENTED_DSOUND();
+    LOG_IGNORED();
 }
 
 // ******************************************************************
@@ -2792,7 +2792,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF4Channel)
 
 	LOG_FUNC();
 
-    LOG_UNIMPLEMENTED_DSOUND();
+    LOG_IGNORED();
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1728,8 +1728,8 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
     int v = 0;
     X_CDirectSoundStream** ppDSoundStreamCache = nullptr;
     for (v = 0; v < SOUNDBUFFER_CACHE_SIZE; v++) {
-        if (ppDSoundStreamCache[v] == nullptr) {
-            ppDSoundStreamCache = &ppDSoundStreamCache[v];
+        if (g_pDSoundStreamCache[v] == nullptr) {
+            ppDSoundStreamCache = &g_pDSoundStreamCache[v];
             break;
         }
     }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2456,8 +2456,8 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFrequency)
 // ******************************************************************
 HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBins)
 (
-    PVOID   pThis, // X_CDirectSoundStream *pThis
-    PVOID   pMixBins)
+    X_CDirectSoundStream*   pThis,
+    PVOID                   pMixBins)
 {
     FUNC_EXPORTS;
 
@@ -3081,8 +3081,8 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetOutputLevels)
 // ******************************************************************
 HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetEG)
 (
-    LPVOID        pThis,
-    LPVOID        pEnvelopeDesc)
+    X_CDirectSoundStream*   pThis,
+    LPVOID                  pEnvelopeDesc)
 {
     FUNC_EXPORTS;
 
@@ -4269,4 +4269,147 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetVoiceProperties)
     leaveCriticalSection;
 
     return DS_OK;
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetVolume
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetVolume)
+(
+    X_CDirectSoundStream*   pThis,
+    LONG                    lVolume)
+{
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(lVolume)
+        LOG_FUNC_END;
+
+    return HybridDirectSoundBuffer_SetVolume(pThis->EmuDirectSoundBuffer8, lVolume, pThis->EmuFlags, &pThis->Xb_Volume, pThis->Xb_VolumeMixbin);
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetPitch
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetPitch)
+(
+    X_CDirectSoundStream*   pThis,
+    LONG                    lPitch)
+{
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(lPitch)
+        LOG_FUNC_END;
+
+    return HybridDirectSoundBuffer_SetPitch(pThis->EmuDirectSoundBuffer8, lPitch);
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetLFO
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetLFO)
+(
+    X_CDirectSoundStream*   pThis,
+    LPCDSLFODESC            pLFODesc) {
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(pLFODesc)
+        LOG_FUNC_END;
+
+    return XTL::EMUPATCH(IDirectSoundStream_SetLFO)(pThis, pLFODesc);
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetEG
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetEG)
+(
+    X_CDirectSoundStream*   pThis,
+    LPVOID                  pEnvelopeDesc)
+{
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(pEnvelopeDesc)
+        LOG_FUNC_END;
+
+    return XTL::EMUPATCH(IDirectSoundStream_SetEG)(pThis, pEnvelopeDesc);
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetFilter
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetFilter)
+(
+    X_CDirectSoundStream*   pThis,
+    X_DSFILTERDESC*         pFilterDesc)
+{
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(pFilterDesc)
+        LOG_FUNC_END;
+
+    return XTL::EMUPATCH(CDirectSoundStream_SetFilter)(pThis, pFilterDesc);
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetHeadroom
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetHeadroom)
+(
+    X_CDirectSoundStream*   pThis,
+    DWORD                   dwHeadroom)
+{
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(dwHeadroom)
+        LOG_FUNC_END;
+
+    return XTL::EMUPATCH(CDirectSoundStream_SetHeadroom)(pThis, dwHeadroom);
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetFrequency
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetFrequency)
+(
+    X_CDirectSoundStream*   pThis,
+    DWORD                   dwFrequency)
+{
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(dwFrequency)
+        LOG_FUNC_END;
+
+    return HybridDirectSoundBuffer_SetFrequency(pThis->EmuDirectSoundBuffer8, dwFrequency);
+}
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetMixBins
+// ******************************************************************
+HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetMixBins)
+(
+    X_CDirectSoundStream*   pThis,
+    PVOID                   pMixBins)
+{
+    FUNC_EXPORTS;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pThis)
+        LOG_FUNC_ARG(pMixBins)
+        LOG_FUNC_END;
+
+    return XTL::EMUPATCH(IDirectSoundStream_SetMixBins)(pThis, pMixBins);
 }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -30,7 +30,7 @@
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2017 blueshogun96
-// *  (c) 2017 RadWolfie
+// *  (c) 2017-2018 RadWolfie
 // *
 // *  All rights reserved
 // *

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -4321,7 +4321,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetLFO)
         LOG_FUNC_ARG(pLFODesc)
         LOG_FUNC_END;
 
-    return XTL::EMUPATCH(IDirectSoundStream_SetLFO)(pThis, pLFODesc);
+    return XTL::EMUPATCH(CDirectSoundStream_SetLFO)(pThis, pLFODesc);
 }
 
 // ******************************************************************
@@ -4339,7 +4339,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetEG)
         LOG_FUNC_ARG(pEnvelopeDesc)
         LOG_FUNC_END;
 
-    return XTL::EMUPATCH(IDirectSoundStream_SetEG)(pThis, pEnvelopeDesc);
+    return XTL::EMUPATCH(CDirectSoundStream_SetEG)(pThis, pEnvelopeDesc);
 }
 
 // ******************************************************************
@@ -4411,5 +4411,5 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetMixBins)
         LOG_FUNC_ARG(pMixBins)
         LOG_FUNC_END;
 
-    return XTL::EMUPATCH(IDirectSoundStream_SetMixBins)(pThis, pMixBins);
+    return XTL::EMUPATCH(CDirectSoundStream_SetMixBins)(pThis, pMixBins);
 }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -785,7 +785,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_8)
 		LOG_FUNC_ARG(pMixBins)
 		LOG_FUNC_END;
 
-    return HybridDirectSoundBuffer_SetMixBinVolumes_8(pThis->EmuDirectSoundBuffer8, pMixBins, pThis->EmuFlags);
+    return HybridDirectSoundBuffer_SetMixBinVolumes_8(pThis->EmuDirectSoundBuffer8, pMixBins, pThis->EmuFlags, pThis->Xb_Volume, pThis->Xb_VolumeMixbin);
 }
 
 // ******************************************************************
@@ -974,7 +974,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
         }
 
         // Pre-set volume to enforce silence if one of audio codec is disabled.
-        HybridDirectSoundBuffer_SetVolume((*ppBuffer)->EmuDirectSoundBuffer8, 0, (*ppBuffer)->EmuFlags);
+        HybridDirectSoundBuffer_SetVolume((*ppBuffer)->EmuDirectSoundBuffer8, 0L, (*ppBuffer)->EmuFlags, nullptr, 0L);
 
         *ppDSoundBufferCache = *ppBuffer;
     }
@@ -1631,10 +1631,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetVolume)
 		LOG_FUNC_ARG(lVolume)
 		LOG_FUNC_END;
 
-    // TODO: Ensure that 4627 & 4361 are intercepting far enough back
-    // (otherwise pThis is manipulated!)
-
-    return HybridDirectSoundBuffer_SetVolume(pThis->EmuDirectSoundBuffer8, lVolume, pThis->EmuFlags);
+    return HybridDirectSoundBuffer_SetVolume(pThis->EmuDirectSoundBuffer8, lVolume, pThis->EmuFlags, &pThis->Xb_Volume, pThis->Xb_VolumeMixbin);
 }
 
 // ******************************************************************
@@ -1724,7 +1721,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
     }
 
     // Pre-set volume to enforce silence if one of audio codec is disabled.
-    HybridDirectSoundBuffer_SetVolume((*ppStream)->EmuDirectSoundBuffer8, 0, (*ppStream)->EmuFlags);
+    HybridDirectSoundBuffer_SetVolume((*ppStream)->EmuDirectSoundBuffer8, 0L, (*ppStream)->EmuFlags, nullptr, 0L);
 
     // cache this sound stream
     {
@@ -1806,7 +1803,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetVolume)
 		LOG_FUNC_ARG(lVolume)
 		LOG_FUNC_END;
 
-    return HybridDirectSoundBuffer_SetVolume(pThis->EmuDirectSoundBuffer8, lVolume, pThis->EmuFlags);
+    return HybridDirectSoundBuffer_SetVolume(pThis->EmuDirectSoundBuffer8, lVolume, pThis->EmuFlags, &pThis->Xb_Volume, pThis->Xb_VolumeMixbin);
 }
 
 // ******************************************************************
@@ -3349,7 +3346,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
 		LOG_FUNC_ARG(pMixBins)
 		LOG_FUNC_END;
 
-    return HybridDirectSoundBuffer_SetMixBinVolumes_8(pThis->EmuDirectSoundBuffer8, pMixBins, pThis->EmuFlags);
+    return HybridDirectSoundBuffer_SetMixBinVolumes_8(pThis->EmuDirectSoundBuffer8, pMixBins, pThis->EmuFlags, pThis->Xb_Volume, pThis->Xb_VolumeMixbin);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -745,7 +745,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBins)
 // This revision API was used in XDK 3911 until API had changed in XDK 4039.
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_12)
 (
-    LPDIRECTSOUND8          pThis,
+    X_CDirectSoundBuffer*   pThis,
     DWORD                   dwMixBinMask,
     const LONG*             alVolumes)
 {
@@ -775,25 +775,17 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_12)
 // This revision is only used in XDK 4039 and higher.
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_8)
 (
-    LPDIRECTSOUND8          pThis,
-    PVOID                   pMixBins)
+    X_CDirectSoundBuffer*   pThis,
+    X_LPDSMIXBINS           pMixBins)
 {
     FUNC_EXPORTS;
-
-    enterCriticalSection;
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pMixBins)
 		LOG_FUNC_END;
 
-    // NOTE: Read the above notes, and the rest is self explanitory...
-
-    LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
-
-    return DS_OK;
+    return HybridDirectSoundBuffer_SetMixBinVolumes_8(pThis->EmuDirectSoundBuffer8, pMixBins, pThis->EmuFlags);
 }
 
 // ******************************************************************
@@ -980,6 +972,10 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
         if (pdsbd->dwFlags & DSBCAPS_CTRL3D) {
             DSound3DBufferCreate((*ppBuffer)->EmuDirectSoundBuffer8, (*ppBuffer)->EmuDirectSound3DBuffer8);
         }
+
+        // Pre-set volume to enforce silence if one of audio codec is disabled.
+        HybridDirectSoundBuffer_SetVolume((*ppBuffer)->EmuDirectSoundBuffer8, 0, (*ppBuffer)->EmuFlags);
+
         *ppDSoundBufferCache = *ppBuffer;
     }
 
@@ -1726,7 +1722,11 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
     if (DSBufferDesc.dwFlags & DSBCAPS_CTRL3D) {
         DSound3DBufferCreate((*ppStream)->EmuDirectSoundBuffer8, (*ppStream)->EmuDirectSound3DBuffer8);
     }
-        // cache this sound stream
+
+    // Pre-set volume to enforce silence if one of audio codec is disabled.
+    HybridDirectSoundBuffer_SetVolume((*ppStream)->EmuDirectSoundBuffer8, 0, (*ppStream)->EmuFlags);
+
+    // cache this sound stream
     {
         int v = 0;
         for (v = 0; v < SOUNDSTREAM_CACHE_SIZE; v++) {
@@ -3340,24 +3340,16 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12)
 HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
 (
     X_CDirectSoundStream*   pThis,
-    LPVOID                  pMixBins)
+    X_LPDSMIXBINS           pMixBins)
 {
     FUNC_EXPORTS;
-
-    enterCriticalSection;
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pMixBins)
 		LOG_FUNC_END;
 
-    // NOTE: Read the above notes, and the rest is self explanitory...
-
-    LOG_UNIMPLEMENTED_DSOUND();
-
-    leaveCriticalSection;
-
-    return S_OK;
+    return HybridDirectSoundBuffer_SetMixBinVolumes_8(pThis->EmuDirectSoundBuffer8, pMixBins, pThis->EmuFlags);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -973,6 +973,8 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
             DSound3DBufferCreate((*ppBuffer)->EmuDirectSoundBuffer8, (*ppBuffer)->EmuDirectSound3DBuffer8);
         }
 
+        DSoundDebugMuteFlag((*ppBuffer)->X_BufferCacheSize, (*ppBuffer)->EmuFlags);
+
         // Pre-set volume to enforce silence if one of audio codec is disabled.
         HybridDirectSoundBuffer_SetVolume((*ppBuffer)->EmuDirectSoundBuffer8, 0L, (*ppBuffer)->EmuFlags, nullptr, 0L);
 
@@ -1055,6 +1057,8 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
         GenerateXboxBufferCache(pThis->EmuBufferDesc, pThis->EmuFlags, dwBufferBytes, &pThis->X_BufferCache, pThis->X_BufferCacheSize);
 
         memcpy_s(pThis->X_BufferCache, pThis->X_BufferCacheSize, pvBufferData, dwBufferBytes);
+
+        DSoundDebugMuteFlag(pThis->X_BufferCacheSize, pThis->EmuFlags);
 
         DSoundBufferUpdate(pThis, pThis->EmuPlayFlags, hRet);
 
@@ -1719,6 +1723,8 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
     if (DSBufferDesc.dwFlags & DSBCAPS_CTRL3D) {
         DSound3DBufferCreate((*ppStream)->EmuDirectSoundBuffer8, (*ppStream)->EmuDirectSound3DBuffer8);
     }
+
+    DSoundDebugMuteFlag((*ppStream)->EmuBufferDesc.dwBufferBytes, (*ppStream)->EmuFlags);
 
     // Pre-set volume to enforce silence if one of audio codec is disabled.
     HybridDirectSoundBuffer_SetVolume((*ppStream)->EmuDirectSoundBuffer8, 0L, (*ppStream)->EmuFlags, nullptr, 0L);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -935,6 +935,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
     if (ppDSoundBufferCache == nullptr || !DSoundSGEMenAllocCheck(pdsbd->dwBufferBytes)) {
 
         hRet = DSERR_OUTOFMEMORY;
+        *ppBuffer = xbnullptr;
     } else {
 
         DSBUFFERDESC DSBufferDesc = { 0 };
@@ -1079,7 +1080,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
         // Free internal buffer cache if exist
         if ((pThis->EmuFlags & DSE_FLAG_BUFFER_EXTERNAL) == 0) {
             free(pThis->X_BufferCache);
-            pThis->X_BufferCache = xbnullptr;
             DSoundSGEMemDealloc(pThis->X_BufferCacheSize);
         }
         pThis->X_BufferCache = pvBufferData;
@@ -3190,7 +3190,7 @@ HRESULT WINAPI XTL::EMUPATCH(XAudioDownloadEffectsImage)
 		LOG_FUNC_ARG(ppImageDesc)
 		LOG_FUNC_END;
 
-	LOG_UNIMPLEMENTED_DSOUND();
+	LOG_IGNORED();
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1406,7 +1406,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPitch)
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetStatus)
 (
     X_CDirectSoundBuffer*   pThis,
-    OUT LPDWORD                 pdwStatus)
+    OUT LPDWORD             pdwStatus)
 {
     FUNC_EXPORTS;
 
@@ -1430,7 +1430,12 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetStatus)
         if ((dwStatusHost & DSBSTATUS_LOOPING) > 0) {
             dwStatusXbox |= X_DSBSTATUS_LOOPING;
         }
+    }
+
+    if (pdwStatus != xbnullptr) {
         *pdwStatus = dwStatusXbox;
+    } else {
+        hRet = DSERR_INVALIDPARAM;
     }
 
     leaveCriticalSection;
@@ -2239,7 +2244,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Pause)
 		LOG_FUNC_END;
 
     return HybridDirectSoundBuffer_Pause(pThis->EmuDirectSoundBuffer8, dwPause, pThis->EmuFlags, pThis->EmuPlayFlags,
-                                        (pThis->Host_BufferPacketArray.size() > 0), 0LL, pThis->Xb_rtPauseEx);
+                                        pThis->Host_isProcessing, 0LL, pThis->Xb_rtPauseEx);
 }
 
 // ******************************************************************
@@ -4088,7 +4093,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_PauseEx)
     // TODO: Implement time stamp feature (a thread maybe?)
 
     HRESULT hRet = HybridDirectSoundBuffer_Pause(pThis->EmuDirectSoundBuffer8, dwPause, pThis->EmuFlags, pThis->EmuPlayFlags, 
-                                                (pThis->Host_BufferPacketArray.size() > 0), rtTimestamp, pThis->Xb_rtPauseEx);
+                                                pThis->Host_isProcessing, rtTimestamp, pThis->Xb_rtPauseEx);
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -52,7 +52,7 @@ namespace xboxkrnl {
 
 
 #ifndef _DEBUG_TRACE
-#define _DEBUG_TRACE
+//#define _DEBUG_TRACE
 #include "Logging.h"
 #undef _DEBUG_TRACE
 #else
@@ -2039,7 +2039,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetStatus)
             dwStatusXbox |= X_DSSSTATUS_READY;
         }
         *pdwStatus = dwStatusXbox;
-        printf("DEBUG: sGetStatus | testSize = %8u | dwStatusHost = %8X | dwStatusXbox = %8X\n", testSize, dwStatusHost, dwStatusXbox);
+
     } else if (pdwStatus != xbnullptr) {
         *pdwStatus = 0;
     }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1048,6 +1048,12 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
         return DS_OK;
     }
     HRESULT hRet = DSERR_OUTOFMEMORY;
+    DWORD dwStatus;
+
+    // force wait until buffer is stop playing.
+    do {
+        pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);
+    } while ((dwStatus & DSBSTATUS_PLAYING) > 0);
 
     if (DSoundSGEMenAllocCheck(dwBufferBytes)) {
 
@@ -1056,7 +1062,10 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
 
         GenerateXboxBufferCache(pThis->EmuBufferDesc, pThis->EmuFlags, dwBufferBytes, &pThis->X_BufferCache, pThis->X_BufferCacheSize);
 
-        memcpy_s(pThis->X_BufferCache, pThis->X_BufferCacheSize, pvBufferData, dwBufferBytes);
+        // Copy if given valid pointer.
+        if (pvBufferData != xbnullptr) {
+            memcpy_s(pThis->X_BufferCache, pThis->X_BufferCacheSize, pvBufferData, dwBufferBytes);
+        }
 
         DSoundDebugMuteFlag(pThis->X_BufferCacheSize, pThis->EmuFlags);
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2045,13 +2045,13 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Discontinuity)
     // default ret = DSERR_GENERIC
 
     // TODO: This part of code should be in CDirectSoundStream_Discontinuity
-    /*pThis->EmuDirectSoundBuffer8->Stop();
+    pThis->EmuDirectSoundBuffer8->Stop();
     pThis->Host_isProcessing = false;
 
     for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
         DSoundStreamClearPacket(buffer._Ptr, XMP_STATUS_FLUSHED, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis->EmuFlags);
         buffer = pThis->Host_BufferPacketArray.erase(buffer);
-    }*/
+    }
 
     leaveCriticalSection;
 
@@ -2072,13 +2072,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
 	LOG_FUNC_ONE_ARG(pThis);
 
     DSoundBufferRemoveSynchPlaybackFlag(pThis->EmuFlags);
-    pThis->EmuDirectSoundBuffer8->Stop();
-    pThis->Host_isProcessing = false;
-
-    for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
-        DSoundStreamClearPacket(buffer._Ptr, XMP_STATUS_FLUSHED, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis->EmuFlags);
-        buffer = pThis->Host_BufferPacketArray.erase(buffer);
-    }
 
     // TODO: How to emulate flush functionality?
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1136,7 +1136,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPlayRegion)
     if ((dwStatus & DSBSTATUS_PLAYING) > 0) {
         if ((dwStatus & DSBSTATUS_LOOPING) == 0) {
             pThis->EmuDirectSoundBuffer8->Stop();
-            DSoundBufferResizeCheckThenSet(pThis, pThis->EmuPlayFlags, hRet);
+            DSoundBufferUpdate(pThis, pThis->EmuPlayFlags, hRet);
             pThis->EmuDirectSoundBuffer8->SetCurrentPosition(0);
             pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
         }
@@ -1326,7 +1326,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetLoopRegion)
     if ((dwStatus & DSBSTATUS_PLAYING) > 0) {
         if ((dwStatus & DSBSTATUS_LOOPING) > 0) {
             pThis->EmuDirectSoundBuffer8->Stop();
-            DSoundBufferResizeCheckThenSet(pThis, pThis->EmuPlayFlags, hRet);
+            DSoundBufferUpdate(pThis, pThis->EmuPlayFlags, hRet);
             pThis->EmuDirectSoundBuffer8->SetCurrentPosition(0);
             pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
         }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -268,14 +268,12 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
     // Set this flag when this function is called
     g_bDSoundCreateCalled = TRUE;
 
-    if (!initialized || !g_pDSound8) {
-        hRet = DirectSoundCreate8(&g_XBAudio.GetAudioAdapter(), ppDirectSound, NULL);
+    if (!initialized || g_pDSound8 == nullptr) {
+        hRet = DirectSoundCreate8(&g_XBAudio.GetAudioAdapter(), &g_pDSound8, NULL);
 
         if (hRet != DS_OK) {
             CxbxKrnlCleanup("DirectSoundCreate8 Failed!");
         }
-
-        g_pDSound8 = *ppDirectSound;
 
         hRet = g_pDSound8->SetCooperativeLevel(g_hEmuWindow, DSSCL_PRIORITY);
 
@@ -332,7 +330,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
 
     // This way we can be sure that this function returns a valid
     // DirectSound8 pointer even if we initialized it elsewhere!
-    if (!(*ppDirectSound) && g_pDSound8) {
+    if (ppDirectSound != nullptr) {
         *ppDirectSound = g_pDSound8;
     }
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2036,7 +2036,17 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Discontinuity)
 
 	LOG_FUNC_ONE_ARG(pThis);
 
-    LOG_UNIMPLEMENTED_DSOUND();
+    // NOTE: Perform check if has pending data. if so, stop stream.
+    // default ret = DSERR_GENERIC
+
+    // TODO: This part of code should be in CDirectSoundStream_Discontinuity
+    pThis->EmuDirectSoundBuffer8->Stop();
+    pThis->Host_isProcessing = false;
+
+    for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
+        DSoundStreamClearPacket(buffer._Ptr, XMP_STATUS_FLUSHED, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis->EmuFlags);
+        buffer = pThis->Host_BufferPacketArray.erase(buffer);
+    }
 
     leaveCriticalSection;
 
@@ -2058,14 +2068,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
 
     DSoundBufferRemoveSynchPlaybackFlag(pThis->EmuFlags);
 
-
-    pThis->EmuDirectSoundBuffer8->Stop();
-    pThis->Host_isProcessing = false;
-
-    for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
-        DSoundStreamClearPacket(buffer._Ptr, XMP_STATUS_FLUSHED, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis->EmuFlags);
-        buffer = pThis->Host_BufferPacketArray.erase(buffer);
-    }
+    // TODO: How to emulate flush functionality?
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -2945,6 +2945,7 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSoundBuffer_AddRef)
 // ******************************************************************
 // * patch: IDirectSoundBuffer_Pause
 // ******************************************************************
+// Introduced in XDK 4721 revision.
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Pause)
 (
     X_CDirectSoundBuffer*   pThis,
@@ -2956,8 +2957,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Pause)
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwPause)
 		LOG_FUNC_END;
-
-    // This function wasn't part of the XDK until 4721.
 
     DSoundGenericUnlock(pThis->EmuFlags,
                         pThis->EmuDirectSoundBuffer8,
@@ -2975,6 +2974,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Pause)
 // ******************************************************************
 // * patch: IDirectSoundBuffer_PauseEx
 // ******************************************************************
+// Introduced in XDK 4721 revision.
 HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_PauseEx)
 (
     X_CDirectSoundBuffer   *pThis,
@@ -2990,9 +2990,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_PauseEx)
             LOG_FUNC_ARG(rtTimestamp)
             LOG_FUNC_ARG(dwPause)
             LOG_FUNC_END;
-
-    // This function wasn't part of the XDK until 4721.
-    // TODO: Implement time stamp feature (a thread maybe?)
 
     HRESULT hRet = HybridDirectSoundBuffer_Pause(pThis->EmuDirectSoundBuffer8, dwPause, pThis->EmuFlags, pThis->EmuPlayFlags,
                                                  1, rtTimestamp, pThis->Xb_rtPauseEx);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1758,10 +1758,12 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
         }
         DSBufferDesc.dwSize = sizeof(DSBUFFERDESC);
         //DSBufferDesc->dwFlags = (pdssd->dwFlags & dwAcceptableMask) | DSBCAPS_CTRLVOLUME | DSBCAPS_GETCURRENTPOSITION2;
-        DSBufferDesc.dwFlags = DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_GETCURRENTPOSITION2; //aka DSBCAPS_DEFAULT + control position
+        DSBufferDesc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_GETCURRENTPOSITION2; //aka DSBCAPS_DEFAULT + control position
 
         if ((pdssd->dwFlags & DSBCAPS_CTRL3D) > 0) {
             DSBufferDesc.dwFlags |= DSBCAPS_CTRL3D;
+        } else {
+            DSBufferDesc.dwFlags |= DSBCAPS_CTRLPAN;
         }
 
         DSoundBufferSetDefault((*ppStream), DSBPLAY_LOOPING);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -983,11 +983,6 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
         *ppDSoundBufferCache = *ppBuffer;
     }
 
-    printf("DEBUG: ==DirectSoundCreateBuffer==\n");
-    printf("DEBUG: *ppBuffer = %8X | requestSize = %8X\n", *ppBuffer, pdsbd->dwBufferBytes);
-    printf("DEBUG: g_dwXbMemAllocated = %8X\n", g_dwXbMemAllocated);
-    printf("DEBUG: ===========================\n");
-
     leaveCriticalSection;
 
     return hRet;

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -3190,8 +3190,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetCaps)
 		LOG_FUNC_END;
 
     // Get PC's DirectSound capabilities
-    DSCAPS DSCapsPC;
-    ZeroMemory(&DSCapsPC, sizeof(DSCAPS));
+    DSCAPS DSCapsPC = { sizeof(DSCAPS), 0 };
 
     HRESULT hRet = g_pDSound8->GetCaps(&DSCapsPC);
     if (hRet != DS_OK) {

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1051,9 +1051,11 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
     DWORD dwStatus;
 
     // force wait until buffer is stop playing.
-    do {
+    pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);
+    while ((dwStatus & DSBSTATUS_PLAYING) > 0) {
+        SwitchToThread();
         pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);
-    } while ((dwStatus & DSBSTATUS_PLAYING) > 0);
+    }
 
     // Allocate memory whenever made request internally
     if (pvBufferData == xbnullptr && DSoundSGEMenAllocCheck(dwBufferBytes)) {

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1067,6 +1067,9 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
     }
     HRESULT hRet;
 
+    // Confirmed it perform a reset to default.
+    DSoundBufferRegionSetDefault(pThis);
+
     GenerateXboxBufferCache(pThis->EmuBufferDesc, pThis->EmuFlags, dwBufferBytes, &pThis->X_BufferCache, pThis->X_BufferCacheSize);
 
     memcpy_s(pThis->X_BufferCache, pThis->X_BufferCacheSize, pvBufferData, dwBufferBytes);
@@ -1103,6 +1106,10 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPlayRegion)
     pThis->EmuBufferToggle = X_DSB_TOGGLE_PLAY;
     pThis->EmuRegionPlayStartOffset = dwPlayStart;
     pThis->EmuRegionPlayLength = dwPlayLength;
+
+    // Confirmed play region do overwrite loop region value.
+    pThis->EmuRegionLoopStartOffset = 0;
+    pThis->EmuRegionLoopLength = 0;
 
     DWORD dwStatus;
     pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -1283,7 +1283,7 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Release)
 
     ULONG uRet = 0;
 
-    //if (!(pThis->EmuFlags & DSB_FLAG_RECIEVEDATA)) {
+    //if (!(pThis->EmuFlags & DSE_FLAG_RECIEVEDATA)) {
         uRet = pThis->EmuDirectSoundBuffer8->Release();
 
         if (uRet == 0) {
@@ -1450,7 +1450,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Play)
 
     if (dwFlags & X_DSBPLAY_SYNCHPLAYBACK) {
         pThis->EmuPlayFlags ^= X_DSBPLAY_SYNCHPLAYBACK;
-        pThis->EmuFlags |= DSB_FLAG_SYNCHPLAYBACK_CONTROL;
+        pThis->EmuFlags |= DSE_FLAG_SYNCHPLAYBACK_CONTROL;
     }
 
     HRESULT hRet = DS_OK;
@@ -1462,7 +1462,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Play)
             EmuWarning("Rewinding buffer failed!");
         }
     }
-    if ((pThis->EmuFlags & DSB_FLAG_SYNCHPLAYBACK_CONTROL) == 0) {
+    if ((pThis->EmuFlags & DSE_FLAG_SYNCHPLAYBACK_CONTROL) == 0) {
         hRet = pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
     }
 
@@ -1910,7 +1910,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetStatus)
 
         } else {
             // TODO: Might not be accurate. Doc state this flag is set when data is queued and paused.
-            if ((pThis->EmuFlags & DSB_FLAG_PAUSE) > 0) {
+            if ((pThis->EmuFlags & DSE_FLAG_PAUSE) > 0) {
                 dwStatusXbox |= X_DSSSTATUS_PAUSED;
             }
 
@@ -2086,11 +2086,11 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_SynchPlayback)
             continue;
         }
 
-        if ((*pDSBuffer)->EmuFlags & DSB_FLAG_SYNCHPLAYBACK_CONTROL) {
+        if ((*pDSBuffer)->EmuFlags & DSE_FLAG_SYNCHPLAYBACK_CONTROL) {
             // RadWolfie: I don't think SetCurrentPosition is necessary?
             //DSoundBufferSelectionT((*pDSBuffer))->SetCurrentPosition(0);
             (*pDSBuffer)->EmuDirectSoundBuffer8->Play(0, 0, (*pDSBuffer)->EmuPlayFlags);
-            (*pDSBuffer)->EmuFlags ^= DSB_FLAG_SYNCHPLAYBACK_CONTROL;
+            (*pDSBuffer)->EmuFlags ^= DSE_FLAG_SYNCHPLAYBACK_CONTROL;
         }
     }
 
@@ -2099,10 +2099,10 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_SynchPlayback)
         if ((*pDSStream) == nullptr || (*pDSStream)->X_BufferCache == nullptr) {
             continue;
         }
-        if ((*pDSStream)->EmuFlags & DSB_FLAG_SYNCHPLAYBACK_CONTROL) {
+        if ((*pDSStream)->EmuFlags & DSE_FLAG_SYNCHPLAYBACK_CONTROL) {
             (*pDSStream)->EmuDirectSoundBuffer8->SetCurrentPosition(0);
             (*pDSStream)->EmuDirectSoundBuffer8->Play(0, 0, DSBPLAY_LOOPING);
-            (*pDSStream)->EmuFlags ^= DSB_FLAG_SYNCHPLAYBACK_CONTROL;
+            (*pDSStream)->EmuFlags ^= DSE_FLAG_SYNCHPLAYBACK_CONTROL;
         }
     }
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -450,7 +450,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_DownloadEffectsImage)
 
     // This function is relative to DSP for Interactive 3-D Audio Level 2 (I3DL2)
 
-    LOG_UNIMPLEMENTED_DSOUND();
+    LOG_IGNORED();
 
     leaveCriticalSection;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -195,11 +195,11 @@ XTL::X_XFileMediaObject::_vtbl XTL::X_XFileMediaObject::vtbl =
 
 // Static Variable(s)
 XBAudio                             g_XBAudio = XBAudio();
-extern LPDIRECTSOUND8               g_pDSound8 = NULL; //This is necessary in order to allow share with EmuDSoundInline.hpp
-static LPDIRECTSOUNDBUFFER          g_pDSoundPrimaryBuffer = NULL;
+extern LPDIRECTSOUND8               g_pDSound8 = nullptr; //This is necessary in order to allow share with EmuDSoundInline.hpp
+static LPDIRECTSOUNDBUFFER          g_pDSoundPrimaryBuffer = nullptr;
 //TODO: RadWolfie - How to implement support if primary does not permit it for DSP usage?
-static LPDIRECTSOUNDBUFFER8         g_pDSoundPrimaryBuffer8 = NULL;
-static LPDIRECTSOUND3DLISTENER8     g_pDSoundPrimary3DListener8 = NULL;
+static LPDIRECTSOUNDBUFFER8         g_pDSoundPrimaryBuffer8 = nullptr;
+static LPDIRECTSOUND3DLISTENER8     g_pDSoundPrimary3DListener8 = nullptr;
 static XTL::X_CDirectSoundBuffer*   g_pDSoundBufferCache[SOUNDBUFFER_CACHE_SIZE] = { 0 }; //Default initialize to all zero'd
 static XTL::X_CDirectSoundStream*   g_pDSoundStreamCache[SOUNDSTREAM_CACHE_SIZE] = { 0 }; //Default initialize to all zero'd
 static int                          g_bDSoundCreateCalled = FALSE;

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -131,7 +131,7 @@ typedef struct _XMEDIAPACKET
         HANDLE  hCompletionEvent;
         PVOID  pContext;
     };
-    PREFERENCE_TIME prtTimestamp;
+    PREFERENCE_TIME prtTimestamp; // Not supported in xbox
 }
 XMEDIAPACKET, *PXMEDIAPACKET, *LPXMEDIAPACKET;
 

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -397,6 +397,7 @@ struct X_CDirectSoundBuffer
 #define DSE_FLAG_ENVELOPE               (1 << 13)
 #define DSE_FLAG_ENVELOPE2              (1 << 14) // NOTE: This flag is a requirement for GetStatus to return X_DSSSTATUS_ENVELOPECOMPLETE value.
 #define DSE_FLAG_RECIEVEDATA            (1 << 20)
+#define DSE_FLAG_DEBUG_MUTE             (1 << 30) // Cxbx-R debugging usage only
 #define DSE_FLAG_AUDIO_CODECS           (DSE_FLAG_PCM | DSE_FLAG_XADPCM | DSE_FLAG_PCM_UNKNOWN)
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -381,6 +381,8 @@ struct X_CDirectSoundBuffer
     DSoundBuffer_Lock       Host_lock;
     DSoundBuffer_Lock       X_lock;
     REFERENCE_TIME          Xb_rtPauseEx;
+    LONG                    Xb_Volume;
+    LONG                    Xb_VolumeMixbin;
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069
@@ -527,6 +529,8 @@ class X_CDirectSoundStream
         LPVOID                                  Xb_lpvContext;
         REFERENCE_TIME                          Xb_rtFlushEx;
         REFERENCE_TIME                          Xb_rtPauseEx;
+        LONG                                    Xb_Volume;
+        LONG                                    Xb_VolumeMixbin;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -27,6 +27,7 @@
 // *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
+// *  (c) 2017-2018 RadWolfie
 // *
 // *  All rights reserved
 // *

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -354,6 +354,7 @@ struct X_CDirectSoundBuffer
     DWORD                   X_BufferCacheSize;
     DSoundBuffer_Lock       Host_lock;
     DSoundBuffer_Lock       X_lock;
+    REFERENCE_TIME          Xb_rtPauseEx;
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -66,6 +66,12 @@ void CxbxInitAudio();
 #define X_DSSPAUSE_SYNCHPLAYBACK      0x00000002
 #define X_DSSPAUSE_PAUSENOACTIVATE    0x00000003
 
+// EmuIDirectSoundStream_FlushEx flags
+#define X_DSSFLUSHEX_IMMEDIATE        0x00000000
+#define X_DSSFLUSHEX_ASYNC            0x00000001
+#define X_DSSFLUSHEX_ENVELOPE         0x00000002
+#define X_DSSFLUSHEX_ENVELOPE2        0x00000004
+
 // EmuIDirectSoundBuffer_GetStatus flags
 #define X_DSSSTATUS_READY             0x00000001
 #define X_DSSSTATUS_PLAYING           0x00010000
@@ -78,7 +84,6 @@ void CxbxInitAudio();
 #define X_DSBSTOPEX_ENVELOPE          0x00000001
 #define X_DSBSTOPEX_RELEASEWAVEFORM   0x00000002
 #define X_DSBSTOPEX_ALL               (X_DSBSTOPEX_ENVELOPE | X_DSBSTOPEX_RELEASEWAVEFORM)
-
 
 // ******************************************************************
 // * X_DSBUFFERDESC
@@ -490,6 +495,8 @@ class X_CDirectSoundStream
         bool                                    Host_isProcessing;
         LPFNXMOCALLBACK                         Xb_lpfnCallback;
         LPVOID                                  Xb_lpvContext;
+        REFERENCE_TIME                          Xb_rtFlushEx;
+        REFERENCE_TIME                          Xb_rtPauseEx;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -123,10 +123,11 @@ typedef struct _XMEDIAPACKET
 }
 XMEDIAPACKET, *PXMEDIAPACKET, *LPXMEDIAPACKET;
 
-#define XMP_STATUS_SUCCESS             S_OK
-#define XMP_STATUS_PENDING             E_PENDING
-#define XMP_STATUS_FLUSHED             E_ABORT
-#define XMP_STATUS_FAILURE             E_FAIL
+#define XMP_STATUS_SUCCESS          S_OK
+#define XMP_STATUS_PENDING          E_PENDING
+#define XMP_STATUS_FLUSHED          E_ABORT
+#define XMP_STATUS_FAILURE          E_FAIL
+#define XMP_STATUS_RELEASE_CXBXR    0xFFFFFFFF
 
 // ******************************************************************
 // * XMEDIAINFO

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -389,6 +389,7 @@ struct X_CDirectSoundBuffer
     REFERENCE_TIME          Xb_rtPauseEx;
     LONG                    Xb_Volume;
     LONG                    Xb_VolumeMixbin;
+    DWORD                   Xb_dwHeadroom;
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069
@@ -539,6 +540,7 @@ class X_CDirectSoundStream
         REFERENCE_TIME                          Xb_rtPauseEx;
         LONG                                    Xb_Volume;
         LONG                                    Xb_VolumeMixbin;
+        DWORD                                   Xb_dwHeadroom;
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -1227,7 +1227,7 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetI3DL2Source)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetMixBins)
 (
-    PVOID   pThis,
+    X_CDirectSoundStream*   pThis,
     PVOID   pMixBins
 );
 
@@ -1488,8 +1488,8 @@ HRESULT WINAPI EMUPATCH(IDirectSound_GetOutputLevels)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetEG)
 (
-    LPVOID        pThis,
-    LPVOID        pEnvelopeDesc
+    X_CDirectSoundStream*   pThis,
+    LPVOID                  pEnvelopeDesc
 );
 
 // ******************************************************************
@@ -1537,8 +1537,8 @@ HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetFilter)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetFilter)
 (
-    X_CDirectSoundStream*    pThis,
-    X_DSFILTERDESC*            pFilterDesc
+    X_CDirectSoundStream*   pThis,
+    X_DSFILTERDESC*         pFilterDesc
 );
 
 // ******************************************************************
@@ -1555,7 +1555,7 @@ HRESULT WINAPI EMUPATCH(IDirectSound_GetCaps)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetPitch)
 (    
-    X_CDirectSoundStream*    pThis,
+    X_CDirectSoundStream*   pThis,
     LONG                    lPitch
 );
 
@@ -1608,8 +1608,8 @@ HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetAllParameters)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetFormat)
 (
-    X_CDirectSoundStream*    pThis,
-    LPCWAVEFORMATEX            pwfxFormat
+    X_CDirectSoundStream*   pThis,
+    LPCWAVEFORMATEX         pwfxFormat
 );
 
 // ******************************************************************
@@ -1810,15 +1810,6 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_PauseEx)
     DWORD                   dwPause);
 
 // ******************************************************************
-// * patch: CDirectSoundStream_PauseEx
-// ******************************************************************
-HRESULT WINAPI EMUPATCH(CDirectSoundStream_PauseEx)
-(
-    X_CDirectSoundStream   *pThis,
-    REFERENCE_TIME          rtTimestamp,
-    DWORD                   dwPause);
-
-// ******************************************************************
 // * patch: XFileCreaeMediaObject
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(XFileCreateMediaObject)
@@ -1881,4 +1872,68 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_GetVoiceProperties)
 (
     X_CDirectSoundStream*   pThis,
     OUT void*               pVoiceProps);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetVolume
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetVolume)
+(
+    X_CDirectSoundStream*   pThis,
+    LONG                    lVolume);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetPitch
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetPitch)
+(
+    X_CDirectSoundStream*   pThis,
+    LONG                    lPitch);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetLFO
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetLFO)
+(
+    X_CDirectSoundStream*   pThis,
+    LPCDSLFODESC            pLFODesc);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetEG
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetEG)
+(
+    X_CDirectSoundStream*   pThis,
+    LPVOID                  pEnvelopeDesc);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetFilter
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetFilter)
+(
+    X_CDirectSoundStream*   pThis,
+    X_DSFILTERDESC*         pFilterDesc);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetHeadroom
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetHeadroom)
+(
+    X_CDirectSoundStream*   pThis,
+    DWORD                   dwHeadroom);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetFrequency
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetFrequency)
+(
+    X_CDirectSoundStream*   pThis,
+    DWORD                   dwFrequency);
+
+// ******************************************************************
+// * patch: IDirectSoundStream_SetMixBins
+// ******************************************************************
+HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetMixBins)
+(
+    X_CDirectSoundStream*   pThis,
+    PVOID                   pMixBins);
 #endif

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -403,6 +403,7 @@ struct X_CDirectSoundBuffer
 #define DSE_FLAG_ENVELOPE2              (1 << 14) // NOTE: This flag is a requirement for GetStatus to return X_DSSSTATUS_ENVELOPECOMPLETE value.
 #define DSE_FLAG_RECIEVEDATA            (1 << 20)
 #define DSE_FLAG_DEBUG_MUTE             (1 << 30) // Cxbx-R debugging usage only
+#define DSE_FLAG_BUFFER_EXTERNAL        (1 << 31)
 #define DSE_FLAG_AUDIO_CODECS           (DSE_FLAG_PCM | DSE_FLAG_XADPCM | DSE_FLAG_PCM_UNKNOWN)
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -66,6 +66,13 @@ void CxbxInitAudio();
 #define X_DSSPAUSE_SYNCHPLAYBACK      0x00000002
 #define X_DSSPAUSE_PAUSENOACTIVATE    0x00000003
 
+// EmuIDirectSoundBuffer_GetStatus flags
+#define X_DSSSTATUS_READY             0x00000001
+#define X_DSSSTATUS_PLAYING           0x00010000
+#define X_DSSSTATUS_PAUSED            0x00020000
+#define X_DSSSTATUS_STARVED           0x00040000
+#define X_DSSSTATUS_ENVELOPECOMPLETE  0x00080000
+
 // EmuIDirectSoundBuffer_StopEx flags
 #define X_DSBSTOPEX_IMMEDIATE         0x00000000
 #define X_DSBSTOPEX_ENVELOPE          0x00000001

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -338,8 +338,6 @@ struct X_CDirectSoundBuffer
     DWORD                   EmuRegionLoopLength;
     DWORD                   EmuRegionPlayStartOffset;
     DWORD                   EmuRegionPlayLength;
-    LPDIRECTSOUNDBUFFER8    EmuDirectSoundBuffer8Region;
-    LPDIRECTSOUND3DBUFFER8  EmuDirectSound3DBuffer8Region;
     DWORD                   X_BufferCacheSize;
     DSoundBuffer_Lock       Host_lock;
     DSoundBuffer_Lock       X_lock;

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -358,13 +358,16 @@ struct X_CDirectSoundBuffer
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069
 //Custom flags (4 bytes support up to 31 shifts,starting from 0)
-#define DSB_FLAG_PCM                    (1 << 0)
-#define DSB_FLAG_XADPCM                 (1 << 1)
-#define DSB_FLAG_PCM_UNKNOWN            (1 << 2)
-#define DSB_FLAG_SYNCHPLAYBACK_CONTROL  (1 << 10)
-#define DSB_FLAG_PAUSE                  (1 << 11)
-#define DSB_FLAG_RECIEVEDATA            (1 << 20)
-#define DSB_FLAG_AUDIO_CODECS           (DSB_FLAG_PCM | DSB_FLAG_XADPCM | DSB_FLAG_PCM_UNKNOWN)
+#define DSE_FLAG_PCM                    (1 << 0)
+#define DSE_FLAG_XADPCM                 (1 << 1)
+#define DSE_FLAG_PCM_UNKNOWN            (1 << 2)
+#define DSE_FLAG_SYNCHPLAYBACK_CONTROL  (1 << 10)
+#define DSE_FLAG_PAUSE                  (1 << 11)
+#define DSE_FLAG_ASYNC                  (1 << 12)
+#define DSE_FLAG_ENVELOPE               (1 << 13)
+#define DSE_FLAG_ENVELOPE2              (1 << 14) // NOTE: This flag is a requirement for GetStatus to return X_DSSSTATUS_ENVELOPECOMPLETE value.
+#define DSE_FLAG_RECIEVEDATA            (1 << 20)
+#define DSE_FLAG_AUDIO_CODECS           (DSE_FLAG_PCM | DSE_FLAG_XADPCM | DSE_FLAG_PCM_UNKNOWN)
 
 // ******************************************************************
 // * X_CMcpxStream

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -161,6 +161,32 @@ XMEDIAINFO, *PXEIDIAINFO, *LPXMEDIAINFO;
 #define XMO_STREAMF_IN_PLACE                    0x00000010      // The object supports in-place modification of data
 #define XMO_STREAMF_MASK                        0x0000001F
 
+enum XDSMIXBIN {
+    XDSMIXBIN_FRONT_LEFT    = 0,
+    XDSMIXBIN_FRONT_RIGHT,  //1
+    XDSMIXBIN_FRONT_CENTER, //2
+    XDSMIXBIN_LOW_FREQUENCY,//3
+    XDSMIXBIN_BACK_LEFT,    //4
+    XDSMIXBIN_BACK_RIGHT,   //5
+    XDSMIXBIN_COUNT_MAX
+};
+
+// ******************************************************************
+// * X_DSMIXBINVOLUMEPAIR
+// ******************************************************************
+typedef struct _XDSMIXBINSVOLUMEPAIR {
+    XDSMIXBIN   dwMixBin;
+    LONG        lVolume;
+} X_DSMIXBINSVOLUMEPAIR, *X_LPDSMIXBINSVOLUMEPAIR;
+
+// ******************************************************************
+// * X_DSMB
+// ******************************************************************
+typedef struct _XDSMIXBINS {
+    DWORD                       dwCount;
+    X_LPDSMIXBINSVOLUMEPAIR     lpMixBinVolumePairs;
+} X_DSMIXBINS, *X_LPDSMIXBINS;
+
 // ******************************************************************
 // * X_DSFILTERDESC
 // ******************************************************************
@@ -717,7 +743,7 @@ HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetMixBins)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_12)
 (
-    LPDIRECTSOUND8          pThis,
+    X_CDirectSoundBuffer*   pThis,
     DWORD                   dwMixBinMask,
     const LONG*             alVolumes
 );
@@ -727,8 +753,8 @@ HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_12)
 // ******************************************************************
 HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_8)
 (
-    LPDIRECTSOUND8          pThis,
-    PVOID                   pMixBins    // TODO: fill this out
+    X_CDirectSoundBuffer*   pThis,
+    X_LPDSMIXBINS           pMixBins
 );
 
 // ******************************************************************
@@ -1533,7 +1559,7 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12)
 (
     X_CDirectSoundStream*    pThis,
     DWORD                    dwMixBinMask,
-    const LONG*                alVolumes
+    const LONG*              alVolumes
 );
 
 // ******************************************************************
@@ -1542,7 +1568,7 @@ HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12)
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
 (
     X_CDirectSoundStream*    pThis,
-    LPVOID                    pMixBins
+    X_LPDSMIXBINS            pMixBins
 );
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -161,21 +161,21 @@ XMEDIAINFO, *PXEIDIAINFO, *LPXMEDIAINFO;
 #define XMO_STREAMF_IN_PLACE                    0x00000010      // The object supports in-place modification of data
 #define XMO_STREAMF_MASK                        0x0000001F
 
-enum XDSMIXBIN {
-    XDSMIXBIN_FRONT_LEFT    = 0,
-    XDSMIXBIN_FRONT_RIGHT,  //1
-    XDSMIXBIN_FRONT_CENTER, //2
-    XDSMIXBIN_LOW_FREQUENCY,//3
-    XDSMIXBIN_BACK_LEFT,    //4
-    XDSMIXBIN_BACK_RIGHT,   //5
-    XDSMIXBIN_COUNT_MAX
-};
+// XDSMIXBIN Flags
+#define XDSMIXBIN_FRONT_LEFT        0
+#define XDSMIXBIN_FRONT_RIGHT       1
+#define XDSMIXBIN_FRONT_CENTER      2
+#define XDSMIXBIN_LOW_FREQUENCY     3
+#define XDSMIXBIN_BACK_LEFT         4
+#define XDSMIXBIN_BACK_RIGHT        5
+#define XDSMIXBIN_SPEAKERS_MAX      6 // Max count for speakers
+// Other flags are used 
 
 // ******************************************************************
 // * X_DSMIXBINVOLUMEPAIR
 // ******************************************************************
 typedef struct _XDSMIXBINSVOLUMEPAIR {
-    XDSMIXBIN   dwMixBin;
+    DWORD       dwMixBin;
     LONG        lVolume;
 } X_DSMIXBINSVOLUMEPAIR, *X_LPDSMIXBINSVOLUMEPAIR;
 

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -364,7 +364,7 @@ struct X_CDirectSoundBuffer
 #define DSE_FLAG_PCM_UNKNOWN            (1 << 2)
 #define DSE_FLAG_SYNCHPLAYBACK_CONTROL  (1 << 10)
 #define DSE_FLAG_PAUSE                  (1 << 11)
-#define DSE_FLAG_ASYNC                  (1 << 12)
+#define DSE_FLAG_FLUSH_ASYNC            (1 << 12)
 #define DSE_FLAG_ENVELOPE               (1 << 13)
 #define DSE_FLAG_ENVELOPE2              (1 << 14) // NOTE: This flag is a requirement for GetStatus to return X_DSSSTATUS_ENVELOPECOMPLETE value.
 #define DSE_FLAG_RECIEVEDATA            (1 << 20)

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -73,12 +73,17 @@ void CxbxInitAudio();
 #define X_DSSFLUSHEX_ENVELOPE         0x00000002
 #define X_DSSFLUSHEX_ENVELOPE2        0x00000004
 
-// EmuIDirectSoundBuffer_GetStatus flags
+// EmuIDirectSoundStream_GetStatus flags
 #define X_DSSSTATUS_READY             0x00000001
 #define X_DSSSTATUS_PLAYING           0x00010000
 #define X_DSSSTATUS_PAUSED            0x00020000
 #define X_DSSSTATUS_STARVED           0x00040000
 #define X_DSSSTATUS_ENVELOPECOMPLETE  0x00080000
+
+// EmuIDirectSoundBuffer_GetStatus flags
+#define X_DSBSTATUS_PLAYING           0x00000001
+#define X_DSBSTATUS_PAUSED            0x00000002
+#define X_DSBSTATUS_LOOPING           0x00000004
 
 // EmuIDirectSoundBuffer_StopEx flags
 #define X_DSBSTOPEX_IMMEDIATE         0x00000000

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -372,12 +372,6 @@ inline void DSoundGenericUnlock(
 
 }
 
-#define DSoundBufferSelectionT(pThis) \
-    (pThis->EmuDirectSoundBuffer8)
-
-#define DSound3DBufferSelectionT(pThis) \
-    (pThis->EmuDirectSound3DBuffer8)
-
 // Temporary creation since we need IDIRECTSOUNDBUFFER8, not IDIRECTSOUNDBUFFER class.
 inline void DSoundBufferCreate(LPDSBUFFERDESC pDSBufferDesc, LPDIRECTSOUNDBUFFER8 &pDSBuffer)
 {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -677,28 +677,6 @@ inline void DSoundBufferReplace(
     }
 }
 
-// resize an emulated directsound buffer, if necessary
-inline void ResizeIDirectSoundBuffer(
-    LPDIRECTSOUNDBUFFER8       &pDSBuffer,
-    DSBUFFERDESC               &DSBufferDesc,
-    DWORD                       PlayFlags,
-    DWORD                       Xbox_dwBytes,
-    LPDIRECTSOUND3DBUFFER8     &pDS3DBuffer,
-    DWORD                       EmuFlags,
-    LPVOID                     &X_BufferCache,
-    DWORD                      &X_BufferCacheSize)
-{
-    if (Xbox_dwBytes == 0 || X_BufferCacheSize == Xbox_dwBytes) {
-        return;
-    }
-
-    GenerateXboxBufferCache(DSBufferDesc, EmuFlags, Xbox_dwBytes, &X_BufferCache, X_BufferCacheSize);
-
-    DSBufferDesc.dwBufferBytes = DSoundBufferGetPCMBufferSize(EmuFlags, X_BufferCacheSize);
-
-    DSoundBufferReplace(pDSBuffer, DSBufferDesc, PlayFlags, pDS3DBuffer);
-}
-
 inline void DSoundStreamWriteToBuffer(
     LPDIRECTSOUNDBUFFER8       &pDSBuffer,
     DWORD                       dwOffset,

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -463,9 +463,7 @@ inline void DSoundBufferTransferSettings(
 
     pDSBufferOld->GetVolume(&lVolume);
     pDSBufferOld->GetFrequency(&dwFrequency);
-    pDSBufferOld->GetPan(&lPan);
 
-    pDSBufferNew->SetPan(lPan);
     pDSBufferNew->SetFrequency(dwFrequency);
     pDSBufferNew->SetVolume(lVolume);
 
@@ -473,6 +471,9 @@ inline void DSoundBufferTransferSettings(
         pDS3DBufferOld->GetAllParameters(&ds3dBuffer);
 
         pDS3DBufferNew->SetAllParameters(&ds3dBuffer, DS3D_IMMEDIATE);
+    } else {
+        pDSBufferOld->GetPan(&lPan);
+        pDSBufferNew->SetPan(lPan);
     }
 }
 

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -180,7 +180,7 @@ inline void GenerateXboxBufferCache(
     // If the size is the same, don't realloc
     if (X_BufferCacheSize != X_BufferSizeRequest) {
         // Check if buffer cache exist, then copy over old ones.
-        if (*X_BufferCache != xbnullptr) {
+        if (*X_BufferCache != xbnullptr && (dwEmuFlags & DSE_FLAG_BUFFER_EXTERNAL) == 0) {
             LPVOID tempBuffer = *X_BufferCache;
             *X_BufferCache = malloc(X_BufferSizeRequest);
 
@@ -379,12 +379,13 @@ inline void DSoundGenericUnlock(
             Host_lock.dwLockBytes1 = DSBufferDesc->dwBufferBytes;
         }*/
 
+        if (X_BufferCache != xbnullptr) {
+            DSoundBufferOutputXBtoHost(dwEmuFlags, DSBufferDesc, ((PBYTE)X_BufferCache + X_Offset), X_dwLockBytes1, Host_lock.pLockPtr1, Host_lock.dwLockBytes1);
 
-        DSoundBufferOutputXBtoHost(dwEmuFlags, DSBufferDesc, ((PBYTE)X_BufferCache + X_Offset), X_dwLockBytes1, Host_lock.pLockPtr1, Host_lock.dwLockBytes1);
+            if (Host_lock.pLockPtr2 != nullptr) {
 
-        if (Host_lock.pLockPtr2 != nullptr) {
-
-            DSoundBufferOutputXBtoHost(dwEmuFlags, DSBufferDesc, X_BufferCache, X_dwLockBytes2, Host_lock.pLockPtr2, Host_lock.dwLockBytes2);
+                DSoundBufferOutputXBtoHost(dwEmuFlags, DSBufferDesc, X_BufferCache, X_dwLockBytes2, Host_lock.pLockPtr2, Host_lock.dwLockBytes2);
+            }
         }
 
         pDSBuffer->Unlock(Host_lock.pLockPtr1, Host_lock.dwLockBytes1, Host_lock.pLockPtr2, Host_lock.dwLockBytes2);

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1009,8 +1009,6 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
             dwEmuFlags &= ~DSE_FLAG_PAUSE;
             break;
         case X_DSSPAUSE_PAUSE:
-        // TODO: NOTE: If stream is playing, it perform same behavior as pause flag. If it is not played, it act as a queue until trigger to play it.
-        case X_DSSPAUSE_PAUSENOACTIVATE:
             hStatus = pDSBuffer->GetStatus(&dwStatus);
             if (hStatus == DS_OK && dwStatus & DSBSTATUS_PLAYING) {
                 pDSBuffer->Stop();
@@ -1036,6 +1034,8 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
                 }
             }
             break;
+        // TODO: NOTE: If stream is playing, it perform same behavior as pause flag. If it is not played, it act as a queue until trigger to play it.
+        case X_DSSPAUSE_PAUSENOACTIVATE:
             break;
     }
 

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -184,9 +184,15 @@ inline void GeneratePCMFormat(
             // in the first place, FYI.
 
             if (DSBufferDesc.lpwfxFormat == nullptr) {
-                DSBufferDesc.lpwfxFormat = (WAVEFORMATEX*)malloc(sizeof(WAVEFORMATEX) + lpwfxFormat->cbSize);
+                    DSBufferDesc.lpwfxFormat = (WAVEFORMATEX*)malloc(sizeof(WAVEFORMATEXTENSIBLE));
             }
-            memcpy(DSBufferDesc.lpwfxFormat, lpwfxFormat, sizeof(WAVEFORMATEX) + lpwfxFormat->cbSize);
+            if (lpwfxFormat->wFormatTag == WAVE_FORMAT_PCM) {
+                // Test case: Hulk crash due to cbSize is not a valid size.
+                memcpy(DSBufferDesc.lpwfxFormat, lpwfxFormat, sizeof(WAVEFORMATEX));
+                DSBufferDesc.lpwfxFormat->cbSize = 0; // Let's enforce this value to prevent any other exception later on.
+            } else {
+                memcpy(DSBufferDesc.lpwfxFormat, lpwfxFormat, sizeof(WAVEFORMATEX) + lpwfxFormat->cbSize);
+            }
 
             dwEmuFlags = dwEmuFlags & ~DSB_FLAG_AUDIO_CODECS;
 

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1722,25 +1722,25 @@ inline HRESULT HybridDirectSoundBuffer_SetVolume(
 
     if ((dwEmuFlags & DSE_FLAG_PCM) > 0) {
         if (!g_XBAudio.GetPCM()) {
-            lVolume = -10000;
+            lVolume = DSBVOLUME_MIN;
         }
     } else if ((dwEmuFlags & DSE_FLAG_XADPCM) > 0) {
         if (!g_XBAudio.GetXADPCM()) {
-            lVolume = -10000;
+            lVolume = DSBVOLUME_MIN;
         }
     } else if ((dwEmuFlags & DSE_FLAG_PCM_UNKNOWN) > 0) {
         if (!g_XBAudio.GetUnknownCodec()) {
-            lVolume = -10000;
+            lVolume = DSBVOLUME_MIN;
         }
     }
-    if (lVolume <= -6400) {
+    if (lVolume <= -6400 && lVolume != DSBVOLUME_MIN) {
         lVolume = DSBVOLUME_MIN;
     } else if (lVolume > 0) {
         EmuWarning("HybridDirectSoundBuffer_SetVolume has received greater than 0: %ld", lVolume);
         lVolume = 0;
     }
     if ((dwEmuFlags & DSE_FLAG_DEBUG_MUTE) > 0) {
-        lVolume = -10000;
+        lVolume = DSBVOLUME_MIN;
     }
 
     HRESULT hRet = pDSBuffer->SetVolume(lVolume);

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -183,6 +183,7 @@ inline void GeneratePCMFormat(
             // be WAVEFORMATEXTENSIBLE if that's what the programmer(s) wanted
             // in the first place, FYI.
 
+            // Allocate only once, does not need to re-allocate.
             if (DSBufferDesc.lpwfxFormat == nullptr) {
                 // Only allocate extra value for setting extra values later on. WAVEFORMATEXTENSIBLE is the highest size I had seen.
                 DSBufferDesc.lpwfxFormat = (WAVEFORMATEX*)calloc(1, sizeof(WAVEFORMATEXTENSIBLE));
@@ -264,6 +265,7 @@ inline void GeneratePCMFormat(
         DSBufferDesc.guid3DAlgorithm = DS3DALG_DEFAULT;
     }
 
+    // TODO: Still a requirement? Need to retest it again. Can't remember which title cause problem or had been resolved.
     // sanity check
     if (!bIsSpecial) {
         if (DSBufferDesc.lpwfxFormat->nBlockAlign != (DSBufferDesc.lpwfxFormat->nChannels*DSBufferDesc.lpwfxFormat->wBitsPerSample) / 8) {
@@ -273,7 +275,10 @@ inline void GeneratePCMFormat(
     }
 
     if (DSBufferDesc.lpwfxFormat != nullptr) {
-        // we NOW support 2+ channels, this conversion is necessary in order to support PC audio.
+
+        // NOTE: This process check for 2+ channels whenever XADPCM or PCM format from xbox titles input in nChannels.
+        // Since the host do not support 2+ channels on PCM only format. We must convert/update allocated wfxFormat to EXTENSIBLE
+        // format which had been allocated enough to update.
         if (DSBufferDesc.lpwfxFormat->nChannels > 2 && DSBufferDesc.lpwfxFormat->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
             PWAVEFORMATEXTENSIBLE lpwfxFormatExtensible = (PWAVEFORMATEXTENSIBLE)DSBufferDesc.lpwfxFormat;
             lpwfxFormatExtensible->Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -803,6 +803,11 @@ inline bool DSoundStreamProcess(XTL::X_CDirectSoundStream* pThis) {
         return 0;
     }
 
+    // Do not allow to process if there is no packets.
+    if (pThis->Host_BufferPacketArray.size() == 0) {
+        return 0;
+    }
+
     DWORD dwAudioBytes;
     HRESULT hRet = pThis->EmuDirectSoundBuffer8->GetStatus(&dwAudioBytes);
     if (hRet == DS_OK) {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1189,6 +1189,8 @@ inline HRESULT HybridDirectSoundBuffer_SetFormat(
 
     enterCriticalSection;
 
+    pDSBuffer->Stop();
+
     if (X_BufferAllocate) {
         GeneratePCMFormat(BufferDesc, pwfxFormat, dwEmuFlags, X_BufferCacheSize, xbnullptr, X_BufferCacheSize);
     // Don't allocate for DS Stream class, it is using straight from the source.

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -194,7 +194,7 @@ inline void GenerateXboxBufferCache(
             memcpy_s(*X_BufferCache, X_BufferSizeRequest, tempBuffer, X_BufferCacheSize);
             free(tempBuffer);
         } else {
-            *X_BufferCache = malloc(X_BufferSizeRequest);
+            *X_BufferCache = calloc(1, X_BufferSizeRequest);
             DSoundSGEMemAlloc(X_BufferSizeRequest);
         }
         X_BufferCacheSize = X_BufferSizeRequest;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -56,9 +56,7 @@ CRITICAL_SECTION                    g_DSoundCriticalSection;
 // Memory managed xbox audio function handler
 inline DWORD DSoundSGEFreeBuffer() {
     int count =  (X_DS_SGE_SIZE_MAX - g_dwXbMemAllocated);
-    printf("DEBUG: size %8d\n", count);
     count =  count / X_DS_SGE_PAGE_MAX;
-    printf("DEBUG: per page %8d\n", count);
     // Check for negative value, we don't need warning as we are allowing overflow one time only.
     if (count < 0) {
         return 0;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1709,6 +1709,7 @@ inline HRESULT HybridDirectSoundBuffer_SetVolume(
         *Xb_lpVolume = lVolume;
     }
 
+    // For time being, this log is kept in case of something changed somewhere making a wrong input into the API.
     printf("DEBUG: SetVolume | lVolume = %ld | volumeMixbin = %ld | dwHeadroom = %8u\n", lVolume, Xb_volumeMixbin, Xb_dwHeadroom);
 
     lVolume += Xb_volumeMixbin - Xb_dwHeadroom;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -887,6 +887,8 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
                 }
             }
             break;
+
+        // TODO: NOTE: If stream is playing, it perform same behavior as pause flag. If it is not played, it act as a queue until trigger to play it.
         case X_DSSPAUSE_PAUSENOACTIVATE:
             EmuWarning("X_DSSPAUSE_PAUSENOACTIVATE is unsupported!");
             break;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -718,6 +718,13 @@ inline void DSoundStreamClearPacket(
     DWORD                   EmuFlags) {
 
     free(buffer->pBuffer_data);
+
+    // Peform release only, don't trigger any events below.
+    if (status == XMP_STATUS_RELEASE_CXBXR) {
+        DSoundSGEMemDealloc(buffer->xmp_data.dwMaxSize);
+        return;
+    }
+
     if (buffer->xmp_data.pdwStatus != xbnullptr) {
         (*buffer->xmp_data.pdwStatus) = status;
     }

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -317,8 +317,20 @@ inline void GeneratePCMFormat(
             lpwfxFormatExtensible->Samples.wValidBitsPerSample = lpwfxFormatExtensible->Format.wBitsPerSample;
             lpwfxFormatExtensible->Samples.wSamplesPerBlock = 0;
             lpwfxFormatExtensible->Samples.wReserved = 0;
-            // TODO: dwChannelMask might need a real time conversion depending on channels given to xbox.
-            lpwfxFormatExtensible->dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_FRONT_CENTER | SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT | SPEAKER_LOW_FREQUENCY;
+            lpwfxFormatExtensible->dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
+
+            // Add rear speakers
+            if (lpwfxFormat->nChannels >= 4) {
+                lpwfxFormatExtensible->dwChannelMask |= SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT;
+            }
+            // Add center speaker
+            if (lpwfxFormat->nChannels >= 5) {
+                lpwfxFormatExtensible->dwChannelMask |= SPEAKER_FRONT_CENTER;
+            }
+            // Add subwoofer mask (pretty sure 3 channels is 2.1, not 3.0 for xbox purpose)
+            if (lpwfxFormat->nChannels == 6 || lpwfxFormat->nChannels == 3) {
+                lpwfxFormatExtensible->dwChannelMask |= SPEAKER_LOW_FREQUENCY;
+            }
             lpwfxFormatExtensible->SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
         }
     }

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -868,6 +868,8 @@ inline HRESULT HybridDirectSoundBuffer_GetCurrentPosition(
     RETURN_RESULT_CHECK(hRet);
 }
 
+/*
+// NOTE: Flags are 100% not compatible, not use Hybrid version
 //IDirectSoundStream
 //IDirectSoundBuffer
 inline HRESULT HybridDirectSoundBuffer_GetStatus(
@@ -882,7 +884,7 @@ inline HRESULT HybridDirectSoundBuffer_GetStatus(
     leaveCriticalSection;
 
     RETURN_RESULT_CHECK(hRet);
-}
+}*/
 
 /*
 inline HRESULT HybridDirectSoundBuffer_GetVoiceProperties(

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1717,7 +1717,7 @@ inline HRESULT HybridDirectSoundBuffer_SetVolume(
     if (lVolume <= -6400) {
         lVolume = DSBVOLUME_MIN;
     } else if (lVolume > 0) {
-        EmuWarning("HybridDirectSoundBuffer_SetVolume has received greater than 0: %d", lVolume);
+        EmuWarning("HybridDirectSoundBuffer_SetVolume has received greater than 0: %ld", lVolume);
         lVolume = 0;
     }
     if ((dwEmuFlags & DSE_FLAG_DEBUG_MUTE) > 0) {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1476,13 +1476,13 @@ inline HRESULT HybridDirectSoundBuffer_SetMixBinVolumes_8(
 
     HRESULT hRet = DSERR_INVALIDPARAM;
 
-    if (pMixBins != xbnullptr && pMixBins->dwCount < XTL::XDSMIXBIN_COUNT_MAX) {
+    if (pMixBins != xbnullptr) {
         DWORD counter = pMixBins->dwCount, count = pMixBins->dwCount;
         LONG volume = 0;
         if (pMixBins->lpMixBinVolumePairs != xbnullptr) {
             // Let's normalize audio level except for low frequency (subwoofer)
             for (DWORD i = 0; i < count; i++) {
-                if (pMixBins->lpMixBinVolumePairs[i].dwMixBin != XTL::XDSMIXBIN_LOW_FREQUENCY) {
+                if (pMixBins->lpMixBinVolumePairs[i].dwMixBin != XDSMIXBIN_LOW_FREQUENCY) {
                     volume += pMixBins->lpMixBinVolumePairs[i].lVolume;
                 } else {
                     counter--;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -28,7 +28,7 @@
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2017 blueshogun96
-// *  (c) 2017 RadWolfie
+// *  (c) 2017-2018 RadWolfie
 // *
 // *  All rights reserved
 // *

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -515,9 +515,7 @@ inline void DSoundBufferRelease(
 
 inline void DSoundBufferResizeSetSize(
     XTL::X_CDirectSoundBuffer*  pThis,
-    DWORD                       dwPlayFlags,
     HRESULT                    &hRet,
-    DWORD                       Xb_dwStartOffset,
     DWORD                       Xb_dwByteLength) {
 
     DWORD Host_dwByteLength = DSoundBufferGetPCMBufferSize(pThis->EmuFlags, Xb_dwByteLength);
@@ -557,7 +555,7 @@ inline void DSoundBufferResizeUpdate(
     DWORD                       Xb_dwStartOffset,
     DWORD                       Xb_dwByteLength) {
 
-    DSoundBufferResizeSetSize(pThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
+    DSoundBufferResizeSetSize(pThis, hRet, Xb_dwByteLength);
 
     hRet = pThis->EmuDirectSoundBuffer8->Lock(0, 0, &pThis->Host_lock.pLockPtr1, &pThis->Host_lock.dwLockBytes1,
                                               nullptr, nullptr, DSBLOCK_ENTIREBUFFER);
@@ -630,7 +628,7 @@ inline void DSoundBufferResizeCheckThenSet(
 
     DSoundBufferRegionCurrentLocation(pThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
 
-    DSoundBufferResizeSetSize(pThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
+    DSoundBufferResizeSetSize(pThis, hRet, Xb_dwStartOffset);
 }
 
 inline void DSoundBufferReplace(
@@ -930,19 +928,18 @@ inline HRESULT HybridDirectSoundBuffer_GetCurrentPosition(
 
     enterCriticalSection;
 
-    HRESULT hRet = pDSBuffer->GetCurrentPosition(pdwCurrentPlayCursor, pdwCurrentWriteCursor);
+    DWORD dwCurrentPlayCursor, dwCurrentWriteCursor;
+    HRESULT hRet = pDSBuffer->GetCurrentPosition(&dwCurrentPlayCursor, &dwCurrentWriteCursor);
 
     if (hRet != DS_OK) {
         EmuWarning("GetCurrentPosition Failed!");
     }
-    if (pdwCurrentPlayCursor != 0 && pdwCurrentWriteCursor != 0) {
-        DbgPrintf("*pdwCurrentPlayCursor := %d, *pdwCurrentWriteCursor := %d\n", *pdwCurrentPlayCursor, *pdwCurrentWriteCursor);
-    }
+
     if (pdwCurrentPlayCursor != xbnullptr) {
-        *pdwCurrentPlayCursor = DSoundBufferGetXboxBufferSize(EmuFlags, *pdwCurrentPlayCursor);
+        *pdwCurrentPlayCursor = DSoundBufferGetXboxBufferSize(EmuFlags, dwCurrentPlayCursor);
     }
     if (pdwCurrentWriteCursor != xbnullptr) {
-        *pdwCurrentWriteCursor = DSoundBufferGetXboxBufferSize(EmuFlags, *pdwCurrentWriteCursor);
+        *pdwCurrentWriteCursor = DSoundBufferGetXboxBufferSize(EmuFlags, dwCurrentWriteCursor);
     }
 
     leaveCriticalSection;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -366,14 +366,14 @@ inline void DSound3DBufferCreate(LPDIRECTSOUNDBUFFER8 pDSBuffer, LPDIRECTSOUND3D
     }
 }
 
-#define DSoundBufferSetDefault(pThis, pdsd, dwEmuFlags, dwEmuPlayFlags) \
+#define DSoundBufferSetDefault(pThis, dwEmuPlayFlags) \
     pThis->EmuDirectSoundBuffer8 = nullptr; \
     pThis->EmuDirectSound3DBuffer8 = nullptr; \
     pThis->X_BufferCache = xbnullptr; \
-    pThis->EmuBufferDesc = pdsd; \
-    pThis->EmuFlags = dwEmuFlags; \
+    pThis->EmuFlags = 0; \
     pThis->EmuPlayFlags = dwEmuPlayFlags; \
     pThis->X_BufferCacheSize = 0;
+    //pThis->EmuBufferDesc = { 0 }; // Enable this when become necessary.
     /*
     pThis->EmuLockPtr1 = xbnullptr; \
     pThis->EmuLockBytes1 = 0; \

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1002,11 +1002,12 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
     HRESULT hRet = DS_OK, hStatus;
     switch (dwPause) {
         case X_DSSPAUSE_RESUME:
-            if (triggerPlayPermission && rtTimeStamp) {
+            if (triggerPlayPermission) {
                 pDSBuffer->Play(0, 0, dwEmuPlayFlags);
             }
             DSoundBufferRemoveSynchPlaybackFlag(dwEmuFlags);
             dwEmuFlags &= ~DSE_FLAG_PAUSE;
+            Xb_rtTimeStamp = 0;
             break;
         case X_DSSPAUSE_PAUSE:
             hStatus = pDSBuffer->GetStatus(&dwStatus);

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1486,7 +1486,9 @@ inline HRESULT HybridDirectSoundBuffer_SetMixBinVolumes_8(
         if (pMixBins->lpMixBinVolumePairs != xbnullptr) {
             // Let's normalize audio level except for low frequency (subwoofer)
             for (DWORD i = 0; i < count; i++) {
-                if (pMixBins->lpMixBinVolumePairs[i].dwMixBin != XDSMIXBIN_LOW_FREQUENCY) {
+                if (pMixBins->lpMixBinVolumePairs[i].dwMixBin != XDSMIXBIN_LOW_FREQUENCY
+                    // We only want to focus on speaker volumes, nothing else.
+                    && pMixBins->lpMixBinVolumePairs[i].dwMixBin < XDSMIXBIN_SPEAKERS_MAX) {
                     volume += pMixBins->lpMixBinVolumePairs[i].lVolume;
                 } else {
                     counter--;

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1019,8 +1019,7 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
 
     enterCriticalSection;
 
-    DWORD dwStatus;
-    HRESULT hRet = DS_OK, hStatus;
+    HRESULT hRet = DS_OK;
     switch (dwPause) {
         case X_DSSPAUSE_RESUME:
             if (triggerPlayPermission) {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -772,6 +772,87 @@ inline void DSoundBufferRemoveSynchPlaybackFlag(
     }
 }
 
+inline bool DSoundStreamProcess(XTL::X_CDirectSoundStream* pThis) {
+
+    // If title want to pause, then don't process the packets.
+    if ((pThis->EmuFlags & DSB_FLAG_PAUSE) > 0) {
+        return;
+    }
+
+    DWORD dwAudioBytes;
+    HRESULT hRet = pThis->EmuDirectSoundBuffer8->GetStatus(&dwAudioBytes);
+    if (hRet == DS_OK) {
+        std::vector<XTL::host_voice_packet>::iterator buffer = pThis->Host_BufferPacketArray.begin();
+        if (buffer->isWritten == false) {
+
+        prepareNextBufferPacket:
+            DSoundStreamWriteToBuffer(pThis->EmuDirectSoundBuffer8, buffer->rangeStart, buffer->pBuffer_data, buffer->xmp_data.dwMaxSize);
+
+            // Debug area begin
+            //printf("DEBUG: next packet process | pThis = %08X | rangeStart = %08d | bufferSize - %08d | dwBufferBytes = %08d | dwWriteOffsetNext = %08d\n", pThis, buffer->rangeStart, buffer->xmp_data.dwMaxSize, pThis->EmuBufferDesc->dwBufferBytes, pThis->Host_dwWriteOffsetNext);
+            // Debug area end
+
+            if (pThis->Host_isProcessing == false) {
+                pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
+                pThis->Host_isProcessing = true;
+            }
+            buffer->isWritten = true;
+
+        } else {
+            // NOTE: p1. Do not use play cursor, use write cursor to check ahead since by the time it gets there. The buffer is already played.
+            // p2. Plus play cursor is not reliable to check, write cursor is reliable as it is update more often.
+            // Test case proof: Gauntlet Dark Legacy give 256 bytes of data to a per packet during intro FMV.
+            DWORD writePos = 0;
+            hRet = pThis->EmuDirectSoundBuffer8->GetCurrentPosition(nullptr, &writePos);
+            if (hRet == DS_OK) {
+
+                int bufPlayed = writePos - buffer->rangeStart;
+
+                // Correct it if buffer was playing and is at beginning.
+                if (bufPlayed < 0 && (buffer->isPlayed || (writePos + pThis->EmuBufferDesc.dwBufferBytes - buffer->rangeStart) < buffer->xmp_data.dwMaxSize)) {
+                    bufPlayed = pThis->EmuBufferDesc.dwBufferBytes - (bufPlayed * -1);
+                }
+
+                if (bufPlayed >= 0) {
+                    if (buffer->isPlayed == false) {
+                        buffer->isPlayed = true;
+                    }
+                    if (bufPlayed >= (int)buffer->xmp_data.dwMaxSize) {
+
+                        DSoundStreamClearPacket(buffer._Ptr, XMP_STATUS_SUCCESS, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis->EmuFlags);
+
+                        buffer = pThis->Host_BufferPacketArray.erase(buffer);
+                        if (pThis->Host_BufferPacketArray.size() == 0) {
+                            goto endOfPacket;
+                        }
+                        if (buffer->isWritten == false) {
+                            goto prepareNextBufferPacket;
+                        }
+                    }
+                    if (buffer->xmp_data.pdwCompletedSize != xbnullptr) {
+                        (*buffer->xmp_data.pdwCompletedSize) = DSoundBufferGetXboxBufferSize(pThis->EmuFlags, bufPlayed);
+                    }
+                    if (pThis->Host_BufferPacketArray.size() > 1) {
+                        if ((buffer + 1)->isWritten == false) {
+                            buffer++;
+                            goto prepareNextBufferPacket;
+                        }
+                    }
+                }
+            }
+            // Out of packets, let's stop it.
+            if (pThis->Host_BufferPacketArray.size() == 0) {
+
+            endOfPacket:
+                pThis->Host_isProcessing = false;
+                pThis->EmuDirectSoundBuffer8->Stop();
+                return 0;
+            }
+        }
+    }
+    return 1;
+}
+
 //TODO: RadWolfie - Need to implement DirectSoundBuffer create support. Or not able to do so due to all three classes function differently.
 //IDirectSound
 //IDirectSoundStream

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1722,6 +1722,8 @@ inline HRESULT HybridDirectSoundBuffer_SetVolume(
         *Xb_lpVolume = lVolume;
     }
 
+    printf("DEBUG: SetVolume | lVolume = %ld | volumeMixbin = %ld | dwHeadroom = %8u\n", lVolume, Xb_volumeMixbin, Xb_dwHeadroom);
+
     lVolume += Xb_volumeMixbin - Xb_dwHeadroom;
 
     if ((dwEmuFlags & DSE_FLAG_PCM) > 0) {
@@ -1737,7 +1739,6 @@ inline HRESULT HybridDirectSoundBuffer_SetVolume(
             lVolume = -10000;
         }
     }
-    printf("DEBUG: SetVolume | lVolume = %ld | volumeMixbin = %ld | dwHeadroom = %8u\n", lVolume, Xb_volumeMixbin, Xb_dwHeadroom);
     if (lVolume <= -6400) {
         lVolume = DSBVOLUME_MIN;
     } else if (lVolume > 0) {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -819,6 +819,7 @@ inline bool DSoundStreamProcess(XTL::X_CDirectSoundStream* pThis) {
                 pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
                 pThis->Host_isProcessing = true;
             }
+
             buffer->isWritten = true;
 
         } else {
@@ -1030,10 +1031,7 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
             Xb_rtTimeStamp = 0;
             break;
         case X_DSSPAUSE_PAUSE:
-            hStatus = pDSBuffer->GetStatus(&dwStatus);
-            if (hStatus == DS_OK && dwStatus & DSBSTATUS_PLAYING) {
-                pDSBuffer->Stop();
-            }
+            pDSBuffer->Stop();
             DSoundBufferSynchPlaybackFlagRemove(dwEmuFlags);
             dwEmuFlags |= DSE_FLAG_PAUSE;
             Xb_rtTimeStamp = rtTimeStamp;
@@ -1044,11 +1042,7 @@ inline HRESULT HybridDirectSoundBuffer_Pause(
             //SynchPlayback flag append should only occur in HybridDirectSoundBuffer_Pause function, nothing else is able to do this.
             hRet = DSoundBufferSynchPlaybackFlagAdd(dwEmuFlags);
             if (hRet == DS_OK) {
-                hRet = pDSBuffer->GetStatus(&dwStatus);
-                if (hRet == DS_OK && dwStatus & DSBSTATUS_PLAYING) {
-                    pDSBuffer->Stop();
-                    pDSBuffer->SetCurrentPosition(0);
-                }
+                pDSBuffer->Stop();
             }
             break;
         // TODO: NOTE: If stream is playing, it perform same behavior as pause flag. If it is not played, it act as a queue until trigger to play it.

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -96,7 +96,7 @@ inline void XADPCM2PCMFormat(LPWAVEFORMATEX lpwfxFormat)
     //lpwfxFormat.nAvgBytesPerSec;    /* for buffer estimation */
     //lpwfxFormat.nBlockAlign;        /* block size of data */
     //lpwfxFormat.wBitsPerSample;     /* number of bits per sample of mono data */
-    //lpwfxFormat.cbSize;             /* the count in bytes of the size of */
+    //lpwfxFormat.cbSize;             /* the count in bytes of the size of extra information (after cbSize) */
 
     lpwfxFormat->wBitsPerSample = 16;
     lpwfxFormat->nBlockAlign = 2 * lpwfxFormat->nChannels;
@@ -184,7 +184,8 @@ inline void GeneratePCMFormat(
             // in the first place, FYI.
 
             if (DSBufferDesc.lpwfxFormat == nullptr) {
-                    DSBufferDesc.lpwfxFormat = (WAVEFORMATEX*)malloc(sizeof(WAVEFORMATEXTENSIBLE));
+                // Only allocate extra value for setting extra values later on. WAVEFORMATEXTENSIBLE is the highest size I had seen.
+                DSBufferDesc.lpwfxFormat = (WAVEFORMATEX*)calloc(1, sizeof(WAVEFORMATEXTENSIBLE));
             }
             if (lpwfxFormat->wFormatTag == WAVE_FORMAT_PCM) {
                 // Test case: Hulk crash due to cbSize is not a valid size.
@@ -239,9 +240,8 @@ inline void GeneratePCMFormat(
             DSBufferDesc.lpwfxFormat->nBlockAlign = 4;
             DSBufferDesc.lpwfxFormat->nAvgBytesPerSec = DSBufferDesc.lpwfxFormat->nSamplesPerSec * DSBufferDesc.lpwfxFormat->nBlockAlign;
             DSBufferDesc.lpwfxFormat->wBitsPerSample = 16;
-            DSBufferDesc.lpwfxFormat->cbSize = sizeof(WAVEFORMATEX);
+            DSBufferDesc.lpwfxFormat->cbSize = 0;
 
-            DSBufferDesc.dwSize = sizeof(DSBUFFERDESC);
             DSBufferDesc.dwFlags = DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY;
             DSBufferDesc.dwBufferBytes = 3 * DSBufferDesc.lpwfxFormat->nAvgBytesPerSec;
 

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -521,11 +521,13 @@ inline void DSoundBufferResizeSetSize(
     HRESULT                    &hRet,
     DWORD                       Xb_dwByteLength) {
 
+    // General return OK, nothing needs to set as invalid for now.
+    hRet = DS_OK;
+
     DWORD Host_dwByteLength = DSoundBufferGetPCMBufferSize(pThis->EmuFlags, Xb_dwByteLength);
 
     // Don't re-create buffer if size is the same.
     if (pThis->EmuBufferDesc.dwBufferBytes == Host_dwByteLength) {
-        hRet = DS_OK;
         return;
     }
 
@@ -619,20 +621,6 @@ inline void DSoundBufferUpdate(
     DSoundBufferRegionCurrentLocation(pThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
 
     DSoundBufferResizeUpdate(pThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
-}
-
-inline void DSoundBufferResizeCheckThenSet(
-    XTL::X_CDirectSoundBuffer*  pThis,
-    DWORD                       dwPlayFlags,
-    HRESULT                    &hRet) {
-
-    // Process Play/Loop Region buffer
-    DWORD Xb_dwByteLength;
-    DWORD Xb_dwStartOffset;
-
-    DSoundBufferRegionCurrentLocation(pThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
-
-    DSoundBufferResizeSetSize(pThis, hRet, Xb_dwByteLength);
 }
 
 inline void DSoundBufferReplace(

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -71,8 +71,8 @@ inline void DSoundSGEMemAlloc(DWORD size) {
 inline void DSoundSGEMemDealloc(DWORD size) {
     g_dwXbMemAllocated -= size;
 }
-inline bool DSoundSGEMenAllocCheck() {
-    int leftOverSize = X_DS_SGE_SIZE_MAX - g_dwXbMemAllocated;
+inline bool DSoundSGEMenAllocCheck(DWORD sizeRequest) {
+    int leftOverSize = X_DS_SGE_SIZE_MAX - (g_dwXbMemAllocated + sizeRequest);
     // Don't let xbox title to alloc any more.
     if (leftOverSize < 0) {
         return false;
@@ -729,7 +729,11 @@ inline void DSoundStreamClearPacket(
     if (Xb_lpfnCallback != xbnullptr) {
         Xb_lpfnCallback(Xb_lpvContext, buffer->xmp_data.pContext, status);
     } else if (buffer->xmp_data.hCompletionEvent != 0) {
-        SetEvent(buffer->xmp_data.hCompletionEvent);
+        BOOL checkHandle = SetEvent(buffer->xmp_data.hCompletionEvent);
+        if (checkHandle == 0) {
+            DWORD error = GetLastError();
+            EmuWarning("DSOUND: Unable to set event on packet's hCompletionEvent. %8X | error = %8X", buffer->xmp_data.hCompletionEvent, error);
+        }
     }
 }
 

--- a/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
@@ -434,26 +434,26 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(IDirectSoundStream_SetConeOutsideVolume, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, later XDK revision may need a patch?
     REGISTER_OOVPAS(IDirectSoundStream_SetDistanceFactor, UNPATCHED, 4134),
     REGISTER_OOVPAS(IDirectSoundStream_SetDopplerFactor, UNPATCHED, 4134),
-    REGISTER_OOVPAS(IDirectSoundStream_SetEG, UNPATCHED, 3911, 4039),
-    REGISTER_OOVPAS(IDirectSoundStream_SetLFO, UNPATCHED, 3911, 4039),
-    REGISTER_OOVPAS(IDirectSoundStream_SetFilter, UNPATCHED, 3911, 4039),
+    REGISTER_OOVPAS(IDirectSoundStream_SetEG, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
+    REGISTER_OOVPAS(IDirectSoundStream_SetLFO, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
+    REGISTER_OOVPAS(IDirectSoundStream_SetFilter, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
     REGISTER_OOVPAS(IDirectSoundStream_SetFormat, UNPATCHED, 4039),
-    REGISTER_OOVPAS(IDirectSoundStream_SetFrequency, UNPATCHED, 3911, 4039),
-    REGISTER_OOVPAS(IDirectSoundStream_SetHeadroom, UNPATCHED, 3911, 4039),
+    REGISTER_OOVPAS(IDirectSoundStream_SetFrequency, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
+    REGISTER_OOVPAS(IDirectSoundStream_SetHeadroom, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
     REGISTER_OOVPAS(IDirectSoundStream_SetI3DL2Source, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, later XDK revision may need a patch?
     REGISTER_OOVPAS(IDirectSoundStream_SetMaxDistance, UNPATCHED, 3911),
     REGISTER_OOVPAS(IDirectSoundStream_SetMinDistance, UNPATCHED, 3911),
-    REGISTER_OOVPAS(IDirectSoundStream_SetMixBins, UNPATCHED, 3911, 4039),
+    REGISTER_OOVPAS(IDirectSoundStream_SetMixBins, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
     REGISTER_OOVPAS(IDirectSoundStream_SetMixBinVolumes_12, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, see more note for CDirectSoundStream_SetMixBinVolumes_12
     REGISTER_OOVPAS(IDirectSoundStream_SetMixBinVolumes_8, UNPATCHED, 4039), //NOTE: 4039 and newer only perform a jmp.
     REGISTER_OOVPAS(IDirectSoundStream_SetMode, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, later XDK revision may need a patch?
     REGISTER_OOVPAS(IDirectSoundStream_SetOutputBuffer, UNPATCHED, 3911), //NOTE: 3911 only perform a jmp, later XDK revision may need a patch?
-    REGISTER_OOVPAS(IDirectSoundStream_SetPitch, UNPATCHED, 3911, 4039),
+    REGISTER_OOVPAS(IDirectSoundStream_SetPitch, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
     REGISTER_OOVPAS(IDirectSoundStream_SetPosition, UNPATCHED, 3911),
     REGISTER_OOVPAS(IDirectSoundStream_SetRolloffCurve, UNPATCHED, 4361),
     REGISTER_OOVPAS(IDirectSoundStream_SetRolloffFactor, UNPATCHED, 4134),
     REGISTER_OOVPAS(IDirectSoundStream_SetVelocity, UNPATCHED, 3911),
-    REGISTER_OOVPAS(IDirectSoundStream_SetVolume, UNPATCHED, 3911, 4039),
+    REGISTER_OOVPAS(IDirectSoundStream_SetVolume, PATCH, 3911, 4039), //NOTE: Is require to be patch since its' calling to voice class.
     REGISTER_OOVPAS(IDirectSoundStream_Use3DVoiceData, UNPATCHED, 5558), // jmp only
     REGISTER_OOVPAS(IDirectSound_AddRef, PATCH, 3911),
     REGISTER_OOVPAS(IDirectSound_CommitDeferredSettings, PATCH, 3911),

--- a/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
+++ b/src/CxbxKrnl/HLEDataBase/DSound.OOVPA.inl
@@ -310,7 +310,7 @@ OOVPATable DSound_OOVPAV2[] = {
     REGISTER_OOVPAS(CDirectSoundStream_AddRef, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_Discontinuity, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_Flush, PATCH, 3911, 4039, 4134, 5028),
-    REGISTER_OOVPAS(CDirectSoundStream_FlushEx, XREF, 4134, 5028),
+    REGISTER_OOVPAS(CDirectSoundStream_FlushEx, PATCH, 4134, 5028),
     REGISTER_OOVPAS(CDirectSoundStream_GetInfo, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_GetStatus, PATCH, 3911, 4039, 4134),
     REGISTER_OOVPAS(CDirectSoundStream_GetVoiceProperties, PATCH, 5028),


### PR DESCRIPTION
**ready to merge**
~~P.S. Wait until "Enable debug trace" commit is revert before merge.~~

~~It is still in WIP I believe. However in this current state, it is safe to test titles.~~
Currently is stable and improved enough to merge.

Currently improve title:
* JSRF (skating, jumping, people audio are no longer silent)
* Hunter Reckoning (? Need to verification)
* Hulk
* Burnout (Menu selection and ingame audio is audible since commit 70be0aa)
* Pocketbike Rider (Fixed music unplayble since commit d4f6514)
* The Simpsons: Road Rage (Fixed music and voiceover audios since commit 44a7045)
* Ghost Recon: Thunder Island (Fix ingame distort noises since commit 44a7045)
* SW: KotOR (Fixed first FMV video since commit 62c4493)

~~EDIT: Now only accepting regression titles.~~

EDIT2:
* Burnout - (Crashed when crash into a car at beginning of the race.)
  * Using GetCaps, can cause crash at any time.
  * **NOTE: This is a minor bug, the rest of the gameplay works fine.**
* NFL Blitz 2002 - (DSound buffer lock failed crash, not sure why this is a problem...)
  * **NOTE: It's happening in master branch anyway. Not a regress issue.**