### PR TITLE
Fix invalid audio adapter crash

### DIFF
--- a/src/Cxbx/DlgAudioConfig.cpp
+++ b/src/Cxbx/DlgAudioConfig.cpp
@@ -225,7 +225,7 @@ VOID RefreshAudioAdapter()
             g_XBAudio.SetAudioAdapter(binGUID);
         }
 
-        // Force save default audio device if selected audo device is invalid.
+        // Force save default audio device if selected audio device is invalid.
         if (pGUID == (LPGUID)CB_ERR) {
             SendMessage(g_hAudioAdapter, CB_SETCURSEL, 0, 0);
             g_EmuShared->SetXBAudio(&g_XBAudio);

--- a/src/Cxbx/DlgAudioConfig.cpp
+++ b/src/Cxbx/DlgAudioConfig.cpp
@@ -229,8 +229,8 @@ VOID RefreshAudioAdapter()
         if (pGUID == (LPGUID)CB_ERR) {
             SendMessage(g_hAudioAdapter, CB_SETCURSEL, 0, 0);
             g_EmuShared->SetXBAudio(&g_XBAudio);
-            MessageBox(nullptr, "Your selected audio device is invalid,\n"
-                                "reverting to default audio device.", "Cxbx-Reloaded", MB_OK | MB_ICONEXCLAMATION);
+            MessageBox(nullptr, "Your selected audio adapter is invalid,\n"
+                                "reverting to default audio adapter.", "Cxbx-Reloaded", MB_OK | MB_ICONEXCLAMATION);
         }
     }
 }

--- a/src/Cxbx/DlgAudioConfig.cpp
+++ b/src/Cxbx/DlgAudioConfig.cpp
@@ -211,17 +211,26 @@ VOID RefreshAudioAdapter()
 
         GUID binGUID;
 
-        if (pGUID) {
+        // Check if pGUID doesn't have CB_ERR. (source of cause to crash)
+        if (pGUID != nullptr && pGUID != (LPGUID)CB_ERR) {
             binGUID = *pGUID;
-        } else {
+        }
+        else {
             binGUID = { 0 };
         }
 
-        if(binGUID != oldGUID)
-        {
+        if(binGUID != oldGUID) {
             g_bHasChanges = TRUE;
 
             g_XBAudio.SetAudioAdapter(binGUID);
+        }
+
+        // Force save default audio device if selected audo device is invalid.
+        if (pGUID == (LPGUID)CB_ERR) {
+            SendMessage(g_hAudioAdapter, CB_SETCURSEL, 0, 0);
+            g_EmuShared->SetXBAudio(&g_XBAudio);
+            MessageBox(nullptr, "Your selected audio device is invalid,\n"
+                                "reverting to default audio device.", "Cxbx-Reloaded", MB_OK | MB_ICONEXCLAMATION);
         }
     }
 }

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -278,7 +278,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
                 // Is not a fatal error.
                 break;
             case DSERR_ALLOCATED:
-                dsErrorMsg = "Audio device is already allocated. Possible fault within Cxbx-Reloaded's emulator."
+                dsErrorMsg = "Audio adapter is already allocated. Possible fault within Cxbx-Reloaded's emulator."
                             "\n\nPlease report to respective game compatibility issue.";
                 break;
             case DSERR_INVALIDPARAM:
@@ -286,11 +286,11 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
                             "\n\nPlease report to respective game compatibility issue.";
                 break;
             case DSERR_NOAGGREGATION:
-                dsErrorMsg = "Audio device does not support aggregation."
-                            "\n\nPlease use different audio device.";
+                dsErrorMsg = "Audio adapter does not support aggregation."
+                            "\n\nPlease use different audio adapter.";
                 break;
             case DSERR_NODRIVER:
-                dsErrorMsg = "Please select a valid audio device from Cxbx-Reloaded's config audio dialog."
+                dsErrorMsg = "Please select a valid audio adapter from Cxbx-Reloaded's config audio dialog."
                             "\n\nThen try again.";
                 break;
             case DSERR_OUTOFMEMORY:

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -295,7 +295,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
                 break;
             case DSERR_OUTOFMEMORY:
                 dsErrorMsg = "Unable to allocate DirectSound subsystem class."
