### PR TITLE
Re-route XInput APIs, try to remove JSRF hacks.

### DIFF
--- a/src/CxbxKrnl/EmuXInput.cpp
+++ b/src/CxbxKrnl/EmuXInput.cpp
@@ -67,6 +67,9 @@ void XTL::EmuXInputPCPoll( XTL::PXINPUT_STATE Controller )
 	//
 	// Now convert those values to Xbox XInput
 	//
+	//Packet# shall be updated, too.
+	Controller->dwPacketNumber = g_Controller.dwPacketNumber;
+
 	// Analog Sticks
 	Controller->Gamepad.sThumbLX = g_Controller.Gamepad.sThumbLX;
 	Controller->Gamepad.sThumbLY = g_Controller.Gamepad.sThumbLY;


### PR DESCRIPTION
This is not for merge. I need test feedback.
Originally I tried this PR for improving the no-response issue of RalliSport Challenge. 
I tried to reroute some XInput APIS.
I also removed the JSRF hack because I couldn't see any thing wrong with the implemented logic.
But somehow I couldn't run RalliSport or JSRF with the latest master on CXBXR, nor with my modification code. 
JSRF simply hangs with latest master, with my code it throws error 6 with unicord.
RalliSport also hangs after intro with latest master. 
ExaSkeleton and MechAssault both crashed in beginning.
DOA3 works but the in game rendering is regressed in master. my code works for the control, also good for smash drive. Blinx also works, but only black screen.
Need more test feedback whether this PR improve the RalliSport input or not. Also JSRF. 
Any regressions/improves feedback are also welcomed.