### PR TITLE
Don't force Depth = 1

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5047,8 +5047,6 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 
 		if (dwDepth != 1) {
 			LOG_TEST_CASE("CreateHostResource : Depth != 1");
-			EmuWarning("Unsupported depth (%d) - resetting to 1 for now", dwDepth);
-			dwDepth = 1;
 		}
 
 		// The following is necessary for DXT* textures (4x4 blocks minimum)


### PR DESCRIPTION
Probably not 100% correct, but does significantly improve Volume Texture XDK samples:

Before:
![vt-before](https://user-images.githubusercontent.com/740003/40782012-e7012afa-64d5-11e8-8b23-8c478939b469.png)
![vs-before](https://user-images.githubusercontent.com/740003/40782016-e888d49a-64d5-11e8-8bbb-f3fa973d3579.png)
![vl-before](https://user-images.githubusercontent.com/740003/40782018-e9dafeea-64d5-11e8-872f-9d0658b2514c.png)

After:
![image](https://user-images.githubusercontent.com/740003/40782044-fbec2bfe-64d5-11e8-8674-c1be0e85edfa.png)
![image](https://user-images.githubusercontent.com/740003/40782051-046b3c70-64d6-11e8-99e8-0a918fb1dd91.png)
![image](https://user-images.githubusercontent.com/740003/40782061-0c8aa6a2-64d6-11e8-8971-2dd75b1ed195.png)

