### PR TITLE
Removing more unnecessary patches

### DIFF
--- a/src/CxbxKrnl/EmuD3D.cpp.unused-patches
+++ b/src/CxbxKrnl/EmuD3D.cpp.unused-patches
@@ -2863,3 +2863,36 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetViewport)
 		}
 	}
 }
+
+// ******************************************************************
+// * patch: D3D_BlockOnResource
+// ******************************************************************
+void WINAPI XTL::EMUPATCH(D3D_BlockOnResource)( X_D3DResource* pResource )
+{
+	FUNC_EXPORTS
+
+	LOG_FUNC_ONE_ARG(pResource);
+
+	// TODO: Implement
+	// NOTE: Azurik appears to call this directly from numerous points
+	LOG_UNIMPLEMENTED();
+		
+}
+
+
+// ******************************************************************
+// * patch: IDirect3DResource8_IsBusy
+// ******************************************************************
+BOOL WINAPI XTL::EMUPATCH(D3DResource_IsBusy)
+(
+    X_D3DResource      *pThis
+)
+{
+	FUNC_EXPORTS
+
+    /* too much output
+	LOG_FUNC_ONE_ARG(pThis);
+    //*/
+
+    return FALSE;
+}

--- a/src/CxbxKrnl/EmuD3D.cpp.unused-patches
+++ b/src/CxbxKrnl/EmuD3D.cpp.unused-patches
@@ -2896,3 +2896,109 @@ BOOL WINAPI XTL::EMUPATCH(D3DResource_IsBusy)
 
     return FALSE;
 }
+
+
+// ******************************************************************
+// * patch: D3DDevice_SetScissors
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(D3DDevice_SetScissors)
+(
+    DWORD          Count,
+    BOOL           Exclusive,
+    CONST D3DRECT  *pRects
+)
+{
+	FUNC_EXPORTS
+
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Count)
+		LOG_FUNC_ARG(Exclusive)
+		LOG_FUNC_ARG(pRects)
+		LOG_FUNC_END;
+
+    // TODO: Implement
+	LOG_UNIMPLEMENTED();
+}
+
+// ******************************************************************
+// * patch: D3DDevice_GetScissors
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(D3DDevice_GetScissors)
+(
+	DWORD	*pCount, 
+	BOOL	*pExclusive, 
+	D3DRECT *pRects
+)
+{
+	FUNC_EXPORTS
+
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(pCount)
+		LOG_FUNC_ARG(pExclusive)
+		LOG_FUNC_ARG(pRects)
+		LOG_FUNC_END;
+
+    // TODO: Save a copy of each scissor rect in case this function is called
+	// in conjunction with D3DDevice::SetScissors. So far, only Outrun2 uses
+	// this function. For now, just return the values within the current
+	// viewport.
+
+	D3DVIEWPORT vp;
+
+	HRESULT hRet = g_pD3DDevice->GetViewport( &vp );
+	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetViewport");
+
+	pRects->x1 = pRects->y1 = 0;
+	pRects->x2 = vp.Width;
+	pRects->y2 = vp.Height;
+
+	pExclusive[0] = FALSE;
+}
+
+
+// ******************************************************************
+// * patch: D3DDevice_SetBackMaterial
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(D3DDevice_SetBackMaterial)
+(
+	X_D3DMATERIAL8* pMaterial
+)
+{
+	FUNC_EXPORTS
+
+	LOG_FUNC_ONE_ARG(pMaterial);
+
+	LOG_NOT_SUPPORTED();
+}
+
+
+
+// ******************************************************************
+// * patch: D3DDevice_GetBackMaterial
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(D3DDevice_GetBackMaterial)
+(
+	X_D3DMATERIAL8* pMaterial
+)
+{
+	FUNC_EXPORTS
+
+	LOG_FUNC_ONE_ARG(pMaterial);
+
+	LOG_NOT_SUPPORTED();
+
+	HRESULT hRet = D3D_OK;
+
+	// TODO: HACK: This is wrong, but better than nothing, right?
+	if (pMaterial)
+	{
+		hRet = g_pD3DDevice->GetMaterial(pMaterial);
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetMaterial");
+	}
+
+	if (FAILED(hRet))
+	{
+		EmuWarning("We're lying about getting a back material!");
+		hRet = D3D_OK;
+	}
+}

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -8878,28 +8878,6 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_BlockUntilNotBusy)
 }
 
 // ******************************************************************
-// * patch: D3DDevice_SetScissors
-// ******************************************************************
-VOID WINAPI XTL::EMUPATCH(D3DDevice_SetScissors)
-(
-    DWORD          Count,
-    BOOL           Exclusive,
-    CONST D3DRECT  *pRects
-)
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(Count)
-		LOG_FUNC_ARG(Exclusive)
-		LOG_FUNC_ARG(pRects)
-		LOG_FUNC_END;
-
-    // TODO: Implement
-	LOG_UNIMPLEMENTED();
-}
-
-// ******************************************************************
 // * patch: D3DDevice_SetScreenSpaceOffset
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_SetScreenSpaceOffset)
@@ -9238,20 +9216,6 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetModelView)(D3DXMATRIX* pModelView)
 	return D3D_OK;
 }
 
