### PR TITLE
If the prefix of a title_id is non printable, render the entire serial as hex

### DIFF
--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -88,13 +88,13 @@ std::string FormatTitleId(uint32_t title_id)
 	char pTitleId1 = (title_id >> 24) & 0xFF;
 	char pTitleId2 = (title_id >> 16) & 0xFF;
 
-	if (isalnum(pTitleId1) && isalnum(pTitleId2)) {
-		ss << pTitleId1 << pTitleId2;
-	} else {
-		// Prefix was non-printable, so we need to print a hex reprentation
-		ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << std::uppercase << (uint16_t)((title_id & 0xFFFF0000) >> 16);
+	if (!isalnum(pTitleId1) || !isalnum(pTitleId2)) {
+		// Prefix was non-printable, so we need to print a hex reprentation of the entire title_id
+		ss << std::setfill('0') << std::setw(8) << std::hex << std::uppercase << title_id;
+		return ss.str();
 	}	
 
+	ss << pTitleId1 << pTitleId2;
 	ss << "-";
 	ss << std::setfill('0') << std::setw(3) << std::dec << (title_id & 0x0000FFFF);
 


### PR DESCRIPTION
This fixes an issue effecting the upcoming website.