### PR TITLE
More multi xbe fixes

### DIFF
--- a/src/Common/Win32/EmuShared.cpp
+++ b/src/Common/Win32/EmuShared.cpp
@@ -137,7 +137,6 @@ EmuShared::EmuShared()
 {
 	Load();
 	m_bDebugging = false;
-	m_bMultiXbeFlag = false;
 	m_bEmulating = false;
 	m_bFirstLaunch = false;
 }

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2349,6 +2349,9 @@ void WndMain::StartEmulation(HWND hwndParent, DebuggerState LocalDebuggerState /
         return;
     }
 
+    // Reset to default
+    g_EmuShared->Reset();
+
     // register xbe path with emulator process
     g_EmuShared->SetXbePath(m_Xbe->m_szPath);
 

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2463,7 +2463,7 @@ DWORD WINAPI WndMain::CrashMonitorWrapper(LPVOID lpParam)
 // monitor for crashes
 void WndMain::CrashMonitor(DWORD dwChildProcID)
 {
-	bool bQuickReboot;
+	int iBootFlags;
 	DWORD dwExitCode = 0;
 
 	// If we do receive valid process ID, let's do the next step.
@@ -2479,9 +2479,9 @@ void WndMain::CrashMonitor(DWORD dwChildProcID)
 	 		GetExitCodeProcess(hProcess, &dwExitCode);
 	 		CloseHandle(hProcess);
 
-	 		g_EmuShared->GetMultiXbeFlag(&bQuickReboot);
+	 		g_EmuShared->GetBootFlags(&iBootFlags);
 
-	 		if (!bQuickReboot) {
+	 		if (!iBootFlags) {
 	 			if (dwExitCode == EXIT_SUCCESS) {// StopEmulation
 	 				return;
 	 			}
@@ -2491,8 +2491,6 @@ void WndMain::CrashMonitor(DWORD dwChildProcID)
 
 	 			// multi-xbe
 	 			// destroy this thread and start a new one
-	 			bQuickReboot = false;
-	 			g_EmuShared->SetMultiXbeFlag(&bQuickReboot);
 	 			return;
 	 		}
 	 	}

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2499,12 +2499,12 @@ void WndMain::CrashMonitor(DWORD dwChildProcID)
 
 	KillTimer(m_hwnd, TIMERID_FPS);
 	KillTimer(m_hwnd, TIMERID_LED);
-	DrawLedBitmap(m_hwnd, true);
 	m_hwndChild = NULL;
 	m_bIsStarted = false;
 	g_EmuShared->SetIsEmulating(false);
 	UpdateCaption();
 	RefreshMenus();
+	DrawLedBitmap(m_hwnd, true);
 }
 
 // monitor for Debugger to close then set as "available" (For limit to 1 debugger per Cxbx GUI.)

--- a/src/Cxbx/WndMain.h
+++ b/src/Cxbx/WndMain.h
@@ -49,6 +49,11 @@ typedef enum _CXBX_DATA {
 	CXBX_DATA_CUSTOM    = 2,
 } CXBX_DATA;
 
+typedef struct _Crash_Manager_Data {
+	LPVOID  pWndMain;
+	DWORD   dwChildProcID;
+} Crash_Manager_Data;
+
 // ******************************************************************
 // * class : WndMain
 // ******************************************************************
@@ -137,12 +142,12 @@ class WndMain : public Wnd
 		// ******************************************************************
 		// * crash monitoring wrapper function
 		// ******************************************************************
-		static DWORD WINAPI CrashMonitorWrapper(LPVOID lpVoid);
+		static DWORD WINAPI CrashMonitorWrapper(LPVOID lpParam);
 
 		// ******************************************************************
 		// * crash monitoring function thread
 		// ******************************************************************
-		void CrashMonitor();
+		void CrashMonitor(DWORD dwChildProcID);
 
 		// ******************************************************************
 		// * Debugger monitoring function thread

--- a/src/Cxbx/WndMain.h
+++ b/src/Cxbx/WndMain.h
@@ -37,6 +37,8 @@
 #include "Wnd.h"
 #include "Common/Xbe.h"
 
+#include <thread>
+
 // ******************************************************************
 // * constants
 // ******************************************************************
@@ -210,7 +212,7 @@ class WndMain : public Wnd
         // ******************************************************************
         HWND        m_hwndChild;
         HANDLE      m_hDebuggerProc;
