### PR TITLE
EmuWarning stack fix + Rename _logPrefix

### DIFF
--- a/src/Common/Logging.cpp
+++ b/src/Common/Logging.cpp
@@ -40,7 +40,7 @@
 
 // For thread_local, see : http://en.cppreference.com/w/cpp/language/storage_duration
 // TODO : Use Boost.Format http://www.boost.org/doc/libs/1_53_0/libs/format/index.html
-thread_local std::string _logPrefix;
+thread_local std::string _logThreadPrefix;
 
 const bool needs_escape(const wint_t _char)
 {

--- a/src/Common/Logging.h
+++ b/src/Common/Logging.h
@@ -169,13 +169,13 @@ constexpr const char* remove_emupatch_prefix(const char* str) {
 
 // For thread_local, see : http://en.cppreference.com/w/cpp/language/storage_duration
 // TODO : Use Boost.Format http://www.boost.org/doc/libs/1_53_0/libs/format/index.html
-extern thread_local std::string _logPrefix;
+extern thread_local std::string _logThreadPrefix;
 
 #define LOG_THREAD_INIT \
-	if (_logPrefix.length() == 0) { \
+	if (_logThreadPrefix.length() == 0) { \
 		std::stringstream tmp; \
 		tmp << "[" << hexstring16 << GetCurrentThreadId() << "] "; \
-		_logPrefix = tmp.str(); \
+		_logThreadPrefix = tmp.str(); \
     }
 
 #define LOG_FUNC_INIT(func) \
@@ -199,7 +199,7 @@ extern thread_local std::string _logPrefix;
 	do { if(g_bPrintfOn) { \
 		bool _had_arg = false; \
 		std::stringstream msg; \
-		msg << _logPrefix << _logFuncPrefix << "(";
+		msg << _logThreadPrefix << _logFuncPrefix << "(";
 
 #define LOG_FUNC_BEGIN \
 	LOG_INIT \
@@ -229,17 +229,17 @@ extern thread_local std::string _logPrefix;
 
 // LOG_FUNC_RESULT logs the function return result
 #define LOG_FUNC_RESULT(r) \
-	std::cout << _logPrefix << _logFuncPrefix << " returns " << _log_sanitize(r) << "\n";
+	std::cout << _logThreadPrefix << _logFuncPrefix << " returns " << _log_sanitize(r) << "\n";
 
 // LOG_FUNC_RESULT_TYPE logs the function return result using the overloaded << operator of the given type
 #define LOG_FUNC_RESULT_TYPE(type, r) \
-	std::cout << _logPrefix << _logFuncPrefix << " returns " << (type)r << "\n";
+	std::cout << _logThreadPrefix << _logFuncPrefix << " returns " << (type)r << "\n";
 
 // LOG_FORWARD indicates that an api is implemented by a forward to another API
 #define LOG_FORWARD(api) \
 	LOG_INIT \
 	do { if(g_bPrintfOn) { \
-		std::cout << _logPrefix << _logFuncPrefix << " forwarding to "#api"...\n"; \
+		std::cout << _logThreadPrefix << _logFuncPrefix << " forwarding to "#api"...\n"; \
 	} } while (0)
 
 #else // _DEBUG_TRACE
@@ -265,7 +265,7 @@ extern thread_local std::string _logPrefix;
 		if(g_bPrintfOn && b_echoOnce) { \
 			LOG_THREAD_INIT \
 			LOG_FUNC_INIT(__func__) \
-			std::cout << _logPrefix << "WARN: " << _logFuncPrefix << " ignored!\n"; \
+			std::cout << _logThreadPrefix << "WARN: " << _logFuncPrefix << " ignored!\n"; \
 			b_echoOnce = false; \
 		} \
 	} while(0)
@@ -277,7 +277,7 @@ extern thread_local std::string _logPrefix;
 		if(g_bPrintfOn && b_echoOnce) { \
 			LOG_THREAD_INIT \
 			LOG_FUNC_INIT(__func__) \
-			std::cout << _logPrefix << "WARN: " << _logFuncPrefix << " unimplemented!\n"; \
+			std::cout << _logThreadPrefix << "WARN: " << _logFuncPrefix << " unimplemented!\n"; \
 			b_echoOnce = false; \
 		} \
 	 } while(0)
@@ -289,7 +289,7 @@ extern thread_local std::string _logPrefix;
 		if(g_bPrintfOn && b_echoOnce) { \
 			LOG_THREAD_INIT \
 			LOG_FUNC_INIT(__func__) \
-			std::cout << _logPrefix << "WARN: " << _logFuncPrefix << " incomplete!\n"; \
+			std::cout << _logThreadPrefix << "WARN: " << _logFuncPrefix << " incomplete!\n"; \
 			b_echoOnce = false; \
 		} \
 	} while(0)
@@ -301,7 +301,7 @@ extern thread_local std::string _logPrefix;
 		if(g_bPrintfOn && b_echoOnce) { \
 			LOG_THREAD_INIT \
 			LOG_FUNC_INIT(__func__) \
-			std::cout << _logPrefix << "WARN: " << _logFuncPrefix << " not supported!\n"; \
+			std::cout << _logThreadPrefix << "WARN: " << _logFuncPrefix << " not supported!\n"; \
 			b_echoOnce = false; \
 		} \
 	} while(0)

--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -50,6 +50,7 @@ namespace xboxkrnl
 #include "EmuShared.h"
 #include "HLEIntercept.h"
 #include "CxbxDebugger.h"
+#include "Logging.h"
 
 #ifdef _DEBUG
 #include <Dbghelp.h>
@@ -79,32 +80,29 @@ static int ExitException(LPEXCEPTION_POINTERS e);
 #ifdef _DEBUG_WARNINGS
 void NTAPI EmuWarning(const char *szWarningMessage, ...)
 {
-    if(szWarningMessage == NULL)
+    if (szWarningMessage == NULL) {
         return;
-
-    char szBuffer1[1024];
-    char szBuffer2[1024];
-
-    va_list argp;
-
-    sprintf(szBuffer1, "[0x%.4X] WARN: ", GetCurrentThreadId());
-
-    va_start(argp, szWarningMessage);
-
-    vsprintf(szBuffer2, szWarningMessage, argp);
-
-    va_end(argp);
-
-    strcat(szBuffer1, szBuffer2);
-
-    if(g_bPrintfOn)
-    {
-        printf("%s\n", szBuffer1);
     }
 
-    fflush(stdout);
+    if(g_bPrintfOn) {
 
-    return;
+        va_list argp;
+
+        LOG_THREAD_INIT;
+
+        std::cout << _logPrefix << "WARN: ";
+
+        va_start(argp, szWarningMessage);
+
+        vfprintf(stdout, szWarningMessage, argp);
+
+        va_end(argp);
+
+        fprintf(stdout, "\n");
+
+        fflush(stdout);
+
+    }
 }
 #endif
 

--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -90,7 +90,7 @@ void NTAPI EmuWarning(const char *szWarningMessage, ...)
 
         LOG_THREAD_INIT;
 
-        std::cout << _logPrefix << "WARN: ";
+        std::cout << _logThreadPrefix << "WARN: ";
 
         va_start(argp, szWarningMessage);
 

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -216,7 +216,7 @@ g_EmuCDPD = {0};
 	do { \
 		if (FAILED(hRet)) \
 			if(g_bPrintfOn) \
-				printf("%s%s : %s D3D error (0x%.08X: %s)\n", _logPrefix.c_str(), _logFuncPrefix.c_str(), message, hRet, D3DErrorString(hRet)); \
+				printf("%s%s : %s D3D error (0x%.08X: %s)\n", _logThreadPrefix.c_str(), _logFuncPrefix.c_str(), message, hRet, D3DErrorString(hRet)); \
 	} while (0)
 
 #else


### PR DESCRIPTION
Test code: `EmuWarning("%s 123 - %d=321, %.4f=1234.5000", "Test", 321, 1234.5f);`
output: `[0x18A8C] WARN: Test 123 - 321=321, 1234.5000=1234.5000`

Resolve #1256