### PR TITLE
Run with limited privileges by default instead of asking evey time

### DIFF
--- a/src/Cxbx/WinMain.cpp
+++ b/src/Cxbx/WinMain.cpp
@@ -75,6 +75,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		return EXIT_FAILURE;
 	}
 
+	bool bElevated = CxbxIsElevated();
+
+	if (bElevated) {
+		if (IsNewProcessLaunched()) {
+			ExitProcess(0);
+		}
+	}
+
 	/*! initialize shared memory */
 	EmuShared::Init();
 
@@ -83,7 +91,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     /* check if process is launch with elevated access then prompt for continue on or not. */
 	if (!bFirstLaunch) {
-		bool bElevated = CxbxIsElevated();
 		if (bElevated && !bFirstLaunch) {
 			int ret = MessageBox(NULL, "Cxbx-Reloaded has detected that it has been launched with Administrator rights.\n"
 								"\nThis is dangerous, as a maliciously modified Xbox titles could take control of your system.\n"

--- a/src/CxbxKrnl/CxbxKrnl.h
+++ b/src/CxbxKrnl/CxbxKrnl.h
@@ -297,6 +297,8 @@ bool CxbxExec(std::string &execCommand, HANDLE* hProcess, bool requestHandleProc
 
 bool CxbxIsElevated();
 
+bool IsNewProcessLaunched();
+
 /*! kernel thunk table */
 extern uint32 CxbxKrnl_KernelThunkTable[379];
 


### PR DESCRIPTION
Tested with Windows 7 and confirmed as working (the child process also inherits the limited privileges as well). Better also testing this with Windows 10 since, according to the original StackOverflow question, this could not work with that OS 