-// ******************************************************************
-// * patch: D3DDevice_SetBackMaterial
-// ******************************************************************
-VOID WINAPI XTL::EMUPATCH(D3DDevice_SetBackMaterial)
-(
-	X_D3DMATERIAL8* pMaterial
-)
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC_ONE_ARG(pMaterial);
-
-	LOG_NOT_SUPPORTED();
-}
 
 DWORD PushBuffer[64 * 1024 / sizeof(DWORD)];
 
@@ -9324,71 +9288,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderTargetFast)
 	// Redirect to the standard version.
 	
 	EMUPATCH(D3DDevice_SetRenderTarget)(pRenderTarget, pNewZStencil);
-}
-
-// ******************************************************************
-// * patch: D3DDevice_GetScissors
-// ******************************************************************
-VOID WINAPI XTL::EMUPATCH(D3DDevice_GetScissors)
-(
-	DWORD	*pCount, 
-	BOOL	*pExclusive, 
-	D3DRECT *pRects
-)
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(pCount)
-		LOG_FUNC_ARG(pExclusive)
-		LOG_FUNC_ARG(pRects)
-		LOG_FUNC_END;
-
-    // TODO: Save a copy of each scissor rect in case this function is called
-	// in conjunction with D3DDevice::SetScissors. So far, only Outrun2 uses
-	// this function. For now, just return the values within the current
-	// viewport.
-
-	D3DVIEWPORT vp;
-
-	HRESULT hRet = g_pD3DDevice->GetViewport( &vp );
-	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetViewport");
-
-	pRects->x1 = pRects->y1 = 0;
-	pRects->x2 = vp.Width;
-	pRects->y2 = vp.Height;
-
-	pExclusive[0] = FALSE;
-}
-
-// ******************************************************************
-// * patch: D3DDevice_GetBackMaterial
-// ******************************************************************
-VOID WINAPI XTL::EMUPATCH(D3DDevice_GetBackMaterial)
-(
-	X_D3DMATERIAL8* pMaterial
-)
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC_ONE_ARG(pMaterial);
-
-	LOG_NOT_SUPPORTED();
-
-	HRESULT hRet = D3D_OK;
-
-	// TODO: HACK: This is wrong, but better than nothing, right?
-	if (pMaterial)
-	{
-		hRet = g_pD3DDevice->GetMaterial(pMaterial);
-		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetMaterial");
-	}
-
-	if (FAILED(hRet))
-	{
-		EmuWarning("We're lying about getting a back material!");
-		hRet = D3D_OK;
-	}
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2615,18 +2615,6 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice)
 }
 
 // ******************************************************************
-// * patch: IDirect3DResource8_IsBusy
-// ******************************************************************
-BOOL WINAPI XTL::EMUPATCH(D3DDevice_IsBusy)()
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC();
-    
-    return FALSE;
-}
-
-// ******************************************************************
 // * patch: D3DDevice_GetDisplayFieldStatus
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_GetDisplayFieldStatus)(X_D3DFIELD_STATUS *pFieldStatus)
@@ -5548,23 +5536,6 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
 	}
 
     return uRet;
-}
-
-// ******************************************************************
-// * patch: IDirect3DResource8_IsBusy
-// ******************************************************************
-BOOL WINAPI XTL::EMUPATCH(D3DResource_IsBusy)
-(
-    X_D3DResource      *pThis
-)
-{
-	FUNC_EXPORTS
-
-    /* too much output
-	LOG_FUNC_ONE_ARG(pThis);
-    //*/
-
-    return FALSE;
 }
 
 // ******************************************************************
@@ -9301,6 +9272,21 @@ void WINAPI XTL::EMUPATCH(D3D_SetCommonDebugRegisters)()
 }
 
 // ******************************************************************
+// * patch: D3DDevice_IsBusy
+// ******************************************************************
+BOOL WINAPI XTL::EMUPATCH(D3DDevice_IsBusy)()
+{
+	FUNC_EXPORTS
+
+		LOG_FUNC();
+
+	// NOTE: This function returns FALSE when the NV2A FIFO is empty/complete, or NV_PGRAPH_STATUS = 0
+	// Otherwise, it returns true.
+
+	return FALSE;
+}
+
+// ******************************************************************
 // * patch: D3D_BlockOnTime
 // ******************************************************************
 void WINAPI XTL::EMUPATCH(D3D_BlockOnTime)( DWORD Unknown1, int Unknown2 )
@@ -9319,21 +9305,6 @@ void WINAPI XTL::EMUPATCH(D3D_BlockOnTime)( DWORD Unknown1, int Unknown2 )
 	//__asm int 3;
 
 	LOG_UNIMPLEMENTED();
-}
-
-// ******************************************************************
-// * patch: D3D_BlockOnResource
-// ******************************************************************
-void WINAPI XTL::EMUPATCH(D3D_BlockOnResource)( X_D3DResource* pResource )
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC_ONE_ARG(pResource);
-
-	// TODO: Implement
-	// NOTE: Azurik appears to call this directly from numerous points
-	LOG_UNIMPLEMENTED();
-		
 }
 
 // ******************************************************************


### PR DESCRIPTION
These block/wait functions are not required because they don't access hardware directly, they use internal reference counts which still get updated when we call trampolines within our patches.

Get/Set back-material were unimplemented in their patches, and are safe to unpatch.
