### PR TITLE
skip push buffer rendering when there is no vertex data or possible non-FVF detected.

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -300,13 +300,16 @@ extern void XTL::EmuExecutePushBufferRaw
             pVertexData = pdwPushData;
 			//move pushpuffer to the end of vertex data.
             pdwPushData += dwCount;
-
+			if (dwCount == 0) {
+				continue;
+			}
             // retrieve vertex shader
 			DWORD dwVertexShader = g_CurrentXboxVertexShaderHandle;
 
 			if (VshHandleIsVertexShader(dwVertexShader)) 
 			{
                 EmuWarning("Non-FVF Vertex Shaders not yet supported for PushBuffer emulation!");
+				continue;
             }
             if(dwVertexShader == 0)
             {


### PR DESCRIPTION
This will make the scene rendering clear in RalliSport.