### PR TITLE
Fix Render Targets/Render to texture functionality

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4617,7 +4617,7 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 				/* pSrcSurface = */ pXboxBackBufferHostSurface,
 				/* pSrcPalette = */ nullptr,
 				/* pSrcRect = */ nullptr,
-				/* Filter = */ D3DX_DEFAULT,
+				/* Filter = */ D3DX_FILTER_POINT,//D3DX_DEFAULT,
 				/* ColorKey = */ 0);
 			if (BackBufferDesc.MultiSampleType != D3DMULTISAMPLE_NONE) {
 				if (hRet != D3D_OK) {
@@ -5130,7 +5130,7 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 			}
 			else {
 #ifdef CXBX_USE_D3D9
-				D3DPool = D3DPOOL_SYSTEMMEM;
+				D3DPool = XTL::D3DPOOL_SYSTEMMEM;
 				hRet = g_pD3DDevice->CreateOffscreenPlainSurface(dwWidth, dwHeight, PCFormat, D3DPool, &pNewHostSurface, nullptr);
 				DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateOffscreenPlainSurface");
 #else

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4623,9 +4623,7 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 		// Get backbuffer dimenions; TODO : remember this once, at creation/resize time
 		D3DSURFACE_DESC BackBufferDesc;
 		pCurrentHostBackBuffer->GetDesc(&BackBufferDesc);
-		RECT EmuDestRect;
-		SetRect(&EmuDestRect, 0, 0, BackBufferDesc.Width, BackBufferDesc.Height);
-
+		
 		const DWORD LoadSurfaceFilter = D3DX_DEFAULT; // == D3DX_FILTER_TRIANGLE | D3DX_FILTER_DITHER
 		// Previously we used D3DX_FILTER_POINT here, but that gave jagged edges in Dashboard.
 		// Dxbx note : D3DX_FILTER_LINEAR gives a smoother image, but 'bleeds' across borders
@@ -4639,7 +4637,7 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 				/* pDestRect = */ nullptr,
 				/* pSrcSurface = */ pXboxBackBufferHostSurface,
 				/* pSrcPalette = */ nullptr,
-				/* pSrcRect = */ &EmuDestRect,
+				/* pSrcRect = */ nullptr,
 				/* Filter = */ LoadSurfaceFilter,
 				/* ColorKey = */ 0);
 
@@ -4668,6 +4666,7 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 				&OverlayWidth, &OverlayHeight, &OverlayDepth, &OverlayRowPitch, &OverlaySlicePitch);
 
 			RECT EmuSourRect;
+			RECT EmuDestRect;
 
 			if (g_OverlayProxy.SrcRect.right > 0) {
 				EmuSourRect = g_OverlayProxy.SrcRect;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4628,6 +4628,9 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 			if (g_OverlayProxy.DstRect.right > 0) {
 				// If there's a destination rectangle given, copy that into our local variable :
 				EmuDestRect = g_OverlayProxy.DstRect;
+			} else {
+				// Should this be our backbuffer size rather than the actual window size?
+				GetClientRect(g_hEmuWindow, &EmuDestRect);
 			}
 
 			// load the YUY2 into the backbuffer

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4619,11 +4619,19 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 				/* pSrcRect = */ nullptr,
 				/* Filter = */ D3DX_DEFAULT,
 				/* ColorKey = */ 0);
-			if (hRet == D3D_OK) {
-				LOG_TEST_CASE("Curiously, D3DXLoadSurfaceFromSurface never succeeds, but we still get output!?!");
+			if (BackBufferDesc.MultiSampleType != D3DMULTISAMPLE_NONE) {
+				if (hRet != D3D_OK) {
+					// D3DXLoadSurfaceFromSurface fails for MultiSample backbuffers, but curiously we still get output!?!
+					// In any case, don't log failure on each swap
+				}
+				else {
+					LOG_TEST_CASE("D3DXLoadSurfaceFromSurface succeeded for MultiSample backbuffer!");
+				}
 			}
 			else {
-				// Avoid logging this each frame : EmuWarning("Couldn't blit Xbox BackBuffer to host BackBuffer : %X", hRet);
+				if (hRet != D3D_OK) {
+					EmuWarning("Couldn't blit Xbox BackBuffer to host BackBuffer : %X", hRet);
+				}
 			}
 		}
 
