### PR TITLE
Drawing primitives

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7059,7 +7059,7 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
 
 	CxbxUpdateActiveIndexBuffer(pIndexData, DrawContext.dwVertexCount);
 	CxbxVertexBufferConverter VertexBufferConverter;
-	VertexBufferConverter.Apply(&DrawContext, NULL);
+	VertexBufferConverter.Apply(&DrawContext);
 	if (DrawContext.XboxPrimitiveType == X_D3DPT_QUADLIST) {
 		UINT uiStartIndex = 0;
 		int iNumVertices = (int)DrawContext.dwVertexCount;
@@ -7141,7 +7141,7 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 	assert(DrawContext.uiXboxVertexStreamZeroStride > 0);
 
 	CxbxVertexBufferConverter VertexBufferConverter;
-	VertexBufferConverter.Apply(&DrawContext, NULL);
+	VertexBufferConverter.Apply(&DrawContext);
 	if (DrawContext.XboxPrimitiveType == X_D3DPT_QUADLIST) {
 		// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // X-Marbles and XDK Sample PlayField hits this case
 		// Draw quadlists using a single 'quad-to-triangle mapping' index buffer :
@@ -7319,7 +7319,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 		}
 
 		CxbxVertexBufferConverter VertexBufferConverter;
-		VertexBufferConverter.Apply(&DrawContext, NULL);
+		VertexBufferConverter.Apply(&DrawContext);
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_QUADLIST) {
 			// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // ?X-Marbles and XDK Sample (Cartoon, ?maybe PlayField?) hits this case
 			// Draw quadlists using a single 'quad-to-triangle mapping' index buffer :
@@ -7529,7 +7529,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
 		CxbxVertexBufferConverter VertexBufferConverter;
-		VertexBufferConverter.Apply(&DrawContext, NULL);
+		VertexBufferConverter.Apply(&DrawContext);
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_QUADLIST) {
 			// Indexed quadlist can be drawn using unpatched indexes via multiple draws of 2 'strip' triangles :
 			// Those 4 vertices are just enough for two triangles (a fan starts with 3 vertices for 1 triangle,

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4033,6 +4033,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SwitchTexture)
 		// Switch Texture updates the data pointer of an active texture using pushbuffer commands
 		// assert(EmuD3DActiveTexture[Stage] != xbnullptr);
 		LOG_TEST_CASE("Using CxbxActiveTextureCopies");
+		// test-case : Need For Speed Most Wanted
 
 		// Update data and format separately, instead of via GetDataFromXboxResource()
 		CxbxActiveTextureCopies[Stage].Common = EmuD3DActiveTexture[Stage]->Common;
