### PR TITLE
New Speedhack: Render Directly to Host BackBuffer

### DIFF
--- a/resource/Cxbx.rc
+++ b/resource/Cxbx.rc
@@ -482,9 +482,13 @@ BEGIN
         END
         POPUP "Hacks",                          65535,MFT_STRING,MFS_ENABLED
         BEGIN
+            POPUP "Speed Hacks",                    ID_HACKS_SPEEDHACKS,MFT_STRING,MFS_ENABLED
+            BEGIN
+                MENUITEM "Run Xbox threads on all cores", ID_HACKS_RUNXBOXTHREADSONALLCORES,MFT_STRING,MFS_ENABLED
+                MENUITEM "Render directly to Host Backbuffer", ID_HACKS_RENDERDIRECTLYTOHOSTBACKBUFFER,MFT_STRING,MFS_ENABLED
+                MENUITEM "Uncap Framerate",             ID_HACKS_UNCAPFRAMERATE,MFT_STRING,MFS_ENABLED
+            END
             MENUITEM "Disable Pixel Shaders",       ID_HACKS_DISABLEPIXELSHADERS,MFT_STRING,MFS_ENABLED
-            MENUITEM "Uncap Framerate",             ID_HACKS_UNCAPFRAMERATE,MFT_STRING,MFS_ENABLED
-            MENUITEM "Run Xbox threads on all cores", ID_HACKS_RUNXBOXTHREADSONALLCORES,MFT_STRING,MFS_ENABLED
             MENUITEM "Skip rdtsc patching",         ID_HACKS_SKIPRDTSCPATCHING,MFT_STRING,MFS_ENABLED
             MENUITEM "Scale Xbox viewport to host (and back)", ID_HACKS_SCALEVIEWPORT,MFT_STRING,MFS_ENABLED
         END

--- a/src/Cxbx/ResCxbx.h
+++ b/src/Cxbx/ResCxbx.h
@@ -1,6 +1,6 @@
 ﻿//{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
-// Used by C:\Work\Cxbx-Reloaded\resource\Cxbx.rc
+// Used by C:\Users\lukeu\Desktop\Projects\cxbx-reloaded\resource\Cxbx.rc
 //
 #define IDI_CXBX                        101
 #define IDB_SPLASH                      102
@@ -277,6 +277,8 @@
 #define ID_HACKS_SKIPRDTSCPATCHING      40099
 #define ID_HACKS_SCALEVIEWPORT          40100
 #define ID_SETTINGS_CONFIG_XBOX_CONTROLLER_MAPPING 40101
