### PR TITLE
Show title_id/version in Cxbx-Reloaded header:

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -1919,6 +1919,8 @@ void WndMain::UpdateRecentFiles()
     }
 }
 
+extern std::string FormatTitleId(uint32_t title_id);
+
 void WndMain::UpdateCaption()
 {
 	char AsciiTitle[MAX_PATH];
@@ -1932,7 +1934,7 @@ void WndMain::UpdateCaption()
 			i += sprintf(AsciiTitle + i, " : Loaded ");
 		}
 
-		i += sprintf(AsciiTitle + i, m_Xbe->m_szAsciiTitle);
+		i += sprintf(AsciiTitle + i, "%s v1.%02d (%s)", FormatTitleId(m_Xbe->m_Certificate.dwTitleId).c_str(), m_Xbe->m_Certificate.dwVersion, m_Xbe->m_szAsciiTitle);
 
 		// Append FPS menu text
 		HMENU hMenu = GetMenu(m_hwnd);


### PR DESCRIPTION
 Now we can tell what title and version is in screenshots, making bug reports and such easier to follow!
We can even look up this information in Redump's database to check which exact release of the game is used