-        HANDLE      m_hDebuggerMonitorThread;
+        std::thread m_hDebuggerMonitorThread;
 
         // ******************************************************************
         // * Recent Xbe files

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -909,7 +909,7 @@ void CxbxKrnlMain(int argc, char* argv[])
     if (CxbxKrnl_hEmuParent == NULL) {
         CxbxKrnlCleanup("GUI process does not exist!");
     } else {
-        SendMessage(CxbxKrnl_hEmuParent, WM_PARENTNOTIFY, WM_USER, ID_KRNL_IS_READY);
+        SendMessage(CxbxKrnl_hEmuParent, WM_PARENTNOTIFY, MAKELONG(WM_USER, ID_KRNL_IS_READY), GetCurrentProcessId());
     }
 
     // Force wait until first allocated process is ready
@@ -938,14 +938,6 @@ void CxbxKrnlMain(int argc, char* argv[])
     } while (true);
 
     g_EmuShared->SetIsReady(false);
-
-    bool bQuickReboot;
-    g_EmuShared->GetMultiXbeFlag(&bQuickReboot);
-
-    // precaution for multi-xbe titles in the case CrashMonitor has still not destoyed the previous mutex
-    while (bQuickReboot) {
-        g_EmuShared->GetMultiXbeFlag(&bQuickReboot);
-    }
 
 	// Write a header to the log
 	{

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -906,38 +906,65 @@ void CxbxKrnlMain(int argc, char* argv[])
 
 	g_CurrentProcessHandle = GetCurrentProcess(); // OpenProcess(PROCESS_ALL_ACCESS, FALSE, GetCurrentProcessId());
 
-    if (CxbxKrnl_hEmuParent == NULL) {
-        CxbxKrnlCleanup("GUI process does not exist!");
-    } else {
-        SendMessage(CxbxKrnl_hEmuParent, WM_PARENTNOTIFY, MAKELONG(WM_USER, ID_KRNL_IS_READY), GetCurrentProcessId());
-    }
+	if (CxbxKrnl_hEmuParent != NULL) {
+		SendMessage(CxbxKrnl_hEmuParent, WM_PARENTNOTIFY, MAKELONG(WM_USER, ID_KRNL_IS_READY), GetCurrentProcessId());
 
-    // Force wait until first allocated process is ready
-    do {
-        int waitCounter = 10;
-        bool isReady = false;
+		// Force wait until GUI process is ready
+		do {
+			int waitCounter = 10;
+			bool isReady = false;
 
-        while (waitCounter > 0) {
-            g_EmuShared->GetIsReady(&isReady);
-            if (isReady) {
-                break;
-            }
-            waitCounter--;
-            Sleep(100);
-        }
-        if (!isReady) {
-            EmuWarning("GUI process is not ready!");
-            int mbRet = MessageBox(NULL, "GUI process is not ready, do you wish to retry?", TEXT("Cxbx-Reloaded"),
-                                   MB_ICONWARNING | MB_RETRYCANCEL | MB_TOPMOST | MB_SETFOREGROUND);
-            if (mbRet == IDRETRY) {
-                continue;
-            }
-            CxbxKrnlShutDown();
-        }
-        break;
-    } while (true);
+			while (waitCounter > 0) {
+				g_EmuShared->GetIsReady(&isReady);
+				if (isReady) {
+					break;
+				}
+				waitCounter--;
+				Sleep(100);
+			}
+			if (!isReady) {
+				EmuWarning("GUI process is not ready!");
+				int mbRet = MessageBox(NULL, "GUI process is not ready, do you wish to retry?", TEXT("Cxbx-Reloaded"),
+										MB_ICONWARNING | MB_RETRYCANCEL | MB_TOPMOST | MB_SETFOREGROUND);
+				if (mbRet == IDRETRY) {
+					continue;
+				}
+				CxbxKrnlShutDown();
+			}
+			break;
+		} while (true);
+	}
 
-    g_EmuShared->SetIsReady(false);
+	g_EmuShared->SetIsReady(false);
+
+	UINT prevKrnlProcID = 0;
+	DWORD dwExitCode = EXIT_SUCCESS;
+	g_EmuShared->GetKrnlProcID(&prevKrnlProcID);
+
+	// Force wait until previous kernel process is closed.
+	if (prevKrnlProcID != 0) {
+		HANDLE hProcess = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_INFORMATION, FALSE, prevKrnlProcID);
+		// If we do receive valid handle, let's do the next step.
+		if (hProcess != NULL) {
+
+			WaitForSingleObject(hProcess, INFINITE);
+
+			GetExitCodeProcess(hProcess, &dwExitCode);
+			CloseHandle(hProcess);
+		}
+	}
+
+	if (dwExitCode != EXIT_SUCCESS) {// StopEmulation
+		CxbxKrnlShutDown();
+	}
+
+	int BootFlags = BOOT_NONE;
+	g_EmuShared->GetBootFlags(&BootFlags);
+
+	g_EmuShared->ResetKrnl();
+
+	// Save current kernel proccess id for next reboot if will occur in the future.
+	g_EmuShared->SetKrnlProcID(GetCurrentProcessId());
 
 	// Write a header to the log
 	{
@@ -1082,7 +1109,7 @@ void CxbxKrnlMain(int argc, char* argv[])
 
 
 		// Initialize the virtual manager
-		g_VMManager.Initialize(hMemoryBin, hPageTables);
+		g_VMManager.Initialize(hMemoryBin, hPageTables, BootFlags);
 
 		// Commit the memory used by the xbe header
 		size_t HeaderSize = CxbxKrnl_Xbe->m_Header.dwSizeofHeaders;
@@ -1144,7 +1171,8 @@ void CxbxKrnlMain(int argc, char* argv[])
 			DebugFileName.c_str(),
 			(Xbe::Header*)CxbxKrnl_Xbe->m_Header.dwBaseAddr,
 			CxbxKrnl_Xbe->m_Header.dwSizeofHeaders,
-			(void(*)())EntryPoint
+			(void(*)())EntryPoint,
+ 			BootFlags
 		);
 	}
 }
