### PR TITLE
Unset DepthStencil flag on ARGB conversion

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -4877,6 +4877,10 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 		if (EmuXBFormatRequiresConversionToARGB(X_Format)) {
 			bConvertToARGB = true;
 			PCFormat = XTL::D3DFMT_A8R8G8B8;
+
+			// Unset D3DUSAGE_DEPTHSTENCIL: It's not possible for ARGB textures to be depth stencils
+			// Fixes CreateTexture error in Virtua Cop 3 (Chihiro)
+			D3DUsage &= ~D3DUSAGE_DEPTHSTENCIL;
 		}
 		else {
 			// TODO : Nuance the following, because the Direct3D 8 docs states


### PR DESCRIPTION
ARGB isn't a valid stencil format, this is the cause of CreateTexture errors in some titles.

With this fix, Virtua Cop 3 (Chihiro title) boots again, but sadly still crashes before going in-game.

This has potential to fix the many titles that currently show CreateTexture errors, please test and report back,