@@ -4576,11 +4577,11 @@ DWORD XTL::EMUPATCH(D3DDevice_Swap_0)
 DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 (
 	DWORD Flags
-	)
+)
 {
 	FUNC_EXPORTS
 
-		LOG_FUNC_ONE_ARG(Flags);
+	LOG_FUNC_ONE_ARG(Flags);
 
 	// TODO: Ensure this flag is always the same across library versions
 	if (Flags != 0)
@@ -7501,6 +7502,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 			// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // ?X-Marbles and XDK Sample (Cartoon, ?maybe PlayField?) hits this case
 			if (StartVertex > 0) {
 				LOG_TEST_CASE("X_D3DPT_QUADLIST StartVertex > 0");
+				// test-case : BLiNX: the time sweeper
+				// test-case : Halo - Combat Evolved
+				// test-case : Worms 3D Special Edition
 				DrawContext.dwStartVertex = StartVertex; // Breakpoint location for testing. 
 			}
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7378,15 +7378,15 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 		DrawContext.dwVertexCount = VertexCount;
 		DrawContext.dwStartVertex = StartVertex;
 		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
-		if (StartVertex > 0) {
-			// LOG_TEST_CASE("StartVertex > 0"); // Test case : XDK Sample (PlayField)
-			DrawContext.dwStartVertex = StartVertex; // Breakpoint location for testing. 
-		}
-
 		CxbxVertexBufferConverter VertexBufferConverter = {};
 		VertexBufferConverter.Apply(&DrawContext);
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_QUADLIST) {
 			// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // ?X-Marbles and XDK Sample (Cartoon, ?maybe PlayField?) hits this case
+			if (StartVertex > 0) {
+				LOG_TEST_CASE("X_D3DPT_QUADLIST StartVertex > 0");
+				DrawContext.dwStartVertex = StartVertex; // Breakpoint location for testing. 
+			}
+
 			// Draw quadlists using a single 'quad-to-triangle mapping' index buffer :
 			// Assure & activate that special index buffer :
 			CxbxAssureQuadListD3DIndexBuffer(/*NrOfQuadVertices=*/DrawContext.dwVertexCount);
@@ -7412,6 +7412,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 			g_dwPrimPerFrame += primCount;
 		}
 		else {
+			// if (StartVertex > 0) LOG_TEST_CASE("StartVertex > 0 (non-quad)"); // Verified test case : XDK Sample (PlayField)
 			HRESULT hRet = g_pD3DDevice->DrawPrimitive(
 				EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 				DrawContext.dwStartVertex,

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5101,7 +5101,7 @@ void CreateHostResource(XTL::X_D3DResource *pResource, int iTextureStage, DWORD 
 					dwDstRowPitch = LockedRect.Pitch;
 					dwDstSlicePitch = 0;
 				}
-
+							else if (CacheFormat != 0) // Do we need to convert to ARGB?
 				uint8_t *pSrc = (uint8_t *)VirtualAddr + dwMipOffset;
 
 				// Do we need to convert to ARGB?
@@ -5128,6 +5128,8 @@ void CreateHostResource(XTL::X_D3DResource *pResource, int iTextureStage, DWORD 
 				}
 				else if (bCompressed) {
 					memcpy(pDst, pSrc, dwMipSize);
+									memcpy(LockedRect.pBits, pSrc + dwCompressedOffset, dwCompressedSize >> (level * 2));
+									dwCompressedOffset += (dwCompressedSize >> (level * 2));
 				}
 				else {
 					/* TODO : // Let DirectX convert the surface (including palette formats) :

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7645,8 +7645,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 		DrawContext.XboxPrimitiveType = PrimitiveType;
 		DrawContext.dwVertexCount = VertexCount;
 		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
-		DrawContext.dwIndexBase = g_XboxBaseVertexIndex; // Used by GetVertexBufferSize
-		DrawContext.pIndexData = pIndexData; // Used by GetVertexBufferSize
+		DrawContext.dwIndexBase = g_XboxBaseVertexIndex; // Used by GetVerticesInBuffer
+		DrawContext.pIndexData = pIndexData; // Used by GetVerticesInBuffer
 
 		// Test case JSRF draws all geometry through this function (only sparks are drawn via another method)
 		// using X_D3DPT_TRIANGLELIST and X_D3DPT_TRIANGLESTRIP PrimitiveType

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2835,7 +2835,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShader)
 	// D3DDevice_LoadVertexShader pushes the program contained in the Xbox VertexShader struct to the NV2A
     if(Address < 136 && VshHandleIsVertexShader(Handle))
     {
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)(VshHandleGetVertexShader(Handle))->Handle;
+        CxbxVertexShader *pVertexShader = (CxbxVertexShader *)(VshHandleGetVertexShader(Handle))->Handle;
         for (DWORD i = Address; i < pVertexShader->Size; i++)
         {
             // TODO: This seems very fishy
@@ -2908,7 +2908,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShader)
 
     if(VshHandleIsVertexShader(Handle))
     {
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)(((X_D3DVertexShader *)(Handle & 0x7FFFFFFF))->Handle);
+        CxbxVertexShader *pVertexShader = (CxbxVertexShader *)(((X_D3DVertexShader *)(Handle & 0x7FFFFFFF))->Handle);
         hRet = g_pD3DDevice->SetVertexShader(pVertexShader->Handle);
 		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShader(VshHandleIsVertexShader)");
     }
@@ -2928,7 +2928,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShader)
 
         if(pVertexShader != NULL)
         {
-			hRet = g_pD3DDevice->SetVertexShader(((VERTEX_SHADER *)((X_D3DVertexShader *)g_VertexShaderSlots[Address])->Handle)->Handle);
+			hRet = g_pD3DDevice->SetVertexShader(((CxbxVertexShader *)((X_D3DVertexShader *)g_VertexShaderSlots[Address])->Handle)->Handle);
 			DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShader(pVertexShader)");
 		}
         else
@@ -3585,7 +3585,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 
     // create emulated shader struct
     X_D3DVertexShader *pD3DVertexShader = (X_D3DVertexShader*)g_VMManager.AllocateZeroed(sizeof(X_D3DVertexShader));
-    VERTEX_SHADER     *pVertexShader = (VERTEX_SHADER*)g_VMManager.AllocateZeroed(sizeof(VERTEX_SHADER));
+    CxbxVertexShader     *pVertexShader = (CxbxVertexShader*)g_VMManager.AllocateZeroed(sizeof(CxbxVertexShader));
 
     // TODO: Intelligently fill out these fields as necessary
 
@@ -3610,7 +3610,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
                                                    &pRecompiledDeclaration,
                                                    &DeclarationSize,
                                                    pFunction == NULL,
-                                                   &pVertexShader->VertexDynamicPatch);
+                                                   &pVertexShader->VertexShaderDynamicPatch);
 
     if(SUCCEEDED(hRet) && pFunction)
     {
@@ -6835,7 +6835,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShader)
     DWORD RealHandle;
     if(VshHandleIsVertexShader(Handle))
     {
-        RealHandle = ((VERTEX_SHADER *)(VshHandleGetVertexShader(Handle))->Handle)->Handle;
+        RealHandle = ((CxbxVertexShader *)(VshHandleGetVertexShader(Handle))->Handle)->Handle;
     }
     else
     {
@@ -7914,7 +7914,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderSize)
     if(pSize  && VshHandleIsVertexShader(Handle))
     {
         X_D3DVertexShader *pD3DVertexShader = (X_D3DVertexShader *)(Handle & 0x7FFFFFFF);
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)pD3DVertexShader->Handle;
+        CxbxVertexShader *pVertexShader = (CxbxVertexShader *)pD3DVertexShader->Handle;
         *pSize = pVertexShader->Size;
     }
     else if(pSize)
@@ -7964,7 +7964,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DeleteVertexShader)
     if(VshHandleIsVertexShader(Handle))
     {
         X_D3DVertexShader *pD3DVertexShader = (X_D3DVertexShader *)(Handle & 0x7FFFFFFF);
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)pD3DVertexShader->Handle;
+        CxbxVertexShader *pVertexShader = (CxbxVertexShader *)pD3DVertexShader->Handle;
 
         RealHandle = pVertexShader->Handle;
 		g_VMManager.Deallocate((VAddr)pVertexShader->pDeclaration);
@@ -8203,7 +8203,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShaderProgram)
     {
 		DWORD hNewShader = 0;
         X_D3DVertexShader *pD3DVertexShader = (X_D3DVertexShader *)(hCurrentShader & 0x7FFFFFFF);
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)pD3DVertexShader->Handle;
+        CxbxVertexShader *pVertexShader = (CxbxVertexShader *)pD3DVertexShader->Handle;
 
 		// Save the contents of the existing vertex shader program
 		DWORD* pDeclaration = (DWORD*) malloc( pVertexShader->DeclarationSize );
@@ -8245,7 +8245,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderType)
 
 	if(pType && VshHandleIsVertexShader(Handle))
     {
-        *pType = ((VERTEX_SHADER *)(VshHandleGetVertexShader(Handle))->Handle)->Type;
+        *pType = ((CxbxVertexShader *)(VshHandleGetVertexShader(Handle))->Handle)->Type;
     }
 }
 
@@ -8282,7 +8282,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderDeclaration)
 
     if(pSizeOfData && VshHandleIsVertexShader(Handle))
     {
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)(VshHandleGetVertexShader(Handle))->Handle;
+        CxbxVertexShader *pVertexShader = (CxbxVertexShader *)(VshHandleGetVertexShader(Handle))->Handle;
         if(*pSizeOfData < pVertexShader->DeclarationSize || !pData)
         {
             *pSizeOfData = pVertexShader->DeclarationSize;
@@ -8332,7 +8332,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderFunction)
 
     if(pSizeOfData && VshHandleIsVertexShader(Handle))
     {
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)(VshHandleGetVertexShader(Handle))->Handle;
+        CxbxVertexShader *pVertexShader = (CxbxVertexShader *)(VshHandleGetVertexShader(Handle))->Handle;
         if(*pSizeOfData < pVertexShader->FunctionSize || !pData)
         {
             *pSizeOfData = pVertexShader->FunctionSize;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -6949,13 +6949,13 @@ void CxbxAssureQuadListD3DIndexBuffer(UINT NrOfQuadVertices)
 			pQuadToTriangleD3DIndexBuffer = nullptr;
 		}
 
-		hRet = g_pD3DDevice8->CreateIndexBuffer(
+		hRet = g_pD3DDevice->CreateIndexBuffer(
 			uiIndexBufferSize,
 			D3DUSAGE_WRITEONLY,
 			XTL::D3DFMT_INDEX16,
 			XTL::D3DPOOL_MANAGED,
 			&pQuadToTriangleD3DIndexBuffer);
-		DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->CreateIndexBuffer");
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateIndexBuffer");
 
 		if (FAILED(hRet))
 			CxbxKrnlCleanup("CxbxAssureQuadListD3DIndexBuffer : IndexBuffer Create Failed!");
@@ -6963,7 +6963,7 @@ void CxbxAssureQuadListD3DIndexBuffer(UINT NrOfQuadVertices)
 		// Put quadlist-to-triangle-list index mappings into this buffer :
 		XTL::INDEX16* pIndexBufferData = nullptr;
 		hRet = pQuadToTriangleD3DIndexBuffer->Lock(0, uiIndexBufferSize, (BYTE **)&pIndexBufferData, D3DLOCK_DISCARD);
-		DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->CreateIndexBuffer");
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateIndexBuffer");
 
 		if (pIndexBufferData == nullptr)
 			CxbxKrnlCleanup("CxbxAssureQuadListD3DIndexBuffer : Could not lock index buffer!");
@@ -6974,8 +6974,8 @@ void CxbxAssureQuadListD3DIndexBuffer(UINT NrOfQuadVertices)
 	}
 
 	// Activate the new native index buffer :
-	hRet = g_pD3DDevice8->SetIndices(pQuadToTriangleD3DIndexBuffer, 0);
-	DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->CreateIndexBuffer");
+	hRet = g_pD3DDevice->SetIndices(pQuadToTriangleD3DIndexBuffer, 0);
+	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateIndexBuffer");
 
 	if (FAILED(hRet))
 		CxbxKrnlCleanup("CxbxAssureQuadListD3DIndexBuffer : SetIndices Failed!"); // +DxbxD3DErrorString(hRet));
@@ -6991,7 +6991,7 @@ void CxbxDrawIndexedClosingLine(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex)
 
 	const UINT uiIndexBufferSize = sizeof(XTL::INDEX16) * 2; // 4 bytes needed for 2 indices
 	if (pClosingLineLoopIndexBuffer == nullptr) {
-		hRet = g_pD3DDevice8->CreateIndexBuffer(uiIndexBufferSize, D3DUSAGE_WRITEONLY, XTL::D3DFMT_INDEX16, XTL::D3DPOOL_DEFAULT, &pClosingLineLoopIndexBuffer);
+		hRet = g_pD3DDevice->CreateIndexBuffer(uiIndexBufferSize, D3DUSAGE_WRITEONLY, XTL::D3DFMT_INDEX16, XTL::D3DPOOL_DEFAULT, &pClosingLineLoopIndexBuffer);
 		if (FAILED(hRet))
 			CxbxKrnlCleanup("Unable to create pClosingLineLoopIndexBuffer for D3DPT_LINELOOP emulation");
 	}
@@ -7006,10 +7006,10 @@ void CxbxDrawIndexedClosingLine(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex)
 	hRet = pClosingLineLoopIndexBuffer->Unlock();
 	DEBUG_D3DRESULT(hRet, "pClosingLineLoopIndexBuffer->Unlock");
 
-	hRet = g_pD3DDevice8->SetIndices(pClosingLineLoopIndexBuffer, 0);
-	DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->SetIndices");
+	hRet = g_pD3DDevice->SetIndices(pClosingLineLoopIndexBuffer, 0);
+	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetIndices");
 
-	hRet = g_pD3DDevice8->DrawIndexedPrimitive
+	hRet = g_pD3DDevice->DrawIndexedPrimitive
 	(
 		XTL::D3DPT_LINELIST,
 		LowIndex, // minIndex
@@ -7017,7 +7017,7 @@ void CxbxDrawIndexedClosingLine(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex)
 		0, // startIndex
 		1 // primCount
 	);
-	DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->DrawIndexedPrimitive(CxbxDrawIndexedClosingLine)");
+	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->DrawIndexedPrimitive(CxbxDrawIndexedClosingLine)");
 
 	g_dwPrimPerFrame++;
 }
@@ -7029,7 +7029,7 @@ void CxbxDrawIndexedClosingLineUP(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex,
 
 	XTL::INDEX16 CxbxClosingLineIndices[2] = { LowIndex, HighIndex };
 
-	HRESULT hRet = g_pD3DDevice8->DrawIndexedPrimitiveUP(
+	HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 		XTL::D3DPT_LINELIST,
 		LowIndex, // MinVertexIndex
 		HighIndex - LowIndex + 1, // NumVertexIndices,
@@ -7039,7 +7039,7 @@ void CxbxDrawIndexedClosingLineUP(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex,
 		pHostVertexStreamZeroData,
 		uiHostVertexStreamZeroStride
 	);
-	DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->DrawIndexedPrimitiveUP(CxbxDrawIndexedClosingLineUP)");
+	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->DrawIndexedPrimitiveUP(CxbxDrawIndexedClosingLineUP)");
 
 	g_dwPrimPerFrame++;
 }
@@ -7082,7 +7082,7 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
 					HighIndex = Index;
 			}
 			// Emulate a quad by drawing each as a fan of 2 triangles
-			HRESULT hRet = g_pD3DDevice8->DrawIndexedPrimitive(
+			HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitive(
 				D3DPT_TRIANGLEFAN,
 //{ $IFDEF DXBX_USE_D3D9 } {BaseVertexIndex = }0, { $ENDIF }
 				LowIndex, // minIndex
@@ -7090,7 +7090,7 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
 				uiStartIndex,
 				TRIANGLES_PER_QUAD // primCount = Draw 2 triangles
 			);
-			DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->DrawIndexedPrimitive(X_D3DPT_QUADLIST)");
+			DEBUG_D3DRESULT(hRet, "g_pD3DDevice->DrawIndexedPrimitive(X_D3DPT_QUADLIST)");
 
 			uiStartIndex += VERTICES_PER_QUAD;
 			iNumVertices -= VERTICES_PER_QUAD;
@@ -7099,14 +7099,14 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
 	}
 	else {
 		// Primitives other than X_D3DPT_QUADLIST can be drawn using one DrawIndexedPrimitive call :
-		HRESULT hRet = g_pD3DDevice8->DrawIndexedPrimitive(
+		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitive(
 			EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 			/* MinVertexIndex = */0,
 			/* NumVertices = */DrawContext.dwVertexCount, // TODO : g_EmuD3DActiveStreamSizes[0], // Note : ATI drivers are especially picky about this -
 			// NumVertices should be the span of covered vertices in the active vertex buffer (TODO : Is stream 0 correct?)
 			DrawContext.dwStartVertex,
 			DrawContext.dwHostPrimitiveCount);
-		DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->DrawIndexedPrimitive");
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->DrawIndexedPrimitive");
 
 		g_dwPrimPerFrame += DrawContext.dwHostPrimitiveCount;
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_LINELOOP) {
@@ -7139,6 +7139,7 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 	assert(DrawContext.dwStartVertex == 0);
 	assert(DrawContext.pXboxVertexStreamZeroData != NULL);
 	assert(DrawContext.uiXboxVertexStreamZeroStride > 0);
+	assert(DrawContext.dwIndexBase == 0); // No IndexBase under Draw*UP
 
 	CxbxVertexBufferConverter VertexBufferConverter;
 	VertexBufferConverter.Apply(&DrawContext);
@@ -7148,7 +7149,7 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 		INDEX16 *pIndexData = CxbxAssureQuadListIndexBuffer(DrawContext.dwVertexCount);
 		// Convert quad vertex-count to triangle vertex count :
 		UINT PrimitiveCount = DrawContext.dwHostPrimitiveCount * TRIANGLES_PER_QUAD;
-		HRESULT hRet = g_pD3DDevice8->DrawIndexedPrimitiveUP(
+		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 			D3DPT_TRIANGLELIST, // Draw indexed triangles instead of quads
 			0, // MinVertexIndex
 			DrawContext.dwVertexCount, // NumVertexIndices
@@ -7158,19 +7159,19 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 			DrawContext.pHostVertexStreamZeroData,
 			DrawContext.uiHostVertexStreamZeroStride
 		);
-		DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->DrawIndexedPrimitieUP(X_D3DPT_QUADLIST)");
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->DrawIndexedPrimitieUP(X_D3DPT_QUADLIST)");
 
 		g_dwPrimPerFrame += PrimitiveCount;
 	}
 	else {
 		// Primitives other than X_D3DPT_QUADLIST can be drawn using one DrawPrimitiveUP call :
-		HRESULT hRet = g_pD3DDevice8->DrawPrimitiveUP(
+		HRESULT hRet = g_pD3DDevice->DrawPrimitiveUP(
 			EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 			DrawContext.dwHostPrimitiveCount,
 			DrawContext.pHostVertexStreamZeroData,
 			DrawContext.uiHostVertexStreamZeroStride
 		);
-		DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->DrawPrimitiveUP");
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->DrawPrimitiveUP");
 
 		g_dwPrimPerFrame += DrawContext.dwHostPrimitiveCount;
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_LINELOOP) {
@@ -7471,6 +7472,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 		DrawContext.XboxPrimitiveType = PrimitiveType;
 		DrawContext.dwVertexCount = VertexCount;
 		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
+		DrawContext.dwIndexBase = indexBase; // Used by GetVertexBufferSize
 
 		// Test case JSRF draws all geometry through this function (only sparks are drawn via another method)
 		// using X_D3DPT_TRIANGLELIST and X_D3DPT_TRIANGLESTRIP PrimitiveType
@@ -7564,7 +7566,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 					DrawContext.pHostVertexStreamZeroData,
 					DrawContext.uiHostVertexStreamZeroStride
 				);
-				DEBUG_D3DRESULT(hRet, "g_pD3DDevice8->DrawIndexedPrimitiveUP(X_D3DPT_QUADLIST)");
+				DEBUG_D3DRESULT(hRet, "g_pD3DDevice->DrawIndexedPrimitiveUP(X_D3DPT_QUADLIST)");
 
 				pWalkIndexData += VERTICES_PER_QUAD;
 				iNumVertices -= VERTICES_PER_QUAD;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4012,6 +4012,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SwitchTexture)
     {
 		// Switch Texture updates the data pointer of an active texture using pushbuffer commands
 		// assert(EmuD3DActiveTexture[Stage] != xbnullptr);
+		LOG_TEST_CASE("Using CxbxActiveTextureCopies");
 
 		// Update data and format separately, instead of via GetDataFromXboxResource()
 		CxbxActiveTextureCopies[Stage].Common = EmuD3DActiveTexture[Stage]->Common;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4923,6 +4923,22 @@ void CreateHostResource(XTL::X_D3DResource *pResource, int iTextureStage, DWORD 
 		// Create the surface/volume/(volume/cube/)texture
 		switch (XboxResourceType) {
 		case XTL::X_D3DRTYPE_SURFACE: {
+#if 0 // TODO : Get this to work (test case Dolphin turns black with this enabled)
+			if (D3DUsage & D3DUSAGE_RENDERTARGET) {
+				hRet = g_pD3DDevice->CreateRenderTarget(dwWidth, dwHeight, PCFormat,
+					g_EmuCDPD.HostPresentationParameters.MultiSampleType,
+#ifdef CXBX_USE_D3D9
+					0, // MultisampleQuality
+#endif
+					true, // Lockable
+					&pNewHostSurface
+#ifdef CXBX_USE_D3D9
+					, nullptr, // pSharedHandle
+#endif
+				);
+				DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateRenderTarget");
+			} else
+#endif
 			if (D3DUsage & D3DUSAGE_DEPTHSTENCIL) {
 				hRet = g_pD3DDevice->CreateDepthStencilSurface(dwWidth, dwHeight, PCFormat,
 					g_EmuCDPD.HostPresentationParameters.MultiSampleType, 
@@ -7897,6 +7913,15 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderTarget)
 #else
 	hRet = g_pD3DDevice->SetRenderTarget(pHostRenderTarget, pHostDepthStencil);
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderTarget");
+#if 0 // tmp test
+	if ((hRet != D3D_OK) && pHostDepthStencil) {
+		// HACK : retry a failed SetRenderTarget without a depth-stencil
+		// (obviously, this will cause render issues, but the lack
+		// of render-target itself is even less desirable, so ...)
+		hRet = g_pD3DDevice->SetRenderTarget(pHostRenderTarget, nullptr);
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderTarget");
+	}
+#endif
 #endif
 }
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4716,6 +4716,15 @@ void CreateHostResource(XTL::X_D3DResource *pResource, int iTextureStage, DWORD 
 		if (pParentXboxTexture) {
 			XTL::IDirect3DBaseTexture *pParentHostBaseTexture = GetHostBaseTexture(pParentXboxTexture, iTextureStage);
 			switch (pParentHostBaseTexture->GetType()) {
+			case XTL::D3DRTYPE_VOLUMETEXTURE: {
+				// TODO
+				break;
+			}
+			case XTL::D3DRTYPE_CUBETEXTURE: {
+				// TODO
+				// test-case : Burnout
+				break;
+			}
 			case XTL::D3DRTYPE_TEXTURE: {
 				// For surfaces with a parent texture, map these to a host texture first
 				XTL::IDirect3DTexture *pParentHostTexture = (XTL::IDirect3DTexture *)pParentHostBaseTexture;
@@ -4729,8 +4738,10 @@ void CreateHostResource(XTL::X_D3DResource *pResource, int iTextureStage, DWORD 
 						SurfaceLevel, pResource, pNewHostSurface);
 					return;
 				}
+				break;
 			}
 			}
+
 			EmuWarning("Failed getting host surface level - falling through to regular surface creation");
 		}
 		// fall through

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7415,7 +7415,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVerticesUP)
 		DrawContext.dwVertexCount = VertexCount;
 		DrawContext.pXboxVertexStreamZeroData = pVertexStreamZeroData;
 		DrawContext.uiXboxVertexStreamZeroStride = VertexStreamZeroStride;
-		DrawContext.hVertexShader = g_CurrentVertexShader;
+		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
 		CxbxDrawPrimitiveUP(DrawContext);
     }

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2038,6 +2038,14 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
                     CxbxKrnlCleanup("IDirect3D::CreateDevice failed");
 
 				// Which texture formats does this device support?
+				memset(g_bSupportsFormatSurface, false, sizeof(g_bSupportsFormatSurface));
+				memset(g_bSupportsFormatSurfaceRenderTarget, false, sizeof(g_bSupportsFormatSurfaceRenderTarget));
+				memset(g_bSupportsFormatSurfaceDepthStencil, false, sizeof(g_bSupportsFormatSurfaceDepthStencil));
+				memset(g_bSupportsFormatTexture, false, sizeof(g_bSupportsFormatTexture));
+				memset(g_bSupportsFormatTextureRenderTarget, false, sizeof(g_bSupportsFormatTextureRenderTarget));
+				memset(g_bSupportsFormatTextureDepthStencil, false, sizeof(g_bSupportsFormatTextureDepthStencil));
+				memset(g_bSupportsFormatVolumeTexture, false, sizeof(g_bSupportsFormatVolumeTexture));
+				memset(g_bSupportsFormatCubeTexture, false, sizeof(g_bSupportsFormatCubeTexture));
 				for (int X_Format = XTL::X_D3DFMT_L8; X_Format <= XTL::X_D3DFMT_LIN_R8G8B8A8; X_Format++) {
 					// Only process Xbox formats that are directly mappable to host
 					if (!XTL::EmuXBFormatRequiresConversionToARGB((XTL::X_D3DFORMAT)X_Format)) {
@@ -2045,46 +2053,46 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 						XTL::D3DFORMAT PCFormat = XTL::EmuXB2PC_D3DFormat((XTL::X_D3DFORMAT)X_Format);
 						if (PCFormat != XTL::D3DFMT_UNKNOWN) {
 							// Index with Xbox D3DFormat, because host FourCC codes are too big to be used as indices
-							g_bSupportsFormatSurface[X_Format] =
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, 0,
-									XTL::D3DRTYPE_SURFACE, PCFormat));
-							g_bSupportsFormatSurfaceRenderTarget[X_Format] =
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+									XTL::D3DRTYPE_SURFACE, PCFormat))
+								g_bSupportsFormatSurface[X_Format] = true;
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, D3DUSAGE_RENDERTARGET,
-									XTL::D3DRTYPE_SURFACE, PCFormat));
-							g_bSupportsFormatSurfaceDepthStencil[X_Format] =
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+									XTL::D3DRTYPE_SURFACE, PCFormat))
+								g_bSupportsFormatSurfaceRenderTarget[X_Format] = true;
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, D3DUSAGE_DEPTHSTENCIL,
-									XTL::D3DRTYPE_SURFACE, PCFormat));
-							g_bSupportsFormatTexture[X_Format] = 
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+									XTL::D3DRTYPE_SURFACE, PCFormat))
+								g_bSupportsFormatSurfaceDepthStencil[X_Format] = true;
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, 0,
-									XTL::D3DRTYPE_TEXTURE, PCFormat));
-							g_bSupportsFormatTextureRenderTarget[X_Format] =
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+									XTL::D3DRTYPE_TEXTURE, PCFormat))
+								g_bSupportsFormatTexture[X_Format] = true;
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, D3DUSAGE_RENDERTARGET,
-									XTL::D3DRTYPE_TEXTURE, PCFormat));
-							g_bSupportsFormatTextureDepthStencil[X_Format] =
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+									XTL::D3DRTYPE_TEXTURE, PCFormat))
+								g_bSupportsFormatTextureRenderTarget[X_Format] = true;
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, D3DUSAGE_DEPTHSTENCIL,
-									XTL::D3DRTYPE_TEXTURE, PCFormat));
-							g_bSupportsFormatVolumeTexture[X_Format] =
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+									XTL::D3DRTYPE_TEXTURE, PCFormat))
+								g_bSupportsFormatTextureDepthStencil[X_Format] = true;
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, 0,
-									XTL::D3DRTYPE_VOLUMETEXTURE, PCFormat));
-							g_bSupportsFormatCubeTexture[X_Format] =
-								(D3D_OK == g_pDirect3D->CheckDeviceFormat(
+									XTL::D3DRTYPE_VOLUMETEXTURE, PCFormat))
+								g_bSupportsFormatVolumeTexture[X_Format] = true;
+							if (D3D_OK == g_pDirect3D->CheckDeviceFormat(
 									g_EmuCDPD.Adapter, g_EmuCDPD.DeviceType,
 									g_EmuCDPD.HostPresentationParameters.BackBufferFormat, 0,
-									XTL::D3DRTYPE_CUBETEXTURE, PCFormat));
+									XTL::D3DRTYPE_CUBETEXTURE, PCFormat))
+								g_bSupportsFormatCubeTexture[X_Format] = true;
 						}
 					}
 				}