-                            "\n\nPlease close any opened application(s) or restart computer before try again.";
+                            "\n\nPlease close any opened application(s) or restart computer before trying again.";
                 break;
             default:
                 dsErrorMsg = "DirectSoundCreate8 unknown failed: 0x%08X";

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -272,7 +272,8 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
         hRet = DirectSoundCreate8(&g_XBAudio.GetAudioAdapter(), &g_pDSound8, NULL);
 
         if (hRet != DS_OK) {
-            CxbxKrnlCleanup("DirectSoundCreate8 Failed!");
+            CxbxKrnlCleanup("DirectSoundCreate8 Failed!"
+                            "\n\nPlease select a valid audio device from Cxbx-Reloaded's config audio dialog.");
         }
 
         hRet = g_pDSound8->SetCooperativeLevel(g_hEmuWindow, DSSCL_PRIORITY);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -271,9 +271,38 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
     if (!initialized || g_pDSound8 == nullptr) {
         hRet = DirectSoundCreate8(&g_XBAudio.GetAudioAdapter(), &g_pDSound8, NULL);
 
-        if (hRet != DS_OK) {
-            CxbxKrnlCleanup("DirectSoundCreate8 Failed!"
-                            "\n\nPlease select a valid audio device from Cxbx-Reloaded's config audio dialog.");
+        LPCSTR dsErrorMsg = nullptr;
+
+        switch (hRet) {
+            case DS_OK:
+                // Is not a fatal error.
+                break;
+            case DSERR_ALLOCATED:
+                dsErrorMsg = "Audio device is already allocated. Possible fault within Cxbx-Reloaded's emulator."
+                            "\n\nPlease report to respective game compatibility issue.";
+                break;
+            case DSERR_INVALIDPARAM:
+                dsErrorMsg = "DirectSoundCreate8 return invalid paramemter."
+                            "\n\nPlease report to respective game compatibility issue.";
+                break;
+            case DSERR_NOAGGREGATION:
+                dsErrorMsg = "Audio device does not support aggregation."
+                            "\n\nPlease use different audio device.";
+                break;
+            case DSERR_NODRIVER:
+                dsErrorMsg = "Please select a valid audio device from Cxbx-Reloaded's config audio dialog."
+                            "\n\nThen try again.";
+                break;
+            case DSERR_OUTOFMEMORY:
+                dsErrorMsg = "Unable to allocate DirectSound subystem class."
+                            "\n\nPlease close any opened applications or restart computer before try again.";
+                break;
+            default:
+                dsErrorMsg = "DirectSoundCreate8 unknown failed: 0x%08X";
+        }
+
+        if (dsErrorMsg != nullptr) {
+            CxbxKrnlCleanup(dsErrorMsg, hRet);
         }
 
         hRet = g_pDSound8->SetCooperativeLevel(g_hEmuWindow, DSSCL_PRIORITY);

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -282,7 +282,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
                             "\n\nPlease report to respective game compatibility issue.";
                 break;
             case DSERR_INVALIDPARAM:
-                dsErrorMsg = "DirectSoundCreate8 return invalid paramemter."
+                dsErrorMsg = "DirectSoundCreate8 return invalid parameter."
                             "\n\nPlease report to respective game compatibility issue.";
                 break;
             case DSERR_NOAGGREGATION:
@@ -294,8 +294,8 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
                             "\n\nThen try again.";
                 break;
             case DSERR_OUTOFMEMORY:
-                dsErrorMsg = "Unable to allocate DirectSound subystem class."
-                            "\n\nPlease close any opened applications or restart computer before try again.";
+                dsErrorMsg = "Unable to allocate DirectSound subsystem class."
+                            "\n\nPlease close any opened application(s) or restart computer before try again.";
                 break;
             default:
                 dsErrorMsg = "DirectSoundCreate8 unknown failed: 0x%08X";


### PR DESCRIPTION
Finally found the fault of the crash. Before, I couldn't find the fault due to a crash occur very deep within Windows' modules.

Contains:
* Fix for invalid audio adapter cause audio dialog to crash.
* Add *more* detail message from emulator side of audio adapter creation failure.

This PR is a low risk.

---
**NOTE:** This is the last pull request from me for v0.1 release.