@@ -4695,8 +4703,8 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 						/* pSrcRect = */ &EmuSourRect,
 						/* Filter = */ D3DX_FILTER_POINT, // Dxbx note : D3DX_FILTER_LINEAR gives a smoother image, but 'bleeds' across borders
 						/* ColorKey = */ g_OverlayProxy.EnableColorKey ? g_OverlayProxy.ColorKey : 0);
-					if (hRet != D3D_OK) {
-						EmuWarning("Couldn't blit Xbox overlay to host BackBuffer : %X", hRet);
+					if (hRet == D3D_OK) {
+						LOG_TEST_CASE("D3DXLoadSurfaceFromSurface(Overlay) succeeded for MultiSample backbuffer!");
 					}
 				}
 			}

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1932,17 +1932,16 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 					}
 
                     // TODO: Support Xbox extensions if possible
-                    if(g_EmuCDPD.XboxPresentationParameters.MultiSampleType != 0)
-                    {
-                        EmuWarning("MultiSampleType 0x%.08X is not supported!", g_EmuCDPD.XboxPresentationParameters.MultiSampleType);
-
-                        g_EmuCDPD.HostPresentationParameters.MultiSampleType = XTL::D3DMULTISAMPLE_NONE;
-
+                    if(g_EmuCDPD.XboxPresentationParameters.MultiSampleType != 0) {
                         // TODO: Check card for multisampling abilities
-            //            if(g_EmuCDPD.XboxPresentationParameters.MultiSampleType == X_D3DMULTISAMPLE_2_SAMPLES_MULTISAMPLE_QUINCUNX) // = 0x00001121
-            //                g_EmuCDPD.HostPresentationParameters.MultiSampleType = D3DMULTISAMPLE_2_SAMPLES;
-            //            else
-            //                CxbxKrnlCleanup("Unknown MultiSampleType (0x%.08X)", g_EmuCDPD.XboxPresentationParameters.MultiSampleType);
+                        if(g_EmuCDPD.XboxPresentationParameters.MultiSampleType == XTL::X_D3DMULTISAMPLE_2_SAMPLES_MULTISAMPLE_QUINCUNX) // = 0x00001121 = 4385
+							// Test-case : Galleon
+                            g_EmuCDPD.HostPresentationParameters.MultiSampleType = XTL::D3DMULTISAMPLE_2_SAMPLES;
+						else {
+							// CxbxKrnlCleanup("Unknown MultiSampleType (0x%.08X)", g_EmuCDPD.XboxPresentationParameters.MultiSampleType);
+							EmuWarning("MultiSampleType 0x%.08X is not supported!", g_EmuCDPD.XboxPresentationParameters.MultiSampleType);
+							g_EmuCDPD.HostPresentationParameters.MultiSampleType = XTL::D3DMULTISAMPLE_NONE;
+						}
                     }
 
                     g_EmuCDPD.HostPresentationParameters.Flags = D3DPRESENTFLAG_LOCKABLE_BACKBUFFER;
@@ -4604,6 +4603,10 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 
 		pCurrentHostBackBuffer->UnlockRect(); // remove any old lock
 
+		// Get backbuffer dimenions; TODO : remember this once, at creation/resize time
+		D3DSURFACE_DESC BackBufferDesc;
+		pCurrentHostBackBuffer->GetDesc(&BackBufferDesc);
+
 		auto pXboxBackBufferHostSurface = GetHostSurface(g_XboxBackBufferSurface);
 		if (pXboxBackBufferHostSurface) {
 			// Blit Xbox BackBuffer to host BackBuffer
@@ -4652,10 +4655,6 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 			}
 
 			// load the YUY2 into the backbuffer
-
-			// Get backbuffer dimenions; TODO : remember this once, at creation/resize time
-			D3DSURFACE_DESC BackBufferDesc;
-			pCurrentHostBackBuffer->GetDesc(&BackBufferDesc);
 
 			// Limit the width and height of the output to the backbuffer dimensions.
 			// This will (hopefully) prevent exceptions in Blinx - The Time Sweeper

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3156,7 +3156,7 @@ XTL::X_D3DSurface* WINAPI XTL::EMUPATCH(D3DDevice_GetBackBuffer2)
 		CxbxKrnlCleanup("D3DDevice_GetBackBuffer2: Could not get Xbox backbuffer");
 	}
 
