### PR TITLE
Remove legacy xinput config option

### DIFF
--- a/src/Cxbx/ResCxbx.h
+++ b/src/Cxbx/ResCxbx.h
@@ -264,7 +264,6 @@
 #define ID_SETTINGS_CACHE               40083
 #define ID_CACHE_CLEARHLECACHE_ALL      40084
 #define ID_CACHE_CLEARHLECACHE_CURRENT  40085
-#define ID_SETTINGS_XINPUT              40086
 #define ID_SETTINGS_HACKS               40088
 #define ID_HACKS_DISABLEPIXELSHADERS    40089
 #define ID_LED                          40090

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -198,12 +198,6 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 			}
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
-			result = RegQueryValueEx(hKey, "XInputEnabled", NULL, &dwType, (PBYTE)&m_XInputEnabled, &dwSize);
-			if (result != ERROR_SUCCESS) {
-				m_XInputEnabled = 0;
-			}
-
-			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			result = RegQueryValueEx(hKey, "HackDisablePixelShaders", NULL, &dwType, (PBYTE)&m_DisablePixelShaders, &dwSize);
 			if (result != ERROR_SUCCESS) {
 				m_DisablePixelShaders = 0;
@@ -416,9 +410,6 @@ WndMain::~WndMain()
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			RegSetValueEx(hKey, "LLEFLAGS", 0, dwType, (PBYTE)&m_FlagsLLE, dwSize);
-
-			dwType = REG_DWORD; dwSize = sizeof(DWORD);
-			RegSetValueEx(hKey, "XInputEnabled", 0, dwType, (PBYTE)&m_XInputEnabled, dwSize);
 
 			dwType = REG_DWORD; dwSize = sizeof(DWORD);
 			RegSetValueEx(hKey, "HackDisablePixelShaders", 0, dwType, (PBYTE)&m_DisablePixelShaders, dwSize);
@@ -1467,11 +1458,6 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 			}
 			break;
 