+#define ID_HACKS_RENDERDIRECTLYTOHOSTBACKBUFFER 40102
+#define ID_HACKS_SPEEDHACKS             40103
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -284,7 +286,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        135
-#define _APS_NEXT_COMMAND_VALUE         40102
+#define _APS_NEXT_COMMAND_VALUE         40104
 #define _APS_NEXT_CONTROL_VALUE         1256
 #define _APS_NEXT_SYMED_VALUE           104
 #endif

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -226,6 +226,13 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 			}
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
+			result = RegQueryValueEx(hKey, "HackDirectBackBufferAccess", NULL, &dwType, (PBYTE)&m_DirectHostBackBufferAccess, &dwSize);
+			if (result != ERROR_SUCCESS) {
+				m_DirectHostBackBufferAccess = 0;
+			}
+
+
+			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			result = RegQueryValueEx(hKey, "CxbxDebug", NULL, &dwType, (PBYTE)&m_CxbxDebug, &dwSize);
 			if (result != ERROR_SUCCESS) {
 				m_CxbxDebug = DebugMode::DM_NONE;
@@ -389,6 +396,9 @@ WndMain::~WndMain()
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			RegSetValueEx(hKey, "HackScaleViewport", 0, dwType, (PBYTE)&m_ScaleViewport, dwSize);
+
+			dwType = REG_DWORD; dwSize = sizeof(DWORD);
+			RegSetValueEx(hKey, "HackDirectBackBufferAccess", 0, dwType, (PBYTE)&m_DirectHostBackBufferAccess, dwSize);
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
             RegSetValueEx(hKey, "CxbxDebug", 0, dwType, (PBYTE)&m_CxbxDebug, dwSize);
@@ -1367,6 +1377,11 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				RefreshMenus();
 				break;
 
+			case ID_HACKS_RENDERDIRECTLYTOHOSTBACKBUFFER:
+				m_DirectHostBackBufferAccess = !m_DirectHostBackBufferAccess;
+				RefreshMenus();
+				break;
+
             case ID_HELP_ABOUT:
             {
 				ShowAboutDialog(hwnd);
@@ -1800,6 +1815,9 @@ void WndMain::RefreshMenus()
       
 			chk_flag = (m_ScaleViewport) ? MF_CHECKED : MF_UNCHECKED;
 			CheckMenuItem(settings_menu, ID_HACKS_SCALEVIEWPORT, chk_flag);
+
+			chk_flag = (m_DirectHostBackBufferAccess) ? MF_CHECKED : MF_UNCHECKED;
+			CheckMenuItem(settings_menu, ID_HACKS_RENDERDIRECTLYTOHOSTBACKBUFFER, chk_flag);
 		}
 
         // emulation menu
@@ -2175,6 +2193,7 @@ void WndMain::StartEmulation(HWND hwndParent, DebuggerState LocalDebuggerState /
 	g_EmuShared->SetUseAllCores(&m_UseAllCores);
 	g_EmuShared->SetSkipRdtscPatching(&m_SkipRdtscPatching);
 	g_EmuShared->SetScaleViewport(&m_ScaleViewport);
+	g_EmuShared->SetDirectHostBackBufferAccess(&m_DirectHostBackBufferAccess);
 
 	if (m_ScaleViewport) {
 		// Set the window size to emulation dimensions

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -91,20 +91,8 @@ void ClearHLECache()
 
 void WndMain::InitializeSettings() {
 	HKEY hKey;
-	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\Cxbx-Reloaded", 0, KEY_SET_VALUE, &hKey) == ERROR_SUCCESS) {
-		for (int v = 0; v < m_dwRecentXbe; v++) {
-			char buffer[32];
-			sprintf(buffer, "RecentXbe%d", v);
-			RegDeleteValue(hKey, buffer);
-		}
-		RegDeleteValue(hKey, "CxbxDebug"); RegDeleteValue(hKey, "CxbxDebugFilename");
-		RegDeleteValue(hKey, "HackDisablePixelShaders"); RegDeleteValue(hKey, "HackUncapFrameRate");
-		RegDeleteValue(hKey, "HackUseAllCores");  RegDeleteValue(hKey, "KrnlDebug");
-		RegDeleteValue(hKey, "KrnlDebugFilename"); RegDeleteValue(hKey, "LLEFLAGS");
-		RegDeleteValue(hKey, "RecentXbe"); RegDeleteValue(hKey, "XInputEnabled");
-
-		RegDeleteTree(hKey, "XBVideo"); RegDeleteTree(hKey, "XBAudio"); RegDeleteTree(hKey, "XBController");
-
+	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\Cxbx-Reloaded", 0, KEY_ENUMERATE_SUB_KEYS | DELETE | KEY_QUERY_VALUE | KEY_SET_VALUE, &hKey) == ERROR_SUCCESS) {
+		RegDeleteTree(hKey, NULL);
 		RegCloseKey(hKey);
 
 		g_SaveOnExit = false;

--- a/src/Cxbx/WndMain.h
+++ b/src/Cxbx/WndMain.h
@@ -223,6 +223,7 @@ class WndMain : public Wnd
 		int		m_UseAllCores;
 		int		m_SkipRdtscPatching;
 		int     m_ScaleViewport;
+		int		m_DirectHostBackBufferAccess;
 
         // ******************************************************************
         // * debug output filenames

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -607,6 +607,7 @@ void PrintCurrentConfigurationLog()
 		printf("Run Xbox threads on all cores: %s\n", g_UseAllCores == 1 ? "On" : "Off");
 		printf("Skip RDTSC Patching: %s\n", g_SkipRdtscPatching == 1 ? "On" : "Off");
 		printf("Scale Xbox to host viewport (and back): %s\n", g_ScaleViewport == 1 ? "On" : "Off");
+		printf("Render directly to Host BackBuffer: %s\n", g_DirectHostBackBufferAccess == 1 ? "On" : "Off");
 	}
 
 	printf("------------------------- END OF CONFIG LOG ------------------------\n");
@@ -1252,6 +1253,8 @@ __declspec(noreturn) void CxbxKrnlInit
 		g_SkipRdtscPatching = !!HackEnabled;
 		g_EmuShared->GetScaleViewport(&HackEnabled);
 		g_ScaleViewport = !!HackEnabled;
+		g_EmuShared->GetDirectHostBackBufferAccess(&HackEnabled);
+		g_DirectHostBackBufferAccess = !!HackEnabled;
 	}
 
 #ifdef _DEBUG_PRINT_CURRENT_CONF

--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -69,6 +69,7 @@ bool g_UncapFramerate = false;
 bool g_UseAllCores = false;
 bool g_SkipRdtscPatching = false;
 bool g_ScaleViewport = false;
+bool g_DirectHostBackBufferAccess = false;
 
 // Delta added to host SystemTime, used in xboxkrnl::KeQuerySystemTime and xboxkrnl::NtSetSystemTime
 LARGE_INTEGER	HostSystemTimeDelta = {};

--- a/src/CxbxKrnl/Emu.h
+++ b/src/CxbxKrnl/Emu.h
@@ -112,4 +112,5 @@ extern bool g_UncapFramerate;
 extern bool g_UseAllCores;
 extern bool g_SkipRdtscPatching;
 extern bool g_ScaleViewport;
+extern bool g_DirectHostBackBufferAccess;
 #endif

--- a/src/CxbxKrnl/EmuShared.h
+++ b/src/CxbxKrnl/EmuShared.h
@@ -130,6 +130,8 @@ class EmuShared : public Mutex
 		void SetSkipRdtscPatching(int* value) { Lock(); m_SkipRdtscPatching = *value; Unlock(); }
 		void GetScaleViewport(int* value) { Lock(); *value = m_ScaleViewport; Unlock(); }
 		void SetScaleViewport(int* value) { Lock(); m_ScaleViewport = *value; Unlock(); }
+		void GetDirectHostBackBufferAccess(int* value) { Lock(); *value = m_DirectHostBackBufferAccess; Unlock(); }
+		void SetDirectHostBackBufferAccess(int* value) { Lock(); m_DirectHostBackBufferAccess = *value; Unlock(); }
 
 		// ******************************************************************
 		// * MSpF/Benchmark values Accessors
@@ -205,6 +207,7 @@ class EmuShared : public Mutex
 		bool		 m_bDebugging;
 		int          m_LedSequence[4];
 		int          m_ScaleViewport;
+		int			 m_DirectHostBackBufferAccess;
 };
 
 // ******************************************************************


### PR DESCRIPTION
If enabled, this speedhack negates the impact of the new SetRenderTarget implementation WITHOUT breaking the functionality, at the expense of a little accuracy.

This could be useful for bumping up the frame-rate for some users, especially when resolution scaling hacks are used.