@@ -1194,7 +1222,8 @@ __declspec(noreturn) void CxbxKrnlInit
 	const char             *szDebugFilename,
 	Xbe::Header            *pXbeHeader,
 	uint32                  dwXbeHeaderSize,
-	void(*Entry)())
+	void(*Entry)(),
+	int BootFlags)
 {
 	// update caches
 	CxbxKrnl_TLS = pTLS;
@@ -1407,9 +1436,6 @@ __declspec(noreturn) void CxbxKrnlInit
 	XTL::CxbxInitWindow(true);
 
 	// Now process the boot flags to see if there are any special conditions to handle
-	int BootFlags = 0;
-	g_EmuShared->GetBootFlags(&BootFlags);
-
 	if (BootFlags & BOOT_EJECT_PENDING) {} // TODO
 	if (BootFlags & BOOT_FATAL_ERROR)
 	{

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -190,16 +190,6 @@ extern "C" {
 #define VECTOR2IRQ(vector)  ((vector)-IRQ_BASE)
 #define VECTOR2IRQL(vector) (MAX_BUS_INTERRUPT_LEVEL - VECTOR2IRQ(vector))
 
-// Kernel boot flags
-enum {
-	BOOT_NONE =           0,
-	BOOT_EJECT_PENDING =  1 << 0,
-	BOOT_FATAL_ERROR =    1 << 1,
-	BOOT_SKIP_ANIMATION = 1 << 2,
-	BOOT_RUN_DASHBOARD =  1 << 3,
-	BOOT_QUICK_REBOOT =   1 << 4,
-};
-
 /* Xbox PAGE Masks */
 #define XBOX_PAGE_NOACCESS          0x01
 #define XBOX_PAGE_READONLY          0x02

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -192,6 +192,7 @@ extern "C" {
 
 // Kernel boot flags
 enum {
+	BOOT_NONE =           0,
 	BOOT_EJECT_PENDING =  1 << 0,
 	BOOT_FATAL_ERROR =    1 << 1,
 	BOOT_SKIP_ANIMATION = 1 << 2,
@@ -261,7 +262,7 @@ extern bool g_bIsDebugKernel;
 void CxbxKrnlMain(int argc, char* argv[]);
 
 /*! initialize emulation */
-__declspec(noreturn) void CxbxKrnlInit(void *pTLSData, Xbe::TLS *pTLS, Xbe::LibraryVersion *LibraryVersion, DebugMode DbgMode, const char *szDebugFilename, Xbe::Header *XbeHeader, uint32 XbeHeaderSize, void (*Entry)());
+__declspec(noreturn) void CxbxKrnlInit(void *pTLSData, Xbe::TLS *pTLS, Xbe::LibraryVersion *LibraryVersion, DebugMode DbgMode, const char *szDebugFilename, Xbe::Header *XbeHeader, uint32 XbeHeaderSize, void (*Entry)(), int BootFlags);
 
 /*! cleanup emulation */
 __declspec(noreturn) void CxbxKrnlCleanup(const char *szErrorMessage, ...);

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -574,7 +574,6 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 				g_EmuShared->GetBootFlags(&QuickReboot);
 				QuickReboot |= BOOT_QUICK_REBOOT;
 				g_EmuShared->SetBootFlags(&QuickReboot);
-				g_EmuShared->SetMultiXbeFlag(&bMultiXbe);
 
 				// Some titles (Xbox Dashboard) use ";" as a final path seperator
 				// This allows the Xbox Live option on the dashboard to properly launch XOnlinedash.xbe
@@ -603,8 +602,10 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 		xboxkrnl::HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_SCRATCH, 0, SMC_SCRATCH_DISPLAY_FATAL_ERROR);
 
 		char szWorkingDirectoy[MAX_PATH];
-		bool bMultiXbe = true;
-		g_EmuShared->SetMultiXbeFlag(&bMultiXbe);
+		int QuickReboot;
+		g_EmuShared->GetBootFlags(&QuickReboot);
+		QuickReboot |= BOOT_FATAL_ERROR;
+		g_EmuShared->SetBootFlags(&QuickReboot);
 		g_EmuShared->GetXbePath(szWorkingDirectoy);
 
 		std::string szProcArgsBuffer;

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -602,10 +602,6 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 		xboxkrnl::HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_SCRATCH, 0, SMC_SCRATCH_DISPLAY_FATAL_ERROR);
 
 		char szWorkingDirectoy[MAX_PATH];
-		int QuickReboot;
-		g_EmuShared->GetBootFlags(&QuickReboot);
-		QuickReboot |= BOOT_FATAL_ERROR;
-		g_EmuShared->SetBootFlags(&QuickReboot);
 		g_EmuShared->GetXbePath(szWorkingDirectoy);
 
 		std::string szProcArgsBuffer;

--- a/src/CxbxKrnl/EmuShared.h
+++ b/src/CxbxKrnl/EmuShared.h
@@ -94,6 +94,12 @@ class EmuShared : public Mutex
 		void SetIsReady(bool isReady) { Lock(); m_bReady = isReady; Unlock(); }
 
 		// ******************************************************************
+		// * Check if previous kernel mode process is running.
+		// ******************************************************************
+		void GetKrnlProcID(unsigned int *krnlProcID) { Lock(); *krnlProcID = m_dwKrnlProcID; Unlock(); }
+		void SetKrnlProcID(unsigned int krnlProcID) { Lock(); m_dwKrnlProcID = krnlProcID; Unlock(); }
+
+		// ******************************************************************
 		// * Xbox Video Accessors
 		// ******************************************************************
 		void GetXBVideo(      XBVideo *video) { Lock(); *video = XBVideo(m_XBVideo); Unlock(); }
@@ -203,6 +209,30 @@ class EmuShared : public Mutex
 		void GetStorageLocation(char *path) { Lock(); strcpy(path, m_StorageLocation); Unlock(); }
 		void SetStorageLocation(char *path) { Lock(); strcpy(m_StorageLocation, path); Unlock(); }
 
+		// ******************************************************************
+		// * Reset specific variables to default for kernel mode.
+		// ******************************************************************
+		void ResetKrnl()
+		{
+			Lock();
+			m_BootFlags = 0;
+			m_MSpF = 0.0f;
+			m_FPS = 0.0f;
+			m_bMultiXbeFlag = 0;
+			Unlock();
+		}
+
+		// ******************************************************************
+		// * Reset specific variables to default for gui mode.
+		// ******************************************************************
+		void Reset()
+		{
+			Lock();
+			ResetKrnl();
+			m_dwKrnlProcID = 0;
+			Unlock();
+		}
+
 	private:
 		// ******************************************************************
 		// * Constructor / Deconstructor
@@ -238,6 +268,7 @@ class EmuShared : public Mutex
 		bool         m_bReserved2;
 		bool         m_bReserved3;
 		bool         m_bReserved4;
+		unsigned int m_dwKrnlProcID; // Only used for kernel mode level.
 };
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuShared.h
+++ b/src/CxbxKrnl/EmuShared.h
@@ -54,6 +54,16 @@ enum {
 	LLE_JIT = 1 << 2,
 };
 
+// Kernel boot flags
+enum {
+	BOOT_NONE =           0,
+	BOOT_EJECT_PENDING =  1 << 0,
+	BOOT_FATAL_ERROR =    1 << 1,
+	BOOT_SKIP_ANIMATION = 1 << 2,
+	BOOT_RUN_DASHBOARD =  1 << 3,
+	BOOT_QUICK_REBOOT =   1 << 4,
+};
+
 // ******************************************************************
 // * EmuShared : Shared memory
 // ******************************************************************

--- a/src/CxbxKrnl/EmuShared.h
+++ b/src/CxbxKrnl/EmuShared.h
@@ -170,12 +170,6 @@ class EmuShared : public Mutex
 		void SetCurrentFPS(float *value) { Lock(); m_FPS = *value; Unlock(); }
 
 		// ******************************************************************
-		// * MultiXbe flag Accessors
-		// ******************************************************************
-		void GetMultiXbeFlag(bool *value) { Lock(); *value = m_bMultiXbeFlag; Unlock(); }
-		void SetMultiXbeFlag(bool *value) { Lock(); m_bMultiXbeFlag = *value; Unlock(); }
-
-		// ******************************************************************
 		// * Debugging flag Accessors
 		// ******************************************************************
 		void GetDebuggingFlag(bool *value) { Lock(); *value = m_bDebugging; Unlock(); }
@@ -218,7 +212,6 @@ class EmuShared : public Mutex
 			m_BootFlags = 0;
 			m_MSpF = 0.0f;
 			m_FPS = 0.0f;
-			m_bMultiXbeFlag = 0;
 			Unlock();
 		}
 
@@ -256,7 +249,7 @@ class EmuShared : public Mutex
 		int          m_SkipRdtscPatching;
 		float        m_MSpF;
 		float        m_FPS;
-		bool         m_bMultiXbeFlag;
+		bool         m_bReserved1;
 		bool         m_bDebugging;
 		bool         m_bReady;
 		bool         m_bEmulating;

--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -60,7 +60,7 @@ bool VirtualMemoryArea::CanBeMergedWith(const VirtualMemoryArea& next) const
 	return false;
 }
 
