### PR TITLE
Fix controller's input conflict between DInput and XInput controllers

### DIFF
--- a/src/Common/Win32/DInputController.cpp
+++ b/src/Common/Win32/DInputController.cpp
@@ -360,13 +360,12 @@ void DInputController::ListenPoll(XTL::X_XINPUT_STATE *Controller)
     HRESULT hRet=0;
     DWORD dwFlags=0;
 
+    // Test case: Smashing Drive, pointer of X_XINPUT_STATE is reused for other controller ports.
+    // By setting Gamepad to zero'd no longer have conflict with input changes from other controller port.
     // ******************************************************************
-    // * Default values necessary for axis
+    // * Set default values
     // ******************************************************************
-    Controller->Gamepad.sThumbLX = 0;
-    Controller->Gamepad.sThumbLY = 0;
-    Controller->Gamepad.sThumbRX = 0;
-    Controller->Gamepad.sThumbRY = 0;
+    Controller->Gamepad = { 0 };
 
     XTL::DIJOYSTATE JoyState = { 0 };
 	BYTE KeyboardState[256] = { 0 };


### PR DESCRIPTION
Tested with:
* Smashing Drive
* Lego Star Wars 1 & 2

I can confirm emulated DInput controller no longer have any input conflict from XInput controller(s) when using same pointer for xbox controller ports.

I also tested with two XInput controllers to ensure there is no input conflict, which has no issue.