@@ -5033,6 +5041,9 @@ void CreateHostResource(XTL::X_D3DResource *pResource, int iTextureStage, DWORD 
 		} // switch XboxResourceType
 
 		DWORD D3DLockFlags = D3DLOCK_NOSYSLOCK; // Note : D3DLOCK_DISCARD is only valid for D3DUSAGE_DYNAMIC
+
+		D3DLockFlags |= D3DLOCK_DISCARD; // tmp test
+
 		DWORD dwCubeFaceOffset = 0;
 		DWORD dwCubeFaceSize = 0;
 		XTL::D3DCUBEMAP_FACES last_face = (bCubemap) ? XTL::D3DCUBEMAP_FACE_NEGATIVE_Z : XTL::D3DCUBEMAP_FACE_POSITIVE_X;
@@ -7211,7 +7222,7 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 		// Instead of calling WalkIndexBuffer on pQuadToTriangleIndexBuffer,
 		// we can derive the LowIndex and HighIndexes ourselves here
 		INDEX16 LowIndex = 0;
-		INDEX16 HighIndex = DrawContext.dwVertexCount;
+		INDEX16 HighIndex = (INDEX16)(DrawContext.dwVertexCount - 1);
 
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 			D3DPT_TRIANGLELIST, // Draw indexed triangles instead of quads

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3610,7 +3610,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
                                                    &pRecompiledDeclaration,
                                                    &DeclarationSize,
                                                    pFunction == NULL,
-                                                   &pVertexShader->VertexShaderDynamicPatch);
+                                                   &pVertexShader->VertexShaderInfo);
 
     if(SUCCEEDED(hRet) && pFunction)
     {

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7127,8 +7127,6 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
 			// NOTE : We don't restore the previously active index buffer
 		}
 	}
-
-	VertexBufferConverter.Restore();
 }
 
 // TODO : Move to own file
@@ -7189,8 +7187,6 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 			);
 		}
 	}
-
-	VertexBufferConverter.Restore();
 }
 
 void EmuUpdateActiveTextureStages()

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7051,7 +7051,7 @@ void CxbxDrawIndexedClosingLine(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex)
 		g_XboxBaseVertexIndex,
 #endif
 		LowIndex, // minIndex
-		HighIndex - LowIndex + 1, // NumVertexIndices
+		(HighIndex - LowIndex) + 1, // NumVertexIndices
 		0, // startIndex
 		1 // primCount
 	);
@@ -7070,7 +7070,7 @@ void CxbxDrawIndexedClosingLineUP(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex,
 	HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 		XTL::D3DPT_LINELIST,
 		LowIndex, // MinVertexIndex
-		HighIndex - LowIndex + 1, // NumVertexIndices,
+		(HighIndex - LowIndex) + 1, // NumVertexIndices,
 		1, // PrimitiveCount,
 		CxbxClosingLineIndices, // pIndexData
 		XTL::D3DFMT_INDEX16, // IndexDataFormat
@@ -7136,7 +7136,7 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext)
 				DrawContext.dwIndexBase,
 #endif
 				LowIndex, // minIndex
-				HighIndex - LowIndex + 1, // NumVertices
+				(HighIndex - LowIndex) + 1, // NumVertices
 				uiStartIndex,
 				TRIANGLES_PER_QUAD // primCount = Draw 2 triangles
 			);
@@ -7160,7 +7160,7 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext)
 			DrawContext.dwIndexBase,
 #endif
 			/* MinVertexIndex = */LowIndex,
-			/* NumVertices = */HighIndex-LowIndex+1,//using index vertex span here.  // TODO : g_EmuD3DActiveStreamSizes[0], // Note : ATI drivers are especially picky about this -
+			/* NumVertices = */(HighIndex - LowIndex) + 1,//using index vertex span here.  // TODO : g_EmuD3DActiveStreamSizes[0], // Note : ATI drivers are especially picky about this -
 			// NumVertices should be the span of covered vertices in the active vertex buffer (TODO : Is stream 0 correct?)
 			DrawContext.dwStartVertex,
 			DrawContext.dwHostPrimitiveCount);
@@ -7208,16 +7208,15 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 		// Convert quad vertex-count to triangle vertex count :
 		UINT PrimitiveCount = DrawContext.dwHostPrimitiveCount * TRIANGLES_PER_QUAD;
 
-		//Scale the index vertexes counts for newly created triangle list index buffer.
-		DWORD dwIndexCount = DrawContext.dwVertexCount + DrawContext.dwVertexCount / 2;
-		//walk through index buffer
-		INDEX16 LowIndex, HighIndex;
-		WalkIndexBuffer(LowIndex, HighIndex, pIndexData, dwIndexCount);
+		// Instead of calling WalkIndexBuffer on pQuadToTriangleIndexBuffer,
+		// we can derive the LowIndex and HighIndexes ourselves here
+		INDEX16 LowIndex = 0;
+		INDEX16 HighIndex = DrawContext.dwVertexCount;
 
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 			D3DPT_TRIANGLELIST, // Draw indexed triangles instead of quads
 			LowIndex, // MinVertexIndex
-			HighIndex - LowIndex + 1, // NumVertexIndices
+			(HighIndex - LowIndex) + 1, // NumVertexIndices
 			PrimitiveCount,
 			pIndexData,
 			D3DFMT_INDEX16, // IndexDataFormat
@@ -7404,7 +7403,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 				0, // BaseVertexIndex
 #endif
 				LowIndex, // minIndex
-				HighIndex - LowIndex + 1, // NumVertices,
+				(HighIndex - LowIndex) + 1, // NumVertices,
 				startIndex,
 				primCount
 			);
@@ -7620,7 +7619,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 				HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 					D3DPT_TRIANGLEFAN, // Draw a triangle-fan instead of a quad
 					LowIndex, // MinVertexIndex
