### PR TITLE
More D3D9 porting work

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1872,7 +1872,11 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
                     g_EmuCDPD.HostPresentationParameters.Windowed = !g_XBVideo.GetFullscreen();
 
                     if(g_XBVideo.GetVSync())
+#ifdef CXBX_USE_D3D9
+                        g_EmuCDPD.HostPresentationParameters.SwapEffect = XTL::D3DSWAPEFFECT_COPY;
+#else
                         g_EmuCDPD.HostPresentationParameters.SwapEffect = XTL::D3DSWAPEFFECT_COPY_VSYNC;
+#endif
 
                     g_EmuCDPD.hFocusWindow = g_hEmuWindow;
 
@@ -2650,7 +2654,12 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShader)
     }
     else if(Handle == NULL)
     {
+#ifdef CXBX_USE_D3D9
+		hRet = g_pD3DDevice->SetVertexShader(nullptr);
+		hRet = g_pD3DDevice->SetFVF(D3DFVF_XYZ | D3DFVF_TEX0);
+#else
 		hRet = g_pD3DDevice->SetVertexShader(D3DFVF_XYZ | D3DFVF_TEX0);
+#endif
 		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShader(D3DFVF_XYZ | D3DFVF_TEX0)");
 	}
     else if(Address < 136)
@@ -2914,7 +2923,12 @@ XTL::X_D3DSurface* WINAPI XTL::EMUPATCH(D3DDevice_GetBackBuffer2)
 		goto skip_backbuffer_copy;
 	}
 	
-	memcpy((void*)GetDataFromXboxResource(pXboxBackBuffer), lockedRect.pBits, copySurfaceDesc.Size);
+#ifdef CXBX_USE_D3D9
+	DWORD Size = lockedRect.Pitch * copySurfaceDesc.Height; // TODO : What about mipmap levels?
+#else
+	DWORD Size = copySurfaceDesc.Size;
+#endif
+	memcpy((void*)GetDataFromXboxResource(pXboxBackBuffer), lockedRect.pBits, Size);
 
 	pCopySrcSurface->UnlockRect();
 	
@@ -6108,7 +6122,12 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShader)
 		RealHandle = Handle;
     }
 
+#ifdef CXBX_USE_D3D9
+	hRet = g_pD3DDevice->SetVertexShader(nullptr);
+	hRet = g_pD3DDevice->SetFVF(RealHandle);
+#else
 	hRet = g_pD3DDevice->SetVertexShader(RealHandle);
+#endif
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShader");    
 }
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5144,7 +5144,12 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_BorderColor)
 		LOG_FUNC_ARG(Value)
 		LOG_FUNC_END;
 
-    HRESULT hRet = g_pD3DDevice->SetTextureStageState(Stage, D3DTSS_BORDERCOLOR, Value);
+    HRESULT hRet;
+#ifdef CXBX_USE_D3D9
+	hRet = g_pD3DDevice->SetSamplerState(Stage, D3DSAMP_BORDERCOLOR, Value);
+#else
+    hRet = g_pD3DDevice->SetTextureStageState(Stage, D3DTSS_BORDERCOLOR, Value);
+#endif
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetTextureStageState");
 }
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3398,12 +3398,21 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant)
 	if(g_BuildVersion <= 4361)
 		Register += 96;
 
-    HRESULT hRet = g_pD3DDevice->SetVertexShaderConstant
+    HRESULT hRet;
+#ifdef CXBX_USE_D3D9
+	hRet = g_pD3DDevice->SetVertexShaderConstantF(
+		Register,
+		(float*)pConstantData,
+		ConstantCount
+	);
+#else
+    hRet = g_pD3DDevice->SetVertexShaderConstant
     (
         Register,
         pConstantData,
         ConstantCount
     );
+#endif
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShaderConstant");
 
     if(FAILED(hRet))
@@ -6095,8 +6104,13 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShader)
         static float vScale[] = { (2.0f / 640), (-2.0f / 480), 0.0f, 0.0f };
         static float vOffset[] = { -1.0f, 1.0f, 0.0f, 1.0f };
 
