### PR TITLE
Preserve window position after stop emulation

### DIFF
--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2439,9 +2439,15 @@ void WndMain::StopEmulation()
     }
 
 	UpdateCaption();
-    RefreshMenus();
-	// Set the window size back to it's GUI dimensions
-	ResizeWindow(m_hwnd, /*bForGUI=*/true);
+	RefreshMenus();
+
+	int iScaleView = FALSE;
+	g_EmuShared->GetScaleViewport(&iScaleView);
+	if (iScaleView != 0) {
+		// Set the window size back to it's GUI dimensions
+		ResizeWindow(m_hwnd, /*bForGUI=*/true);
+	}
+
 	g_EmuShared->SetIsEmulating(false);
 }
 

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -2429,14 +2429,14 @@ void WndMain::StartEmulation(HWND hwndParent, DebuggerState LocalDebuggerState /
 // stop emulation
 void WndMain::StopEmulation()
 {
-    m_bIsStarted = false;
-    if (m_hwndChild != NULL) {
+	m_bIsStarted = false;
+	if (m_hwndChild != NULL) {
 		if (IsWindow(m_hwndChild)) {
 			SendMessage(m_hwndChild, WM_CLOSE, 0, 0);
 		}
 
 		m_hwndChild = NULL;
-    }
+	}
 
 	UpdateCaption();
 	RefreshMenus();

--- a/src/Cxbx/WndMain.h
+++ b/src/Cxbx/WndMain.h
@@ -184,7 +184,7 @@ class WndMain : public Wnd
 		HBITMAP     m_OriLed;
 		HBITMAP     m_SplashBmp;
 		HBITMAP     m_LogoBmp;
-		HBITMAP		m_GameLogoBMP;
+		HBITMAP     m_GameLogoBMP;
 		HBITMAP     m_LedBmp;
 		HBRUSH      m_Brushes[4];
 		HPEN        m_Pens[4];
@@ -239,17 +239,17 @@ class WndMain : public Wnd
 		// ******************************************************************
 		// * XInput Enabled Flag
 		// ******************************************************************		
-		int			m_XInputEnabled;
+		int         m_XInputEnabled;
 
 		// ******************************************************************
 		// * Hack Flags
 		// ******************************************************************	
-		int		m_DisablePixelShaders;
-		int		m_UncapFramerate;
-		int		m_UseAllCores;
-		int		m_SkipRdtscPatching;
-		int     m_ScaleViewport;
-		int		m_DirectHostBackBufferAccess;
+		int         m_DisablePixelShaders;
+		int         m_UncapFramerate;
+		int         m_UseAllCores;
+		int         m_SkipRdtscPatching;
+		int         m_ScaleViewport;
+		int         m_DirectHostBackBufferAccess;
 
         // ******************************************************************
         // * debug output filenames
@@ -262,6 +262,11 @@ class WndMain : public Wnd
 		// ******************************************************************
 		CXBX_DATA   m_StorageToggle;
 		char        m_StorageLocation[MAX_PATH];
+
+		// ******************************************************************
+		// * Previous GUI window location (before start emulation)
+		// ******************************************************************
+		POINT       m_prevWindowLoc;
 };
 
 #endif


### PR DESCRIPTION
Title says it all.

Only thing not tested are left and bottom monitors of main monitor. In theory, it should work as intended.

Resolved #1330 