### PR TITLE
Merge g_RegisteredResources and g_HostResources into a combined g_XboxDirect3DResources.

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -162,7 +162,6 @@ static XTL::INDEX16                *pQuadToTriangleIndexBuffer = nullptr;
 static UINT                         QuadToTriangleIndexBuffer_Size = 0; // = NrOfQuadVertices
 
 static XTL::X_D3DSurface		   *g_XboxBackBufferSurface = NULL;
-static XTL::D3DFORMAT			   g_HostBackBufferFormat = XTL::D3DFMT_X8R8G8B8; // Most common format, will be overwritten at runtime if incorrect
 static XTL::X_D3DSurface           *g_pXboxRenderTarget = NULL;
 static XTL::X_D3DSurface           *g_pXboxDepthStencil = NULL;
 static bool                         g_bColorSpaceConvertYuvToRgb = false;
@@ -2061,9 +2060,6 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 
                 if(FAILED(g_EmuCDPD.hRet))
                     CxbxKrnlCleanup("IDirect3D::CreateDevice failed");
-
-				// Store BackBuffer Format
-				g_HostBackBufferFormat = g_EmuCDPD.HostPresentationParameters.BackBufferFormat;
 
 				// Which texture formats does this device support?
 				memset(g_bSupportsFormatSurface, false, sizeof(g_bSupportsFormatSurface));
@@ -4976,7 +4972,7 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 
 				// If, and ONLY if this is the default backbuffer, make sure the format matches the host backbuffer
 				if (pResource == g_XboxBackBufferSurface) {
-					PCFormat = g_HostBackBufferFormat;
+					PCFormat = g_EmuCDPD.HostPresentationParameters.BackBufferFormat;;
 				}
 			}
 			else {

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5040,8 +5040,6 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 
 		if (dwDepth != 1) {
 			LOG_TEST_CASE("CreateHostResource : Depth != 1");
-			EmuWarning("Unsupported depth (%d) - resetting to 1 for now", dwDepth);
-			dwDepth = 1;
 		}
 
 		// The following is necessary for DXT* textures (4x4 blocks minimum)

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -162,6 +162,7 @@ static XTL::INDEX16                *pQuadToTriangleIndexBuffer = nullptr;
 static UINT                         QuadToTriangleIndexBuffer_Size = 0; // = NrOfQuadVertices
 
 static XTL::X_D3DSurface		   *g_XboxBackBufferSurface = NULL;
+static XTL::D3DFORMAT			   g_HostBackBufferFormat = XTL::D3DFMT_X8R8G8B8; // Most common format, will be overwritten at runtime if incorrect
 static XTL::X_D3DSurface           *g_pXboxRenderTarget = NULL;
 static XTL::X_D3DSurface           *g_pXboxDepthStencil = NULL;
 static bool                         g_bColorSpaceConvertYuvToRgb = false;
@@ -2062,6 +2063,9 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 
                 if(FAILED(g_EmuCDPD.hRet))
                     CxbxKrnlCleanup("IDirect3D::CreateDevice failed");
+
+				// Store BackBuffer Format
+				g_HostBackBufferFormat = g_EmuCDPD.HostPresentationParameters.BackBufferFormat;
 
 				// Which texture formats does this device support?
 				memset(g_bSupportsFormatSurface, false, sizeof(g_bSupportsFormatSurface));
@@ -4972,6 +4976,11 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 			if (pbSupportedFormats[X_Format]) {
 				// Then use matching host format
 				PCFormat = EmuXB2PC_D3DFormat(X_Format);
+
+				// If, and ONLY if this is the default backbuffer, make sure the format matches the host backbuffer
+				if (pResource == g_XboxBackBufferSurface) {
+					PCFormat = g_HostBackBufferFormat;
+				}
 			}
 			else {
 				// Otherwise, choose a fallback for the format not supported on host


### PR DESCRIPTION
This cleans up the code significantly and prevents issues caused by inconsistencies between the two structures.

As a bonus, this pretty much halves the number of map/vector lookups that happen per call to GetHostResource, bringing a (slight) performance boost