### PR TITLE
Fix a crash in the dashboard

### DIFF
--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -84,8 +84,8 @@ std::string FormatTitleId(uint32_t title_id)
 	// EG: MS-001 for 1st tile published by MS, EA-002 for 2nd title by EA, etc
 	// Some special Xbes (Dashboard, XDK Samples) use non-alphanumeric serials
 	// We fall back to Hex for those
-	char pTitleId1 = (title_id >> 24) & 0xFF;
-	char pTitleId2 = (title_id >> 16) & 0xFF;
+	unsigned char pTitleId1 = (title_id >> 24) & 0xFF;
+	unsigned char pTitleId2 = (title_id >> 16) & 0xFF;
 
 	if (!isalnum(pTitleId1) || !isalnum(pTitleId2)) {
 		// Prefix was non-printable, so we need to print a hex reprentation of the entire title_id


### PR DESCRIPTION
Fixes a crash on the dashboard caused by an assertion triggered only on debug builds. The problem was that the char passed to isalnum expects characters to be in the range -1 – 255, and so they must be unsigned, otherwise they can be out of range depending on the value being passed (0xFF and 0xFE in the case of the dashboard). BTW, this is also documented in the docs of the function: “Like all other functions from cctype, the behavior of std::isalnum is undefined if the argument's value is neither representable as unsigned char nor equal to EOF. To use these functions safely with plain chars (or signed chars), the argument should first be converted to unsigned char:” 

![dash_assert](https://user-images.githubusercontent.com/30000751/43648214-188a02cc-973a-11e8-9d04-6d08ebdbf28a.PNG)
![dash_crash](https://user-images.githubusercontent.com/30000751/43648215-18b81220-973a-11e8-84b5-0656bcb7ae9c.PNG)