+#ifdef CXBX_USE_D3D9
+        g_pD3DDevice->SetVertexShaderConstantF(58, vScale, 1);
+        g_pD3DDevice->SetVertexShaderConstantF(59, vOffset, 1);
+#else
         g_pD3DDevice->SetVertexShaderConstant(58, vScale, 1);
         g_pD3DDevice->SetVertexShaderConstant(59, vOffset, 1);
+#endif
     }
 
     DWORD RealHandle;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2288,12 +2288,20 @@ void CxbxUpdateActiveIndexBuffer
 
 	// If we need to create an index buffer, do so.
 	if (indexBuffer.pHostIndexBuffer == nullptr) {
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/bb147168(v=vs.85).aspx
+		// "Managing Resources (Direct3D 9)"
+		// suggests "for resources which change with high frequency" [...]
+		// "D3DPOOL_DEFAULT along with D3DUSAGE_DYNAMIC should be used."
+		const XTL::D3DPOOL D3DPool = XTL::D3DPOOL_DEFAULT; // Was XTL::D3DPOOL_MANAGED
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172625(v=vs.85).aspx
+		// "Buffers created with D3DPOOL_DEFAULT that do not specify D3DUSAGE_WRITEONLY may suffer a severe performance penalty."
+		const DWORD D3DUsage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY; // Was D3DUSAGE_WRITEONLY
 		// Create a new native index buffer of the above determined size :
 		HRESULT hRet = g_pD3DDevice->CreateIndexBuffer(
 			IndexCount * 2,
-			D3DUSAGE_WRITEONLY,
+			D3DUsage,
 			XTL::D3DFMT_INDEX16,
-			XTL::D3DPOOL_MANAGED,
+			D3DPool,
 			&indexBuffer.pHostIndexBuffer
 #ifdef CXBX_USE_D3D9
 			, nullptr

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4406,6 +4406,7 @@ void CreateHostResource(XTL::X_D3DResource *pResource, int iTextureStage, DWORD 
 			}
 			else {
 #ifdef CXBX_USE_D3D9
+				D3DPool = D3DPOOL_SYSTEMMEM;
 				hRet = g_pD3DDevice->CreateOffscreenPlainSurface(dwWidth, dwHeight, PCFormat, D3DPool, &pNewHostSurface, nullptr);
 				DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateOffscreenPlainSurface");
 #else

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5311,7 +5311,14 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_ZBias)
 
 	LOG_FUNC_ONE_ARG(Value);
 
-	HRESULT hRet = g_pD3DDevice->SetRenderState(D3DRS_ZBIAS, Value);
+	HRESULT hRet;
+#ifdef CXBX_USE_D3D9
+	FLOAT Biased = static_cast<FLOAT>(Value) * -0.000005f;
+	Value = *reinterpret_cast<const DWORD *>(&Biased);
+	hRet = g_pD3DDevice->SetRenderState(D3DRS_DEPTHBIAS, Value);
+#else
+    hRet = g_pD3DDevice->SetRenderState(D3DRS_ZBIAS, Value);
+#endif
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderState");
 }
 

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -920,8 +920,31 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x28 X_D3DFMT_V8U8         */ { 16, Swzzld, ____G8B8, XTL::D3DFMT_V8U8      }, // Alias : X_D3DFMT_G8B8 // XQEMU NOTE : This might be signed
 	/* 0x29 X_D3DFMT_R8B8         */ { 16, Swzzld, ____R8B8, XTL::D3DFMT_R5G6B5    , Texture, "X_D3DFMT_R8B8 -> D3DFMT_R5G6B5" }, // XQEMU NOTE : This might be signed
 	/* 0x2A X_D3DFMT_D24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
+#ifdef CXBX_USE_D3D9
+	/* 0x2B X_D3DFMT_F24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24FS8    , DepthBuffer },
+	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
+	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
+	/* 0x2E X_D3DFMT_LIN_D24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
+	/* 0x2F X_D3DFMT_LIN_F24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24FS8    , DepthBuffer },
+	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
+	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
+	/* 0x32 X_D3DFMT_L16          */ { 16, Swzzld, _____L16, XTL::D3DFMT_L16       },
+	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
+	/* 0x34 undefined             */ {},
+	/* 0x35 X_D3DFMT_LIN_L16      */ { 16, Linear, _____L16, XTL::D3DFMT_L16       },
+	/* 0x36 X_D3DFMT_LIN_V16U16   */ { 32, Linear, NoCmpnts, XTL::D3DFMT_V16U16    }, // Note : Seems ununsed on Xbox
+	/* 0x37 X_D3DFMT_LIN_L6V5U5   */ { 16, Linear, __R6G5B5, XTL::D3DFMT_L6V5U5    }, // Alias : X_D3DFMT_LIN_R6G5B5
+	/* 0x38 X_D3DFMT_R5G5B5A1     */ { 16, Swzzld, R5G5B5A1, XTL::D3DFMT_A1R5G5B5  , Texture, "X_D3DFMT_R5G5B5A1 -> D3DFMT_A1R5G5B5" },
+	/* 0x39 X_D3DFMT_R4G4B4A4     */ { 16, Swzzld, R4G4B4A4, XTL::D3DFMT_A4R4G4B4  , Texture, "X_D3DFMT_R4G4B4A4 -> D3DFMT_A4R4G4B4" },
+	/* 0x3A X_D3DFMT_Q8W8V8U8     */ { 32, Swzzld, A8B8G8R8, XTL::D3DFMT_Q8W8V8U8  }, // Alias : X_D3DFMT_A8B8G8R8 // Note : D3DFMT_A8B8G8R8=32 D3DFMT_Q8W8V8U8=63 // TODO : Needs testcase.
+	/* 0x3B X_D3DFMT_B8G8R8A8     */ { 32, Swzzld, B8G8R8A8, XTL::D3DFMT_A8R8G8B8  , Texture, "X_D3DFMT_B8G8R8A8 -> D3DFMT_A8R8G8B8" },
+	/* 0x3C X_D3DFMT_R8G8B8A8     */ { 32, Swzzld, R8G8B8A8, XTL::D3DFMT_A8R8G8B8  , Texture, "X_D3DFMT_R8G8B8A8 -> D3DFMT_A8R8G8B8" },
+	/* 0x3D X_D3DFMT_LIN_R5G5B5A1 */ { 16, Linear, R5G5B5A1, XTL::D3DFMT_A1R5G5B5  , Texture, "X_D3DFMT_LIN_R5G5B5A1 -> D3DFMT_A1R5G5B5" },
+	/* 0x3E X_D3DFMT_LIN_R4G4B4A4 */ { 16, Linear, R4G4B4A4, XTL::D3DFMT_A4R4G4B4  , Texture, "X_D3DFMT_LIN_R4G4B4A4 -> D3DFMT_A4R4G4B4" },
+	/* 0x3F X_D3DFMT_LIN_A8B8G8R8 */ { 32, Linear, A8B8G8R8, XTL::D3DFMT_A8B8G8R8  }, // Note : D3DFMT_A8B8G8R8=32 D3DFMT_Q8W8V8U8=63 // TODO : Needs testcase.
+#else // Direct3D8 :
 	/* 0x2B X_D3DFMT_F24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
-	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Alias : X_D3DFMT_D16_LOCKABLE // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
+	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
 	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
 	/* 0x2E X_D3DFMT_LIN_D24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 	/* 0x2F X_D3DFMT_LIN_F24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_LIN_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
@@ -930,11 +953,7 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x32 X_D3DFMT_L16          */ { 16, Swzzld, _____L16, XTL::D3DFMT_A8L8      , Texture, "X_D3DFMT_L16 -> D3DFMT_A8L8" },
 	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
 	/* 0x34 undefined             */ {},
-#ifdef CXBX_USE_D3D9
-	/* 0x35 X_D3DFMT_LIN_L16      */ { 16, Linear, _____L16, XTL::D3DFMT_L16       },
-#else
 	/* 0x35 X_D3DFMT_LIN_L16      */ { 16, Linear, _____L16, XTL::D3DFMT_A8L8      , Texture, "X_D3DFMT_LIN_L16 -> D3DFMT_A8L8" },
-#endif
 	/* 0x36 X_D3DFMT_LIN_V16U16   */ { 32, Linear, NoCmpnts, XTL::D3DFMT_V16U16    }, // Note : Seems ununsed on Xbox
 	/* 0x37 X_D3DFMT_LIN_L6V5U5   */ { 16, Linear, __R6G5B5, XTL::D3DFMT_L6V5U5    }, // Alias : X_D3DFMT_LIN_R6G5B5
 	/* 0x38 X_D3DFMT_R5G5B5A1     */ { 16, Swzzld, R5G5B5A1, XTL::D3DFMT_A1R5G5B5  , Texture, "X_D3DFMT_R5G5B5A1 -> D3DFMT_A1R5G5B5" },
@@ -945,6 +964,7 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x3D X_D3DFMT_LIN_R5G5B5A1 */ { 16, Linear, R5G5B5A1, XTL::D3DFMT_A1R5G5B5  , Texture, "X_D3DFMT_LIN_R5G5B5A1 -> D3DFMT_A1R5G5B5" },
 	/* 0x3E X_D3DFMT_LIN_R4G4B4A4 */ { 16, Linear, R4G4B4A4, XTL::D3DFMT_A4R4G4B4  , Texture, "X_D3DFMT_LIN_R4G4B4A4 -> D3DFMT_A4R4G4B4" },
 	/* 0x3F X_D3DFMT_LIN_A8B8G8R8 */ { 32, Linear, A8B8G8R8, XTL::D3DFMT_A8R8G8B8  , Texture, "X_D3DFMT_LIN_A8B8G8R8 -> D3DFMT_A8R8G8B8" },
+#endif
 	/* 0x40 X_D3DFMT_LIN_B8G8R8A8 */ { 32, Linear, B8G8R8A8, XTL::D3DFMT_A8R8G8B8  , Texture, "X_D3DFMT_LIN_B8G8R8A8 -> D3DFMT_A8R8G8B8" },
 	/* 0x41 X_D3DFMT_LIN_R8G8B8A8 */ { 32, Linear, R8G8B8A8, XTL::D3DFMT_A8R8G8B8  , Texture, "X_D3DFMT_LIN_R8G8B8A8 -> D3DFMT_A8R8G8B8" },
 #if 0

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -4191,7 +4191,7 @@ static const
       (
         pFunction,
 #ifdef CXBX_USE_D3D9
-        PIDirect3DPixelShader9(&(Result.ConvertedHandle)) {$MESSAGE 'fixme'}
+        (XTL::IDirect3DPixelShader9**)(&(Result.ConvertedHandle)) //fixme
 #else
         /*out*/&(Result.ConvertedHandle)
 #endif
@@ -4276,13 +4276,13 @@ VOID XTL::DxbxUpdateActivePixelShader() // NOPATCH
     ConvertedPixelShaderHandle = RecompiledPixelShader->ConvertedHandle;
 
 #ifdef CXBX_USE_D3D9
-    g_pD3DDevice.GetPixelShader(/*out*/PIDirect3DPixelShader9(&CurrentPixelShader));
+    g_pD3DDevice->GetPixelShader(/*out*/(IDirect3DPixelShader9**)(&CurrentPixelShader));
 #else
     g_pD3DDevice->GetPixelShader(/*out*/&CurrentPixelShader);
 #endif
     if (CurrentPixelShader != ConvertedPixelShaderHandle)
 #ifdef CXBX_USE_D3D9
-		g_pD3DDevice->SetPixelShader((IDirect3DPixelShader9)ConvertedPixelShaderHandle);
+		g_pD3DDevice->SetPixelShader((IDirect3DPixelShader9*)ConvertedPixelShaderHandle);
 #else
 		g_pD3DDevice->SetPixelShader(ConvertedPixelShaderHandle);
 #endif
@@ -4338,7 +4338,7 @@ VOID XTL::DxbxUpdateActivePixelShader() // NOPATCH
         // TODO : Avoid the following setter if it's no different from the previous update (this might speed things up)
         // Set the value locally in this register :
 #ifdef CXBX_USE_D3D9
-        g_pD3DDevice.SetPixelShaderConstantF(Register_, PSingle(&fColor), 1);
+        g_pD3DDevice->SetPixelShaderConstantF(Register_, (float*)(&fColor), 1);
 #else
 		g_pD3DDevice->SetPixelShaderConstant(Register_, &fColor, 1);
 #endif
@@ -4349,7 +4349,7 @@ VOID XTL::DxbxUpdateActivePixelShader() // NOPATCH
   {
     ConvertedPixelShaderHandle = 0;
 #ifdef CXBX_USE_D3D9
-	g_pD3DDevice->SetPixelShader((IDirect3DPixelShader9)ConvertedPixelShaderHandle);
+	g_pD3DDevice->SetPixelShader((IDirect3DPixelShader9*)ConvertedPixelShaderHandle);
 #else
 	g_pD3DDevice->SetPixelShader(ConvertedPixelShaderHandle);
 #endif

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -388,7 +388,15 @@ extern void XTL::EmuExecutePushBufferRaw
                         pIndexBuffer->Release();
                     }
 
-                    hRet = g_pD3DDevice->CreateIndexBuffer(dwCount*2 + 2*2, 0, D3DFMT_INDEX16, D3DPOOL_MANAGED, &pIndexBuffer
+					// https://msdn.microsoft.com/en-us/library/windows/desktop/bb147168(v=vs.85).aspx
+					// "Managing Resources (Direct3D 9)"
+					// suggests "for resources which change with high frequency" [...]
+					// "D3DPOOL_DEFAULT along with D3DUSAGE_DYNAMIC should be used."
+					const D3DPOOL D3DPool = D3DPOOL_DEFAULT; // Was D3DPOOL_MANAGED
+					// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172625(v=vs.85).aspx
+					// "Buffers created with D3DPOOL_DEFAULT that do not specify D3DUSAGE_WRITEONLY may suffer a severe performance penalty."
+					const DWORD D3DUsage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
+					hRet = g_pD3DDevice->CreateIndexBuffer(dwCount*2 + 2*2, D3DUsage, D3DFMT_INDEX16, D3DPool, &pIndexBuffer
 #ifdef CXBX_USE_D3D9
 						, nullptr
 #endif
@@ -562,7 +570,15 @@ extern void XTL::EmuExecutePushBufferRaw
                         pIndexBuffer->Release();
                     }
 
-                    hRet = g_pD3DDevice->CreateIndexBuffer(dwCount*2, 0, D3DFMT_INDEX16, D3DPOOL_MANAGED, &pIndexBuffer
+					// https://msdn.microsoft.com/en-us/library/windows/desktop/bb147168(v=vs.85).aspx
+					// "Managing Resources (Direct3D 9)"
+					// suggests "for resources which change with high frequency" [...]
+					// "D3DPOOL_DEFAULT along with D3DUSAGE_DYNAMIC should be used."
+					const D3DPOOL D3DPool = D3DPOOL_DEFAULT; // Was D3DPOOL_MANAGED
+					// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172625(v=vs.85).aspx
+					// "Buffers created with D3DPOOL_DEFAULT that do not specify D3DUSAGE_WRITEONLY may suffer a severe performance penalty."
+					const DWORD D3DUsage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
+					hRet = g_pD3DDevice->CreateIndexBuffer(dwCount*2, D3DUsage, D3DFMT_INDEX16, D3DPool, &pIndexBuffer
 #ifdef CXBX_USE_D3D9
 						, nullptr
 #endif

--- a/src/CxbxKrnl/EmuD3D8/State.cpp
+++ b/src/CxbxKrnl/EmuD3D8/State.cpp
@@ -174,7 +174,11 @@ void XTL::EmuUpdateDeferredStates()
                 if(pCur[0+Adjust2] == 5)
 					EmuWarning("ClampToEdge is unsupported (temporarily)");
 				else
+#ifdef CXBX_USE_D3D9
+					g_pD3DDevice->SetSamplerState(v, D3DSAMP_ADDRESSU, pCur[0 + Adjust2]);
+#else
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_ADDRESSU, pCur[0+Adjust2]);
+#endif
             }
 
             if(pCur[1+Adjust2] != X_D3DTSS_UNK)
@@ -182,7 +186,11 @@ void XTL::EmuUpdateDeferredStates()
                 if(pCur[1+Adjust2] == 5)
 					EmuWarning("ClampToEdge is unsupported (temporarily)");
 				else
+#ifdef CXBX_USE_D3D9
+					g_pD3DDevice->SetSamplerState(v, D3DSAMP_ADDRESSV, pCur[1 + Adjust2]);
+#else
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_ADDRESSV, pCur[1+Adjust2]);
+#endif
             }
 
             if(pCur[2+Adjust2] != X_D3DTSS_UNK)
@@ -190,7 +198,11 @@ void XTL::EmuUpdateDeferredStates()
                 if(pCur[2+Adjust2] == 5)
 					EmuWarning("ClampToEdge is unsupported (temporarily)");
 				else
+#ifdef CXBX_USE_D3D9
+					g_pD3DDevice->SetSamplerState(v, D3DSAMP_ADDRESSW, pCur[2 + Adjust2]);
+#else
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_ADDRESSW, pCur[2+Adjust2]);
+#endif
             }
 
             if(pCur[3+Adjust2] != X_D3DTSS_UNK)