-	auto pCopySrcSurface = GetHostSurface(pXboxBackBuffer);
+	auto pCopySrcSurface = GetHostSurface(pXboxBackBuffer, D3DUSAGE_RENDERTARGET);
 
 	D3DLOCKED_RECT copyLockedRect;
 	HRESULT hRet = pCopySrcSurface->LockRect(&copyLockedRect, NULL, D3DLOCK_READONLY);

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1931,8 +1931,10 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 						g_EmuCDPD.HostPresentationParameters.BackBufferCount = 1;
 					}
 
-                    // We ignore multisampling! Why? Because if the title uses multisampling (and therfore has a larger than screen backbuffer)
-					// That still works, and we stretch it to fit the host backbuffer anyway, preserving the effect (for the most part)
+                    // We ignore multisampling completely for now
+					// It causes issues with backbuffer locking.
+					// NOTE: It is possible to fix multisampling by having the host backbuffer normal size, the Xbox backbuffer being multisamples
+					// and scaling that way, but that can be done as a future PR
 					g_EmuCDPD.HostPresentationParameters.MultiSampleType = XTL::D3DMULTISAMPLE_NONE;
 					/*
                     if(g_EmuCDPD.XboxPresentationParameters.MultiSampleType != 0) {
@@ -2396,6 +2398,9 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice_4)
 		LOG_FUNC_ARG(pPresentationParameters)
 		LOG_FUNC_END;
 
+	// HACK: Disable multisampling... See comment in CreateDevice proxy for more info
+	pPresentationParameters->MultiSampleType = XTL::X_D3DMULTISAMPLE_NONE;
+
 	// create default device *before* calling Xbox Direct3D_CreateDevice trampline
 	// to avoid hitting EMUPATCH'es that need a valid g_pD3DDevice
 	{
@@ -2450,6 +2455,9 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice_16)
 		LOG_FUNC_ARG(hFocusWindow)
 		LOG_FUNC_ARG(pPresentationParameters)
 		LOG_FUNC_END;
+
+	// HACK: Disable multisampling... See comment in CreateDevice proxy for more info
+	pPresentationParameters->MultiSampleType = XTL::X_D3DMULTISAMPLE_NONE;
 
 	// create default device *before* calling Xbox Direct3D_CreateDevice trampline
 	// to avoid hitting EMUPATCH'es that need a valid g_pD3DDevice
@@ -2530,7 +2538,9 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice)
 		LOG_FUNC_ARG(ppReturnedDeviceInterface)
 		LOG_FUNC_END;
 
-	
+	// HACK: Disable multisampling... See comment in CreateDevice proxy for more info
+	pPresentationParameters->MultiSampleType = XTL::X_D3DMULTISAMPLE_NONE;
+
 	// create default device *before* calling Xbox Direct3D_CreateDevice trampline
 	// to avoid hitting EMUPATCH'es that need a valid g_pD3DDevice
 	{

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -922,12 +922,12 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x2A X_D3DFMT_D24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 #ifdef CXBX_USE_D3D9
 	/* 0x2B X_D3DFMT_F24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24FS8    , DepthBuffer },
-	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
+	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
 	/* 0x2E X_D3DFMT_LIN_D24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 	/* 0x2F X_D3DFMT_LIN_F24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24FS8    , DepthBuffer },
-	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
+	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int) // TODO : Use D3DFMT_R16F?
 	/* 0x32 X_D3DFMT_L16          */ { 16, Swzzld, _____L16, XTL::D3DFMT_L16       },
 	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
 	/* 0x34 undefined             */ {},
@@ -944,12 +944,12 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x3F X_D3DFMT_LIN_A8B8G8R8 */ { 32, Linear, A8B8G8R8, XTL::D3DFMT_A8B8G8R8  }, // Note : D3DFMT_A8B8G8R8=32 D3DFMT_Q8W8V8U8=63 // TODO : Needs testcase.
 #else // Direct3D8 :
 	/* 0x2B X_D3DFMT_F24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
-	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
+	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
 	/* 0x2E X_D3DFMT_LIN_D24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 	/* 0x2F X_D3DFMT_LIN_F24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_LIN_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
-	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
+	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer }, // Note : X_D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not, but D3DFMT_D16_LOCKABLE often fails SetRenderTarget.
+	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16       , DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
 	/* 0x32 X_D3DFMT_L16          */ { 16, Swzzld, _____L16, XTL::D3DFMT_A8L8      , Texture, "X_D3DFMT_L16 -> D3DFMT_A8L8" },
 	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
 	/* 0x34 undefined             */ {},
