### PR TITLE
Revert rc files to binary (changed in 02141bd1c65)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,7 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Microsoft Visual C++ generated resource script with forced Unicode
+*.RC	binary
+*.rc	binary


### PR DESCRIPTION
The reason it was added in f0a409a1 is probably still valid.