### PR TITLE
Fix false positive of title is still emulating after crash.

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2355,6 +2355,7 @@ void WndMain::CrashMonitor()
 	DrawLedBitmap(m_hwnd, true);
 	m_hwndChild = NULL;
 	m_bIsStarted = false;
+	g_EmuShared->SetIsEmulating(false);
 	UpdateCaption();
 	RefreshMenus();
 }


### PR DESCRIPTION
Resolve #1283

Whoops, forgot about crash manager to set emulating to false. (I thought it does call to StopEmulation function, guess I was wrong.)