### PR TITLE
D3D : Fix pushbuffer based drawing 

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7468,7 +7468,7 @@ void EmuUpdateActiveTextureStages()
 	}
 }
 
-void CxbxUpdateNativeD3DResources()
+void XTL::CxbxUpdateNativeD3DResources()
 {
 	EmuUpdateActiveTextureStages();
 

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -205,9 +205,7 @@ extern void XTL::EmuExecutePushBufferRaw
 
     X_D3DPRIMITIVETYPE  XboxPrimitiveType = X_D3DPT_INVALID;
 
-    // TODO: This technically should be enabled
-    XTL::EmuUpdateDeferredStates();
-	EmuUpdateActiveTextureStages();
+	CxbxUpdateNativeD3DResources();
 
     #ifdef _DEBUG_TRACK_PB
     bool bShowPB = false;

--- a/src/CxbxKrnl/EmuD3D8/State.h
+++ b/src/CxbxKrnl/EmuD3D8/State.h
@@ -53,4 +53,6 @@ extern DWORD *EmuD3DDeferredTextureState;
 
 extern void EmuUpdateDeferredStates();
 
+extern void CxbxUpdateNativeD3DResources();
+
 #endif

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -820,8 +820,7 @@ void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext)
 
 VOID XTL::EmuFlushIVB()
 {
-    XTL::EmuUpdateDeferredStates();
-	EmuUpdateActiveTextureStages();
+	CxbxUpdateNativeD3DResources();
 
     // Parse IVB table with current FVF shader if possible.
     bool bFVF = VshHandleIsFVF(g_CurrentXboxVertexShaderHandle);

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2404,7 +2404,7 @@ extern HRESULT XTL::EmuRecompileVshFunction
 	// Build an array of registers that are declared
 	// This is used to remove instructions that haven't been declared
 	// as they cause CreateVertexShader to fail
-	bool declaredRegisters[13];
+	bool declaredRegisters[13] = { false };
 	DWORD* pDeclToken = pRecompiledDeclaration;
 	do {
 		DWORD regNum = *pDeclToken & X_D3DVSD_VERTEXREGMASK;


### PR DESCRIPTION
This pull request fixes drawing errors in push-buffer based drawing, by calling CxbxUpdateNativeD3DResources from there too.

Test-case : BeginPush XDK sample

