### PR TITLE
Fix for issue #1342

### DIFF
--- a/src/Common/CxbxCommon.cpp
+++ b/src/Common/CxbxCommon.cpp
@@ -180,9 +180,6 @@ void unix2dos(std::string& string)
 {
 	size_t position = 0;
 	while (true) {
-		if (position > string.length()) {
-			break;
-		}
 		position = string.find('\n', position);
 		if (position == std::string::npos) {
 			break;

--- a/src/Common/CxbxCommon.cpp
+++ b/src/Common/CxbxCommon.cpp
@@ -44,7 +44,7 @@
 #endif
 
 
-// Acknowledgment: all the functions present at the moment are from XQEMU (GPLv2)
+// Acknowledgment: some the functions present are from XQEMU (GPLv2)
 // https://xqemu.com/
 
 
@@ -173,5 +173,25 @@ void WriteWords(xbaddr Paddr, uint16_t* Buffer, int Number)
 {
 	for (int i = 0; i < Number; i++, Buffer++, Paddr += sizeof(*Buffer)) {
 		std::memcpy(reinterpret_cast<void*>(Paddr + CONTIGUOUS_MEMORY_BASE), Buffer, 2); // dropped big -> little endian conversion from XQEMU
+	}
+}
+
+void unix2dos(std::string& string)
+{
+	size_t position = 0;
+	while (true) {
+		if (position > string.length()) {
+			break;
+		}
+		position = string.find('\n', position);
+		if (position == std::string::npos) {
+			break;
+		}
+		if (position != 0 && string.compare(position - 1, 2U, "\r\n") == 0) {
+			position++;
+			continue;
+		}
+		string.insert(position, 1, '\r');
+		position += 2;
 	}
 }

--- a/src/Common/CxbxCommon.h
+++ b/src/Common/CxbxCommon.h
@@ -40,6 +40,7 @@
 #include "Cxbx.h"
 #include <stdint.h>
 #include <assert.h>
+#include <string>
 
 /* This is a linux struct for vectored I/O. See readv() and writev() */
 struct IoVec
@@ -67,6 +68,8 @@ void WriteDwords(xbaddr Paddr, uint32_t* Buffer, int Number);
 void GetDwords(xbaddr Paddr, uint32_t* Buffer, int Number);
 void GetWords(xbaddr Paddr, uint16_t* Buffer, int Number);
 void WriteWords(xbaddr Paddr, uint16_t* Buffer, int Number);
+
+void unix2dos(std::string& string);
 
 #define GET_WORD_LOW(value) (uint8_t)((value) & 0xFF)
 #define GET_WORD_HIGH(value) (uint8_t)(((value) >> 8) & 0xFF)

--- a/src/Cxbx/DlgAbout.cpp
+++ b/src/Cxbx/DlgAbout.cpp
@@ -39,6 +39,7 @@
 #include "CxbxVersion.h"
 #include "DlgAbout.h"
 #include "ResCxbx.h"
+#include "CxbxCommon.h"
 
 #include <commctrl.h>
 #include <string>
@@ -111,22 +112,7 @@ INT_PTR CALLBACK DlgAboutProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				SizeofResource(GetModuleHandle(NULL), rContributors)
 			);
 
-			size_t position = 0;
-			while (true) {
-				if (position > contributors.length()) {
-					break;
-				}
-				position = contributors.find('\n', position);
-				if (position == std::string::npos) {
-					break;
-				}
-				if (position != 0 && contributors.compare(position - 1, 2U, "\r\n") == 0) {
-					position++;
-					continue;
-				}
-				contributors.insert(position, 1, '\r');
-				position += 2;
-			}
+			unix2dos(contributors);
 
 			tab = CreateWindowEx(
 				NULL, "EDIT", contributors.c_str(),
@@ -151,22 +137,7 @@ INT_PTR CALLBACK DlgAboutProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				SizeofResource(GetModuleHandle(NULL), rCopying)
 			);
 
-			position = 0;
-			while (true) {
-				if (position > copying.length()) {
-					break;
-				}
-				position = copying.find('\n', position);
-				if (position == std::string::npos) {
-					break;
-				}
-				if (position != 0 && copying.compare(position - 1, 2U, "\r\n") == 0) {
-					position++;
-					continue;
-				}
-				copying.insert(position, 1, '\r');
-				position += 2;
-			}
+			unix2dos(copying);
 
 			tab = CreateWindowEx(
 				NULL, "EDIT", copying.c_str(),

--- a/src/Cxbx/DlgAbout.cpp
+++ b/src/Cxbx/DlgAbout.cpp
@@ -111,6 +111,23 @@ INT_PTR CALLBACK DlgAboutProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				SizeofResource(GetModuleHandle(NULL), rContributors)
 			);
 
+			size_t position = 0;
+			while (true) {
+				if (position > contributors.length()) {
+					break;
+				}
+				position = contributors.find('\n', position);
+				if (position == std::string::npos) {
+					break;
+				}
+				if (position != 0 && contributors.compare(position - 1, 2U, "\r\n") == 0) {
+					position++;
+					continue;
+				}
+				contributors.insert(position, 1, '\r');
+				position += 2;
+			}
+
 			tab = CreateWindowEx(
 				NULL, "EDIT", contributors.c_str(),
 				WS_CHILD | WS_VSCROLL |ES_MULTILINE | ES_READONLY,
@@ -133,6 +150,23 @@ INT_PTR CALLBACK DlgAboutProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				(char*)LockResource(LoadResource(GetModuleHandle(NULL), rCopying)),
 				SizeofResource(GetModuleHandle(NULL), rCopying)
 			);
+
+			position = 0;
+			while (true) {
+				if (position > copying.length()) {
+					break;
+				}
+				position = copying.find('\n', position);
+				if (position == std::string::npos) {
+					break;
+				}
+				if (position != 0 && copying.compare(position - 1, 2U, "\r\n") == 0) {
+					position++;
+					continue;
+				}
+				copying.insert(position, 1, '\r');
+				position += 2;
+			}
 
 			tab = CreateWindowEx(
 				NULL, "EDIT", copying.c_str(),


### PR DESCRIPTION
It also applies the same fix to the copyright tab, since it was affected by the same problem (LF line endings instead of CRLF).

![1](https://user-images.githubusercontent.com/30000751/43595622-763b17ac-967d-11e8-91e5-863a02ef450f.PNG)
![2](https://user-images.githubusercontent.com/30000751/43595623-7665ce34-967d-11e8-92ce-cf3818b47565.PNG)
