### PR TITLE
Update LOG_TEST_CASE to add a log entry instead of a dialog.

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -237,11 +237,10 @@ typedef enum _CxbxMsgDlgIcon {
 
 void CxbxPopupMessage(CxbxMsgDlgIcon icon, const char *message, ...);
 
-#define LOG_TEST_CASE(message) do { static bool bPopupShown = false; \
-    if (!bPopupShown) { bPopupShown = true; \
-    CxbxPopupMessage(CxbxMsgDlgIcon_Info, "Please report that %s shows this test-case: %s\nIn %s (%s line %d)", \
-    CxbxKrnl_Xbe->m_szAsciiTitle, message, __func__, __FILE__, __LINE__); } } while(0)
-// was g_pCertificate->wszTitleName
+#define LOG_TEST_CASE(message) do { static bool bTestCaseLogged = false; \
+    if (!bTestCaseLogged) { bTestCaseLogged = true; \
+    printf("LOG_TEST_CASE: %s\nIn %s (%s line %d)", \
+    message, __func__, __FILE__, __LINE__); } } while(0)
 
 extern Xbe::Certificate *g_pCertificate;
 


### PR DESCRIPTION
The purpose of this is twofold.
1. Prevent interrupting game-play when a test-case is hit
2. Allow the future Cxbx-Reloaded website to automatically parse logs to generate a list of test-cases (useful for developers)

Note: The submodule update fixes a compilation failure when Visual Studio 2017 is installed without also installing the VS2015 toolset.