### PR TITLE
Change Unsupported D3DVERTEXBLENDFLAGS from Fatal to Test Case

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -6373,7 +6373,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_VertexBlend)
     } else {
         LOG_TEST_CASE("Unsupported D3DVERTEXBLENDFLAGS (%d)", Value);
         return;
-}
+	}
 
     HRESULT hRet = g_pD3DDevice->SetRenderState(D3DRS_VERTEXBLEND, Value);
     DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderState");

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -6359,22 +6359,24 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_VertexBlend)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+    FUNC_EXPORTS
 
-	LOG_FUNC_ONE_ARG(Value);
+    LOG_FUNC_ONE_ARG(Value);
 
     // convert from Xbox direct3d to PC direct3d enumeration
-    if(Value <= 1)
+    if(Value <= 1) {
         Value = Value;
-    else if(Value == 3)
+    } else if(Value == 3) {
         Value = 2;
-    else if(Value == 5)
+    } else if(Value == 5) {
         Value = 3;
-    else
-        CxbxKrnlCleanup("Unsupported D3DVERTEXBLENDFLAGS (%d)", Value);
+    } else {
+        LOG_TEST_CASE("Unsupported D3DVERTEXBLENDFLAGS (%d)", Value);
+        return;
+}
 
-	HRESULT hRet = g_pD3DDevice->SetRenderState(D3DRS_VERTEXBLEND, Value);
-	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderState");
+    HRESULT hRet = g_pD3DDevice->SetRenderState(D3DRS_VERTEXBLEND, Value);
+    DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderState");
 }
 
 // ******************************************************************


### PR DESCRIPTION
Comments by Luke
1. Changes the error to a warning
2. makes sure to log a test case so we can find out WHY the game sends invalid data later