### PR TITLE
Hotfix for LLE support

### DIFF
--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -81,18 +81,6 @@ void* GetXboxFunctionPointer(std::string functionName)
     if (symbol != g_SymbolAddresses.end()) {
         return (void*)symbol->second;
     }
-    
-    // No function was matched, however, it is currently possible for a symbol to exist 
-    // and be suffixed with _UNPATCHED. (Due to the HLE Database UNPATCHED flag)
-    // In this case, the above will fail despite us actually knowing the location of the symbol
-    // So do the check (again) with the _UNPATCHED suffix
-    // NOTE: A proper solution would be to completely separate the OOVPA table and Patch
-    // flags: Perhaps renaming HLEDatabase to SymbolDatabase, then having a separate PatchTable
-    // file, mapping symbol names to patch functions.
-    symbol = g_SymbolAddresses.find(functionName + "_UNPATCHED");
-    if (symbol != g_SymbolAddresses.end()) {
-        return (void*)symbol->second;
-    }
 
     // Finally, if none of the above were matched, return nullptr
     return nullptr;

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -423,15 +423,15 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
             }
 
             // Fix up Render state and Texture States
-            if (g_SymbolAddresses.find("D3DDeferredRenderState") == g_SymbolAddresses.end()) {
+            if (g_SymbolAddresses["D3DDeferredRenderState"] == 0) {
                 EmuWarning("EmuD3DDeferredRenderState was not found!");
             }
             
-            if (g_SymbolAddresses.find("D3DDeferredTextureState") == g_SymbolAddresses.end()) {
+            if (g_SymbolAddresses["D3DDeferredTextureState"] == 0) {
                 EmuWarning("EmuD3DDeferredTextureState was not found!");
             }
 
-            if (g_SymbolAddresses.find("D3DDEVICE") == g_SymbolAddresses.end()) {
+            if (g_SymbolAddresses["D3DDEVICE"] == 0) {
                 EmuWarning("D3DDEVICE was not found!");
             }
 


### PR DESCRIPTION
In kernel log, first round will have actual memory address even if LLE is enabled. However, 2nd start up will show as zeroes if one of LLE is enabled. It is normal for time being.

Plus enforce show warning of D3D message after symbol scan.