### PR TITLE
Fixup stuff

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/State.cpp
+++ b/src/CxbxKrnl/EmuD3D8/State.cpp
@@ -39,8 +39,8 @@
 #include "CxbxKrnl/EmuXTL.h"
 
 // deferred state lookup tables
-DWORD *XTL::EmuD3DDeferredRenderState;
-DWORD *XTL::EmuD3DDeferredTextureState;
+DWORD *XTL::EmuD3DDeferredRenderState = nullptr;
+DWORD *XTL::EmuD3DDeferredTextureState = nullptr;
 
 extern uint32 g_BuildVersion;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -283,16 +283,16 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
         // clear sound buffer cache
         vector_ds_buffer::iterator ppDSBuffer = g_pDSoundBufferCache.begin();
         for (; ppDSBuffer != g_pDSoundBufferCache.end();) {
-            while (XTL::EMUPATCH(IDirectSoundBuffer_Release)((*ppDSBuffer))) {};
-            ppDSBuffer = g_pDSoundBufferCache.erase(ppDSBuffer);
+            while (XTL::EMUPATCH(IDirectSoundBuffer_Release)((*ppDSBuffer)) != 0) {};
+            ppDSBuffer = g_pDSoundBufferCache.begin();
         }
         g_pDSoundBufferCache.reserve(X_DIRECTSOUND_CACHE_MAX);
 
         // clear sound stream cache
         vector_ds_stream::iterator ppDSStream = g_pDSoundStreamCache.begin();
         for (; ppDSStream != g_pDSoundStreamCache.end();) {
-            while (XTL::EMUPATCH(CDirectSoundStream_Release)((*ppDSStream)));
-            ppDSStream = g_pDSoundStreamCache.erase(ppDSStream);
+            while (XTL::EMUPATCH(CDirectSoundStream_Release)((*ppDSStream)) != 0);
+            ppDSStream = g_pDSoundStreamCache.begin();
         }
         g_pDSoundStreamCache.reserve(X_DIRECTSOUND_CACHE_MAX);
 

--- a/src/CxbxKrnl/HLEIntercept.cpp
+++ b/src/CxbxKrnl/HLEIntercept.cpp
@@ -304,8 +304,12 @@ void CDECL EmuRegisterSymbol(const char* library_str,
 // TODO: Move this into a function rather than duplicating from HLE scanning code
 void EmuD3D_Init_DeferredStates()
 {
-    XTL::EmuD3DDeferredRenderState = (DWORD*)g_SymbolAddresses["D3DDeferredRenderState"];
-    XTL::EmuD3DDeferredTextureState = (DWORD*)g_SymbolAddresses["D3DDeferredTextureState"];
+    if (g_SymbolAddresses.find("D3DDeferredRenderState") != g_SymbolAddresses.end()) {
+        XTL::EmuD3DDeferredRenderState = (DWORD*)g_SymbolAddresses["D3DDeferredRenderState"];
+    }
+    if (g_SymbolAddresses.find("D3DDeferredTextureState") != g_SymbolAddresses.end()) {
+        XTL::EmuD3DDeferredTextureState = (DWORD*)g_SymbolAddresses["D3DDeferredTextureState"];
+    }
 
     if (XTL::EmuD3DDeferredRenderState != nullptr) {
         for (int v = 0; v < 44; v++) {
@@ -423,15 +427,18 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
             }
 
             // Fix up Render state and Texture States
-            if (g_SymbolAddresses["D3DDeferredRenderState"] == 0) {
+            if (g_SymbolAddresses.find("D3DDeferredRenderState") == g_SymbolAddresses.end()
+                || g_SymbolAddresses["D3DDeferredRenderState"] == 0) {
                 EmuWarning("EmuD3DDeferredRenderState was not found!");
             }
             
-            if (g_SymbolAddresses["D3DDeferredTextureState"] == 0) {
+            if (g_SymbolAddresses.find("D3DDeferredTextureState") == g_SymbolAddresses.end()
+                || g_SymbolAddresses["D3DDeferredTextureState"] == 0) {
                 EmuWarning("EmuD3DDeferredTextureState was not found!");
             }
 
-            if (g_SymbolAddresses["D3DDEVICE"] == 0) {
+            if (g_SymbolAddresses.find("D3DDEVICE") == g_SymbolAddresses.end()
+                || g_SymbolAddresses["D3DDEVICE"] == 0) {
                 EmuWarning("D3DDEVICE was not found!");
             }
 


### PR DESCRIPTION
Fixup for following things:
* Initialize nullptr for both D3D state variables, check if symbol is not exist in vector then check the value is 0.
* Pre-fixup for DSound's re-initialize DirectSoundCreate function. (Currently not active at the moment.)