-			case ID_SETTINGS_XINPUT:
-				m_XInputEnabled = !m_XInputEnabled;
-				RefreshMenus();
-				break;
-
             case ID_EMULATION_START:
                 if (m_Xbe != nullptr)
                 {
@@ -1936,9 +1922,6 @@ void WndMain::RefreshMenus()
 			chk_flag = (m_FlagsLLE & LLE_GPU) ? MF_CHECKED : MF_UNCHECKED;
 			CheckMenuItem(settings_menu, ID_EMULATION_LLE_GPU, chk_flag);
 
-			chk_flag = (m_XInputEnabled) ? MF_CHECKED : MF_UNCHECKED;
-			CheckMenuItem(settings_menu, ID_SETTINGS_XINPUT, chk_flag);
-
 			chk_flag = (m_DisablePixelShaders) ? MF_CHECKED : MF_UNCHECKED;
 			CheckMenuItem(settings_menu, ID_HACKS_DISABLEPIXELSHADERS, chk_flag);
 
@@ -2356,9 +2339,6 @@ void WndMain::StartEmulation(HWND hwndParent, DebuggerState LocalDebuggerState /
 
 	// register LLE flags with emulator process
 	g_EmuShared->SetFlagsLLE(&m_FlagsLLE);
-
-	// register XInput flags with emulator process
-	g_EmuShared->SetXInputEnabled(&m_XInputEnabled);
 
 	// register Hacks with emulator process
 	g_EmuShared->SetDisablePixelShaders(&m_DisablePixelShaders);

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -569,12 +569,6 @@ void PrintCurrentConfigurationLog()
 		printf("LLE for JIT is %s\n", bLLE_JIT ? "enabled" : "disabled");
 	}
 
-	// Print current INPUT configuration
-	{
-		printf("--------------------------- INPUT CONFIG ---------------------------\n");
-		printf("Using %s\n", g_XInputEnabled ? "XInput" : "DirectInput");
-	}
-
 	// Print current video configuration (DirectX/HLE)
 	if (!bLLE_GPU) {
 		XBVideo XBVideoConf;
@@ -1300,13 +1294,6 @@ __declspec(noreturn) void CxbxKrnlInit
 		bLLE_APU = (CxbxLLE_Flags & LLE_APU) > 0;
 		bLLE_GPU = (CxbxLLE_Flags & LLE_GPU) > 0;
 		bLLE_JIT = (CxbxLLE_Flags & LLE_JIT) > 0;
-	}
-
-	// Process XInput Enabled flag
-	{
-		int XInputEnabled;
-		g_EmuShared->GetXInputEnabled(&XInputEnabled);
-		g_XInputEnabled = !!XInputEnabled;
 	}
 
 	// Process Hacks

--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -62,7 +62,6 @@ CHAR            *g_strCurDrive= NULL;
 volatile thread_local  bool    g_bEmuException = false;
 volatile bool    g_bEmuSuspended = false;
 volatile bool    g_bPrintfOn = true;
-bool g_XInputEnabled = false;
 bool g_DisablePixelShaders = false;
 bool g_UncapFramerate = false;
 bool g_UseAllCores = false;

--- a/src/CxbxKrnl/Emu.h
+++ b/src/CxbxKrnl/Emu.h
@@ -97,7 +97,6 @@ g_pXInputSetStateStatus[XINPUT_SETSTATE_SLOTS];
 // 4 controllers
 #define XINPUT_HANDLE_SLOTS 4
 
-extern bool g_XInputEnabled;
 extern HANDLE g_hInputHandle[XINPUT_HANDLE_SLOTS];
 
 typedef struct DUMMY_KERNEL

--- a/src/CxbxKrnl/EmuShared.h
+++ b/src/CxbxKrnl/EmuShared.h
@@ -146,12 +146,6 @@ class EmuShared : public Mutex
 		void SetBootFlags(int *value) { Lock(); m_BootFlags = *value; Unlock(); }
 
 		// ******************************************************************
-		// * XInput Flag Accessors
-		// ******************************************************************
-		void GetXInputEnabled(int* value) { Lock(); *value = m_XInputEnabled; Unlock(); }
-		void SetXInputEnabled(int* value) { Lock(); m_XInputEnabled = *value; Unlock(); }
-
-		// ******************************************************************
 		// * Hack Flag Accessors
 		// ******************************************************************
 		void GetDisablePixelShaders(int* value) { Lock(); *value = m_DisablePixelShaders; Unlock(); }
@@ -252,7 +246,7 @@ class EmuShared : public Mutex
 		char         m_XbePath[MAX_PATH];
 		int          m_BootFlags;
 		int          m_FlagsLLE;
-		int          m_XInputEnabled;
+		int          m_Reserved1;
 		int          m_DisablePixelShaders;
 		int          m_UncapFramerate;
 		int          m_UseAllCores;

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -277,6 +277,7 @@ VOID WINAPI XTL::EMUPATCH(XInitDevices)
 		LOG_FUNC_ARG(dwPreallocTypeCount)
 		LOG_FUNC_ARG((DWORD)PreallocTypes)
 		LOG_FUNC_END;
+
 /*    for(int v=0;v<XINPUT_SETSTATE_SLOTS;v++)
     {
         g_pXInputSetStateStatus[v].hDevice = 0;
@@ -288,18 +289,7 @@ VOID WINAPI XTL::EMUPATCH(XInitDevices)
     {
         g_hInputHandle[v] = 0;
     }
-*/	
-	if (g_XInputEnabled)
-	{
-		//query the total connected xinput gamepad.
-		total_xinput_gamepad = XInputGamepad_Connected();
-	}
-	else 
-	{
-		//using keyboard, we set the gamd pad count to 1
-		total_xinput_gamepad = 1;
-	}
-	
+*/
 }
 
 bool TitleIsJSRF()

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -258,7 +258,6 @@ void SetupXboxDeviceTypes()
 		}
 
 		printf("XAPI: XDEVICE_TYPE_GAMEPAD Found at 0x%08X\n", gDeviceType_Gamepad);
-        InitXboxControllerHostBridge();
 	}
 }
 
@@ -290,6 +289,9 @@ VOID WINAPI XTL::EMUPATCH(XInitDevices)
         g_hInputHandle[v] = 0;
     }
 */
+
+	InitXboxControllerHostBridge();
+
 }
 
 bool TitleIsJSRF()


### PR DESCRIPTION
Title say it all. Plus InitXboxControllerHostBridge is suppose to be call within XInitDevices patch function. Since XInitDevices is called first before start using any of XInput function.

I have tested several titles and confirmed are working as normal.