### PR TITLE
More porting work towards Direct3D 9

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -9504,11 +9504,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPixelShaderConstant_4)
 #endif
     (
         Register,
-#ifdef CXBX_USE_D3D9
-		(float*)pConstantData,
-#else
-        pConstantData,
-#endif
+		(PixelShaderConstantType*)pConstantData,
         ConstantCount
     );
     //DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetPixelShaderConstant");

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -124,7 +124,7 @@ struct {
 // D3D based variables
 static GUID                         g_ddguid;               // DirectDraw driver GUID
 static XTL::IDirect3D              *g_pDirect3D = nullptr;
-static XTL::D3DCAPS                 g_D3DCaps;              // Direct3D Caps
+static XTL::D3DCAPS                 g_D3DCaps = {};         // Direct3D Caps
 
 // wireframe toggle
 static int                          g_iWireframe    = 0;
@@ -7555,6 +7555,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 				// test-case : BLiNX: the time sweeper
 				// test-case : Halo - Combat Evolved
 				// test-case : Worms 3D Special Edition
+				// test-case : XDK sample Lensflare 
 				DrawContext.dwStartVertex = StartVertex; // Breakpoint location for testing. 
 			}
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -8087,7 +8087,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderTarget)
 		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderTarget");
 		if (FAILED(hRet)) {
 			// If Direct3D 9 SetRenderTarget failed, skip setting depth stencil
-			return hRet;
+			return;
 		}
 	}
 
@@ -9497,10 +9497,18 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPixelShaderConstant_4)
     if(g_BuildVersion <= 4361)
         Register += 96;
 
+#ifdef CXBX_USE_D3D9
+	HRESULT hRet = g_pD3DDevice->SetPixelShaderConstantF
+#else
     HRESULT hRet = g_pD3DDevice->SetPixelShaderConstant
+#endif
     (
         Register,
+#ifdef CXBX_USE_D3D9
+		(float*)pConstantData,
+#else
         pConstantData,
+#endif
         ConstantCount
     );
     //DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetPixelShaderConstant");

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -4338,10 +4338,15 @@ VOID XTL::DxbxUpdateActivePixelShader() // NOPATCH
         // TODO : Avoid the following setter if it's no different from the previous update (this might speed things up)
         // Set the value locally in this register :
 #ifdef CXBX_USE_D3D9
-        g_pD3DDevice->SetPixelShaderConstantF(Register_, (float*)(&fColor), 1);
+        g_pD3DDevice->SetPixelShaderConstantF
 #else
-		g_pD3DDevice->SetPixelShaderConstant(Register_, &fColor, 1);
+		g_pD3DDevice->SetPixelShaderConstant
 #endif
+		(
+			Register_, 
+			(PixelShaderConstantType*)(&fColor),
+			1
+		);
       }
     }
   }

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -4107,10 +4107,9 @@ PSH_RECOMPILED_SHADER XTL_EmuRecompilePshDef(XTL::X_D3DPIXELSHADERDEF *pPSDef)
 	uint32 PSVersion = D3DPS_VERSION(1, 3); // Use pixel shader model 1.3 by default
 
 #if 0 // Once PS.1.4 can be generated, enable this :
-	XTL::D3DCAPS g_D3DCaps = {};
-	if (g_pD3DDevice->GetDeviceCaps(&g_D3DCaps) == D3D_OK) {
-		PSVersion = g_D3DCaps.PixelShaderVersion;
-	}
+	extern XTL::D3DCAPS g_D3DCaps;
+
+	PSVersion = g_D3DCaps.PixelShaderVersion;
 #endif
 	// TODO : Make the pixel shader version configurable
 

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -415,25 +415,43 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				case X_D3DVSDT_NORMSHORT1: { // 0x11:
 					// Test-cases : Halo - Combat Evolved
 					XboxElementByteSize = 1 * sizeof(SHORT);
-#if CXBX_USE_D3D9	// Make it SHORT2N
-					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
-					pHostVertexAsShort[1] = 0;
-#else				// Make it FLOAT1
-					pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
-					//pHostVertexAsFloat[1] = 0.0f; // Would be needed for FLOAT2
+#if CXBX_USE_D3D9
+					if (g_D3DCaps.DeclTypes & D3DDTCAPS_SHORT2N) {
+						// Make it SHORT2N
+						pHostVertexAsShort[0] = pXboxVertexAsShort[0];
+						pHostVertexAsShort[1] = 0;
+					}
+					else
 #endif
+					{
+						// Make it FLOAT1
+						pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
+						//pHostVertexAsFloat[1] = 0.0f; // Would be needed for FLOAT2
+					}
 					break;
 				}
-#if !CXBX_USE_D3D9 // No need for patching in D3D9
 				case X_D3DVSDT_NORMSHORT2: { // 0x21:
 					// Test-cases : Baldur's Gate: Dark Alliance 2, F1 2002, Gun, Halo - Combat Evolved, Scrapland 
 					XboxElementByteSize = 2 * sizeof(SHORT);
-					// Make it FLOAT2
-					pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
-					pHostVertexAsFloat[1] = NormShortToFloat(pXboxVertexAsShort[1]);
+#if CXBX_USE_D3D9
+					if (g_D3DCaps.DeclTypes & D3DDTCAPS_SHORT2N) {
+						// No need for patching when D3D9 supports D3DDECLTYPE_SHORT2N
+						// TODO : goto default; // ??
+						//assert(XboxElementByteSize == 2 * sizeof(SHORT));
+						//memcpy(pHostVertexAsByte, pXboxVertexAsByte, XboxElementByteSize);
+						// Make it SHORT2N
+						pHostVertexAsShort[0] = pXboxVertexAsShort[0];
+						pHostVertexAsShort[1] = pXboxVertexAsShort[1];
+					}
+					else
+#endif
+					{
+						// Make it FLOAT2
+						pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
+						pHostVertexAsFloat[1] = NormShortToFloat(pXboxVertexAsShort[1]);
+					}
 					break;
 				}
