### PR TITLE
Fix grammatical error

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2191,7 +2191,7 @@ void WndMain::StartEmulation(HWND hwndParent, DebuggerState LocalDebuggerState /
     g_EmuShared->GetIsEmulating(&isEmulating);
 
     if (isEmulating) {
-        MessageBox(m_hwnd, "A title is currently emulating, please stop emulation before attempt start again.",
+        MessageBox(m_hwnd, "A title is currently emulating, please stop emulation before attempting to start again.",
                    "Cxbx-Reloaded", MB_ICONERROR | MB_OK);
         return;
     }


### PR DESCRIPTION
This PR just addresses a grammatical problem in the message box that appears if a title is already currently emulating. (Should be "attempting to start again" instead of "attempt start again")