@@ -198,7 +210,11 @@ void XTL::EmuUpdateDeferredStates()
                 if(pCur[3+Adjust2] == 4)
                     EmuWarning("QuinCunx is unsupported (temporarily)");
 				else
+#ifdef CXBX_USE_D3D9
+					g_pD3DDevice->SetSamplerState(v, D3DSAMP_MAGFILTER, pCur[3 + Adjust2]);
+#else
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_MAGFILTER, pCur[3+Adjust2]);
+#endif
             }
 
             if(pCur[4+Adjust2] != X_D3DTSS_UNK)
@@ -206,7 +222,11 @@ void XTL::EmuUpdateDeferredStates()
                 if(pCur[4+Adjust2] == 4)
 					EmuWarning("QuinCunx is unsupported (temporarily)");
 				else
+#ifdef CXBX_USE_D3D9
+					g_pD3DDevice->SetSamplerState(v, D3DSAMP_MINFILTER, pCur[4 + Adjust2]);
+#else
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_MINFILTER, pCur[4+Adjust2]);
+#endif
             }
 
             if(pCur[5+Adjust2] != X_D3DTSS_UNK)
@@ -214,17 +234,33 @@ void XTL::EmuUpdateDeferredStates()
                 if(pCur[5+Adjust2] == 4)
 					EmuWarning("QuinCunx is unsupported (temporarily)");
 				else
