### PR TITLE
Enable Host Backbuffer by default

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -222,7 +222,7 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			result = RegQueryValueEx(hKey, "HackScaleViewport", NULL, &dwType, (PBYTE)&m_ScaleViewport, &dwSize);
 			if (result != ERROR_SUCCESS) {
-				m_ScaleViewport = 1;
+				m_ScaleViewport = 0;
 			}
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -222,13 +222,13 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			result = RegQueryValueEx(hKey, "HackScaleViewport", NULL, &dwType, (PBYTE)&m_ScaleViewport, &dwSize);
 			if (result != ERROR_SUCCESS) {
-				m_ScaleViewport = 0;
+				m_ScaleViewport = 1;
 			}
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			result = RegQueryValueEx(hKey, "HackDirectBackBufferAccess", NULL, &dwType, (PBYTE)&m_DirectHostBackBufferAccess, &dwSize);
 			if (result != ERROR_SUCCESS) {
-				m_DirectHostBackBufferAccess = 0;
+				m_DirectHostBackBufferAccess = 1;
 			}
 
 

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -607,7 +607,7 @@ void PrintCurrentConfigurationLog()
 		printf("Uncap Framerate: %s\n", g_UncapFramerate == 1 ? "On" : "Off (Default)");
 		printf("Run Xbox threads on all cores: %s\n", g_UseAllCores == 1 ? "On" : "Off (Default)");
 		printf("Skip RDTSC Patching: %s\n", g_SkipRdtscPatching == 1 ? "On" : "Off (Default)");
-		printf("Scale Xbox to host viewport (and back): %s\n", g_ScaleViewport == 1 ? "On (Default)" : "Off");
+		printf("Scale Xbox to host viewport (and back): %s\n", g_ScaleViewport == 1 ? "On" : "Off (Default)");
 		printf("Render directly to Host BackBuffer: %s\n", g_DirectHostBackBufferAccess == 1 ? "On (Default)" : "Off");
 	}
 

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -603,12 +603,12 @@ void PrintCurrentConfigurationLog()
 	// Print Enabled Hacks
 	{
 		printf("--------------------------- HACKS CONFIG ---------------------------\n");
-		printf("Disable Pixel Shaders: %s\n", g_DisablePixelShaders == 1 ? "On" : "Off");
-		printf("Uncap Framerate: %s\n", g_UncapFramerate == 1 ? "On" : "Off");
-		printf("Run Xbox threads on all cores: %s\n", g_UseAllCores == 1 ? "On" : "Off");
-		printf("Skip RDTSC Patching: %s\n", g_SkipRdtscPatching == 1 ? "On" : "Off");
-		printf("Scale Xbox to host viewport (and back): %s\n", g_ScaleViewport == 1 ? "On" : "Off");
-		printf("Render directly to Host BackBuffer: %s\n", g_DirectHostBackBufferAccess == 1 ? "On" : "Off");
+		printf("Disable Pixel Shaders: %s\n", g_DisablePixelShaders == 1 ? "On" : "Off (Default)");
+		printf("Uncap Framerate: %s\n", g_UncapFramerate == 1 ? "On" : "Off (Default)");
+		printf("Run Xbox threads on all cores: %s\n", g_UseAllCores == 1 ? "On" : "Off (Default)");
+		printf("Skip RDTSC Patching: %s\n", g_SkipRdtscPatching == 1 ? "On" : "Off (Default)");
+		printf("Scale Xbox to host viewport (and back): %s\n", g_ScaleViewport == 1 ? "On (Default)" : "Off");
+		printf("Render directly to Host BackBuffer: %s\n", g_DirectHostBackBufferAccess == 1 ? "On (Default)" : "Off");
 	}
 
 	printf("------------------------- END OF CONFIG LOG ------------------------\n");


### PR DESCRIPTION
Enable Direct Host Back Buffer Access hacks by default. This hacks improves performance and allow resolutions scaling to (kind-of) work. (When the Scale Viewport hack is also enabled)

Also: The hacks config in the Kernel Log now specifies if they're the default setting, or modified.