@@ -1079,7 +1079,7 @@ XTL::D3DFORMAT XTL::EmuXB2PC_D3DFormat(X_D3DFORMAT Format)
 	return D3DFMT_UNKNOWN;
 }
 
-XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format)
+XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format, bool bPreferLinear = true)
 {
 	X_D3DFORMAT result;
     switch(Format)
@@ -1091,91 +1091,69 @@ XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format)
 		result = X_D3DFMT_UYVY;
 		break;
 	case D3DFMT_R5G6B5:
-		result = X_D3DFMT_LIN_R5G6B5;
-		break; // Linear
-			   //      Result := X_D3DFMT_R5G6B5; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_R5G6B5 : X_D3DFMT_R5G6B5;
+		break;
 	case D3DFMT_D24S8:
-		result = X_D3DFMT_D24S8;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_D24S8 : X_D3DFMT_D24S8;
+		break;
 	case D3DFMT_DXT5:
-		result = X_D3DFMT_DXT5;
-		break; // Compressed
-
+		result = X_D3DFMT_DXT5; // Compressed
+		break;
 	case D3DFMT_DXT4:
-		result = X_D3DFMT_DXT4; // Same as X_D3DFMT_DXT5
-		break; // Compressed
-
+		result = X_D3DFMT_DXT4;  // Compressed // Same as X_D3DFMT_DXT5
+		break;
 	case D3DFMT_DXT3:
-		result = X_D3DFMT_DXT3;
-		break; // Compressed
-
+		result = X_D3DFMT_DXT3; // Compressed
+		break;
 	case D3DFMT_DXT2:
-		result = X_D3DFMT_DXT2; // Same as X_D3DFMT_DXT3
-		break; // Compressed
-
+		result = X_D3DFMT_DXT2; // Compressed // Same as X_D3DFMT_DXT3
+		break;
 	case D3DFMT_DXT1:
-		result = X_D3DFMT_DXT1;
-		break; // Compressed
-
+		result = X_D3DFMT_DXT1; // Compressed
+		break;
 	case D3DFMT_A1R5G5B5:
-		result = X_D3DFMT_LIN_A1R5G5B5;
-		break; // Linear
-
+		result = bPreferLinear ? X_D3DFMT_LIN_A1R5G5B5 : X_D3DFMT_A1R5G5B5;
+		break;
 	case D3DFMT_X8R8G8B8:
-		result = X_D3DFMT_LIN_X8R8G8B8;
-		break; // Linear
-			   //      Result := X_D3DFMT_X8R8G8B8; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_X8R8G8B8 : X_D3DFMT_X8R8G8B8;
+		break;
 	case D3DFMT_A8R8G8B8:
-		//      Result := X_D3DFMT_LIN_A8R8G8B8; // Linear
-		result = X_D3DFMT_A8R8G8B8;
+		result = bPreferLinear ? X_D3DFMT_LIN_A8R8G8B8 : X_D3DFMT_A8R8G8B8;
 		break;
 	case D3DFMT_A4R4G4B4:
-		result = X_D3DFMT_LIN_A4R4G4B4;
-		break; // Linear
-			   //      Result := X_D3DFMT_A4R4G4B4; // Swizzled
-	case D3DFMT_X1R5G5B5:	// Linear
-		result = X_D3DFMT_LIN_X1R5G5B5;
+		result = bPreferLinear ? X_D3DFMT_LIN_A4R4G4B4 : X_D3DFMT_A4R4G4B4;
+		break;
+	case D3DFMT_X1R5G5B5:
+		result = bPreferLinear ? X_D3DFMT_LIN_X1R5G5B5 : X_D3DFMT_X1R5G5B5;
 		break;
 	case D3DFMT_A8:
-		result = X_D3DFMT_A8;
+		result = bPreferLinear ? X_D3DFMT_LIN_A8 : X_D3DFMT_A8;
 		break;
 	case D3DFMT_L8:
-		result = X_D3DFMT_LIN_L8;
-		break; // Linear
-			   //        Result := X_D3DFMT_L8; // Swizzled
-
-	case D3DFMT_D16: // Swizzled
-		return X_D3DFMT_D16;
+		result = bPreferLinear ? X_D3DFMT_LIN_L8 : X_D3DFMT_L8;
 		break;
