### PR TITLE
Settings class hotfix

### DIFF
--- a/src/Common/Settings.cpp
+++ b/src/Common/Settings.cpp
@@ -612,6 +612,7 @@ void Settings::Verify()
 	// Prevent using an incorrect path from the registry if the debug folders have been moved
 	char szDebugPath[MAX_PATH];
 	char szDebugName[MAX_PATH];
+	unsigned int strLen;
 
 	if (m_gui.CxbxDebugMode == DM_FILE) {
 
@@ -626,7 +627,9 @@ void Settings::Verify()
 				m_gui.CxbxDebugMode = DM_NONE;
 			}
 			else {
-				std::strncpy(szDebugPath, m_gui.szCxbxDebugFile.c_str(), m_gui.szCxbxDebugFile.size() - std::strlen(szDebugName));
+				strLen = m_gui.szCxbxDebugFile.size() - std::strlen(szDebugName);
+				std::strncpy(szDebugPath, m_gui.szCxbxDebugFile.c_str(), strLen);
+				szDebugPath[strLen] = '\0'; // Require to include terminate string.
 
 				if(std::experimental::filesystem::exists(szDebugPath) == false) {
 					m_gui.szCxbxDebugFile = "";
@@ -649,7 +652,9 @@ void Settings::Verify()
 				m_core.KrnlDebugMode = DM_NONE;
 			}
 			else {
-				std::strncpy(szDebugPath, m_core.szKrnlDebug, std::strlen(m_core.szKrnlDebug) - std::strlen(szDebugName));
+				strLen = std::strlen(m_core.szKrnlDebug) - std::strlen(szDebugName);
+				std::strncpy(szDebugPath, m_core.szKrnlDebug, strLen);
+				szDebugPath[strLen] = '\0'; // Require to include terminate string.
 
 				if(std::experimental::filesystem::exists(szDebugPath) == false) {
 					memset(m_core.szKrnlDebug, '\0', MAX_PATH);

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -157,13 +157,7 @@ extern volatile bool g_bPrintfOn;
 #define CxbxSetThreadName(Name)
 #endif
 
-// NOTE: The reason filesystem is here is for force compress "experimental" namespace
-// to work with same old and new filesystem's functions. Untested, yet should work fine.
-#include <filesystem>
-#ifdef _EXPERIMENTAL_FILESYSTEM_
-namespace std {
-	namespace filesystem = std::experimental::filesystem;
-}
-#endif
+// NOTE: #include <filesystem> didn't work plus C++ 17 is still using experimental filesystem.
+#include <experimental/filesystem>
 
 #endif


### PR DESCRIPTION
Contain fixes to able use debug build properly. Plus support other compilers too when having issue with `<filesystem>` state as not found.