### PR TITLE
Fix unicode characters printed in the dashboard title

### DIFF
--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -84,10 +84,10 @@ std::string FormatTitleId(uint32_t title_id)
 	// EG: MS-001 for 1st tile published by MS, EA-002 for 2nd title by EA, etc
 	// Some special Xbes (Dashboard, XDK Samples) use non-alphanumeric serials
 	// We fall back to Hex for those
-	unsigned char pTitleId1 = (title_id >> 24) & 0xFF;
-	unsigned char pTitleId2 = (title_id >> 16) & 0xFF;
+	uint8_t pTitleId1 = (title_id >> 24) & 0xFF;
+	uint8_t pTitleId2 = (title_id >> 16) & 0xFF;
 
-	if (!isalnum(pTitleId1) || !isalnum(pTitleId2)) {
+	if ((pTitleId1 < 65 || pTitleId1 > 90) || (pTitleId2 < 65 || pTitleId2 > 90)) {
 		// Prefix was non-printable, so we need to print a hex reprentation of the entire title_id
 		ss << std::setfill('0') << std::setw(8) << std::hex << std::uppercase << title_id;
 		return ss.str();

--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -85,7 +85,7 @@ std::string FormatTitleId(uint32_t title_id)
 	// Some special Xbes (Dashboard, XDK Samples) use non-alphanumeric serials
 	// We fall back to Hex for those
 	// ergo720: we cannot use isalnum() here because it will treat chars in the range -1 - 255 as valid ascii chars which can
-	// lead to unicode characters being printed in the title (e.g.: dashboard uses 0xFE and 0xFE)
+	// lead to unicode characters being printed in the title (e.g.: dashboard uses 0xFE and 0xFF)
 	uint8_t pTitleId1 = (title_id >> 24) & 0xFF;
 	uint8_t pTitleId2 = (title_id >> 16) & 0xFF;
 

--- a/src/CxbxKrnl/Emu.cpp
+++ b/src/CxbxKrnl/Emu.cpp
@@ -84,6 +84,8 @@ std::string FormatTitleId(uint32_t title_id)
 	// EG: MS-001 for 1st tile published by MS, EA-002 for 2nd title by EA, etc
 	// Some special Xbes (Dashboard, XDK Samples) use non-alphanumeric serials
 	// We fall back to Hex for those
+	// ergo720: we cannot use isalnum() here because it will treat chars in the range -1 - 255 as valid ascii chars which can
+	// lead to unicode characters being printed in the title (e.g.: dashboard uses 0xFE and 0xFE)
 	uint8_t pTitleId1 = (title_id >> 24) & 0xFF;
 	uint8_t pTitleId2 = (title_id >> 16) & 0xFF;
 


### PR DESCRIPTION
Fixes unicode characters being printed in the dashboard

![dash](https://user-images.githubusercontent.com/30000751/43654238-d694f3e8-974a-11e8-85ee-2e9749ceb482.PNG)
![doa3](https://user-images.githubusercontent.com/30000751/43654239-d6c10762-974a-11e8-9021-6bf1bd7454a3.PNG)