-	case D3DFMT_D16_LOCKABLE: // Swizzled
+	case D3DFMT_D16:
+		result = bPreferLinear ? X_D3DFMT_LIN_D16 : X_D3DFMT_D16;
+		break;
+	case D3DFMT_D16_LOCKABLE:
 		result = X_D3DFMT_D16_LOCKABLE;
 		break; 
-
 	case D3DFMT_UNKNOWN:
-		result = ((X_D3DFORMAT)0xffffffff);
+		result = ((X_D3DFORMAT)0xffffffff); // TODO : return X_D3DFMT_UNKNOWN ?
 		break;
-
-		// Dxbx additions :
-
+	// Dxbx additions :
 	case D3DFMT_L6V5U5:
-		result = X_D3DFMT_L6V5U5;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_L6V5U5 : X_D3DFMT_L6V5U5;
+		break;
 	case D3DFMT_V8U8:
-		result = X_D3DFMT_V8U8;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_V8U8 : X_D3DFMT_V8U8;
+		break;
 	case D3DFMT_V16U16:
-		result = X_D3DFMT_V16U16;
-		break; // Swizzled
-
+		result = bPreferLinear ? X_D3DFMT_LIN_V16U16 : X_D3DFMT_V16U16;
+		break;
 	case D3DFMT_VERTEXDATA:
 		result = X_D3DFMT_VERTEXDATA;
 		break;
-
 	default:
 		CxbxKrnlCleanup("EmuPC2XB_D3DFormat: Unknown Format (%d)", Format);
     }

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -944,12 +944,12 @@ static const FormatInfo FormatInfos[] = {
 	/* 0x3F X_D3DFMT_LIN_A8B8G8R8 */ { 32, Linear, A8B8G8R8, XTL::D3DFMT_A8B8G8R8  }, // Note : D3DFMT_A8B8G8R8=32 D3DFMT_Q8W8V8U8=63 // TODO : Needs testcase.
 #else // Direct3D8 :
 	/* 0x2B X_D3DFMT_F24S8        */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
-	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
+	/* 0x2C X_D3DFMT_D16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
+	/* 0x2D X_D3DFMT_F16          */ { 16, Swzzld, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer, "X_D3DFMT_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
 	/* 0x2E X_D3DFMT_LIN_D24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer },
 	/* 0x2F X_D3DFMT_LIN_F24S8    */ { 32, Linear, NoCmpnts, XTL::D3DFMT_D24S8     , DepthBuffer, "X_D3DFMT_LIN_F24S8 -> D3DFMT_D24S8" }, // HACK : PC doesn't have D3DFMT_F24S8 (Float vs Int)
-	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
-	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16_LOCKABLE, DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
+	/* 0x30 X_D3DFMT_LIN_D16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer }, // Note : D3DFMT_D16 is always lockable on Xbox, D3DFMT_D16 on host is not.
+	/* 0x31 X_D3DFMT_LIN_F16      */ { 16, Linear, NoCmpnts, XTL::D3DFMT_D16, DepthBuffer, "X_D3DFMT_LIN_F16 -> D3DFMT_D16" }, // HACK : PC doesn't have D3DFMT_F16 (Float vs Int)
 	/* 0x32 X_D3DFMT_L16          */ { 16, Swzzld, _____L16, XTL::D3DFMT_A8L8      , Texture, "X_D3DFMT_L16 -> D3DFMT_A8L8" },
 	/* 0x33 X_D3DFMT_V16U16       */ { 32, Swzzld, NoCmpnts, XTL::D3DFMT_V16U16    },
 	/* 0x34 undefined             */ {},
@@ -1147,9 +1147,12 @@ XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format)
 		break; // Linear
 			   //        Result := X_D3DFMT_L8; // Swizzled
 
-	case D3DFMT_D16: case D3DFMT_D16_LOCKABLE:
+	case D3DFMT_D16: // Swizzled
+		return X_D3DFMT_D16;
+		break;
+	case D3DFMT_D16_LOCKABLE: // Swizzled
 		result = X_D3DFMT_D16_LOCKABLE;
-		break; // Swizzled
+		break; 
 
 	case D3DFMT_UNKNOWN:
 		result = ((X_D3DFORMAT)0xffffffff);

--- a/src/CxbxKrnl/EmuD3D8/Convert.cpp
+++ b/src/CxbxKrnl/EmuD3D8/Convert.cpp
@@ -1079,7 +1079,7 @@ XTL::D3DFORMAT XTL::EmuXB2PC_D3DFormat(X_D3DFORMAT Format)
 	return D3DFMT_UNKNOWN;
 }
 
-XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format, bool bPreferLinear = true)
+XTL::X_D3DFORMAT XTL::EmuPC2XB_D3DFormat(D3DFORMAT Format, bool bPreferLinear)
 {
 	X_D3DFORMAT result;
     switch(Format)

--- a/src/CxbxKrnl/EmuD3D8/Convert.h
+++ b/src/CxbxKrnl/EmuD3D8/Convert.h
@@ -77,7 +77,7 @@ extern BOOL EmuXBFormatIsDepthBuffer(X_D3DFORMAT Format);
 extern D3DFORMAT EmuXB2PC_D3DFormat(X_D3DFORMAT Format);
 
 // convert from pc to xbox color formats
-extern X_D3DFORMAT EmuPC2XB_D3DFormat(D3DFORMAT Format);
+extern X_D3DFORMAT EmuPC2XB_D3DFormat(D3DFORMAT Format, bool bPreferLinear = true);
 
 // convert from xbox to pc d3d lock flags
 extern DWORD EmuXB2PC_D3DLock(DWORD Flags);

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -162,7 +162,13 @@ void ActivatePatchedStream
 		pDrawContext->uiHostVertexStreamZeroStride = pPatchedStream->uiCachedHostVertexStride;
 	}
 	else {
-		HRESULT hRet = g_pD3DDevice->SetStreamSource(uiStream, pPatchedStream->pCachedHostVertexBuffer, pPatchedStream->uiCachedHostVertexStride);
+		HRESULT hRet = g_pD3DDevice->SetStreamSource(
+			uiStream, 
+			pPatchedStream->pCachedHostVertexBuffer, 
+#ifdef CXBX_USE_D3D9
+			0, // OffsetInBytes
+#endif
+			pPatchedStream->uiCachedHostVertexStride);
 		//DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetStreamSource");
 		if (FAILED(hRet)) {
 			CxbxKrnlCleanup("Failed to set the type patched buffer as the new stream source!\n");
@@ -348,7 +354,13 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 		XTL::X_D3DVertexBuffer *pXboxVertexBuffer = g_D3DStreams[uiStream];
         pXboxVertexData = (uint08*)GetDataFromXboxResource(pXboxVertexBuffer);
 		if (pXboxVertexData == NULL) {
-			HRESULT hRet = g_pD3DDevice->SetStreamSource(uiStream, nullptr, 0);
+			HRESULT hRet = g_pD3DDevice->SetStreamSource(
+				uiStream, 
+				nullptr, 
+#ifdef CXBX_USE_D3D9
+				0, // OffsetInBytes
+#endif
+				0);
 //			DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetStreamSource");
 			if (FAILED(hRet)) {
 				EmuWarning("g_pD3DDevice->SetStreamSource(uiStream, nullptr, 0)");

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -579,6 +579,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 							break;
 						case 3:
 							LOG_TEST_CASE("Normalize 3D");
+							// Test case : HeatShimmer
 							pVertexUVData[0] /= pActivePixelContainer[i].Width;
 							pVertexUVData[1] /= pActivePixelContainer[i].Height;
 							pVertexUVData[2] /= pActivePixelContainer[i].Depth;

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1917,7 +1917,7 @@ static void VshConvertToken_STREAMDATA_REG(DWORD          *pToken,
 
     XTL::DWORD VertexRegister = VshGetVertexRegister(*pToken);
     XTL::DWORD HostVertexRegister;
-	BOOL NeedPatching = FALSE;
+	XTL::BOOL NeedPatching = FALSE;
 
     DbgVshPrintf("\t\tD3DVSD_REG(");
     HostVertexRegister = Xb2PCRegisterType(VertexRegister, IsFixedFunction);


### PR DESCRIPTION
This PR got started by Luke, separating Xbox back buffer from host back buffer.

Thanks to that, I improved upon that with overlay fixes, including D3D format conversion from host back to Xbox (only used for icons, but still).

The main benefit of this work is it's less crash-prone (because I now copy the overlay surface into the proxy overlay struct) and it tries to honor the color-space conversion render state (by interpreting overlay data as RGB when the NV2A is asked to do so). This work also restores the limiting of the overlay dimensions to backbuffer dimensions (a fix for BLinx - the time sweeper).