### PR TITLE
Fix in SetState polling loop

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -1782,12 +1782,15 @@ static DWORD WINAPI EmuUpdateTickCount(LPVOID)
 
                 if(pFeedback->Header.dwStatus != ERROR_SUCCESS)
                 {
+                    pFeedback->Header.dwStatus = ERROR_SUCCESS;
+
                     if(pFeedback->Header.hEvent != 0)
                     {
                         SetEvent(pFeedback->Header.hEvent);
                     }
 
-                    pFeedback->Header.dwStatus = ERROR_SUCCESS;
+                    //Make sure we don't check the pFeedback again, as it could be freed by the game
+                    g_pXInputSetStateStatus[v].pFeedback = 0;
                 }
             }
         }


### PR DESCRIPTION
Once the pFeedback->Header.hEvent event is set, the game is free to free the buffer that it was pointing to. In HP1 game, the pointer even lead to the stack. Because that stack was changing a lot, pFeedback->Header.dwStatus eventually resolved to a non-zero value and we started to overwrite some random memory.

Harry Potter and the Philosopher's Stone now gets in-game.

![image](https://user-images.githubusercontent.com/2465633/40282958-f8588238-5c76-11e8-8ddb-de72142b8846.png)