-					HighIndex - LowIndex + 1, // NumVertexIndices
+					(HighIndex - LowIndex) + 1, // NumVertexIndices
 					TRIANGLES_PER_QUAD, // primCount = Draw 2 triangles
 					pWalkIndexData,
 					D3DFMT_INDEX16, // IndexDataFormat
@@ -7644,7 +7643,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 			HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 				EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 				LowIndex, // MinVertexIndex
-				HighIndex - LowIndex + 1, //this shall be Vertex Spans DrawContext.dwVertexCount, // NumVertexIndices
+				(HighIndex - LowIndex) + 1, //this shall be Vertex Spans DrawContext.dwVertexCount, // NumVertexIndices
 				DrawContext.dwHostPrimitiveCount,
 				pIndexData,
 				D3DFMT_INDEX16, // IndexDataFormat

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7472,6 +7472,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 		DrawContext.dwVertexCount = VertexCount;
 		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
 
+		// Test case JSRF draws all geometry through this function (only sparks are drawn via another method)
+		// using X_D3DPT_TRIANGLELIST and X_D3DPT_TRIANGLESTRIP PrimitiveType
 		CxbxDrawIndexed(DrawContext, (INDEX16*)pIndexData);
 	}
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2824,7 +2824,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShader_4)
 	// D3DDevice_LoadVertexShader pushes the program contained in the Xbox VertexShader struct to the NV2A
     if(Address < 136 && VshHandleIsVertexShader(Handle))
     {
-        VERTEX_SHADER *pVertexShader = (VERTEX_SHADER *)(VshHandleGetVertexShader(Handle))->Handle;
+		CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
         for (DWORD i = Address; i < pVertexShader->Size; i++)
         {
             // TODO: This seems very fishy

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7537,7 +7537,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 			// This is slower (because of call-overhead) but doesn't require any index buffer patching
 
 			// Draw 1 quad as a 2 triangles in a fan (which both have the same winding order) :
-			LOG_TEST_CASE("X_D3DPT_QUADLIST"); // Test-case : Buffy: The Vampire Slayer, FastLoad XDK Sample
+			// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // Test-case : Buffy: The Vampire Slayer, FastLoad XDK Sample
 			INDEX16* pWalkIndexData = (INDEX16*)pIndexData;
 			int iNumVertices = (int)VertexCount;
 			while (iNumVertices >= VERTICES_PER_QUAD) {
@@ -7571,7 +7571,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 			g_dwPrimPerFrame += VertexCount / VERTICES_PER_QUAD * TRIANGLES_PER_QUAD;
 		}
 		else {
-			LOG_TEST_CASE("DrawIndexedPrimitiveUP"); // Test-case : Burnout, Namco Museum 50th Anniversary
+			// LOG_TEST_CASE("DrawIndexedPrimitiveUP"); // Test-case : Burnout, Namco Museum 50th Anniversary
 			HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 				EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 				0, // MinVertexIndex

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7151,7 +7151,7 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext)
 		//Walk through index buffer
 		// Determine highest and lowest index in use :
 		INDEX16 LowIndex, HighIndex;
-		WalkIndexBuffer(LowIndex,  HighIndex, DrawContext.pIndexData, DrawContext.dwVertexCount);
+		WalkIndexBuffer(LowIndex,  HighIndex, &(DrawContext.pIndexData[DrawContext.dwStartVertex]), DrawContext.dwVertexCount);
 
 		// Primitives other than X_D3DPT_QUADLIST can be drawn using one DrawIndexedPrimitive call :
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitive(

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -36,6 +36,10 @@
 
 #include "CxbxKrnl.h"
 
+#define VERTICES_PER_TRIANGLE 3
+#define VERTICES_PER_QUAD 4
+#define TRIANGLES_PER_QUAD 2
+
 // simple render state encoding lookup table
 #define X_D3DRSSE_UNK 0x7fffffff
 extern CONST DWORD EmuD3DRenderStateSimpleEncoded[174];
@@ -237,6 +241,11 @@ inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(X_D3DPRIMITIVETYPE PrimitiveTy
         return D3DPT_FORCE_DWORD;
 
     return EmuPrimitiveTypeLookup[PrimitiveType];
+}
+
+inline int EmuD3DIndexCountToVertexCount(X_D3DPRIMITIVETYPE XboxPrimitiveType, int IndexCount)
+{
+	return IndexCount;
 }
 
 extern void EmuUnswizzleBox

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -4239,9 +4239,9 @@ VOID XTL::DxbxUpdateActivePixelShader() // NOPATCH
 
   HRESULT Result = D3D_OK;
 
-  // TODO: Is this even right? he first RenderState is PSAlpha,
+  // TODO: Is this even right? The first RenderState is PSAlpha,
   // The pixel shader is stored in pDevice->m_pPixelShader
-  // For now, we still patch SetPixleShader and read from there...
+  // For now, we still patch SetPixelShader and read from there...
   //DWORD *XTL_D3D__RenderState = XTL::EmuMappedD3DRenderState[0];
   //pPSDef = (XTL::X_D3DPIXELSHADERDEF*)(XTL_D3D__RenderState);
 	  pPSDef = g_D3DActivePixelShader != nullptr ? g_D3DActivePixelShader->pPSDef : nullptr;

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -44,7 +44,7 @@
 // TODO: Find somewhere to put this that doesn't conflict with XTL::
 extern void EmuUpdateActiveTextureStages();
 #ifdef CXBX_USE_D3D9
-extern DWORD g_CachedIndexBase;
+extern DWORD g_XboxBaseVertexIndex;
 #endif
 
 uint32  XTL::g_dwPrimaryPBCount = 0;

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -203,7 +203,6 @@ extern void XTL::EmuExecutePushBufferRaw
     // cache of last 4 indices
 	INDEX16 pIBMem[4] = {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF};
 
-    D3DPRIMITIVETYPE    PCPrimitiveType = (D3DPRIMITIVETYPE)-1;
     X_D3DPRIMITIVETYPE  XboxPrimitiveType = X_D3DPT_INVALID;
 
     // TODO: This technically should be enabled
@@ -289,7 +288,6 @@ extern void XTL::EmuExecutePushBufferRaw
                 #endif
 				//retrieve the D3DPRIMITIVETYPE info in parameter
                 XboxPrimitiveType = (X_D3DPRIMITIVETYPE)*pdwPushData;
-                PCPrimitiveType = EmuXB2PC_D3DPrimitiveType(XboxPrimitiveType);
 				pdwPushData++;
             }
         }

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -461,7 +461,7 @@ extern void XTL::EmuExecutePushBufferRaw
 
                 D3DVERTEXBUFFER_DESC VBDesc;
 
-                BYTE *pVBData = 0;
+				D3DLockData *pVBData = nullptr;
                 UINT  uiStride;
 
                 // retrieve stream data
@@ -590,7 +590,7 @@ void DbgDumpMesh(WORD *pIndexData, DWORD dwCount)
 
     XTL::D3DVERTEXBUFFER_DESC VBDesc;
 
-    BYTE *pVBData = 0;
+    BYTE *pVBData = nullptr;
     UINT  uiStride;
 
     // retrieve stream data
@@ -611,7 +611,7 @@ void DbgDumpMesh(WORD *pIndexData, DWORD dwCount)
     pActiveVB->Unlock();
 
     // grab ptr
-    pActiveVB->Lock(0, 0, &pVBData, D3DLOCK_READONLY);
+    pActiveVB->Lock(0, 0, (D3DLockData **)&pVBData, D3DLOCK_READONLY);
 
     // print out stream data
     {

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -419,8 +419,9 @@ extern void XTL::EmuExecutePushBufferRaw
 							DrawContext.XboxPrimitiveType = XboxPrimitiveType;
 							DrawContext.dwVertexCount = EmuD3DIndexCountToVertexCount(XboxPrimitiveType, uiIndexCount);
 							DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
+							DrawContext.pIndexData = pIBMem; // Used by GetVertexBufferSize
 
-							CxbxDrawIndexed(DrawContext, pIBMem);
+							CxbxDrawIndexed(DrawContext);
                         }
                     }
                 }
@@ -525,8 +526,9 @@ extern void XTL::EmuExecutePushBufferRaw
 							DrawContext.XboxPrimitiveType = XboxPrimitiveType;
 							DrawContext.dwVertexCount = EmuD3DIndexCountToVertexCount(XboxPrimitiveType, dwIndexCount);
 							DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
+							DrawContext.pIndexData = pIndexData; // Used by GetVertexBufferSize
 
-							CxbxDrawIndexed(DrawContext, pIndexData);
+							CxbxDrawIndexed(DrawContext);
 						}
 					}
                 }

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -419,7 +419,7 @@ extern void XTL::EmuExecutePushBufferRaw
 							DrawContext.XboxPrimitiveType = XboxPrimitiveType;
 							DrawContext.dwVertexCount = EmuD3DIndexCountToVertexCount(XboxPrimitiveType, uiIndexCount);
 							DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
-							DrawContext.pIndexData = pIBMem; // Used by GetVertexBufferSize
+							DrawContext.pIndexData = pIBMem; // Used by GetVerticesInBuffer
 
 							CxbxDrawIndexed(DrawContext);
                         }
@@ -526,7 +526,7 @@ extern void XTL::EmuExecutePushBufferRaw
 							DrawContext.XboxPrimitiveType = XboxPrimitiveType;
 							DrawContext.dwVertexCount = EmuD3DIndexCountToVertexCount(XboxPrimitiveType, dwIndexCount);
 							DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
-							DrawContext.pIndexData = pIndexData; // Used by GetVertexBufferSize
+							DrawContext.pIndexData = pIndexData; // Used by GetVerticesInBuffer
 
 							CxbxDrawIndexed(DrawContext);
 						}

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.h
@@ -37,7 +37,7 @@
 extern int DxbxFVF_GetNumberOfTextureCoordinates(DWORD dwFVF, int aTextureIndex);
 extern UINT DxbxFVFToVertexSizeInBytes(DWORD dwFVF, BOOL bIncludeTextures);
 
-extern void CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData);
+extern void CxbxDrawIndexed(CxbxDrawContext &DrawContext);
 extern void CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext);
 
 extern void EmuExecutePushBuffer

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.h
@@ -34,7 +34,7 @@
 #ifndef PUSHBUFFER_H
 #define PUSHBUFFER_H
 
-extern int DxbxFVF_GetTextureSize(DWORD dwFVF, int aTextureIndex);
+extern int DxbxFVF_GetNumberOfTextureCoordinates(DWORD dwFVF, int aTextureIndex);
 extern UINT DxbxFVFToVertexSizeInBytes(DWORD dwFVF, BOOL bIncludeTextures);
 
 extern void CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData);

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.h
@@ -34,9 +34,6 @@
 #ifndef PUSHBUFFER_H
 #define PUSHBUFFER_H
 
-typedef VertexPatchDesc CxbxDrawContext; // TODO : Temporary
-typedef VertexPatcher CxbxVertexBufferConverter; // TODO : Temporary
-
 extern int DxbxFVF_GetTextureSize(DWORD dwFVF, int aTextureIndex);
 extern UINT DxbxFVFToVertexSizeInBytes(DWORD dwFVF, BOOL bIncludeTextures);
 

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.h
@@ -34,9 +34,14 @@
 #ifndef PUSHBUFFER_H
 #define PUSHBUFFER_H
 
-extern int DxbxFVF_GetTextureSize(DWORD dwFVF, int aTextureIndex);
+typedef VertexPatchDesc CxbxDrawContext; // TODO : Temporary
+typedef VertexPatcher CxbxVertexBufferConverter; // TODO : Temporary
 
+extern int DxbxFVF_GetTextureSize(DWORD dwFVF, int aTextureIndex);
 extern UINT DxbxFVFToVertexSizeInBytes(DWORD dwFVF, BOOL bIncludeTextures);
