### PR TITLE
Fix GitHub tab style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_size = 4


### PR DESCRIPTION
For comparison between main repo vs this commit for tab size.

**Before: (default to 8 spaces)**
![image](https://user-images.githubusercontent.com/3938312/40050470-37038146-57fd-11e8-8739-eab3ba8180f0.png)

**After: (set to 4 spaces as default in config file)**
![image](https://user-images.githubusercontent.com/3938312/40050493-44e029a4-57fd-11e8-8c9e-b8da6d942b7d.png)

It also affect Visual Studio 2017 as integrated support. VS 2015 and below are not affected.