-#endif
 				case X_D3DVSDT_NORMSHORT3: { // 0x31:
 					// Test-cases : Cel Damage, Constantine, Destroy All Humans!
 					XboxElementByteSize = 3 * sizeof(SHORT);
@@ -569,6 +587,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 				case X_D3DVSDT_PBYTE4: { // 0x44:
 					// Hit by Jet Set Radio Future
+					XboxElementByteSize = 4 * sizeof(BYTE);
 #if CXBX_USE_D3D9
 					if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
 						// No need for patching when D3D9 supports D3DDECLTYPE_UBYTE4N
@@ -585,7 +604,6 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 #endif
 					{
 						// Make it FLOAT4
-						XboxElementByteSize = 4 * sizeof(BYTE);
 						pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
 						pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
 						pHostVertexAsFloat[2] = ByteToFloat(pXboxVertexAsByte[2]);

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -284,6 +284,10 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
     UINT             uiStream
 )
 {
+#if CXBX_USE_D3D9
+	extern XTL::D3DCAPS g_D3DCaps;
+#endif
+
 	bool bVshHandleIsFVF = VshHandleIsFVF(pDrawContext->hVertexShader);
 	DWORD XboxFVF = bVshHandleIsFVF ? pDrawContext->hVertexShader : 0;
 	// Texture normalization can only be set for FVF shaders
@@ -586,7 +590,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					break;
 				}
 				case X_D3DVSDT_PBYTE4: { // 0x44:
-					// Hit by Jet Set Radio Future
+					// Test-case : Jet Set Radio Future
 					XboxElementByteSize = 4 * sizeof(BYTE);
 #if CXBX_USE_D3D9
 					if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
@@ -621,6 +625,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					break;
 				}
 				case X_D3DVSDT_NONE: { // 0x02: // Skip it
+					// Test-case : WWE RAW2
 					LOG_TEST_CASE("X_D3DVSDT_NONE");
 					break;
 				}

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -466,12 +466,12 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					// Cxbx note : to make each component signed, two need to be shifted towards the sign-bit first :
 					pHostVertexAsFloat[0] = ((FLOAT)((iPacked << 21) >> 21)) / 1023.0f;
 					pHostVertexAsFloat[1] = ((FLOAT)((iPacked << 10) >> 21)) / 1023.0f;
-					pHostVertexAsFloat[2] = ((FLOAT)((iPacked      ) >> 22)) / 511.0f;
+					pHostVertexAsFloat[2] = ((FLOAT)((iPacked) >> 22)) / 511.0f;
 					break;
 				}
 				case X_D3DVSDT_SHORT1: { // 0x15: // Make it SHORT2 and set the second short to 0
 					XboxElementByteSize = 1 * sizeof(SHORT);
-					//memcpy(pHostVertexAsFloat, pXboxVertexAsByte, XboxElementByteSize);
+					//memcpy(pHostVertexAsByte, pXboxVertexAsByte, XboxElementByteSize);
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = 0;
 					break;
@@ -479,7 +479,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				case X_D3DVSDT_SHORT3: { // 0x35: // Make it a SHORT4 and set the fourth short to 1
 					// Test-cases : Turok
 					XboxElementByteSize = 3 * sizeof(SHORT);
-					//memcpy(pHostVertexAsFloat, pXboxVertexAsByte, XboxElementByteSize);
+					//memcpy(pHostVertexAsByte, pXboxVertexAsByte, XboxElementByteSize);
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = pXboxVertexAsShort[1];
 					pHostVertexAsShort[2] = pXboxVertexAsShort[2];
@@ -488,42 +488,59 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 				case X_D3DVSDT_PBYTE1: { // 0x14:
 					XboxElementByteSize = 1 * sizeof(BYTE);
-#if CXBX_USE_D3D9	// Make it UBYTE4N
-					pHostVertexAsByte[0] = pXboxVertexAsByte[0];
-					pHostVertexAsByte[1] = 0;
-					pHostVertexAsByte[2] = 0;
-					pHostVertexAsByte[3] = 255; // TODO : Verify
-#else				// Make it FLOAT1
-					pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
+#if CXBX_USE_D3D9
+					if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+						// Make it UBYTE4N
+						pHostVertexAsByte[0] = pXboxVertexAsByte[0];
+						pHostVertexAsByte[1] = 0;
+						pHostVertexAsByte[2] = 0;
+						pHostVertexAsByte[3] = 255; // TODO : Verify
+					}
+					else
 #endif
+					{
+						// Make it FLOAT1
+						pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
+					}
 					break;
 				}
 				case X_D3DVSDT_PBYTE2: { // 0x24:
 					XboxElementByteSize = 2 * sizeof(BYTE);
-#if CXBX_USE_D3D9	// Make it UBYTE4N
-					pHostVertexAsByte[0] = pXboxVertexAsByte[0];
-					pHostVertexAsByte[1] = pXboxVertexAsByte[1];
-					pHostVertexAsByte[2] = 0;
-					pHostVertexAsByte[3] = 255; // TODO : Verify
-#else				// Make it FLOAT2
-					pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
-					pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
+#if CXBX_USE_D3D9
+					if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+						// Make it UBYTE4N
+						pHostVertexAsByte[0] = pXboxVertexAsByte[0];
+						pHostVertexAsByte[1] = pXboxVertexAsByte[1];
+						pHostVertexAsByte[2] = 0;
+						pHostVertexAsByte[3] = 255; // TODO : Verify
+					}
+					else
 #endif
-					break;
+					{
+						// Make it FLOAT2
+						pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
+						pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
+					}					break;
 				}
 				case X_D3DVSDT_PBYTE3: { // 0x34:
 					// Test-cases : Turok
 					XboxElementByteSize = 3 * sizeof(BYTE);
-#if CXBX_USE_D3D9	// Make it UBYTE4N
-					pHostVertexAsByte[0] = pXboxVertexAsByte[0];
-					pHostVertexAsByte[1] = pXboxVertexAsByte[1];
-					pHostVertexAsByte[2] = pXboxVertexAsByte[2];
-					pHostVertexAsByte[3] = 255; // TODO : Verify
-#else				// Make it FLOAT3
-					pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
-					pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
-					pHostVertexAsFloat[2] = ByteToFloat(pXboxVertexAsByte[2]);
+#if CXBX_USE_D3D9
+					if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+						// Make it UBYTE4N
+						pHostVertexAsByte[0] = pXboxVertexAsByte[0];
+						pHostVertexAsByte[1] = pXboxVertexAsByte[1];
+						pHostVertexAsByte[2] = pXboxVertexAsByte[2];
+						pHostVertexAsByte[3] = 255; // TODO : Verify
+					}
+					else
 #endif
+					{
+						// Make it FLOAT3
+						pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
+						pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
+						pHostVertexAsFloat[2] = ByteToFloat(pXboxVertexAsByte[2]);
+					}
 					break;
 				}
 				case X_D3DVSDT_PBYTE4: { // 0x44:
@@ -532,7 +549,12 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
 						// No need for patching when D3D9 supports D3DDECLTYPE_UBYTE4N
 						// TODO : goto default; // ??
-						memcpy(pHostVertexAsByte, pXboxVertexAsByte, XboxElementByteSize);
+						//assert(XboxElementByteSize == 4 * sizeof(BYTE));
+						//memcpy(pHostVertexAsByte, pXboxVertexAsByte, XboxElementByteSize);
+						pHostVertexAsByte[0] = pXboxVertexAsByte[0];
+						pHostVertexAsByte[1] = pXboxVertexAsByte[1];
+						pHostVertexAsByte[2] = pXboxVertexAsByte[2];
+						pHostVertexAsByte[3] = pXboxVertexAsByte[3];
 					}
 					else
 #endif

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -268,6 +268,16 @@ UINT XTL::CxbxVertexBufferConverter::GetNbrStreams(CxbxDrawContext *pDrawContext
     return 0;
 }
 
+inline FLOAT NormShortToFloat(const SHORT value)
+{
+	return ((FLOAT)value) / 32767.0f;
+}
+
+inline FLOAT ByteToFloat(const BYTE value)
+{
+	return ((FLOAT)value) / 255.0f;
+}
+
 void XTL::CxbxVertexBufferConverter::ConvertStream
 (
 	CxbxDrawContext *pDrawContext,
@@ -391,18 +401,14 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 	if (bNeedVertexPatching) {
 	    // assert(bNeedStreamCopy || "bNeedVertexPatching implies bNeedStreamCopy (but copies via conversions");
 		for (uint32 uiVertex = 0; uiVertex < uiVertexCount; uiVertex++) {
-			uint08 *pXboxVertex = &pXboxVertexData[uiVertex * uiXboxVertexStride];
-			uint08 *pHostVertex = &pHostVertexData[uiVertex * uiHostVertexStride];
+			uint08 *pXboxVertexAsByte = &pXboxVertexData[uiVertex * uiXboxVertexStride];
+			uint08 *pHostVertexAsByte = &pHostVertexData[uiVertex * uiHostVertexStride];
 			for (UINT uiElement = 0; uiElement < pVertexShaderStreamInfo->NumberOfVertexElements; uiElement++) {
-				FLOAT *pXboxVertexAsFloat = (FLOAT*)pXboxVertex;
-				SHORT *pXboxVertexAsShort = (SHORT*)pXboxVertex;
-				BYTE *pXboxVertexAsByte = (BYTE*)pXboxVertex;
+				FLOAT *pXboxVertexAsFloat = (FLOAT*)pXboxVertexAsByte;
+				SHORT *pXboxVertexAsShort = (SHORT*)pXboxVertexAsByte;
 				int XboxElementByteSize = pVertexShaderStreamInfo->VertexElements[uiElement].HostByteSize;
-				FLOAT *pHostVertexAsFloat = (FLOAT*)pHostVertex;
-				SHORT *pHostVertexAsShort = (SHORT*)pHostVertex;
-#if CXBX_USE_D3D9
-				BYTE *pHostVertexAsByte = (BYTE*)pHostVertex;
-#endif
+				FLOAT *pHostVertexAsFloat = (FLOAT*)pHostVertexAsByte;
+				SHORT *pHostVertexAsShort = (SHORT*)pHostVertexAsByte;
 				// Dxbx note : The following code handles only the D3DVSDT enums that need conversion;
 				// All other cases are catched by the memcpy in the default-block.
 				switch (pVertexShaderStreamInfo->VertexElements[uiElement].XboxType) {
@@ -413,7 +419,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = 0;
 #else				// Make it FLOAT1
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsShort[0]) / 32767.0f;
+					pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
 					//pHostVertexAsFloat[1] = 0.0f; // Would be needed for FLOAT2
 #endif
 					break;
@@ -422,8 +428,8 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				case X_D3DVSDT_NORMSHORT2: { // 0x21: // Make it FLOAT2
 					// Test-cases : Baldur's Gate: Dark Alliance 2, F1 2002, Gun, Halo - Combat Evolved, Scrapland 
 					XboxElementByteSize = 2 * sizeof(SHORT);
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsShort[0]) / 32767.0f;
-					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsShort[1]) / 32767.0f;
+					pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
+					pHostVertexAsFloat[1] = NormShortToFloat(pXboxVertexAsShort[1]);
 					break;
 				}
 #endif
@@ -436,9 +442,9 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					pHostVertexAsShort[2] = pXboxVertexAsShort[2];
 					pHostVertexAsShort[3] = 32767; // TODO : verify
 #else				// Make it FLOAT3
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsShort[0]) / 32767.0f;
-					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsShort[1]) / 32767.0f;
-					pHostVertexAsFloat[2] = ((FLOAT)pXboxVertexAsShort[2]) / 32767.0f;
+					pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
+					pHostVertexAsFloat[1] = NormShortToFloat(pXboxVertexAsShort[1]);
+					pHostVertexAsFloat[2] = NormShortToFloat(pXboxVertexAsShort[2]);
 #endif
 					break;
 				}