-void VMManager::Initialize(HANDLE memory_view, HANDLE pagetables_view)
+void VMManager::Initialize(HANDLE memory_view, HANDLE pagetables_view, int BootFlags)
 {
 	// Set up the critical section to synchronize accesses
 	InitializeCriticalSectionAndSpinCount(&m_CriticalSection, 0x400);
@@ -78,9 +78,7 @@ void VMManager::Initialize(HANDLE memory_view, HANDLE pagetables_view)
 	ConstructMemoryRegion(SYSTEM_MEMORY_BASE, SYSTEM_MEMORY_SIZE, SystemRegion);
 	ConstructMemoryRegion(DEVKIT_MEMORY_BASE, DEVKIT_MEMORY_SIZE, DevkitRegion);
 
-	int QuickReboot;
-	g_EmuShared->GetBootFlags(&QuickReboot);
-	if ((QuickReboot & BOOT_QUICK_REBOOT) != 0)
+	if ((BootFlags & BOOT_QUICK_REBOOT) != 0)
 	{
 		UCHAR PreviousXbeType = *(UCHAR*)(CONTIGUOUS_MEMORY_BASE + PAGE_SIZE - 9);
 		if (PreviousXbeType != g_XbeType)
@@ -135,7 +133,7 @@ dashboard from non-retail xbe?");
 	LIST_ENTRY_INSERT_HEAD(ListEntry, &block->ListEntry);
 
 	// Set up the pfn database
-	if ((QuickReboot & BOOT_QUICK_REBOOT) == 0) {
+	if ((BootFlags & BOOT_QUICK_REBOOT) == 0) {
 
 		// Quote from LukeUsher "Yeah, known issue. Contiguous memory persists more than it should so the framebuffer doesn't get cleared.
 		// The memory manager needs updating to only persist areas of memory marked with MmPersistContiguousMemory and discard the rest.

--- a/src/CxbxKrnl/VMManager.h
+++ b/src/CxbxKrnl/VMManager.h
@@ -118,7 +118,7 @@ class VMManager : public PhysicalMemory
 			CloseHandle(m_hPTFile);
 		}
 		// initializes the memory manager to the default configuration
-		void Initialize(HANDLE memory_view, HANDLE pagetables_view);
+		void Initialize(HANDLE memory_view, HANDLE pagetables_view, int BootFlags);
 		// retrieves memory statistics
 		void MemoryStatistics(xboxkrnl::PMM_STATISTICS memory_statistics);
 		// allocates memory in the user region


### PR DESCRIPTION
!!!Ready to merge!!!

Contains:
* Trigger CrashMonitor thread earlier.
* Check boot flag before kernel reset from EmuShared.
  * It helps to stop load bad reboot data.
* Replace bMultiXbeFlags to BootFlags variable.
  * I can confirm bMultiXbeFlags is only used to check if xbe will reboot and BootFlags is set for this.
* More focus toward kernel mode handling. (Still incomplete anyway.)