### PR TITLE
Vertex shader improvements

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3545,7 +3545,8 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 			&VertexShaderSize,
 			g_VertexShaderConstantMode == X_D3DSCM_NORESERVEDCONSTANTS,
 			&bUseDeclarationOnly,
-			pRecompiledDeclaration);
+			pRecompiledDeclaration,
+            DeclarationSize);
 		if (SUCCEEDED(hRet))
 		{
 			if (!bUseDeclarationOnly)

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -3533,6 +3533,11 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 	// Create the vertex declaration
 	hRet = g_pD3DDevice->CreateVertexDeclaration((XTL::D3DVERTEXELEMENT9*)pRecompiledDeclaration, &pVertexShader->pHostDeclaration);
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateVertexDeclaration");
+
+	if (FAILED(hRet)) {
+		// NOTE: This is a fatal error because it ALWAYS triggers a crash within DrawVertices if not set
+		CxbxKrnlCleanup("Failed to create Vertex Declaration");
+	}
 	g_pD3DDevice->SetVertexDeclaration(pVertexShader->pHostDeclaration);
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexDeclaration");
 

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2440,7 +2440,8 @@ extern HRESULT XTL::EmuRecompileVshFunction
     DWORD        *pOriginalSize,
     boolean      bNoReservedConstants,
 	boolean		 *pbUseDeclarationOnly,
-	DWORD		 *pRecompiledDeclaration
+	DWORD		 *pRecompiledDeclaration,
+    DWORD        DeclarationSize
 )
 {
     VSH_SHADER_HEADER   *pShaderHeader = (VSH_SHADER_HEADER*)pFunction;
@@ -2455,6 +2456,7 @@ extern HRESULT XTL::EmuRecompileVshFunction
 	// as they cause CreateVertexShader to fail
 	bool declaredRegisters[13] = { false };
 	DWORD* pDeclToken = pRecompiledDeclaration;
+    DWORD* pDeclEnd = (DWORD*)((BYTE*)pDeclToken + DeclarationSize);
 	do {
 		DWORD regNum = *pDeclToken & X_D3DVSD_VERTEXREGMASK;
 		if (regNum > 12) {
@@ -2466,7 +2468,7 @@ extern HRESULT XTL::EmuRecompileVshFunction
 
 		declaredRegisters[regNum] = true;
 		pDeclToken++;
-	} while (*pDeclToken != X_D3DVSD_END());
+	} while (pDeclToken < pDeclEnd && *pDeclToken != X_D3DVSD_END());
 
     // TODO: support this situation..
     if(pFunction == NULL)

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -2129,22 +2129,32 @@ static void VshConvertToken_STREAMDATA_REG(
 		DbgVshPrintf("D3DVSDT_FLOAT2");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT2;
 		HostVertexElementByteSize = 2 * sizeof(FLOAT);
+		//HostVertexRegister = D3DDECLUSAGE_TEXCOORD;	
 		break;
 	case X_D3DVSDT_FLOAT3: // 0x32:
 		DbgVshPrintf("D3DVSDT_FLOAT3");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT3;
 		HostVertexElementByteSize = 3 * sizeof(FLOAT);
+
+		/*
+		if (pPatchData->pCurrentVertexShaderStreamInfo->DeclPosition) {
+			pPatchData->pCurrentVertexShaderStreamInfo->DeclPosition = true;
+			HostVertexRegister = D3DDECLUSAGE_POSITION;
+		} else {
+			HostVertexRegister = D3DDECLUSAGE_NORMAL;
+		} */
 		break;
 	case X_D3DVSDT_FLOAT4: // 0x42:
 		DbgVshPrintf("D3DVSDT_FLOAT4");
 		HostVertexElementDataType = D3DDECLTYPE_FLOAT4;
 		HostVertexElementByteSize = 4 * sizeof(FLOAT);
+		//HostVertexRegister = D3DDECLUSAGE_COLOR;
 		break;
 	case X_D3DVSDT_D3DCOLOR: // 0x40:
 		DbgVshPrintf("D3DVSDT_D3DCOLOR");
 		HostVertexElementDataType = D3DDECLTYPE_D3DCOLOR;
 		HostVertexElementByteSize = 1 * sizeof(D3DCOLOR);
-		HostVertexRegister = D3DDECLUSAGE_COLOR;
+		//HostVertexRegister = D3DDECLUSAGE_COLOR;
 		break;
 	case X_D3DVSDT_SHORT2: // 0x25:
 		DbgVshPrintf("D3DVSDT_SHORT2");

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1498,7 +1498,7 @@ static boolean VshConvertShader(VSH_XBOX_SHADER *pShader,
         // Combining not supported in vs.1.1
         pIntermediate->IsCombined = FALSE;
 
-        if(pIntermediate->Output.Type == IMD_OUTPUT_O && pIntermediate->Output.Address == OREG_OFOG)
+        if(pIntermediate->Output.Type == IMD_OUTPUT_O && (pIntermediate->Output.Address == OREG_OPTS || pIntermediate->Output.Address == OREG_OFOG))
         {
             // The PC shader assembler doesn't like masks on scalar registers
             VshSetOutputMask(&pIntermediate->Output, TRUE, TRUE, TRUE, TRUE);

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.h
@@ -67,7 +67,8 @@ extern HRESULT EmuRecompileVshFunction
     DWORD        *pOriginalSize,
     boolean      bNoReservedConstants,
 	boolean		 *pbUseDeclarationOnly,
-	DWORD		 *pRecompiledDeclaration
+	DWORD		 *pRecompiledDeclaration,
+    DWORD        DeclarationSize
 );
 
 extern void FreeVertexDynamicPatch(CxbxVertexShader *pVertexShader);


### PR DESCRIPTION
Updates vertex shader compilation to use version 2.x
- Maximum register and instruction counts increased

Fixes for vertex shader conversion
- Instructions restricted to single swizzle component use correct swizzle masks
- Write masks excluded for oPts register
- Checks to prevent buffer overruns and access violations during token traversal