+#ifdef CXBX_USE_D3D9
+					g_pD3DDevice->SetSamplerState(v, D3DSAMP_MIPFILTER, pCur[5 + Adjust2]);
+#else
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_MIPFILTER, pCur[5+Adjust2]);
+#endif
             }
 
             if(pCur[6+Adjust2] != X_D3DTSS_UNK)
+#ifdef CXBX_USE_D3D9
+				g_pD3DDevice->SetSamplerState(v, D3DSAMP_MIPMAPLODBIAS, pCur[6 + Adjust2]);
+#else
                 g_pD3DDevice->SetTextureStageState(v, D3DTSS_MIPMAPLODBIAS, pCur[6+Adjust2]);
+#endif
 
             if(pCur[7+Adjust2] != X_D3DTSS_UNK)
+#ifdef CXBX_USE_D3D9
+				g_pD3DDevice->SetSamplerState(v, D3DSAMP_MAXMIPLEVEL, pCur[7 + Adjust2]);
+#else
                 g_pD3DDevice->SetTextureStageState(v, D3DTSS_MAXMIPLEVEL, pCur[7+Adjust2]);
+#endif
 
             if(pCur[8+Adjust2] != X_D3DTSS_UNK)
+#ifdef CXBX_USE_D3D9
+				g_pD3DDevice->SetSamplerState(v, D3DSAMP_MAXANISOTROPY, pCur[8 + Adjust2]);
+#else
                 g_pD3DDevice->SetTextureStageState(v, D3DTSS_MAXANISOTROPY, pCur[8+Adjust2]);
