### PR TITLE
Show correct icon to popup message dialog

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -489,7 +489,7 @@ HANDLE CxbxRestorePageTablesMemory(char* szFilePath_page_tables)
 
 #pragma optimize("", off)
 
-void CxbxPopupMessage(CxbxPopupMsgIcon icon, const char *message, ...)
+void CxbxPopupMessage(CxbxMsgDlgIcon icon, const char *message, ...)
 {
 	char Buffer[1024];
 	va_list argp;

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -227,11 +227,19 @@ enum {
 #define XBOX_MEM_NOZERO             0x800000 // Replaces MEM_ROTATE on WinXP+
 #define XBOX_MEM_IMAGE              0x1000000 // ?
 
-void CxbxPopupMessage(const char *message, ...);
+typedef enum _CxbxMsgDlgIcon {
+    CxbxMsgDlgIcon_Info=0,
+    CxbxMsgDlgIcon_Warn,
+    CxbxMsgDlgIcon_Error,
+    CxbxMsgDlgIcon_Unknown
+
+} CxbxPopupMsgIcon;
+
+void CxbxPopupMessage(CxbxPopupMsgIcon icon, const char *message, ...);
 
 #define LOG_TEST_CASE(message) do { static bool bPopupShown = false; \
     if (!bPopupShown) { bPopupShown = true; \
-    CxbxPopupMessage("Please report that %s shows this test-case: %s\nIn %s (%s line %d)", \
+    CxbxPopupMessage(CxbxMsgDlgIcon_Info, "Please report that %s shows this test-case: %s\nIn %s (%s line %d)", \
     CxbxKrnl_Xbe->m_szAsciiTitle, message, __func__, __FILE__, __LINE__); } } while(0)
 // was g_pCertificate->wszTitleName
 

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -233,9 +233,9 @@ typedef enum _CxbxMsgDlgIcon {
     CxbxMsgDlgIcon_Error,
     CxbxMsgDlgIcon_Unknown
 
-} CxbxPopupMsgIcon;
+} CxbxMsgDlgIcon;
 
-void CxbxPopupMessage(CxbxPopupMsgIcon icon, const char *message, ...);
+void CxbxPopupMessage(CxbxMsgDlgIcon icon, const char *message, ...);
 
 #define LOG_TEST_CASE(message) do { static bool bPopupShown = false; \
     if (!bPopupShown) { bPopupShown = true; \

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -517,7 +517,7 @@ VOID XTL::CxbxInitWindow(bool bFullInit)
 		if (hRenderWindowThread == NULL) {
 			char szBuffer[1024] = { 0 };
 			sprintf(szBuffer, "Creating EmuRenderWindowThread Failed: %08X", GetLastError());
-			CxbxPopupMessage(szBuffer);
+			CxbxPopupMessage(CxbxMsgDlgIcon_Error, szBuffer);
 			EmuShared::Cleanup();
 			ExitProcess(0);
 		}

--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -303,7 +303,7 @@ XBSYSAPI EXPORTNUM(264) xboxkrnl::VOID NTAPI xboxkrnl::RtlAssert
 		LOG_FUNC_ARG(Message)
 		LOG_FUNC_END;
 
-	CxbxPopupMessage("RtlAssert() raised by emulated program - consult Debug log");
+	CxbxPopupMessage(CxbxMsgDlgIcon_Warn, "RtlAssert() raised by emulated program - consult Debug log");
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -216,7 +216,7 @@ bool TitleIsJSRF()
 		wcstombs(tAsciiTitle, g_pCertificate->wszTitleName, sizeof(tAsciiTitle));
 
 		if (_strnicmp(tAsciiTitle, "Jet Set Radio", 13) == 0) {
-			CxbxPopupMessage("Detected JSRF by name, not title ID, please report that [%08X] should be added to the list", g_pCertificate->dwTitleId);
+			CxbxPopupMessage(CxbxMsgDlgIcon_Info, "Detected JSRF by name, not title ID, please report that [%08X] should be added to the list", g_pCertificate->dwTitleId);
 			result = true;
 		}
 	}


### PR DESCRIPTION
Proper fix for message dialog's icon. This is to lead correct icon such as test case is information, warning is warning, error is error, etc.