@@ -446,17 +452,17 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				case X_D3DVSDT_NORMSHORT4: { // 0x41: // Make it FLOAT4
 					// Test-cases : Judge Dredd: Dredd vs Death, NHL Hitz 2002, Silent Hill 2, Sneakers, Tony Hawk Pro Skater 4
 					XboxElementByteSize = 4 * sizeof(SHORT);
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsShort[0]) / 32767.0f;
-					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsShort[1]) / 32767.0f;
-					pHostVertexAsFloat[2] = ((FLOAT)pXboxVertexAsShort[2]) / 32767.0f;
-					pHostVertexAsFloat[3] = ((FLOAT)pXboxVertexAsShort[3]) / 32767.0f;
+					pHostVertexAsFloat[0] = NormShortToFloat(pXboxVertexAsShort[0]);
+					pHostVertexAsFloat[1] = NormShortToFloat(pXboxVertexAsShort[1]);
+					pHostVertexAsFloat[2] = NormShortToFloat(pXboxVertexAsShort[2]);
+					pHostVertexAsFloat[3] = NormShortToFloat(pXboxVertexAsShort[3]);
 					break;
 				}
 #endif
 				case X_D3DVSDT_NORMPACKED3: { // 0x16: // Make it FLOAT3
 					// Test-cases : Dashboard
 					XboxElementByteSize = 1 * sizeof(int32);
-					int32 iPacked = ((int32 *)pXboxVertex)[0];
+					int32 iPacked = ((int32 *)pXboxVertexAsByte)[0];
 					// Cxbx note : to make each component signed, two need to be shifted towards the sign-bit first :
 					pHostVertexAsFloat[0] = ((FLOAT)((iPacked << 21) >> 21)) / 1023.0f;
 					pHostVertexAsFloat[1] = ((FLOAT)((iPacked << 10) >> 21)) / 1023.0f;
@@ -465,19 +471,19 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 				case X_D3DVSDT_SHORT1: { // 0x15: // Make it SHORT2 and set the second short to 0
 					XboxElementByteSize = 1 * sizeof(SHORT);
-					//memcpy(pHostVertexAsFloat, pXboxVertex, XboxElementByteSize);
+					//memcpy(pHostVertexAsFloat, pXboxVertexAsByte, XboxElementByteSize);
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
-					pHostVertexAsShort[1] = 0x00;
+					pHostVertexAsShort[1] = 0;
 					break;
 				}
 				case X_D3DVSDT_SHORT3: { // 0x35: // Make it a SHORT4 and set the fourth short to 1
 					// Test-cases : Turok
 					XboxElementByteSize = 3 * sizeof(SHORT);
-					//memcpy(pHostVertexAsFloat, pXboxVertex, XboxElementByteSize);
+					//memcpy(pHostVertexAsFloat, pXboxVertexAsByte, XboxElementByteSize);
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = pXboxVertexAsShort[1];
 					pHostVertexAsShort[2] = pXboxVertexAsShort[2];
-					pHostVertexAsShort[3] = 0x01; // Turok verified (character disappears when this is 32767)
+					pHostVertexAsShort[3] = 1; // Turok verified (character disappears when this is 32767)
 					break;
 				}
 				case X_D3DVSDT_PBYTE1: { // 0x14:
@@ -488,7 +494,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					pHostVertexAsByte[2] = 0;
 					pHostVertexAsByte[3] = 255; // TODO : Verify
 #else				// Make it FLOAT1
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsByte[0]) / 255.0f;
+					pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
 #endif
 					break;
 				}
@@ -500,8 +506,8 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					pHostVertexAsByte[2] = 0;
 					pHostVertexAsByte[3] = 255; // TODO : Verify
 #else				// Make it FLOAT2
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsByte[0]) / 255.0f;
-					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsByte[1]) / 255.0f;
+					pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
+					pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
 #endif
 					break;
 				}
@@ -514,23 +520,32 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					pHostVertexAsByte[2] = pXboxVertexAsByte[2];
 					pHostVertexAsByte[3] = 255; // TODO : Verify
 #else				// Make it FLOAT3
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsByte[0]) / 255.0f;
-					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsByte[1]) / 255.0f;
-					pHostVertexAsFloat[2] = ((FLOAT)pXboxVertexAsByte[2]) / 255.0f;
+					pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
+					pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
+					pHostVertexAsFloat[2] = ByteToFloat(pXboxVertexAsByte[2]);
 #endif
 					break;
 				}
-#if !CXBX_USE_D3D9 // No need for patching in D3D9
-				case X_D3DVSDT_PBYTE4: { // 0x44: // Make it FLOAT4
+				case X_D3DVSDT_PBYTE4: { // 0x44:
 					// Hit by Jet Set Radio Future
-					XboxElementByteSize = 4 * sizeof(BYTE);
-					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsByte[0]) / 255.0f;
-					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsByte[1]) / 255.0f;
-					pHostVertexAsFloat[2] = ((FLOAT)pXboxVertexAsByte[2]) / 255.0f;
-					pHostVertexAsFloat[3] = ((FLOAT)pXboxVertexAsByte[3]) / 255.0f;
+#if CXBX_USE_D3D9
+					if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+						// No need for patching when D3D9 supports D3DDECLTYPE_UBYTE4N
+						// TODO : goto default; // ??
+						memcpy(pHostVertexAsByte, pXboxVertexAsByte, XboxElementByteSize);
+					}
+					else
+#endif
+					{
+						// Make it FLOAT4
+						XboxElementByteSize = 4 * sizeof(BYTE);
+						pHostVertexAsFloat[0] = ByteToFloat(pXboxVertexAsByte[0]);
+						pHostVertexAsFloat[1] = ByteToFloat(pXboxVertexAsByte[1]);
+						pHostVertexAsFloat[2] = ByteToFloat(pXboxVertexAsByte[2]);
+						pHostVertexAsFloat[3] = ByteToFloat(pXboxVertexAsByte[3]);
+					}
 					break;
 				}
-#endif
 				case X_D3DVSDT_FLOAT2H: { // 0x72: // Make it FLOAT4 and set the third float to 0.0
 					XboxElementByteSize = 3 * sizeof(FLOAT);
 					pHostVertexAsFloat[0] = pXboxVertexAsFloat[0];
@@ -545,15 +560,15 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 				default: {
 					// Generic 'conversion' - just make a copy :
-					memcpy(pHostVertex, pXboxVertex, XboxElementByteSize);
+					memcpy(pHostVertexAsByte, pXboxVertexAsByte, XboxElementByteSize);
 					break;
 				}
 				} // switch
 
 				// Increment the Xbox pointer :
-				pXboxVertex += XboxElementByteSize;
+				pXboxVertexAsByte += XboxElementByteSize;
 				// Increment the host pointer :
-				pHostVertex += pVertexShaderStreamInfo->VertexElements[uiElement].HostByteSize;
+				pHostVertexAsByte += pVertexShaderStreamInfo->VertexElements[uiElement].HostByteSize;
 			} // for NumberOfVertexElements
 		} // for uiVertexCount
     }

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -397,7 +397,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				FLOAT *pXboxVertexAsFloat = (FLOAT*)pXboxVertex;
 				SHORT *pXboxVertexAsShort = (SHORT*)pXboxVertex;
 				BYTE *pXboxVertexAsByte = (BYTE*)pXboxVertex;
-				int XboxElementSizeInBytes = pVertexShaderStreamInfo->VertexElements[uiElement].HostByteSize;
+				int XboxElementByteSize = pVertexShaderStreamInfo->VertexElements[uiElement].HostByteSize;
 				FLOAT *pHostVertexAsFloat = (FLOAT*)pHostVertex;
 				SHORT *pHostVertexAsShort = (SHORT*)pHostVertex;
 #if CXBX_USE_D3D9
