### PR TITLE
Shader improvements

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -867,7 +867,7 @@ static void VshWriteShader(VSH_XBOX_SHADER *pShader,
 				std::stringstream dclStream;
 				switch (usage) {
 				case XTL::D3DDECLUSAGE_POSITION:
-					dclStream << "dcl_position";
+                    dclStream << "dcl_position" << (int)PCUsageIndex;
 					break;
 				case XTL::D3DDECLUSAGE_BLENDWEIGHT:
 					dclStream << "dcl_blendweight";


### PR DESCRIPTION
Additional fix for vertex shaders that contain multiple position declarations

Initial changes for improvements of pixel shader compilation and preparations for enabling support for later pixel shader versions
- Updated shader optimization logic to ensure converted xbox-specific instructions are optimized before their patterns are altered by other optimizations later in the processing
- Updated logic to based fake register usage against 't#' registers as these become read-only in later pixel shader versions and thus must be replaced in more cases with the increased number of 'r#' registers
