### PR TITLE
Fix an issue with Vertex Shaders containing EXP instruction

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1433,6 +1433,44 @@ static boolean VshConvertShader(VSH_XBOX_SHADER *pShader,
             pIntermediate->ILU = ILU_RCP;
         }
 
+		if (pIntermediate->InstructionType == IMD_ILU && pIntermediate->ILU == ILU_EXP)
+		{
+			// EXP on DX8 requires that exactly one swizzle is specified on the output
+
+			// Count how many swizzles are set
+			int swizzles = 0;
+			for (int i = 0; i < 4; i++) {
+				if (pIntermediate->Parameters[0].Parameter.Swizzle[i]) {
+					swizzles++;
+				}
+			}
+
+			// If we had more than 1 swizzle, set the same swizzle on the ouput as the input
+			// Test case: THP2X
+			if (swizzles > 1) {
+				int swizzle = (pIntermediate->Output.Mask[0]) | (pIntermediate->Output.Mask[1] << 1) | (pIntermediate->Output.Mask[2] << 2) | (pIntermediate->Output.Mask[3] << 3);
+				switch (swizzle)
+				{
+				case 1:
+					VshSetSwizzle(&pIntermediate->Parameters[0], SWIZZLE_X, SWIZZLE_X, SWIZZLE_X, SWIZZLE_X);
+					break;
+				case 2:
+					VshSetSwizzle(&pIntermediate->Parameters[0], SWIZZLE_Y, SWIZZLE_Y, SWIZZLE_Y, SWIZZLE_Y);
+					break;
+				case 4:
+					VshSetSwizzle(&pIntermediate->Parameters[0], SWIZZLE_Z, SWIZZLE_Z, SWIZZLE_Z, SWIZZLE_Z);
+					break;
+				case 8:
+					VshSetSwizzle(&pIntermediate->Parameters[0], SWIZZLE_W, SWIZZLE_W, SWIZZLE_W, SWIZZLE_W);
+					break;
+				case 15:
+				default:
+					LOG_TEST_CASE("exp instruction with invalid swizzle");
+					break;
+				}
+			}
+		}
+
         if(pIntermediate->Output.Type == IMD_OUTPUT_R)
         {
             RUsage[pIntermediate->Output.Address] = TRUE;
@@ -2473,17 +2511,17 @@ extern HRESULT XTL::EmuRecompileVshFunction
 		}
 
         char* pShaderDisassembly = (char*)malloc(pShader->IntermediateCount * 100); // Should be plenty
-        DbgVshPrintf("-- Before conversion --\n");
+		DbgVshPrintf("-- Before conversion --\n");
         VshWriteShader(pShader, pShaderDisassembly, FALSE);
-        DbgVshPrintf("%s", pShaderDisassembly);
-        DbgVshPrintf("-----------------------\n");
+		DbgVshPrintf("%s", pShaderDisassembly);
+		DbgVshPrintf("-----------------------\n");
 
         VshConvertShader(pShader, bNoReservedConstants, declaredRegisters);
         VshWriteShader(pShader, pShaderDisassembly, TRUE);
 
-        DbgVshPrintf("-- After conversion ---\n");
-        DbgVshPrintf("%s", pShaderDisassembly);
-        DbgVshPrintf("-----------------------\n");
+		DbgVshPrintf("-- After conversion ---\n");
+		DbgVshPrintf("%s", pShaderDisassembly);
+		DbgVshPrintf("-----------------------\n");
 
         // HACK: Azurik. Prevent Direct3D from trying to assemble this.
 		if(!strcmp(pShaderDisassembly, "vs.1.1\n"))


### PR DESCRIPTION
Fix an issue where Vertex Shaders containing exp instructions without a swizzle failed to compile.

Can't remember why I didn't PR this sooner: Make sure to test for regressions and report back.