### PR TITLE
DSound Volume Hot-fix

### DIFF
--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1508,7 +1508,7 @@ inline HRESULT HybridDirectSoundBuffer_SetMixBinVolumes_8(
                 }
             }
             if (counter > 0) {
-                Xb_volumeMixBin = volume / counter;
+                Xb_volumeMixBin = LONG((float)volume / (float)counter);
                 hRet = HybridDirectSoundBuffer_SetVolume(pDSBuffer, Xb_volume, EmuFlags, nullptr,
                                                          Xb_volumeMixBin, Xb_dwHeadroom);
             } else {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1513,7 +1513,7 @@ inline HRESULT HybridDirectSoundBuffer_SetMixBinVolumes_8(
                 }
             }
             if (counter > 0) {
-                Xb_volumeMixBin = LONG((float)volume / (float)counter);
+                Xb_volumeMixBin = volume / (LONG)counter;
                 hRet = HybridDirectSoundBuffer_SetVolume(pDSBuffer, Xb_volume, EmuFlags, nullptr,
                                                          Xb_volumeMixBin, Xb_dwHeadroom);
             } else {

--- a/src/CxbxKrnl/EmuDSoundInline.hpp
+++ b/src/CxbxKrnl/EmuDSoundInline.hpp
@@ -1499,9 +1499,14 @@ inline HRESULT HybridDirectSoundBuffer_SetMixBinVolumes_8(
         if (pMixBins->lpMixBinVolumePairs != xbnullptr) {
             // Let's normalize audio level except for low frequency (subwoofer)
             for (DWORD i = 0; i < count; i++) {
+#if 0 // This code isn't ideal for DirectSound, since it's not possible to set volume for each speakers.
                 if (pMixBins->lpMixBinVolumePairs[i].dwMixBin != XDSMIXBIN_LOW_FREQUENCY
                     // We only want to focus on speaker volumes, nothing else.
                     && pMixBins->lpMixBinVolumePairs[i].dwMixBin < XDSMIXBIN_SPEAKERS_MAX) {
+#endif
+                if (pMixBins->lpMixBinVolumePairs[i].dwMixBin == XDSMIXBIN_FRONT_LEFT
+                    // We only want to focus on front speaker volumes, nothing else.
+                    || pMixBins->lpMixBinVolumePairs[i].dwMixBin == XDSMIXBIN_FRONT_RIGHT) {
                     volume += pMixBins->lpMixBinVolumePairs[i].lVolume;
                 } else {
                     counter--;


### PR DESCRIPTION
Resolve titles having issue with audio adjustment plus prevent silent to occur for surround sound due to individual speaker volume setup.

Test case:
* Splinter Cell - Double Agent
* FarCry Instincts (affecting menu selection audio)

This pull request should resolve false positive warning of `HybridDirectSoundBuffer_SetVolume has received greater than 0` output.