+
+extern void CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData);
+extern void CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext);
 
 extern void EmuExecutePushBuffer
 (

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -318,7 +318,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 	UINT uiHostVertexStride;
 	DWORD dwHostVertexDataSize;
 	uint08 *pHostVertexData;
-	IDirect3DVertexBuffer8 *pNewHostVertexBuffer = nullptr;
+	IDirect3DVertexBuffer *pNewHostVertexBuffer = nullptr;
 
     if (pDrawContext->pXboxVertexStreamZeroData != xbnullptr) {
 		// There should only be one stream (stream zero) in this case
@@ -370,7 +370,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 		dwHostVertexDataSize = uiVertexCount * uiHostVertexStride;
 		GetCachedVertexBufferObject(pXboxVertexBuffer->Data, dwHostVertexDataSize, &pNewHostVertexBuffer);
 
-        if (FAILED(pNewHostVertexBuffer->Lock(0, 0, &pHostVertexData, D3DLOCK_DISCARD))) {
+        if (FAILED(pNewHostVertexBuffer->Lock(0, 0, (D3DLockData **)&pHostVertexData, D3DLOCK_DISCARD))) {
             CxbxKrnlCleanup("Couldn't lock the new buffer");
         }
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -431,7 +431,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					break;
 				}
 				case X_D3DVSDT_NORMSHORT1: { // 0x11: // Make it FLOAT1
-					LOG_TEST_CASE("X_D3DVSDT_NORMSHORT1"); // UNTESTED - Need test-case!
+					// Test-cases : Halo - Combat Evolved
 
 					((FLOAT *)pNewDataPos)[0] = ((FLOAT)((SHORT*)pOrigVertex)[0]) / 32767.0f;
 					//((FLOAT *)pNewDataPos)[1] = 0.0f; // Would be needed for FLOAT2
@@ -440,7 +440,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 #if !DXBX_USE_D3D9 // No need for patching in D3D9
 				case X_D3DVSDT_NORMSHORT2: { // 0x21: // Make it FLOAT2
-					LOG_TEST_CASE("X_D3DVSDT_NORMSHORT2"); // UNTESTED - Need test-case!
+					// Test-cases : Baldur's Gate: Dark Alliance 2, F1 2002, Gun, Halo - Combat Evolved, Scrapland 
 					((FLOAT *)pNewDataPos)[0] = ((FLOAT)((SHORT*)pOrigVertex)[0]) / 32767.0f;
 					((FLOAT *)pNewDataPos)[1] = ((FLOAT)((SHORT*)pOrigVertex)[1]) / 32767.0f;
 					pOrigVertex += 2 * sizeof(SHORT);
@@ -448,7 +448,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 #endif
 				case X_D3DVSDT_NORMSHORT3: { // 0x31: // Make it FLOAT3
-					LOG_TEST_CASE("X_D3DVSDT_NORMSHORT3"); // UNTESTED - Need test-case!
+					// Test-cases : Cel Damage, Constantine, Destroy All Humans!
 					((FLOAT *)pNewDataPos)[0] = ((FLOAT)((SHORT*)pOrigVertex)[0]) / 32767.0f;
 					((FLOAT *)pNewDataPos)[1] = ((FLOAT)((SHORT*)pOrigVertex)[1]) / 32767.0f;
 					((FLOAT *)pNewDataPos)[2] = ((FLOAT)((SHORT*)pOrigVertex)[2]) / 32767.0f;

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -599,21 +599,6 @@ bool XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 			}
 		}
-#if 0
-		if (pNewVertexBuffer)
-		{
-			pNewVertexBuffer->Unlock();
-
-			if (FAILED(g_pD3DDevice->SetStreamSource(uiStream, pNewVertexBuffer, uiStride)))
-			{
-				CxbxKrnlCleanup("Failed to set the texcoord patched FVF buffer as the new stream source.");
-			}
-
-			pStream->pPatchedStream = pNewVertexBuffer;
-			pStream->uiCachedXboxVertexStride = uiStride;
-			pStream->uiCachedHostVertexStride = uiStride;
-		}
-#endif
 	}
 
 	CxbxPatchedStream *pPatchedStream = &m_PatchedStreams[uiStream];
@@ -685,7 +670,7 @@ void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext)
 
 			memcpy(pVertexDataData, GetDataFromXboxResource(g_D3DStreams[uiStream]), pDrawContext->uiSize);
 			pHostVertexBuffer->Unlock();
-			
+
 			// Set the buffer as a stream source
 			g_pD3DDevice->SetStreamSource(
 				uiStream, 
@@ -776,87 +761,80 @@ VOID XTL::EmuFlushIVB()
 		g_InlineVertexBuffer_pData = (FLOAT*)malloc(g_InlineVertexBuffer_DataSize);
 	}
 
-    DWORD *pdwVB = (DWORD*)g_InlineVertexBuffer_pData;
-	for(uint v=0;v<g_InlineVertexBuffer_TableOffset;v++)
-    {
-		switch (dwPos) {
-        case D3DFVF_XYZ:
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
-            DbgPrintf("IVB Position := {%f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z);
-			break;
-		case D3DFVF_XYZRHW:
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Rhw;
-            DbgPrintf("IVB Position := {%f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Rhw);
-			break;
-		case D3DFVF_XYZB1:
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
-			DbgPrintf("IVB Position := {%f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0]);
-			break;
-		case D3DFVF_XYZB2:
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[1];
-			DbgPrintf("IVB Position := {%f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1]);
-			break;
-		case D3DFVF_XYZB3:
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[1];
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[2];
-			DbgPrintf("IVB Position := {%f, %f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1], g_InlineVertexBuffer_Table[v].Blend[2]);
-			break;
-		case D3DFVF_XYZB4:
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.x;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.y;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Position.z;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[0];
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[1];
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[2];
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Blend[3];
-			DbgPrintf("IVB Position := {%f, %f, %f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1], g_InlineVertexBuffer_Table[v].Blend[2], g_InlineVertexBuffer_Table[v].Blend[3]);
-			break;
-		default:
-			CxbxKrnlCleanup("Unsupported Position Mask (FVF := 0x%.08X dwPos := 0x%.08X)", dwCurFVF, dwPos);
-			break;
+	FLOAT *pVertexBufferData = g_InlineVertexBuffer_pData;
+	for(uint v=0;v<g_InlineVertexBuffer_TableOffset;v++) {
+        *pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Position.x;
+        *pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Position.y;
+        *pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Position.z;
+		if (dwPos == D3DFVF_XYZRHW) {
+            *pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Rhw;
+            DbgPrintf("IVB Position := {%f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Rhw);
+		}
+		else { // XYZRHW cannot be combined with NORMAL, but the other XYZ formats can :
+			switch (dwPos) {
+			case D3DFVF_XYZ:
+				DbgPrintf("IVB Position := {%f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z);
+				break;
+			case D3DFVF_XYZB1:
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[0];
+				DbgPrintf("IVB Position := {%f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0]);
+				break;
+			case D3DFVF_XYZB2:
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[0];
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[1];
+				DbgPrintf("IVB Position := {%f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1]);
+				break;
+			case D3DFVF_XYZB3:
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[0];
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[1];
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[2];
+				DbgPrintf("IVB Position := {%f, %f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1], g_InlineVertexBuffer_Table[v].Blend[2]);
+				break;
+			case D3DFVF_XYZB4:
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[0];
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[1];
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[2];
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Blend[3];
+				DbgPrintf("IVB Position := {%f, %f, %f, %f, %f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Position.x, g_InlineVertexBuffer_Table[v].Position.y, g_InlineVertexBuffer_Table[v].Position.z, g_InlineVertexBuffer_Table[v].Blend[0], g_InlineVertexBuffer_Table[v].Blend[1], g_InlineVertexBuffer_Table[v].Blend[2], g_InlineVertexBuffer_Table[v].Blend[3]);
+				break;
+			default:
+				CxbxKrnlCleanup("Unsupported Position Mask (FVF := 0x%.08X dwPos := 0x%.08X)", dwCurFVF, dwPos);
+				break;
+			}
+
+			if (dwCurFVF & D3DFVF_NORMAL) {
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Normal.x;
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Normal.y;
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Normal.z;
+				DbgPrintf("IVB Normal := {%f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Normal.x, g_InlineVertexBuffer_Table[v].Normal.y, g_InlineVertexBuffer_Table[v].Normal.z);
+			}
 		}
 
-		if (dwCurFVF & D3DFVF_NORMAL) {
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Normal.x;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Normal.y;
-			*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].Normal.z;
-			DbgPrintf("IVB Normal := {%f, %f, %f}\n", g_InlineVertexBuffer_Table[v].Normal.x, g_InlineVertexBuffer_Table[v].Normal.y, g_InlineVertexBuffer_Table[v].Normal.z);
-        }
+#if 0 // TODO : Was this supported on Xbox from some point in time (pun intended)?
+		if (dwCurFVF & D3DFVF_PSIZE) {
+			*(DWORD*)pVertexBufferData++ = g_InlineVertexBuffer_Table[v].PointSize;
+			DbgPrintf("IVB PointSize := 0x%.08X\n", g_InlineVertexBuffer_Table[v].PointSize);
+		}
+#endif
 
         if (dwCurFVF & D3DFVF_DIFFUSE) {
-            *(DWORD*)pdwVB++ = g_InlineVertexBuffer_Table[v].Diffuse;
+            *(DWORD*)pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Diffuse;
             DbgPrintf("IVB Diffuse := 0x%.08X\n", g_InlineVertexBuffer_Table[v].Diffuse);
         }
 
 		if (dwCurFVF & D3DFVF_SPECULAR) {
-			*(DWORD*)pdwVB++ = g_InlineVertexBuffer_Table[v].Specular;
+			*(DWORD*)pVertexBufferData++ = g_InlineVertexBuffer_Table[v].Specular;
 			DbgPrintf("IVB Specular := 0x%.08X\n", g_InlineVertexBuffer_Table[v].Specular);
 		}
 
 		for (uint i = 0; i < dwTexN; i++) {
-            *(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].x;
+            *pVertexBufferData++ = g_InlineVertexBuffer_Table[v].TexCoord[i].x;
 			if (TexSize[i] >= 2) {
-				*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].y;
+				*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].TexCoord[i].y;
 				if (TexSize[i] >= 3) {
-					*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].z;
+					*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].TexCoord[i].z;
 					if (TexSize[i] >= 4) {
-						*(FLOAT*)pdwVB++ = g_InlineVertexBuffer_Table[v].TexCoord[i].w;
+						*pVertexBufferData++ = g_InlineVertexBuffer_Table[v].TexCoord[i].w;
 					}
 				}
 			}
@@ -872,14 +850,14 @@ VOID XTL::EmuFlushIVB()
         }
 
 		if (v == 0) {
-			uint VertexBufferUsage = (uintptr_t)pdwVB - (uintptr_t)g_InlineVertexBuffer_pData;
+			uint VertexBufferUsage = (uintptr_t)pVertexBufferData - (uintptr_t)g_InlineVertexBuffer_pData;
 			if (VertexBufferUsage != uiStride) {
 				CxbxKrnlCleanup("EmuFlushIVB uses wrong stride!");
 			}
 		}
 	}
 
-	CxbxDrawContext DrawContext;
+	CxbxDrawContext DrawContext = {};
 	DrawContext.XboxPrimitiveType = g_InlineVertexBuffer_PrimitiveType;
 	DrawContext.dwVertexCount = g_InlineVertexBuffer_TableOffset;
 	DrawContext.pXboxVertexStreamZeroData = g_InlineVertexBuffer_pData;

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -510,16 +510,6 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 		if (bNeedStreamCopy) {
 			memcpy(pHostVertexData, pXboxVertexData, dwHostVertexDataSize);
 		}
-#if 0
-		pDrawContext->pXboxVertexStreamZeroData = pHostVertexData;
-        pDrawContext->uiXboxVertexStreamZeroStride = pVertexShaderStreamInfo->HostVertexStride;
-        if (!m_bAllocatedStreamZeroData)
-        {
-            // The stream was not previously patched. We'll need this when restoring
-            m_bAllocatedStreamZeroData = true;
-            m_pNewVertexStreamZeroData = pHostVertexData;
-        }
-#endif
 	}
 
 	// Xbox FVF shaders are identical to host Direct3D 8.1, however

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -216,14 +216,14 @@ size_t GetVertexBufferSize(DWORD dwVertexCount, DWORD dwStride, PWORD pIndexData
 
 int CountActiveD3DStreams()
 {
-	int lastStreamIndex = -1;
+	int lastStreamIndex = 0;
 	for (int i = 0; i < 16; i++) {
 		if (g_D3DStreams[i] != nullptr) {
-			lastStreamIndex = i;
+			lastStreamIndex = i + 1;
 		}
 	}
 
-	return lastStreamIndex + 1;
+	return lastStreamIndex;
 }
 
 UINT XTL::CxbxVertexBufferConverter::GetNbrStreams(CxbxDrawContext *pDrawContext)
@@ -631,13 +631,13 @@ bool XTL::CxbxVertexBufferConverter::ConvertStream
 		pPatchedStream->pCachedHostVertexStreamZeroData = pHostVertexData;
 #if 0 // new
 		pPatchedStream->bCachedHostVertexStreamZeroDataIsAllocated = bNeedStreamCopy;
+#endif
 	}
 	else {
-		assert(pNewHostVertexBuffer != nullptr);
+		// assert(pNewHostVertexBuffer != nullptr);
 
 		pNewHostVertexBuffer->Unlock();
 		pPatchedStream->pCachedHostVertexBuffer = pNewHostVertexBuffer;
-#endif
 	}
 
 	ActivatePatchedStream(pDrawContext, uiStream, pPatchedStream, 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -301,7 +301,7 @@ bool XTL::CxbxVertexBufferConverter::ConvertStream
 	UINT uiXboxVertexStride;
 	UINT uiXboxVertexDataSize;
 	UINT uiVertexCount;
-	UINT uiHostVertexStride;
+	UINT uiHostVertexStride = (bNeedVertexPatching) ? pStreamDynamicPatch->ConvertedStride : uiXboxVertexStride;
 	DWORD dwHostVertexDataSize;
 	uint08 *pHostVertexData;
 	IDirect3DVertexBuffer8 *pNewHostVertexBuffer = nullptr;
@@ -318,7 +318,6 @@ bool XTL::CxbxVertexBufferConverter::ConvertStream
 		uiXboxVertexDataSize = pDrawContext->uiSize;
 		uiVertexCount = uiXboxVertexDataSize / uiXboxVertexStride;
 
-		uiHostVertexStride = (bNeedVertexPatching) ? pStreamDynamicPatch->ConvertedStride : uiXboxVertexStride;
 		dwHostVertexDataSize = uiVertexCount * uiHostVertexStride;
 		if (bNeedStreamCopy) {
 			pHostVertexData = (uint08*)malloc(dwHostVertexDataSize);
@@ -348,14 +347,11 @@ bool XTL::CxbxVertexBufferConverter::ConvertStream
 
         // Set a new (exact) vertex count
 		uiVertexCount = uiXboxVertexDataSize / uiXboxVertexStride;
-
 		// Dxbx note : Don't overwrite pDrawContext.dwVertexCount with uiVertexCount, because an indexed draw
 		// can (and will) use less vertices than the supplied nr of indexes. Thix fixes
 		// the missing parts in the CompressedVertices sample (in Vertex shader mode).
-		uiHostVertexStride = (bNeedVertexPatching) ? pStreamDynamicPatch->ConvertedStride : uiXboxVertexStride;
-		//pStreamDynamicPatch->ConvertedStride = std::max((uint32_t)pStreamDynamicPatch->ConvertedStride, (uint32_t)uiXboxVertexStride); // ??
-		dwHostVertexDataSize = uiVertexCount * uiHostVertexStride;
 
+		dwHostVertexDataSize = uiVertexCount * uiHostVertexStride;
 		GetCachedVertexBufferObject(pXboxVertexBuffer->Data, dwHostVertexDataSize, &pNewHostVertexBuffer);
 
         if (FAILED(pNewHostVertexBuffer->Lock(0, 0, &pHostVertexData, D3DLOCK_DISCARD))) {

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -219,7 +219,7 @@ size_t GetVertexBufferSize(DWORD dwVertexCount, DWORD dwStride, PWORD pIndexData
 	// The highest index we see can be used to determine the vertex buffer size
 	DWORD highestVertexIndex = 0;
 	for (DWORD i = 0; i < dwVertexCount; i++) {
-		if (pIndexData[i] > highestVertexIndex) {
+		if (highestVertexIndex < pIndexData[i]) {
 			highestVertexIndex = pIndexData[i];
 		}
 	}

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -861,10 +861,10 @@ VOID XTL::EmuFlushIVB()
 		}
 	}
 
-    CxbxDrawContext DrawContext;
-    DrawContext.XboxPrimitiveType = g_InlineVertexBuffer_PrimitiveType;
-    DrawContext.dwVertexCount = g_InlineVertexBuffer_TableOffset;
-    DrawContext.pXboxVertexStreamZeroData = g_InlineVertexBuffer_pData;
+	CxbxDrawContext DrawContext;
+	DrawContext.XboxPrimitiveType = g_InlineVertexBuffer_PrimitiveType;
+	DrawContext.dwVertexCount = g_InlineVertexBuffer_TableOffset;
+	DrawContext.pXboxVertexStreamZeroData = g_InlineVertexBuffer_pData;
 	DrawContext.uiXboxVertexStreamZeroStride = uiStride;
 	DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -321,7 +321,7 @@ bool XTL::CxbxVertexBufferConverter::ConvertStream
 		uiHostVertexStride = (bNeedVertexPatching) ? pStreamDynamicPatch->ConvertedStride : uiXboxVertexStride;
 		dwHostVertexDataSize = uiVertexCount * uiHostVertexStride;
 		if (bNeedStreamCopy) {
-			pHostVertexData = (uint08*)g_VMManager.Allocate(dwHostVertexDataSize);
+			pHostVertexData = (uint08*)malloc(dwHostVertexDataSize);
 			if (pHostVertexData == nullptr) {
 				CxbxKrnlCleanup("Couldn't allocate the new stream zero buffer");
 			}
@@ -629,9 +629,7 @@ bool XTL::CxbxVertexBufferConverter::ConvertStream
 	pPatchedStream->bCacheIsStreamZeroDrawUP = (pDrawContext->pXboxVertexStreamZeroData != NULL);
 	if (pPatchedStream->bCacheIsStreamZeroDrawUP) {
 		pPatchedStream->pCachedHostVertexStreamZeroData = pHostVertexData;
-#if 0 // new
 		pPatchedStream->bCachedHostVertexStreamZeroDataIsAllocated = bNeedStreamCopy;
-#endif
 	}
 	else {
 		// assert(pNewHostVertexBuffer != nullptr);

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -301,6 +301,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 	}
 
     CxbxStreamDynamicPatch *pStreamDynamicPatch = (m_pVertexShaderDynamicPatch != nullptr) ? (&m_pVertexShaderDynamicPatch->pStreamPatches[uiStream]) : nullptr;
+
 	bool bNeedVertexPatching = (pStreamDynamicPatch != nullptr && pStreamDynamicPatch->NeedPatch);
 	bool bNeedRHWReset = bVshHandleIsFVF && ((pDrawContext->hVertexShader & D3DFVF_POSITION_MASK) == D3DFVF_XYZRHW);
 	bool bNeedStreamCopy = bNeedTextureNormalization || bNeedVertexPatching || bNeedRHWReset;
@@ -615,7 +616,7 @@ void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext)
     m_uiNbrStreams = GetNbrStreams(pDrawContext);
 
     if (VshHandleIsVertexShader(pDrawContext->hVertexShader)) {
-        m_pVertexShaderDynamicPatch = &((CxbxVertexShader *)VshHandleGetVertexShader(pDrawContext->hVertexShader)->Handle)->VertexShaderDynamicPatch;
+        m_pVertexShaderDynamicPatch = &(MapXboxVertexShaderHandleToCxbxVertexShader(pDrawContext->hVertexShader)->VertexShaderDynamicPatch);
     }
 
     for(UINT uiStream = 0; uiStream < m_uiNbrStreams; uiStream++) {

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -350,7 +350,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 			HRESULT hRet = g_pD3DDevice->SetStreamSource(uiStream, nullptr, 0);
 //			DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetStreamSource");
 			if (FAILED(hRet)) {
-				CxbxKrnlCleanup("g_pD3DDevice->SetStreamSource(uiStream, nullptr, 0)\n");
+				EmuWarning("g_pD3DDevice->SetStreamSource(uiStream, nullptr, 0)");
 			}
 
 			return;
@@ -407,7 +407,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					((SHORT *)pHostVertexAsFloat)[0] = ((SHORT*)pXboxVertex)[0];
 					((SHORT *)pHostVertexAsFloat)[1] = ((SHORT*)pXboxVertex)[1];
 					((SHORT *)pHostVertexAsFloat)[2] = ((SHORT*)pXboxVertex)[2];
-					((SHORT *)pHostVertexAsFloat)[3] = 0x01;
+					((SHORT *)pHostVertexAsFloat)[3] = 0x01; // Turok verified (character disappears when this is 32767)
 					pXboxVertex += 3 * sizeof(SHORT);
 					break;
 				}

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -739,7 +739,7 @@ VOID XTL::EmuFlushIVB()
 	switch (dwCurFVF & D3DFVF_POSITION_MASK) {
 	case 0: // No position ?
 		if (bFVF) {
-			EmuWarning("EmuFlushIVB(): g_CurrentVertexShader isn't a valid FVF - using D3DFVF_XYZRHW instead!");
+			EmuWarning("EmuFlushIVB(): g_CurrentXboxVertexShaderHandle isn't a valid FVF - using D3DFVF_XYZRHW instead!");
 			dwCurFVF |= D3DFVF_XYZRHW;
 		}
 		else {
@@ -897,7 +897,7 @@ VOID XTL::EmuFlushIVB()
 
 	CxbxDrawPrimitiveUP(DrawContext);
 	if (bFVF) {
-		hRet = g_pD3DDevice->SetVertexShader(g_CurrentVertexShader);
+		hRet = g_pD3DDevice->SetVertexShader(g_CurrentXboxVertexShaderHandle);
 		//DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShader");
 	}
     g_InlineVertexBuffer_TableOffset = 0; // Might not be needed (also cleared in D3DDevice_Begin)

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -819,7 +819,12 @@ VOID XTL::EmuFlushIVB()
 	HRESULT hRet;
 
 	if (bFVF) {
+#ifdef CXBX_USE_D3D9
+		g_pD3DDevice->SetVertexShader(nullptr);
+		hRet = g_pD3DDevice->SetFVF(dwCurFVF);
+#else
 		hRet = g_pD3DDevice->SetVertexShader(dwCurFVF);
+#endif
 		//DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShader");
 	}
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -88,7 +88,6 @@ class CxbxVertexBufferConverter
 
         // Returns the number of streams of a patch
         UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);
-        void CacheStream(VertexPatchDesc *pPatchDesc,
 
         // Patches the types of the stream
         bool PatchStream(CxbxDrawContext *pPatchDesc, UINT uiStream);

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -91,7 +91,7 @@ class CxbxVertexBufferConverter
         UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);
 
         // Patches the types of the stream
-        bool ConvertStream(CxbxDrawContext *pPatchDesc, UINT uiStream);
+        void ConvertStream(CxbxDrawContext *pPatchDesc, UINT uiStream);
 };
 
 // inline vertex buffer emulation

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -53,6 +53,8 @@ typedef struct _VertexPatchDesc
     IN PVOID                     pXboxVertexStreamZeroData;
     IN UINT                      uiXboxVertexStreamZeroStride;
 	// Values to be used on host
+	OUT PVOID                    pHostVertexStreamZeroData;
+	OUT UINT                     uiHostVertexStreamZeroStride;
     OUT DWORD                    dwHostPrimitiveCount;
 }
 VertexPatchDesc;

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -59,13 +59,14 @@ typedef struct _CxbxDrawContext
 }
 CxbxDrawContext;
 
-typedef struct _PATCHEDSTREAM
+typedef struct _CxbxPatchedStream
 {
-    XTL::X_D3DVertexBuffer *pOriginalStream;
-    XTL::IDirect3DVertexBuffer *pPatchedStream;
-    UINT                    uiOrigStride;
-    UINT                    uiNewStride;
-} PATCHEDSTREAM;
+    UINT                    uiCachedXboxVertexStride;
+    UINT                    uiCachedHostVertexStride;
+    bool                    bCacheIsStreamZeroDrawUP;
+    void                   *pCachedHostVertexStreamZeroData;
+    XTL::IDirect3DVertexBuffer *pCachedHostVertexBuffer;
+} CxbxPatchedStream;
 
 class CxbxVertexBufferConverter
 {
@@ -73,15 +74,14 @@ class CxbxVertexBufferConverter
         CxbxVertexBufferConverter();
        ~CxbxVertexBufferConverter();
 
-        bool Apply(CxbxDrawContext *pPatchDesc, bool *pbFatalError);
+        void Apply(CxbxDrawContext *pPatchDesc);
     private:
 
         UINT m_uiNbrStreams;
-        PATCHEDSTREAM m_pStreams[MAX_NBR_STREAMS];
+        CxbxPatchedStream m_PatchedStreams[MAX_NBR_STREAMS];
 
         PVOID m_pNewVertexStreamZeroData;
 
-        bool m_bPatched;
         bool m_bAllocatedStreamZeroData;
 
         CxbxVertexShaderDynamicPatch *m_pVertexShaderDynamicPatch;
@@ -90,10 +90,7 @@ class CxbxVertexBufferConverter
         UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);
 
         // Patches the types of the stream
-        bool PatchStream(CxbxDrawContext *pPatchDesc, UINT uiStream);
-
-        // Normalize texture coordinates in FVF stream if needed
-        bool NormalizeTexCoords(CxbxDrawContext *pPatchDesc, UINT uiStream);
+        bool ConvertStream(CxbxDrawContext *pPatchDesc, UINT uiStream);
 };
 
 // inline vertex buffer emulation

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -46,8 +46,8 @@ typedef struct _CxbxDrawContext
     IN     DWORD                 dwStartVertex; // Only D3DDevice_DrawVertices sets this (potentially higher than default 0)
     // The current vertex shader, used to identify the streams
     IN     DWORD                 hVertexShader;
-	IN	   PWORD				 pIndexData = nullptr;
-	IN	   DWORD				 dwIndexBase = 0;
+	IN	   PWORD				 pIndexData;
+	IN	   DWORD				 dwIndexBase;
 	IN	   size_t				 uiSize;
     // Data if Draw...UP call
     IN PVOID                     pXboxVertexStreamZeroData;

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -84,7 +84,7 @@ class CxbxVertexBufferConverter
         bool m_bPatched;
         bool m_bAllocatedStreamZeroData;
 
-        VERTEX_DYNAMIC_PATCH *m_pDynamicPatch;
+        CxbxVertexShaderDynamicPatch *m_pVertexShaderDynamicPatch;
 
         // Returns the number of streams of a patch
         UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -94,9 +94,6 @@ class VertexPatcher
 
         // Normalize texture coordinates in FVF stream if needed
         bool NormalizeTexCoords(VertexPatchDesc *pPatchDesc, UINT uiStream);
-
-        // Patches the primitive of the stream
-        bool PatchPrimitive(VertexPatchDesc *pPatchDesc, UINT uiStream);
 };
 
 // inline vertex buffer emulation

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -65,6 +65,7 @@ typedef struct _CxbxPatchedStream
     UINT                    uiCachedHostVertexStride;
     bool                    bCacheIsStreamZeroDrawUP;
     void                   *pCachedHostVertexStreamZeroData;
+    bool                    bCachedHostVertexStreamZeroDataIsAllocated;
     XTL::IDirect3DVertexBuffer *pCachedHostVertexBuffer;
 } CxbxPatchedStream;
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -48,7 +48,7 @@ typedef struct _CxbxDrawContext
     IN     DWORD                 hVertexShader;
 	IN	   PWORD				 pIndexData;
 	IN	   DWORD				 dwIndexBase;
-	IN	   size_t				 uiSize;
+	IN	   size_t				 VerticesInBuffer;
     // Data if Draw...UP call
     IN PVOID                     pXboxVertexStreamZeroData;
     IN UINT                      uiXboxVertexStreamZeroStride;

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -85,7 +85,7 @@ class CxbxVertexBufferConverter
 
         bool m_bAllocatedStreamZeroData;
 
-        CxbxVertexShaderDynamicPatch *m_pVertexShaderDynamicPatch;
+        XTL::CxbxVertexShaderInfo *m_pVertexShaderInfo;
 
         // Returns the number of streams of a patch
         UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -39,7 +39,7 @@
 
 #define MAX_NBR_STREAMS 16
 
-typedef struct _VertexPatchDesc
+typedef struct _CxbxDrawContext
 {
     IN     X_D3DPRIMITIVETYPE    XboxPrimitiveType;
     IN     DWORD                 dwVertexCount;
@@ -57,7 +57,7 @@ typedef struct _VertexPatchDesc
 	OUT UINT                     uiHostVertexStreamZeroStride;
     OUT DWORD                    dwHostPrimitiveCount;
 }
-VertexPatchDesc;
+CxbxDrawContext;
 
 typedef struct _PATCHEDSTREAM
 {
@@ -67,13 +67,13 @@ typedef struct _PATCHEDSTREAM
     UINT                    uiNewStride;
 } PATCHEDSTREAM;
 
-class VertexPatcher
+class CxbxVertexBufferConverter
 {
     public:
-        VertexPatcher();
-       ~VertexPatcher();
+        CxbxVertexBufferConverter();
+       ~CxbxVertexBufferConverter();
 
-        bool Apply(VertexPatchDesc *pPatchDesc, bool *pbFatalError);
+        bool Apply(CxbxDrawContext *pPatchDesc, bool *pbFatalError);
     private:
 
         UINT m_uiNbrStreams;
@@ -87,13 +87,14 @@ class VertexPatcher
         VERTEX_DYNAMIC_PATCH *m_pDynamicPatch;
 
         // Returns the number of streams of a patch
-        UINT GetNbrStreams(VertexPatchDesc *pPatchDesc);
+        UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);
+        void CacheStream(VertexPatchDesc *pPatchDesc,
 
         // Patches the types of the stream
-        bool PatchStream(VertexPatchDesc *pPatchDesc, UINT uiStream);
+        bool PatchStream(CxbxDrawContext *pPatchDesc, UINT uiStream);
 
         // Normalize texture coordinates in FVF stream if needed
-        bool NormalizeTexCoords(VertexPatchDesc *pPatchDesc, UINT uiStream);
+        bool NormalizeTexCoords(CxbxDrawContext *pPatchDesc, UINT uiStream);
 };
 
 // inline vertex buffer emulation

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2380,7 +2380,7 @@ extern void XTL::FreeVertexDynamicPatch(CxbxVertexShader *pVertexShader)
 extern boolean XTL::IsValidCurrentShader(void)
 {
 	// Dxbx addition : There's no need to call
-	// XTL_EmuIDirect3DDevice_GetVertexShader, just check g_CurrentVertexShader :
+	// XTL_EmuIDirect3DDevice_GetVertexShader, just check g_CurrentXboxVertexShaderHandle :
 	return VshHandleIsValidShader(g_CurrentXboxVertexShaderHandle);
 }
 

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1604,30 +1604,30 @@ static boolean VshConvertShader(VSH_XBOX_SHADER *pShader,
 // * Vertex shader declaration recompiler
 // ****************************************************************************
 
-typedef struct _VSH_TYPE_PATCH_DATA
+typedef struct _CxbxVertexShaderTypePatchData
 {
     DWORD NbrTypes;
     UINT  Types[256];
 	UINT  NewSizes[256];
 }
-VSH_TYPE_PATCH_DATA;
+CxbxVertexShaderTypePatchData;
 
-typedef struct _VSH_STREAM_PATCH_DATA
+typedef struct _CxbxVertexStreamPatchData
 {
     DWORD                     NbrStreams;
     XTL::CxbxStreamDynamicPatch pStreamPatches[256];
 }
-VSH_STREAM_PATCH_DATA;
+CxbxVertexStreamPatchData;
 
-typedef struct _VSH_PATCH_DATA
+typedef struct _CxbxVertexShaderPatchData
 {
     boolean              NeedPatching;
 	WORD                 CurrentStreamNumber;
 	DWORD                ConvertedStride;
-    VSH_TYPE_PATCH_DATA  TypePatchData;
-    VSH_STREAM_PATCH_DATA StreamPatchData;
+    CxbxVertexShaderTypePatchData  TypePatchData;
+    CxbxVertexStreamPatchData StreamPatchData;
 }
-VSH_PATCH_DATA;
+CxbxVertexShaderPatchData;
 
 // VERTEX SHADER
 #define DEF_VSH_END 0xFFFFFFFF
@@ -1861,7 +1861,7 @@ static void VshConverToken_TESSELATOR(DWORD   *pToken,
     }
 }
 
-static boolean VshAddStreamPatch(VSH_PATCH_DATA *pPatchData)
+static boolean VshAddStreamPatch(CxbxVertexShaderPatchData *pPatchData)
 {
     int CurrentStream = pPatchData->CurrentStreamNumber;
 
@@ -1875,8 +1875,8 @@ static boolean VshAddStreamPatch(VSH_PATCH_DATA *pPatchData)
         pStreamPatch->NbrTypes = pPatchData->TypePatchData.NbrTypes;
         pStreamPatch->NeedPatch = pPatchData->NeedPatching;
 		// 2010/01/12 - revel8n - fixed allocated data size and type
-        pStreamPatch->pTypes = (UINT *)malloc(pPatchData->TypePatchData.NbrTypes * sizeof(UINT)); //VSH_TYPE_PATCH_DATA));
-        memcpy(pStreamPatch->pTypes, pPatchData->TypePatchData.Types, pPatchData->TypePatchData.NbrTypes * sizeof(UINT)); //VSH_TYPE_PATCH_DATA));
+        pStreamPatch->pTypes = (UINT *)malloc(pPatchData->TypePatchData.NbrTypes * sizeof(UINT)); //CxbxVertexShaderTypePatchData));
+        memcpy(pStreamPatch->pTypes, pPatchData->TypePatchData.Types, pPatchData->TypePatchData.NbrTypes * sizeof(UINT)); //CxbxVertexShaderTypePatchData));
         // 2010/12/06 - PatrickvL - do the same for new sizes :
 		pStreamPatch->pSizes = (UINT *)malloc(pPatchData->TypePatchData.NbrTypes * sizeof(UINT));
 		memcpy(pStreamPatch->pSizes, pPatchData->TypePatchData.NewSizes, pPatchData->TypePatchData.NbrTypes * sizeof(UINT));
@@ -1887,7 +1887,7 @@ static boolean VshAddStreamPatch(VSH_PATCH_DATA *pPatchData)
 }
 
 static void VshConvertToken_STREAM(DWORD          *pToken,
-                                   VSH_PATCH_DATA *pPatchData)
+                                   CxbxVertexShaderPatchData *pPatchData)
 {
     // D3DVSD_STREAM_TESS
     if(*pToken & D3DVSD_STREAMTESSMASK)
@@ -1942,7 +1942,7 @@ static void VshConvertToken_STREAMDATA_SKIPBYTES(DWORD *pToken)
 
 static void VshConvertToken_STREAMDATA_REG(DWORD          *pToken,
                                            boolean         IsFixedFunction,
-                                           VSH_PATCH_DATA *pPatchData)
+                                           CxbxVertexShaderPatchData *pPatchData)
 {
     using namespace XTL;
 
@@ -2103,7 +2103,7 @@ static void VshConvertToken_STREAMDATA_REG(DWORD          *pToken,
 
 static void VshConvertToken_STREAMDATA(DWORD          *pToken,
                                        boolean         IsFixedFunction,
-                                       VSH_PATCH_DATA *pPatchData)
+                                       CxbxVertexShaderPatchData *pPatchData)
 {
     using namespace XTL;
 	if (*pToken & D3DVSD_MASK_SKIP)
@@ -2123,7 +2123,7 @@ static void VshConvertToken_STREAMDATA(DWORD          *pToken,
 
 static DWORD VshRecompileToken(DWORD          *pToken,
                                boolean         IsFixedFunction,
-                               VSH_PATCH_DATA *pPatchData)
+                               CxbxVertexShaderPatchData *pPatchData)
 {
     using namespace XTL;
 
@@ -2188,7 +2188,7 @@ DWORD XTL::EmuRecompileVshDeclaration
     *pDeclarationSize = DeclarationSize;
 
     // TODO: Put these in one struct
-    VSH_PATCH_DATA       PatchData = { 0 };
+    CxbxVertexShaderPatchData       PatchData = { 0 };
 
     DbgVshPrintf("DWORD dwVSHDecl[] =\n{\n");
 

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2054,7 +2054,7 @@ static void VshConvertToken_STREAMDATA_REG(DWORD          *pToken,
 	pCurrentElement->XboxType = XboxVertexElementDataType;
 	pCurrentElement->HostByteSize = HostVertexElementByteSize;
 	pPatchData->pCurrentVertexShaderStreamInfo->NumberOfVertexElements++;
-	pPatchData->pCurrentVertexShaderStreamInfo->NeedPatch = NeedPatching;
+	pPatchData->pCurrentVertexShaderStreamInfo->NeedPatch |= NeedPatching;
 
     *pToken = D3DVSD_REG(HostVertexRegister, HostVertexElementDataType);
 

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.h
@@ -56,7 +56,7 @@ extern DWORD EmuRecompileVshDeclaration
     DWORD               **ppRecompiledDeclaration,
     DWORD                *pDeclarationSize,
     boolean               IsFixedFunction,
-    CxbxVertexShaderDynamicPatch *pVertexDynamicPatch
+    XTL::CxbxVertexShaderInfo *pVertexShaderInfo
 );
 
 // recompile xbox vertex shader function

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.h
@@ -56,7 +56,7 @@ extern DWORD EmuRecompileVshDeclaration
     DWORD               **ppRecompiledDeclaration,
     DWORD                *pDeclarationSize,
     boolean               IsFixedFunction,
-    VERTEX_DYNAMIC_PATCH *pVertexDynamicPatch
+    CxbxVertexShaderDynamicPatch *pVertexDynamicPatch
 );
 
 // recompile xbox vertex shader function
@@ -70,7 +70,7 @@ extern HRESULT EmuRecompileVshFunction
 	DWORD		 *pRecompiledDeclaration
 );
 
-extern void FreeVertexDynamicPatch(VERTEX_SHADER *pVertexShader);
+extern void FreeVertexDynamicPatch(CxbxVertexShader *pVertexShader);
 
 // Checks for failed vertex shaders, and shaders that would need patching
 extern boolean IsValidCurrentShader(void);
@@ -84,7 +84,7 @@ extern boolean VshHandleIsValidShader(DWORD Handle);
 inline boolean VshHandleIsFVF(DWORD Handle) { return (Handle > NULL) && (Handle <= XBE_MAX_VA); }
 inline boolean VshHandleIsVertexShader(DWORD Handle) { return (Handle > XBE_MAX_VA) ? TRUE : FALSE; }
 inline X_D3DVertexShader *VshHandleGetVertexShader(DWORD Handle) { return VshHandleIsVertexShader(Handle) ? (X_D3DVertexShader *)Handle : nullptr; }
-VERTEX_DYNAMIC_PATCH *VshGetVertexDynamicPatch(DWORD Handle);
+CxbxVertexShaderDynamicPatch *VshGetVertexDynamicPatch(DWORD Handle);
 
 #ifdef _DEBUG_TRACK_VS
 #define DbgVshPrintf if(g_bPrintfOn) printf

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.h
@@ -74,7 +74,6 @@ extern void FreeVertexDynamicPatch(CxbxVertexShader *pVertexShader);
 
 // Checks for failed vertex shaders, and shaders that would need patching
 extern boolean IsValidCurrentShader(void);
-extern boolean VshHandleIsValidShader(DWORD Handle);
 
 // NOTE: Comparing with 0xFFFF breaks some titles (like Kingdom Under Fire)
 // The real Xbox checks the D3DFVF_RESERVED0 flag but we can't do that without 
@@ -86,13 +85,14 @@ inline boolean VshHandleIsVertexShader(DWORD Handle) { return (Handle > XBE_MAX_
 
 inline CxbxVertexShader *MapXboxVertexShaderHandleToCxbxVertexShader(DWORD Handle)
 {
-	X_D3DVertexShader *pD3DVertexShader = VshHandleIsVertexShader(Handle) ? (X_D3DVertexShader *)Handle : nullptr;
-	if (pD3DVertexShader != nullptr)
+	if (VshHandleIsVertexShader(Handle)) {
+		X_D3DVertexShader *pD3DVertexShader = (X_D3DVertexShader *)Handle;
+		//assert(pD3DVertexShader != nullptr);
 		return (CxbxVertexShader *)(pD3DVertexShader->Handle);
+	}
 
 	return nullptr;
 }
-CxbxVertexShaderDynamicPatch *VshGetVertexDynamicPatch(DWORD Handle);
 
 #ifdef _DEBUG_TRACK_VS
 #define DbgVshPrintf if(g_bPrintfOn) printf

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.h
@@ -83,7 +83,15 @@ extern boolean VshHandleIsValidShader(DWORD Handle);
 // exist above the XBE reserved region, not great, but it'l do for now.
 inline boolean VshHandleIsFVF(DWORD Handle) { return (Handle > NULL) && (Handle <= XBE_MAX_VA); }
 inline boolean VshHandleIsVertexShader(DWORD Handle) { return (Handle > XBE_MAX_VA) ? TRUE : FALSE; }
-inline X_D3DVertexShader *VshHandleGetVertexShader(DWORD Handle) { return VshHandleIsVertexShader(Handle) ? (X_D3DVertexShader *)Handle : nullptr; }
+
+inline CxbxVertexShader *MapXboxVertexShaderHandleToCxbxVertexShader(DWORD Handle)
+{
+	X_D3DVertexShader *pD3DVertexShader = VshHandleIsVertexShader(Handle) ? (X_D3DVertexShader *)Handle : nullptr;
+	if (pD3DVertexShader != nullptr)
+		return (CxbxVertexShader *)(pD3DVertexShader->Handle);
+
+	return nullptr;
+}
 CxbxVertexShaderDynamicPatch *VshGetVertexDynamicPatch(DWORD Handle);
 
 #ifdef _DEBUG_TRACK_VS

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -69,6 +69,7 @@
 #define Direct3DCreate			 Direct3DCreate9
 #define D3DXAssembleShader		 D3DXCompileShader
 #define FullScreen_PresentationInterval PresentationInterval // a field in D3DPRESENT_PARAMETERS
+#define D3DLockData              void
 
 #define D3DADAPTER_IDENTIFIER    D3DADAPTER_IDENTIFIER9
 #define D3DCAPS                  D3DCAPS9
@@ -110,6 +111,7 @@ typedef D3DVIEWPORT9 X_D3DVIEWPORT8;
 #define Direct3DCreate			 Direct3DCreate8
 #define DXGetErrorString         DXGetErrorString8A
 #define DXGetErrorDescription    DXGetErrorDescription8A
+#define D3DLockData              BYTE
 
 #define D3DADAPTER_IDENTIFIER    D3DADAPTER_IDENTIFIER8
 #define D3DCAPS                  D3DCAPS8

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -1178,6 +1178,8 @@ const int X_D3DVSDT_NONE        = 0x02; // xbox ext. nsp
 
 const int MAX_NBR_STREAMS = 16;
 
+typedef WORD INDEX16;
+
 #define X_D3DVSD_TOKENTYPESHIFT   29
 #define X_D3DVSD_TOKENTYPEMASK    (7 << X_D3DVSD_TOKENTYPESHIFT)
 

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -509,12 +509,12 @@ typedef struct _CxbxPixelShader
 }
 CxbxPixelShader;
 
-typedef struct _CxbxVertexElement
+typedef struct _CxbxVertexShaderStreamElement
 {
 	UINT XboxType; // The stream data types (xbox)
 	UINT HostByteSize; // The stream data sizes (pc)
 }
-CxbxVertexElement;
+CxbxVertexShaderStreamElement;
 
 /* See typedef struct _D3DVERTEXELEMENT9
 {
@@ -527,21 +527,21 @@ CxbxVertexElement;
 } D3DVERTEXELEMENT9, *LPD3DVERTEXELEMENT9;
 */
 
-typedef struct _CxbxStreamDynamicPatch
+typedef struct _CxbxVertexShaderStreamInfo
 {
     BOOL  NeedPatch;       // This is to know whether it's data which must be patched
     DWORD HostVertexStride;
     DWORD NumberOfVertexElements;        // Number of the stream data types
-	CxbxVertexElement VertexElements[32];
+	CxbxVertexShaderStreamElement VertexElements[32];
 }
-CxbxStreamDynamicPatch;
+CxbxVertexShaderStreamInfo;
 
-typedef struct _CxbxVertexDynamicPatch
+typedef struct _CxbxVertexShaderInfo
 {
-    UINT                         NumberOfVertexStreams; // The number of streams the vertex shader uses
-    CxbxStreamDynamicPatch       StreamPatches[16];
+    UINT                       NumberOfVertexStreams; // The number of streams the vertex shader uses
+    CxbxVertexShaderStreamInfo VertexStreams[16];
 }
-CxbxVertexShaderDynamicPatch;
+CxbxVertexShaderInfo;
 
 typedef struct _CxbxVertexShader
 {
@@ -558,7 +558,7 @@ typedef struct _CxbxVertexShader
     DWORD                 Status;
 
     // Needed for dynamic stream patching
-    CxbxVertexShaderDynamicPatch  VertexShaderDynamicPatch;
+    CxbxVertexShaderInfo  VertexShaderInfo;
 }
 CxbxVertexShader;
 

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -714,6 +714,11 @@ struct X_D3DCubeTexture : public X_D3DBaseTexture
 
 };
 
+struct X_D3DVolume : public X_D3DPixelContainer
+{
+	X_D3DBaseTexture *Parent;
+};
+
 struct X_D3DSurface : public X_D3DPixelContainer
 {
 	X_D3DBaseTexture *Parent;

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -484,7 +484,7 @@ typedef struct _X_PixelShader
 } X_PixelShader;
 
 // These structures are used by Cxbx, not by the Xbox!!!
-typedef struct _PixelShader_ 
+typedef struct _CxbxPixelShader 
 {
 	//IDirect3DPixelShader9* pShader;
 	//ID3DXConstantTable *pConstantTable;
@@ -507,9 +507,9 @@ typedef struct _PixelShader_
 	DWORD dwStageMap[TEXTURE_STAGES];
 
 }
-PIXEL_SHADER;
+CxbxPixelShader;
 
-typedef struct _STREAM_DYNAMIC_PATCH_
+typedef struct _CxbxStreamDynamicPatch
 {
     BOOL  NeedPatch;       // This is to know whether it's data which must be patched
     DWORD ConvertedStride;
@@ -517,16 +517,16 @@ typedef struct _STREAM_DYNAMIC_PATCH_
     UINT  *pTypes;         // The stream data types (xbox)
 	UINT  *pSizes;         // The stream data sizes (pc)
 }
-STREAM_DYNAMIC_PATCH;
+CxbxStreamDynamicPatch;
 
-typedef struct _VERTEX_DYNAMIC_PATCH_
+typedef struct _CxbxVertexDynamicPatch
 {
     UINT                         NbrStreams; // The number of streams the vertex shader uses
-    STREAM_DYNAMIC_PATCH        *pStreamPatches;
+    CxbxStreamDynamicPatch        *pStreamPatches;
 }
-VERTEX_DYNAMIC_PATCH;
+CxbxVertexShaderDynamicPatch;
 
-typedef struct _VERTEX_SHADER
+typedef struct _CxbxVertexShader
 {
     DWORD Handle;
 
@@ -541,9 +541,9 @@ typedef struct _VERTEX_SHADER
     DWORD                 Status;
 
     // Needed for dynamic stream patching
-    VERTEX_DYNAMIC_PATCH  VertexDynamicPatch;
+    CxbxVertexShaderDynamicPatch  VertexShaderDynamicPatch;
 }
-VERTEX_SHADER;
+CxbxVertexShader;
 
 struct X_D3DResource
 {

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -509,20 +509,37 @@ typedef struct _CxbxPixelShader
 }
 CxbxPixelShader;
 
+typedef struct _CxbxVertexElement
+{
+	UINT XboxType; // The stream data types (xbox)
+	UINT HostByteSize; // The stream data sizes (pc)
+}
+CxbxVertexElement;
+
+/* See typedef struct _D3DVERTEXELEMENT9
+{
+	WORD    Stream;     // Stream index
+	WORD    Offset;     // Offset in the stream in bytes
+	BYTE    Type;       // Data type
+	BYTE    Method;     // Processing method
+	BYTE    Usage;      // Semantics
+	BYTE    UsageIndex; // Semantic index
+} D3DVERTEXELEMENT9, *LPD3DVERTEXELEMENT9;
+*/
+
 typedef struct _CxbxStreamDynamicPatch
 {
     BOOL  NeedPatch;       // This is to know whether it's data which must be patched
-    DWORD ConvertedStride;
-    DWORD NbrTypes;        // Number of the stream data types
-    UINT  *pTypes;         // The stream data types (xbox)
-	UINT  *pSizes;         // The stream data sizes (pc)
+    DWORD HostVertexStride;
+    DWORD NumberOfVertexElements;        // Number of the stream data types
+	CxbxVertexElement VertexElements[32];
 }
 CxbxStreamDynamicPatch;
 
 typedef struct _CxbxVertexDynamicPatch
 {
-    UINT                         NbrStreams; // The number of streams the vertex shader uses
-    CxbxStreamDynamicPatch        *pStreamPatches;
+    UINT                         NumberOfVertexStreams; // The number of streams the vertex shader uses
+    CxbxStreamDynamicPatch       StreamPatches[16];
 }
 CxbxVertexShaderDynamicPatch;
 


### PR DESCRIPTION
Finally this can be tested!

This branch introduces correct render-emulation for all Xbox-exclusive primitive types.
Fixes #1133

Besides that, lots of refactoring behind the scenes, to make code more readable and maintenance on vertex-buffer conversion easier.

Also, this brings more Direct3D 9 porting (but that's still unfinished - vertex declarations are the most difficult part to port.)