+#endif
 
             if(pCur[12-Adjust1] != X_D3DTSS_UNK)
             {
@@ -356,7 +392,12 @@ void XTL::EmuUpdateDeferredStates()
                 g_pD3DDevice->SetTextureStageState(v, D3DTSS_TEXTURETRANSFORMFLAGS, pCur[21-Adjust1]);
 
             /*if(pCur[29] != X_D3DTSS_UNK)	// This is NOT a deferred texture state!
-                g_pD3DDevice->SetTextureStageState(v, D3DTSS_BORDERCOLOR, pCur[29]);*/
+#ifdef CXBX_USE_D3D9
+                g_pD3DDevice->SetSamplerState(v, D3DSAMP_BORDERCOLOR, pCur[29]);
+#else
+                g_pD3DDevice->SetTextureStageState(v, D3DTSS_BORDERCOLOR, pCur[29]);
+#endif
+				*/
 
             /** To check for unhandled texture stage state changes
             for(int r=0;r<32;r++)
@@ -409,8 +450,18 @@ void XTL::EmuUpdateDeferredStates()
                 {
                     ::DWORD dwValue;
 
-                    g_pD3DDevice->GetTextureStageState(3, (D3DTEXTURESTAGESTATETYPE)v, &dwValue);
-                    g_pD3DDevice->SetTextureStageState(0, (D3DTEXTURESTAGESTATETYPE)v, dwValue);
+#ifdef CXBX_USE_D3D9
+					// For Direct3D9, everything below X_D3DSAMP_MAXANISOTROPY needs to call GetSamplerState / SetSamplerState  :
+					if (v <= X_D3DTSS_MAXANISOTROPY) {
+						g_pD3DDevice->GetSamplerState(3, (D3DSAMPLERSTATETYPE)v, &dwValue);
+						g_pD3DDevice->SetSamplerState(0, (D3DSAMPLERSTATETYPE)v, dwValue);
+					}
+					else
+#endif
+					{
+						g_pD3DDevice->GetTextureStageState(3, (D3DTEXTURESTAGESTATETYPE)v, &dwValue);
+						g_pD3DDevice->SetTextureStageState(0, (D3DTEXTURESTAGESTATETYPE)v, dwValue);
+					}
                 }
             }
         }

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -1043,7 +1043,12 @@ VOID XTL::EmuFlushIVB()
 
     if(bFVF)
     {
+#ifdef CXBX_USE_D3D9
+        g_pD3DDevice->SetVertexShader(nullptr);
+        g_pD3DDevice->SetFVF(dwCurFVF);
+#else
         g_pD3DDevice->SetVertexShader(dwCurFVF);
+#endif
     }
 
     g_pD3DDevice->DrawPrimitiveUP(
@@ -1056,7 +1061,12 @@ VOID XTL::EmuFlushIVB()
 
     if(bFVF)
     {
+#ifdef CXBX_USE_D3D9
+		g_pD3DDevice->SetVertexShader(nullptr);
+		g_pD3DDevice->SetFVF(g_CurrentXboxVertexShaderHandle);
+#else
         g_pD3DDevice->SetVertexShader(g_CurrentXboxVertexShaderHandle);
+#endif
     }
 
     g_InlineVertexBuffer_TableOffset = 0;


### PR DESCRIPTION
This PR is another small step towards porting Cxbx-Reloaded to call directly into Direct3D 9.

The existing HLE rendering path, using Direct3D 8 is unchanged (except for 1 detail, explained below).

I prefer to merge this work early, **_even though the Direct3D 9 path still doesn't compile fully_**, to prevent dumping a big, hard-to-review PR at the end of this work, to keep master as up-to-date as possible, and to profit from a few fall-out improvements. (And since I might not have enough time the coming months to finish this work, someone else could continue where I left off.)


On the subject of improvements : Normally, in a port like this, no existing functionality is changed. An exception however in this PR, are the Usage and Pool arguments given to `CreateIndexBuffer`; I've updated them such that it could bring a performance boost under the existing HLE (Direct3D 8 based) rendering.

Because of this, regression-testing is needed before merging this!