@@ -408,7 +408,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				switch (pVertexShaderStreamInfo->VertexElements[uiElement].XboxType) {
 				case X_D3DVSDT_NORMSHORT1: { // 0x11:
 					// Test-cases : Halo - Combat Evolved
-					XboxElementSizeInBytes = 1 * sizeof(SHORT);
+					XboxElementByteSize = 1 * sizeof(SHORT);
 #if CXBX_USE_D3D9	// Make it SHORT2N
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = 0;
@@ -421,7 +421,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 #if !CXBX_USE_D3D9 // No need for patching in D3D9
 				case X_D3DVSDT_NORMSHORT2: { // 0x21: // Make it FLOAT2
 					// Test-cases : Baldur's Gate: Dark Alliance 2, F1 2002, Gun, Halo - Combat Evolved, Scrapland 
-					XboxElementSizeInBytes = 2 * sizeof(SHORT);
+					XboxElementByteSize = 2 * sizeof(SHORT);
 					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsShort[0]) / 32767.0f;
 					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsShort[1]) / 32767.0f;
 					break;
@@ -429,7 +429,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 #endif
 				case X_D3DVSDT_NORMSHORT3: { // 0x31:
 					// Test-cases : Cel Damage, Constantine, Destroy All Humans!
-					XboxElementSizeInBytes = 3 * sizeof(SHORT);
+					XboxElementByteSize = 3 * sizeof(SHORT);
 #if CXBX_USE_D3D9	// Make it SHORT4N
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = pXboxVertexAsShort[1];
@@ -445,7 +445,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 #if !CXBX_USE_D3D9 // No need for patching in D3D9
 				case X_D3DVSDT_NORMSHORT4: { // 0x41: // Make it FLOAT4
 					// Test-cases : Judge Dredd: Dredd vs Death, NHL Hitz 2002, Silent Hill 2, Sneakers, Tony Hawk Pro Skater 4
-					XboxElementSizeInBytes = 4 * sizeof(SHORT);
+					XboxElementByteSize = 4 * sizeof(SHORT);
 					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsShort[0]) / 32767.0f;
 					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsShort[1]) / 32767.0f;
 					pHostVertexAsFloat[2] = ((FLOAT)pXboxVertexAsShort[2]) / 32767.0f;
@@ -455,7 +455,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 #endif
 				case X_D3DVSDT_NORMPACKED3: { // 0x16: // Make it FLOAT3
 					// Test-cases : Dashboard
-					XboxElementSizeInBytes = 1 * sizeof(int32);
+					XboxElementByteSize = 1 * sizeof(int32);
 					int32 iPacked = ((int32 *)pXboxVertex)[0];
 					// Cxbx note : to make each component signed, two need to be shifted towards the sign-bit first :
 					pHostVertexAsFloat[0] = ((FLOAT)((iPacked << 21) >> 21)) / 1023.0f;
@@ -464,16 +464,16 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					break;
 				}
 				case X_D3DVSDT_SHORT1: { // 0x15: // Make it SHORT2 and set the second short to 0
-					XboxElementSizeInBytes = 1 * sizeof(SHORT);
-					//memcpy(pHostVertexAsFloat, pXboxVertex, XboxElementSizeInBytes);
+					XboxElementByteSize = 1 * sizeof(SHORT);
+					//memcpy(pHostVertexAsFloat, pXboxVertex, XboxElementByteSize);
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = 0x00;
 					break;
 				}
 				case X_D3DVSDT_SHORT3: { // 0x35: // Make it a SHORT4 and set the fourth short to 1
 					// Test-cases : Turok
-					XboxElementSizeInBytes = 3 * sizeof(SHORT);
-					//memcpy(pHostVertexAsFloat, pXboxVertex, XboxElementSizeInBytes);
+					XboxElementByteSize = 3 * sizeof(SHORT);
+					//memcpy(pHostVertexAsFloat, pXboxVertex, XboxElementByteSize);
 					pHostVertexAsShort[0] = pXboxVertexAsShort[0];
 					pHostVertexAsShort[1] = pXboxVertexAsShort[1];
 					pHostVertexAsShort[2] = pXboxVertexAsShort[2];
@@ -481,7 +481,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					break;
 				}
 				case X_D3DVSDT_PBYTE1: { // 0x14:
-					XboxElementSizeInBytes = 1 * sizeof(BYTE);
+					XboxElementByteSize = 1 * sizeof(BYTE);
 #if CXBX_USE_D3D9	// Make it UBYTE4N
 					pHostVertexAsByte[0] = pXboxVertexAsByte[0];
 					pHostVertexAsByte[1] = 0;
@@ -493,7 +493,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 					break;
 				}
 				case X_D3DVSDT_PBYTE2: { // 0x24:
-					XboxElementSizeInBytes = 2 * sizeof(BYTE);
+					XboxElementByteSize = 2 * sizeof(BYTE);
 #if CXBX_USE_D3D9	// Make it UBYTE4N
 					pHostVertexAsByte[0] = pXboxVertexAsByte[0];
 					pHostVertexAsByte[1] = pXboxVertexAsByte[1];
@@ -507,7 +507,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 				case X_D3DVSDT_PBYTE3: { // 0x34:
 					// Test-cases : Turok
-					XboxElementSizeInBytes = 3 * sizeof(BYTE);
+					XboxElementByteSize = 3 * sizeof(BYTE);
 #if CXBX_USE_D3D9	// Make it UBYTE4N
 					pHostVertexAsByte[0] = pXboxVertexAsByte[0];
 					pHostVertexAsByte[1] = pXboxVertexAsByte[1];
@@ -523,7 +523,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 #if !CXBX_USE_D3D9 // No need for patching in D3D9
 				case X_D3DVSDT_PBYTE4: { // 0x44: // Make it FLOAT4
 					// Hit by Jet Set Radio Future
-					XboxElementSizeInBytes = 4 * sizeof(BYTE);
+					XboxElementByteSize = 4 * sizeof(BYTE);
 					pHostVertexAsFloat[0] = ((FLOAT)pXboxVertexAsByte[0]) / 255.0f;
 					pHostVertexAsFloat[1] = ((FLOAT)pXboxVertexAsByte[1]) / 255.0f;
 					pHostVertexAsFloat[2] = ((FLOAT)pXboxVertexAsByte[2]) / 255.0f;
@@ -532,7 +532,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 #endif
 				case X_D3DVSDT_FLOAT2H: { // 0x72: // Make it FLOAT4 and set the third float to 0.0
-					XboxElementSizeInBytes = 3 * sizeof(FLOAT);
+					XboxElementByteSize = 3 * sizeof(FLOAT);
 					pHostVertexAsFloat[0] = pXboxVertexAsFloat[0];
 					pHostVertexAsFloat[1] = pXboxVertexAsFloat[1];
 					pHostVertexAsFloat[2] = 0.0f;
@@ -545,13 +545,13 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 				}
 				default: {
 					// Generic 'conversion' - just make a copy :
-					memcpy(pHostVertex, pXboxVertex, XboxElementSizeInBytes);
+					memcpy(pHostVertex, pXboxVertex, XboxElementByteSize);
 					break;
 				}
 				} // switch
 
 				// Increment the Xbox pointer :
-				pXboxVertex += XboxElementSizeInBytes;
+				pXboxVertex += XboxElementByteSize;
 				// Increment the host pointer :
 				pHostVertex += pVertexShaderStreamInfo->VertexElements[uiElement].HostByteSize;
 			} // for NumberOfVertexElements

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1800,7 +1800,7 @@ static inline DWORD VshGetVertexStream(DWORD Token)
 
 static void VshConvertToken_NOP(
 	DWORD *pToken,
-	D3DVERTEXELEMENT *pRecompiled
+	XTL::D3DVERTEXELEMENT *pRecompiled
 )
 {
     // D3DVSD_NOP
@@ -1813,7 +1813,7 @@ static void VshConvertToken_NOP(
 
 static DWORD VshConvertToken_CONSTMEM(
 	DWORD *pToken,
-	D3DVERTEXELEMENT *pRecompiled
+	XTL::D3DVERTEXELEMENT *pRecompiled
 )
 {
     // D3DVSD_CONST
@@ -1835,7 +1835,7 @@ static DWORD VshConvertToken_CONSTMEM(
 
 static void VshConvertToken_TESSELATOR(
 	DWORD *pToken,
-	D3DVERTEXELEMENT *pRecompiled,
+	XTL::D3DVERTEXELEMENT *pRecompiled,
 	boolean IsFixedFunction
 )
 {
@@ -1899,7 +1899,7 @@ static void VshEndPreviousStreamPatch(CxbxVertexShaderPatch *pPatchData)
 
 static void VshConvertToken_STREAM(
 	DWORD          *pToken,
-	D3DVERTEXELEMENT *pRecompiled,
+	XTL::D3DVERTEXELEMENT *pRecompiled,
 	CxbxVertexShaderPatch *pPatchData
 )
 {
@@ -1932,7 +1932,7 @@ static void VshConvertToken_STREAM(
 
 static void VshConvertToken_STREAMDATA_SKIP(
 	DWORD *pToken,
-	D3DVERTEXELEMENT *pRecompiled
+	XTL::D3DVERTEXELEMENT *pRecompiled
 )
 {
     using namespace XTL;
@@ -1944,7 +1944,7 @@ static void VshConvertToken_STREAMDATA_SKIP(
 
 static void VshConvertToken_STREAMDATA_SKIPBYTES(
 	DWORD *pToken,
-	D3DVERTEXELEMENT *pRecompiled
+	XTL::D3DVERTEXELEMENT *pRecompiled
 )
 {
     using namespace XTL;
@@ -1960,12 +1960,23 @@ static void VshConvertToken_STREAMDATA_SKIPBYTES(
 
 static void VshConvertToken_STREAMDATA_REG(
 	DWORD *pToken,
-	D3DVERTEXELEMENT *pRecompiled,
+	XTL::D3DVERTEXELEMENT *pRecompiled,
 	boolean IsFixedFunction,
 	CxbxVertexShaderPatch *pPatchData
 )
 {
     using namespace XTL;
+
+#if !CXBX_USE_D3D9 // For simpler support for both Direct3D 8 and 9, use these '9' constants in below '8' code paths too:
+#define	D3DDECLTYPE_FLOAT1 D3DVSDT_FLOAT1
+#define	D3DDECLTYPE_FLOAT2 D3DVSDT_FLOAT2
+#define	D3DDECLTYPE_FLOAT3 D3DVSDT_FLOAT3
+#define	D3DDECLTYPE_FLOAT4 D3DVSDT_FLOAT4
+#define	D3DDECLTYPE_D3DCOLOR D3DVSDT_D3DCOLOR
+#define	D3DDECLTYPE_SHORT2 D3DVSDT_SHORT2
+#define	D3DDECLTYPE_SHORT4 D3DVSDT_SHORT4
+#define	D3DDECLTYPE_UNUSED 0xFF
+#endif
 
     XTL::DWORD VertexRegister = VshGetVertexRegister(*pToken);
     XTL::DWORD HostVertexRegister;
@@ -1983,118 +1994,161 @@ static void VshConvertToken_STREAMDATA_REG(
     {
 	case X_D3DVSDT_FLOAT1: // 0x12:
         DbgVshPrintf("D3DVSDT_FLOAT1");
-        HostVertexElementDataType = D3DVSDT_FLOAT1;
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
 		HostVertexElementByteSize = 1*sizeof(FLOAT);
         break;
 	case X_D3DVSDT_FLOAT2: // 0x22:
         DbgVshPrintf("D3DVSDT_FLOAT2");
-        HostVertexElementDataType = D3DVSDT_FLOAT2;
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
 		HostVertexElementByteSize = 2*sizeof(FLOAT);
         break;
 	case X_D3DVSDT_FLOAT3: // 0x32:
         DbgVshPrintf("D3DVSDT_FLOAT3");
-        HostVertexElementDataType = D3DVSDT_FLOAT3;
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
 		HostVertexElementByteSize = 3*sizeof(FLOAT);
         break;
 	case X_D3DVSDT_FLOAT4: // 0x42:
         DbgVshPrintf("D3DVSDT_FLOAT4");
-        HostVertexElementDataType = D3DVSDT_FLOAT4;
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
 		HostVertexElementByteSize = 4*sizeof(FLOAT);
         break;
 	case X_D3DVSDT_D3DCOLOR: // 0x40:
         DbgVshPrintf("D3DVSDT_D3DCOLOR");
-        HostVertexElementDataType = D3DVSDT_D3DCOLOR;
-		HostVertexElementByteSize = sizeof(D3DCOLOR);
+		HostVertexElementDataType = D3DDECLTYPE_D3DCOLOR;
+		HostVertexElementByteSize = 1*sizeof(D3DCOLOR);
         break;
 	case X_D3DVSDT_SHORT2: // 0x25:
         DbgVshPrintf("D3DVSDT_SHORT2");
-        HostVertexElementDataType = D3DVSDT_SHORT2;
+		HostVertexElementDataType = D3DDECLTYPE_SHORT2;
 		HostVertexElementByteSize = 2*sizeof(XTL::SHORT);
         break;
 	case X_D3DVSDT_SHORT4: // 0x45:
         DbgVshPrintf("D3DVSDT_SHORT4");
-        HostVertexElementDataType = D3DVSDT_SHORT4;
+		HostVertexElementDataType = D3DDECLTYPE_SHORT4;
 		HostVertexElementByteSize = 4*sizeof(XTL::SHORT);
         break;
 	case X_D3DVSDT_NORMSHORT1: // 0x11:
         DbgVshPrintf("D3DVSDT_NORMSHORT1 /* xbox ext. */");
-        HostVertexElementDataType = D3DVSDT_FLOAT1; // TODO -oDxbx : Is it better to use D3DVSDT_NORMSHORT2 in Direct3D9 ?
-		HostVertexElementByteSize = sizeof(FLOAT);
+#if CXBX_USE_D3D9
+		HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
+		HostVertexElementByteSize = 2*sizeof(SHORT);
+#else
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
+		HostVertexElementByteSize = 1*sizeof(FLOAT);
+#endif
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_NORMSHORT2: // 0x21:
-        DbgVshPrintf("D3DVSDT_NORMSHORT2 /* xbox ext. */");
-        HostVertexElementDataType = D3DVSDT_FLOAT2;
+#if CXBX_USE_D3D9
+		DbgVshPrintf("D3DVSDT_NORMSHORT2");
+		HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
+		HostVertexElementByteSize = 2*sizeof(SHORT);
+		// No need for patching in D3D9
+#else
+		DbgVshPrintf("D3DVSDT_NORMSHORT2 /* xbox ext. */");
+        HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
 		HostVertexElementByteSize = 2*sizeof(FLOAT);
         NeedPatching = TRUE;
-        break;
+#endif
+		break;
 	case X_D3DVSDT_NORMSHORT3: // 0x31:
-        DbgVshPrintf("D3DVSDT_NORMSHORT3 /* xbox ext. nsp */");
-        HostVertexElementDataType = D3DVSDT_FLOAT3; // TODO -oDxbx : Is it better to use D3DVSDT_NORMSHORT4 in Direct3D9 ?
+        DbgVshPrintf("D3DVSDT_NORMSHORT3 /* xbox ext. */");
+#if CXBX_USE_D3D9
+		HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
+		HostVertexElementByteSize = 4*sizeof(SHORT);
+#else
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
 		HostVertexElementByteSize = 3*sizeof(FLOAT);
+#endif
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_NORMSHORT4: // 0x41:
-        DbgVshPrintf("D3DVSDT_NORMSHORT4 /* xbox ext. */");
-        HostVertexElementDataType = D3DVSDT_FLOAT4;
+#if CXBX_USE_D3D9
+		DbgVshPrintf("D3DVSDT_NORMSHORT4");
+		HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
+		HostVertexElementByteSize = 4*sizeof(SHORT);
+		// No need for patching in D3D9
+#else
+		DbgVshPrintf("D3DVSDT_NORMSHORT4 /* xbox ext. */");
+        HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
 		HostVertexElementByteSize = 4*sizeof(FLOAT);
         NeedPatching = TRUE;
+#endif
         break;
 	case X_D3DVSDT_NORMPACKED3: // 0x16:
-        DbgVshPrintf("D3DVSDT_NORMPACKED3 /* xbox ext. nsp */");
-        HostVertexElementDataType = D3DVSDT_FLOAT3;
+        DbgVshPrintf("D3DVSDT_NORMPACKED3 /* xbox ext. */");
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
 		HostVertexElementByteSize = 3*sizeof(FLOAT);
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_SHORT1: // 0x15:
-        DbgVshPrintf("D3DVSDT_SHORT1 /* xbox ext. nsp */");
-        HostVertexElementDataType = D3DVSDT_SHORT2;
+        DbgVshPrintf("D3DVSDT_SHORT1 /* xbox ext. */");
+        HostVertexElementDataType = D3DDECLTYPE_SHORT2;
 		HostVertexElementByteSize = 2*sizeof(XTL::SHORT);
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_SHORT3: // 0x35:
-        DbgVshPrintf("D3DVSDT_SHORT3 /* xbox ext. nsp */");
-        HostVertexElementDataType = D3DVSDT_SHORT4;
+        DbgVshPrintf("D3DVSDT_SHORT3 /* xbox ext. */");
+        HostVertexElementDataType = D3DDECLTYPE_SHORT4;
 		HostVertexElementByteSize = 4*sizeof(XTL::SHORT);
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_PBYTE1: // 0x14:
-        DbgVshPrintf("D3DVSDT_PBYTE1 /* xbox ext. nsp */");
-        HostVertexElementDataType = D3DVSDT_FLOAT1; // TODO -oDxbx : Is it better to use D3DVSDT_NORMSHORT2 in Direct3D9 ?
+        DbgVshPrintf("D3DVSDT_PBYTE1 /* xbox ext. */");
+#if CXBX_USE_D3D9
+		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+		HostVertexElementByteSize = 4*sizeof(BYTE);
+#else
+        HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
 		HostVertexElementByteSize = 1*sizeof(FLOAT);
-        NeedPatching = TRUE;
+#endif
+		NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_PBYTE2: // 0x24:
-        DbgVshPrintf("D3DVSDT_PBYTE2 /* xbox ext. nsp */");
-        HostVertexElementDataType = D3DVSDT_FLOAT2; // TODO -oDxbx : Is it better to use D3DVSDT_NORMSHORT2 in Direct3D9 ?
+        DbgVshPrintf("D3DVSDT_PBYTE2 /* xbox ext. */");
+#if CXBX_USE_D3D9
+		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+		HostVertexElementByteSize = 4*sizeof(BYTE);
+#else
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
 		HostVertexElementByteSize = 2*sizeof(FLOAT);
+#endif
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_PBYTE3: // 0x34:
-        DbgVshPrintf("D3DVSDT_PBYTE3 /* xbox ext. nsp */");
-        HostVertexElementDataType = D3DVSDT_FLOAT3; // TODO -oDxbx : Is it better to use D3DVSDT_NORMSHORT4 in Direct3D9 ?
+        DbgVshPrintf("D3DVSDT_PBYTE3 /* xbox ext. */");
+#if CXBX_USE_D3D9
+		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+		HostVertexElementByteSize = 4*sizeof(BYTE);
+#else
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
 		HostVertexElementByteSize = 3*sizeof(FLOAT);
+#endif
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_PBYTE4: // 0x44: // Hit by Panzer
+#if CXBX_USE_D3D9
+        DbgVshPrintf("D3DVSDT_PBYTE4");
+		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+		HostVertexElementByteSize = 4*sizeof(BYTE);
+		// No need for patching in D3D9
+#else
         DbgVshPrintf("D3DVSDT_PBYTE4 /* xbox ext. */");
-        HostVertexElementDataType = D3DVSDT_FLOAT4; // TODO -oDxbx : Is it better to use D3DVSDT_NORMSHORT4 or D3DDECLTYPE_UBYTE4N (if in caps) in Direct3D9 ?
+        HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
 		HostVertexElementByteSize = 4*sizeof(FLOAT);
 		NeedPatching = TRUE;
+#endif
 		break;
 	case X_D3DVSDT_FLOAT2H: // 0x72:
         DbgVshPrintf("D3DVSDT_FLOAT2H /* xbox ext. */");
-        HostVertexElementDataType = D3DVSDT_FLOAT4;
+        HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
 		HostVertexElementByteSize = 4*sizeof(FLOAT);
         NeedPatching = TRUE;
         break;
 	case X_D3DVSDT_NONE: // 0x02:
-        DbgVshPrintf("D3DVSDT_NONE /* xbox ext. nsp */");
-#if CXBX_USE_D3D9
-		HostVertexElementDataType = D3DVSDT_NONE;
-#endif
-	    // TODO -oDxbx: Use D3DVSD_NOP ?
-        HostVertexElementDataType = 0xFF;
+		DbgVshPrintf("D3DVSDT_NONE /* xbox ext. */");
+        HostVertexElementDataType = D3DDECLTYPE_UNUSED;
+        NeedPatching = TRUE;
         break;
     default:
         DbgVshPrintf("Unknown data type for D3DVSD_REG: 0x%02X\n", XboxVertexElementDataType);
@@ -2114,7 +2168,7 @@ static void VshConvertToken_STREAMDATA_REG(
 
     DbgVshPrintf("),\n");
 
-    if(HostVertexElementDataType == 0xFF)
+    if(HostVertexElementDataType == D3DDECLTYPE_UNUSED)
     {
         EmuWarning("/* WARNING: Fatal type mismatch, no fitting type! */");
     }
@@ -2122,7 +2176,7 @@ static void VshConvertToken_STREAMDATA_REG(
 
 static void VshConvertToken_STREAMDATA(
 	DWORD          *pToken,
-	D3DVERTEXELEMENT *pRecompiled,
+	XTL::D3DVERTEXELEMENT *pRecompiled,
 	boolean         IsFixedFunction,
 	CxbxVertexShaderPatch *pPatchData
 )
@@ -2145,7 +2199,7 @@ static void VshConvertToken_STREAMDATA(
 
 static DWORD VshRecompileToken(
 	DWORD          *pToken,
-	D3DVERTEXELEMENT *&pRecompiled,
+	XTL::D3DVERTEXELEMENT *&pRecompiled,
 	boolean         IsFixedFunction,
 	CxbxVertexShaderPatch *pPatchData
 )
@@ -2190,7 +2244,7 @@ static DWORD VshRecompileToken(
 DWORD XTL::EmuRecompileVshDeclaration
 (
     DWORD                *pDeclaration,
-	D3DVERTEXELEMENT **ppRecompiledDeclaration,
+	D3DVERTEXELEMENT    **ppRecompiledDeclaration,
     DWORD                *pDeclarationSize,
     boolean               IsFixedFunction,
     CxbxVertexShaderInfo *pVertexShaderInfo

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2030,50 +2030,66 @@ static void VshConvertToken_STREAMDATA_REG(
 	case X_D3DVSDT_NORMSHORT1: // 0x11:
 		DbgVshPrintf("D3DVSDT_NORMSHORT1 /* xbox ext. */");
 #if CXBX_USE_D3D9
-		HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
-		HostVertexElementByteSize = 2 * sizeof(SHORT);
-#else
-		HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
-		HostVertexElementByteSize = 1 * sizeof(FLOAT);
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_SHORT2N) {
+			HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
+			HostVertexElementByteSize = 2 * sizeof(SHORT);
+		}
+		else
 #endif
+		{
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
+			HostVertexElementByteSize = 1 * sizeof(FLOAT);
+		}
 		NeedPatching = TRUE;
 		break;
 	case X_D3DVSDT_NORMSHORT2: // 0x21:
 #if CXBX_USE_D3D9
-		DbgVshPrintf("D3DVSDT_NORMSHORT2");
-		HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
-		HostVertexElementByteSize = 2 * sizeof(SHORT);
-		// No need for patching in D3D9
-#else
-		DbgVshPrintf("D3DVSDT_NORMSHORT2 /* xbox ext. */");
-		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
-		HostVertexElementByteSize = 2 * sizeof(FLOAT);
-		NeedPatching = TRUE;
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_SHORT2N) {
+			DbgVshPrintf("D3DVSDT_NORMSHORT2");
+			HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
+			HostVertexElementByteSize = 2 * sizeof(SHORT);
+			// No need for patching in D3D9
+		}
+		else
 #endif
+		{
+			DbgVshPrintf("D3DVSDT_NORMSHORT2 /* xbox ext. */");
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
+			HostVertexElementByteSize = 2 * sizeof(FLOAT);
+			NeedPatching = TRUE;
+		}
 		break;
 	case X_D3DVSDT_NORMSHORT3: // 0x31:
 		DbgVshPrintf("D3DVSDT_NORMSHORT3 /* xbox ext. */");
 #if CXBX_USE_D3D9
-		HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
-		HostVertexElementByteSize = 4 * sizeof(SHORT);
-#else
-		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
-		HostVertexElementByteSize = 3 * sizeof(FLOAT);
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_SHORT4N) {
+			HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
+			HostVertexElementByteSize = 4 * sizeof(SHORT);
+		}
+		else
 #endif
+		{
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
+			HostVertexElementByteSize = 3 * sizeof(FLOAT);
+		}
 		NeedPatching = TRUE;
 		break;
 	case X_D3DVSDT_NORMSHORT4: // 0x41:
 #if CXBX_USE_D3D9
-		DbgVshPrintf("D3DVSDT_NORMSHORT4");
-		HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
-		HostVertexElementByteSize = 4 * sizeof(SHORT);
-		// No need for patching in D3D9
-#else
-		DbgVshPrintf("D3DVSDT_NORMSHORT4 /* xbox ext. */");
-		HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
-		HostVertexElementByteSize = 4 * sizeof(FLOAT);
-		NeedPatching = TRUE;
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_SHORT4N) {
+			DbgVshPrintf("D3DVSDT_NORMSHORT4");
+			HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
+			HostVertexElementByteSize = 4 * sizeof(SHORT);
+			// No need for patching in D3D9
+		}
+		else
 #endif
+		{
+			DbgVshPrintf("D3DVSDT_NORMSHORT4 /* xbox ext. */");
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
+			HostVertexElementByteSize = 4 * sizeof(FLOAT);
+			NeedPatching = TRUE;
+		}
 		break;
 	case X_D3DVSDT_NORMPACKED3: // 0x16:
 		DbgVshPrintf("D3DVSDT_NORMPACKED3 /* xbox ext. */");
@@ -2096,34 +2112,46 @@ static void VshConvertToken_STREAMDATA_REG(
 	case X_D3DVSDT_PBYTE1: // 0x14:
 		DbgVshPrintf("D3DVSDT_PBYTE1 /* xbox ext. */");
 #if CXBX_USE_D3D9
-		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
-		HostVertexElementByteSize = 4 * sizeof(BYTE);
-#else
-		HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
-		HostVertexElementByteSize = 1 * sizeof(FLOAT);
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+			HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+			HostVertexElementByteSize = 4 * sizeof(BYTE);
+		}
+		else
 #endif
+		{
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
+			HostVertexElementByteSize = 1 * sizeof(FLOAT);
+		}
 		NeedPatching = TRUE;
 		break;
 	case X_D3DVSDT_PBYTE2: // 0x24:
 		DbgVshPrintf("D3DVSDT_PBYTE2 /* xbox ext. */");
 #if CXBX_USE_D3D9
-		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
-		HostVertexElementByteSize = 4 * sizeof(BYTE);
-#else
-		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
-		HostVertexElementByteSize = 2 * sizeof(FLOAT);
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+			HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+			HostVertexElementByteSize = 4 * sizeof(BYTE);
+		}
+		else
 #endif
+		{
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
+			HostVertexElementByteSize = 2 * sizeof(FLOAT);
+		}
 		NeedPatching = TRUE;
 		break;
 	case X_D3DVSDT_PBYTE3: // 0x34:
 		DbgVshPrintf("D3DVSDT_PBYTE3 /* xbox ext. */");
 #if CXBX_USE_D3D9
-		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
-		HostVertexElementByteSize = 4 * sizeof(BYTE);
-#else
-		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
-		HostVertexElementByteSize = 3 * sizeof(FLOAT);
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+			HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+			HostVertexElementByteSize = 4 * sizeof(BYTE);
+		}
+		else
 #endif
+		{
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
+			HostVertexElementByteSize = 3 * sizeof(FLOAT);
+		}
 		NeedPatching = TRUE;
 		break;
 	case X_D3DVSDT_PBYTE4: // 0x44: // Hit by Panzer

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1990,154 +1990,158 @@ static void VshConvertToken_STREAMDATA_REG(
     XTL::DWORD HostVertexElementDataType = 0;
 	XTL::DWORD HostVertexElementByteSize = 0;
 
-    switch(XboxVertexElementDataType)
-    {
+	switch (XboxVertexElementDataType)
+	{
 	case X_D3DVSDT_FLOAT1: // 0x12:
-        DbgVshPrintf("D3DVSDT_FLOAT1");
+		DbgVshPrintf("D3DVSDT_FLOAT1");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
-		HostVertexElementByteSize = 1*sizeof(FLOAT);
-        break;
+		HostVertexElementByteSize = 1 * sizeof(FLOAT);
+		break;
 	case X_D3DVSDT_FLOAT2: // 0x22:
-        DbgVshPrintf("D3DVSDT_FLOAT2");
+		DbgVshPrintf("D3DVSDT_FLOAT2");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
-		HostVertexElementByteSize = 2*sizeof(FLOAT);
-        break;
+		HostVertexElementByteSize = 2 * sizeof(FLOAT);
+		break;
 	case X_D3DVSDT_FLOAT3: // 0x32:
-        DbgVshPrintf("D3DVSDT_FLOAT3");
+		DbgVshPrintf("D3DVSDT_FLOAT3");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
-		HostVertexElementByteSize = 3*sizeof(FLOAT);
-        break;
+		HostVertexElementByteSize = 3 * sizeof(FLOAT);
+		break;
 	case X_D3DVSDT_FLOAT4: // 0x42:
-        DbgVshPrintf("D3DVSDT_FLOAT4");
+		DbgVshPrintf("D3DVSDT_FLOAT4");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
-		HostVertexElementByteSize = 4*sizeof(FLOAT);
-        break;
+		HostVertexElementByteSize = 4 * sizeof(FLOAT);
+		break;
 	case X_D3DVSDT_D3DCOLOR: // 0x40:
-        DbgVshPrintf("D3DVSDT_D3DCOLOR");
+		DbgVshPrintf("D3DVSDT_D3DCOLOR");
 		HostVertexElementDataType = D3DDECLTYPE_D3DCOLOR;
-		HostVertexElementByteSize = 1*sizeof(D3DCOLOR);
-        break;
+		HostVertexElementByteSize = 1 * sizeof(D3DCOLOR);
+		break;
 	case X_D3DVSDT_SHORT2: // 0x25:
-        DbgVshPrintf("D3DVSDT_SHORT2");
+		DbgVshPrintf("D3DVSDT_SHORT2");
 		HostVertexElementDataType = D3DDECLTYPE_SHORT2;
-		HostVertexElementByteSize = 2*sizeof(XTL::SHORT);
-        break;
+		HostVertexElementByteSize = 2 * sizeof(XTL::SHORT);
+		break;
 	case X_D3DVSDT_SHORT4: // 0x45:
-        DbgVshPrintf("D3DVSDT_SHORT4");
+		DbgVshPrintf("D3DVSDT_SHORT4");
 		HostVertexElementDataType = D3DDECLTYPE_SHORT4;
-		HostVertexElementByteSize = 4*sizeof(XTL::SHORT);
-        break;
+		HostVertexElementByteSize = 4 * sizeof(XTL::SHORT);
+		break;
 	case X_D3DVSDT_NORMSHORT1: // 0x11:
-        DbgVshPrintf("D3DVSDT_NORMSHORT1 /* xbox ext. */");
+		DbgVshPrintf("D3DVSDT_NORMSHORT1 /* xbox ext. */");
 #if CXBX_USE_D3D9
 		HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
-		HostVertexElementByteSize = 2*sizeof(SHORT);
+		HostVertexElementByteSize = 2 * sizeof(SHORT);
 #else
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
-		HostVertexElementByteSize = 1*sizeof(FLOAT);
+		HostVertexElementByteSize = 1 * sizeof(FLOAT);
 #endif
-        NeedPatching = TRUE;
-        break;
+		NeedPatching = TRUE;
+		break;
 	case X_D3DVSDT_NORMSHORT2: // 0x21:
 #if CXBX_USE_D3D9
 		DbgVshPrintf("D3DVSDT_NORMSHORT2");
 		HostVertexElementDataType = D3DDECLTYPE_SHORT2N;
-		HostVertexElementByteSize = 2*sizeof(SHORT);
+		HostVertexElementByteSize = 2 * sizeof(SHORT);
 		// No need for patching in D3D9
 #else
 		DbgVshPrintf("D3DVSDT_NORMSHORT2 /* xbox ext. */");
-        HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
-		HostVertexElementByteSize = 2*sizeof(FLOAT);
-        NeedPatching = TRUE;
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
+		HostVertexElementByteSize = 2 * sizeof(FLOAT);
+		NeedPatching = TRUE;
 #endif
 		break;
 	case X_D3DVSDT_NORMSHORT3: // 0x31:
-        DbgVshPrintf("D3DVSDT_NORMSHORT3 /* xbox ext. */");
+		DbgVshPrintf("D3DVSDT_NORMSHORT3 /* xbox ext. */");
 #if CXBX_USE_D3D9
 		HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
-		HostVertexElementByteSize = 4*sizeof(SHORT);
+		HostVertexElementByteSize = 4 * sizeof(SHORT);
 #else
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
-		HostVertexElementByteSize = 3*sizeof(FLOAT);
+		HostVertexElementByteSize = 3 * sizeof(FLOAT);
 #endif
-        NeedPatching = TRUE;
-        break;
+		NeedPatching = TRUE;
+		break;
 	case X_D3DVSDT_NORMSHORT4: // 0x41:
 #if CXBX_USE_D3D9
 		DbgVshPrintf("D3DVSDT_NORMSHORT4");
 		HostVertexElementDataType = D3DDECLTYPE_SHORT4N;
-		HostVertexElementByteSize = 4*sizeof(SHORT);
+		HostVertexElementByteSize = 4 * sizeof(SHORT);
 		// No need for patching in D3D9
 #else
 		DbgVshPrintf("D3DVSDT_NORMSHORT4 /* xbox ext. */");
-        HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
-		HostVertexElementByteSize = 4*sizeof(FLOAT);
-        NeedPatching = TRUE;
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
+		HostVertexElementByteSize = 4 * sizeof(FLOAT);
+		NeedPatching = TRUE;
 #endif
-        break;
+		break;
 	case X_D3DVSDT_NORMPACKED3: // 0x16:
-        DbgVshPrintf("D3DVSDT_NORMPACKED3 /* xbox ext. */");
+		DbgVshPrintf("D3DVSDT_NORMPACKED3 /* xbox ext. */");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
-		HostVertexElementByteSize = 3*sizeof(FLOAT);
-        NeedPatching = TRUE;
-        break;
+		HostVertexElementByteSize = 3 * sizeof(FLOAT);
+		NeedPatching = TRUE;
+		break;
 	case X_D3DVSDT_SHORT1: // 0x15:
-        DbgVshPrintf("D3DVSDT_SHORT1 /* xbox ext. */");
-        HostVertexElementDataType = D3DDECLTYPE_SHORT2;
-		HostVertexElementByteSize = 2*sizeof(XTL::SHORT);
-        NeedPatching = TRUE;
-        break;
+		DbgVshPrintf("D3DVSDT_SHORT1 /* xbox ext. */");
+		HostVertexElementDataType = D3DDECLTYPE_SHORT2;
+		HostVertexElementByteSize = 2 * sizeof(XTL::SHORT);
+		NeedPatching = TRUE;
+		break;
 	case X_D3DVSDT_SHORT3: // 0x35:
-        DbgVshPrintf("D3DVSDT_SHORT3 /* xbox ext. */");
-        HostVertexElementDataType = D3DDECLTYPE_SHORT4;
-		HostVertexElementByteSize = 4*sizeof(XTL::SHORT);
-        NeedPatching = TRUE;
-        break;
+		DbgVshPrintf("D3DVSDT_SHORT3 /* xbox ext. */");
+		HostVertexElementDataType = D3DDECLTYPE_SHORT4;
+		HostVertexElementByteSize = 4 * sizeof(XTL::SHORT);
+		NeedPatching = TRUE;
+		break;
 	case X_D3DVSDT_PBYTE1: // 0x14:
-        DbgVshPrintf("D3DVSDT_PBYTE1 /* xbox ext. */");
+		DbgVshPrintf("D3DVSDT_PBYTE1 /* xbox ext. */");
 #if CXBX_USE_D3D9
 		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
-		HostVertexElementByteSize = 4*sizeof(BYTE);
+		HostVertexElementByteSize = 4 * sizeof(BYTE);
 #else
-        HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
-		HostVertexElementByteSize = 1*sizeof(FLOAT);
+		HostVertexElementDataType = D3DDECLTYPE_FLOAT1;
+		HostVertexElementByteSize = 1 * sizeof(FLOAT);
 #endif
 		NeedPatching = TRUE;
-        break;
+		break;
 	case X_D3DVSDT_PBYTE2: // 0x24:
-        DbgVshPrintf("D3DVSDT_PBYTE2 /* xbox ext. */");
+		DbgVshPrintf("D3DVSDT_PBYTE2 /* xbox ext. */");
 #if CXBX_USE_D3D9
 		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
-		HostVertexElementByteSize = 4*sizeof(BYTE);
+		HostVertexElementByteSize = 4 * sizeof(BYTE);
 #else
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
-		HostVertexElementByteSize = 2*sizeof(FLOAT);
+		HostVertexElementByteSize = 2 * sizeof(FLOAT);
 #endif
-        NeedPatching = TRUE;
-        break;
+		NeedPatching = TRUE;
+		break;
 	case X_D3DVSDT_PBYTE3: // 0x34:
-        DbgVshPrintf("D3DVSDT_PBYTE3 /* xbox ext. */");
+		DbgVshPrintf("D3DVSDT_PBYTE3 /* xbox ext. */");
 #if CXBX_USE_D3D9
 		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
-		HostVertexElementByteSize = 4*sizeof(BYTE);
+		HostVertexElementByteSize = 4 * sizeof(BYTE);
 #else
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
-		HostVertexElementByteSize = 3*sizeof(FLOAT);
+		HostVertexElementByteSize = 3 * sizeof(FLOAT);
 #endif
-        NeedPatching = TRUE;
-        break;
+		NeedPatching = TRUE;
+		break;
 	case X_D3DVSDT_PBYTE4: // 0x44: // Hit by Panzer
 #if CXBX_USE_D3D9
-        DbgVshPrintf("D3DVSDT_PBYTE4");
-		HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
-		HostVertexElementByteSize = 4*sizeof(BYTE);
-		// No need for patching in D3D9
-#else
-        DbgVshPrintf("D3DVSDT_PBYTE4 /* xbox ext. */");
-        HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
-		HostVertexElementByteSize = 4*sizeof(FLOAT);
-		NeedPatching = TRUE;
+		if (g_D3DCaps.DeclTypes & D3DDTCAPS_UBYTE4N) {
+			DbgVshPrintf("D3DVSDT_PBYTE4");
+			HostVertexElementDataType = D3DDECLTYPE_UBYTE4N;
+			HostVertexElementByteSize = 4 * sizeof(BYTE);
+			// No need for patching when D3D9 supports D3DDECLTYPE_UBYTE4N
+		}
+		else
 #endif
+		{
+			DbgVshPrintf("D3DVSDT_PBYTE4 /* xbox ext. */");
+			HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
+			HostVertexElementByteSize = 4 * sizeof(FLOAT);
+			NeedPatching = TRUE;
+		}
 		break;
 	case X_D3DVSDT_FLOAT2H: // 0x72:
         DbgVshPrintf("D3DVSDT_FLOAT2H /* xbox ext. */");
@@ -2148,7 +2152,7 @@ static void VshConvertToken_STREAMDATA_REG(
 	case X_D3DVSDT_NONE: // 0x02:
 		DbgVshPrintf("D3DVSDT_NONE /* xbox ext. */");
         HostVertexElementDataType = D3DDECLTYPE_UNUSED;
-        NeedPatching = TRUE;
+        // NeedPatching = TRUE; // TODO : This seems to cause regressions?
         break;
     default:
         DbgVshPrintf("Unknown data type for D3DVSD_REG: 0x%02X\n", XboxVertexElementDataType);

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.h
@@ -53,7 +53,7 @@ VSH_SHADER_HEADER;
 extern DWORD EmuRecompileVshDeclaration
 (
     DWORD                *pDeclaration,
-    DWORD               **ppRecompiledDeclaration,
+    D3DVERTEXELEMENT    **ppRecompiledDeclaration,
     DWORD                *pDeclarationSize,
     boolean               IsFixedFunction,
     XTL::CxbxVertexShaderInfo *pVertexShaderInfo

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -70,6 +70,7 @@
 #define D3DXAssembleShader		 D3DXCompileShader
 #define FullScreen_PresentationInterval PresentationInterval // a field in D3DPRESENT_PARAMETERS
 #define D3DLockData              void
+#define PixelShaderConstantType  float
 
 #define D3DADAPTER_IDENTIFIER    D3DADAPTER_IDENTIFIER9
 #define D3DCAPS                  D3DCAPS9
@@ -113,6 +114,7 @@ typedef D3DVIEWPORT9 X_D3DVIEWPORT8;
 #define DXGetErrorString         DXGetErrorString8A
 #define DXGetErrorDescription    DXGetErrorDescription8A
 #define D3DLockData              BYTE
+#define PixelShaderConstantType  void
 
 #define D3DADAPTER_IDENTIFIER    D3DADAPTER_IDENTIFIER8
 #define D3DCAPS                  D3DCAPS8

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -1208,6 +1208,18 @@ const int MAX_NBR_STREAMS = 16;
 
 typedef WORD INDEX16;
 
+typedef enum _X_D3DVSD_TOKENTYPE
+{
+	X_D3DVSD_TOKEN_NOP = 0,           // NOP or extension
+	X_D3DVSD_TOKEN_STREAM,            // stream selector
+	X_D3DVSD_TOKEN_STREAMDATA,        // stream data definition (map to vertex input memory)
+	X_D3DVSD_TOKEN_TESSELLATOR,       // vertex input memory from tessellator
+	X_D3DVSD_TOKEN_CONSTMEM,          // constant memory from shader
+	X_D3DVSD_TOKEN_EXT,               // extension
+	X_D3DVSD_TOKEN_END = 7,           // end-of-array (requires all DWORD bits to be 1)
+	X_D3DVSD_FORCE_DWORD = 0x7fffffff,// force 32-bit size enum
+} X_D3DVSD_TOKENTYPE;
+
 #define X_D3DVSD_TOKENTYPESHIFT   29
 #define X_D3DVSD_TOKENTYPEMASK    (7 << X_D3DVSD_TOKENTYPESHIFT)
 
@@ -1243,5 +1255,7 @@ typedef WORD INDEX16;
 
 #define X_D3DVSD_EXTINFOSHIFT 0
 #define X_D3DVSD_EXTINFOMASK (0xFFFFFF << X_D3DVSD_EXTINFOSHIFT)
+
+#define X_D3DVSD_END() 0xFFFFFFFF
 
 #endif

--- a/src/CxbxKrnl/EmuD3D8Types.h
+++ b/src/CxbxKrnl/EmuD3D8Types.h
@@ -73,6 +73,7 @@
 
 #define D3DADAPTER_IDENTIFIER    D3DADAPTER_IDENTIFIER9
 #define D3DCAPS                  D3DCAPS9
+#define D3DVERTEXELEMENT         D3DVERTEXELEMENT9
 #define D3DVIEWPORT              D3DVIEWPORT9
 
 #define IDirect3D                IDirect3D9
@@ -115,6 +116,7 @@ typedef D3DVIEWPORT9 X_D3DVIEWPORT8;
 
 #define D3DADAPTER_IDENTIFIER    D3DADAPTER_IDENTIFIER8
 #define D3DCAPS                  D3DCAPS8
+#define D3DVERTEXELEMENT         DWORD
 #define D3DVIEWPORT              D3DVIEWPORT8
 
 #define IDirect3D                IDirect3D8


### PR DESCRIPTION
This pull request contains just a few things I've recently done to get closer to compiling Cxbx-Reloaded with Direct3D 9 HLE rendering.

**This work is NOT finished!**

The default compile (both Debug and Release) will still use Direct3D 8 for HLE rendering.
Nothing should have changed on that.
But, since this contains updates to vertex buffer conversion, please verify with a few titles that nothing regressed (it shouldn't have, but still).