### PR TITLE
Performance tuning: First batch

### DIFF
--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -156,6 +156,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <FloatingPointModel>Precise</FloatingPointModel>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -770,16 +770,24 @@ uint08 *Xbe::GetLogoBitmap(uint32 x_dwSize)
     return 0;
 }
 
-void *Xbe::FindSection(char *zsSectionName, uint32_t fileAddress)
+void *Xbe::FindSection(char *zsSectionName)
 {
-	// It is possible for multiple sections to exist with the same name
-	// For now, we implement these cases by using an optional fileAddress paramater
-	// Fixes a crash with the Xbox Wireless Adapter Setup Disc
 	for (uint32 v = 0; v < m_Header.dwSections; v++) {
-		if ((fileAddress == 0 || m_SectionHeader[v].dwRawAddr == fileAddress) && (strcmp(m_szSectionName[v], zsSectionName) == 0)) {
+		if (strcmp(m_szSectionName[v], zsSectionName) == 0) {
 			if (m_SectionHeader[v].dwVirtualAddr > 0 && m_SectionHeader[v].dwVirtualSize > 0) {
 				return m_bzSection[v];
 			}
+		}
+	}
+
+	return NULL;
+}
+
+void* Xbe::FindSection(xboxkrnl::PXBEIMAGE_SECTION section)
+{
+	for (uint32 v = 0; v < m_Header.dwSections; v++) {
+		if (m_SectionHeader[v].dwRawAddr == section->FileAddress && (m_SectionHeader[v].dwVirtualAddr > 0 && m_SectionHeader[v].dwVirtualSize > 0)) {
+			return m_bzSection[v];
 		}
 	}
 

--- a/src/Common/Xbe.cpp
+++ b/src/Common/Xbe.cpp
@@ -770,11 +770,13 @@ uint08 *Xbe::GetLogoBitmap(uint32 x_dwSize)
     return 0;
 }
 
-
-void *Xbe::FindSection(char *zsSectionName)
+void *Xbe::FindSection(char *zsSectionName, uint32_t fileAddress)
 {
+	// It is possible for multiple sections to exist with the same name
+	// For now, we implement these cases by using an optional fileAddress paramater
+	// Fixes a crash with the Xbox Wireless Adapter Setup Disc
 	for (uint32 v = 0; v < m_Header.dwSections; v++) {
-		if (strcmp(m_szSectionName[v], zsSectionName) == 0) {
+		if ((fileAddress == 0 || m_SectionHeader[v].dwRawAddr == fileAddress) && (strcmp(m_szSectionName[v], zsSectionName) == 0)) {
 			if (m_SectionHeader[v].dwVirtualAddr > 0 && m_SectionHeader[v].dwVirtualSize > 0) {
 				return m_bzSection[v];
 			}

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -57,7 +57,7 @@ class Xbe : public Error
        ~Xbe();
 
 	   // find an image by name
-	   void *FindSection(char *zsSectionName);
+	   void *FindSection(char *zsSectionName, uint32_t fileAddress = 0);
 
         // export to Xbe file
         void Export(const char *x_szXbeFilename);

--- a/src/Common/Xbe.h
+++ b/src/Common/Xbe.h
@@ -46,6 +46,11 @@
 #define XPR_IMAGE_DATA_SIZE (XPR_IMAGE_WH * XPR_IMAGE_WH) / 2
 #define XPR_IMAGE_HDR_SIZE 2048
 
+namespace xboxkrnl
+{
+	typedef struct _XBE_SECTION	XBEIMAGE_SECTION, *PXBEIMAGE_SECTION;
+}
+
 // Xbe (Xbox Executable) file object
 class Xbe : public Error
 {
@@ -56,8 +61,11 @@ class Xbe : public Error
         // deconstructor
        ~Xbe();
 
-	   // find an image by name
-	   void *FindSection(char *zsSectionName, uint32_t fileAddress = 0);
+		// find an section by name
+		void *FindSection(char *zsSectionName);
+
+		// Find a section by its definition
+		void* FindSection(xboxkrnl::PXBEIMAGE_SECTION section);
 
         // export to Xbe file
         void Export(const char *x_szXbeFilename);

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.cpp
@@ -285,7 +285,8 @@ inline FLOAT ByteToFloat(const BYTE value)
 void XTL::CxbxVertexBufferConverter::ConvertStream
 (
 	CxbxDrawContext *pDrawContext,
-    UINT             uiStream
+    UINT             uiStream,
+	DWORD			 StartIndex
 )
 {
 	extern XTL::D3DCAPS g_D3DCaps;
@@ -404,7 +405,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 	
 	if (bNeedVertexPatching) {
 	    // assert(bNeedStreamCopy || "bNeedVertexPatching implies bNeedStreamCopy (but copies via conversions");
-		for (uint32 uiVertex = 0; uiVertex < uiVertexCount; uiVertex++) {
+		for (uint32 uiVertex = StartIndex; uiVertex < uiVertexCount; uiVertex++) {
 			uint08 *pXboxVertexAsByte = &pXboxVertexData[uiVertex * uiXboxVertexStride];
 			uint08 *pHostVertexAsByte = &pHostVertexData[uiVertex * uiHostVertexStride];
 			for (UINT uiElement = 0; uiElement < pVertexShaderStreamInfo->NumberOfVertexElements; uiElement++) {
@@ -659,7 +660,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 			// the uiTextureCoordinatesByteOffsetInVertex on host will match Xbox 
 		}
 
-		for (uint32 uiVertex = 0; uiVertex < uiVertexCount; uiVertex++) {
+		for (uint32 uiVertex = StartIndex; uiVertex < uiVertexCount; uiVertex++) {
 			FLOAT *pVertexDataAsFloat = (FLOAT*)(&pHostVertexData[uiVertex * uiHostVertexStride]);
 
 			// Handle pre-transformed vertices (which bypass the vertex shader pipeline)
@@ -742,7 +743,7 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 		/*Release=*/!bNeedStreamCopy); // Release when it won't get cached
 }
 
-void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext)
+void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext, DWORD StartIndex)
 {
 	if ((pDrawContext->XboxPrimitiveType < X_D3DPT_POINTLIST) || (pDrawContext->XboxPrimitiveType > X_D3DPT_POLYGON))
 		CxbxKrnlCleanup("Unknown primitive type: 0x%.02X\n", pDrawContext->XboxPrimitiveType);
@@ -764,7 +765,7 @@ void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext)
     for(UINT uiStream = 0; uiStream < m_uiNbrStreams; uiStream++) {
 		// TODO: Check for cached vertex buffer, and use it if possible
 
-		ConvertStream(pDrawContext, uiStream);
+		ConvertStream(pDrawContext, uiStream, StartIndex);
 
 		// TODO: Cache Vertex Buffer Data
     }

--- a/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
+++ b/src/CxbxKrnl/EmuD3D8/VertexBuffer.h
@@ -75,7 +75,7 @@ class CxbxVertexBufferConverter
         CxbxVertexBufferConverter();
        ~CxbxVertexBufferConverter();
 
-        void Apply(CxbxDrawContext *pPatchDesc);
+	   void Apply(CxbxDrawContext *pPatchDesc, DWORD StartIndex = 0);
     private:
 
         UINT m_uiNbrStreams;
@@ -91,7 +91,7 @@ class CxbxVertexBufferConverter
         UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);
 
         // Patches the types of the stream
-        void ConvertStream(CxbxDrawContext *pPatchDesc, UINT uiStream);
+        void ConvertStream(CxbxDrawContext *pPatchDesc, UINT uiStream, DWORD StartIndex);
 };
 
 // inline vertex buffer emulation

--- a/src/CxbxKrnl/EmuKrnlXe.cpp
+++ b/src/CxbxKrnl/EmuKrnlXe.cpp
@@ -81,7 +81,7 @@ XBSYSAPI EXPORTNUM(327) xboxkrnl::NTSTATUS NTAPI xboxkrnl::XeLoadSection
 
 	NTSTATUS ret = STATUS_SUCCESS;
 
-	void* sectionData = CxbxKrnl_Xbe->FindSection((char*)std::string(Section->SectionName, 9).c_str());
+	void* sectionData = CxbxKrnl_Xbe->FindSection((char*)std::string(Section->SectionName, 9).c_str(), Section->FileAddress);
 	if (sectionData != nullptr) {
 		// If the reference count was zero, load the section
 		if (Section->SectionReferenceCount == 0) {

--- a/src/CxbxKrnl/EmuKrnlXe.cpp
+++ b/src/CxbxKrnl/EmuKrnlXe.cpp
@@ -81,7 +81,7 @@ XBSYSAPI EXPORTNUM(327) xboxkrnl::NTSTATUS NTAPI xboxkrnl::XeLoadSection
 
 	NTSTATUS ret = STATUS_SUCCESS;
 
-	void* sectionData = CxbxKrnl_Xbe->FindSection((char*)std::string(Section->SectionName, 9).c_str(), Section->FileAddress);
+	void* sectionData = CxbxKrnl_Xbe->FindSection(Section);
 	if (sectionData != nullptr) {
 		// If the reference count was zero, load the section
 		if (Section->SectionReferenceCount == 0) {


### PR DESCRIPTION
This PR dramatically improves performance in certain situations involving Indexed drawing that requires vertex format conversion.

On one of my computers, this made the Dashboard dump from ~5fps to 40fps
On my other computer, the dashboard jumped from 20fps to a perfect 60fps.

Many titles should show at least some improvement, but others show no improvement at all.
There is no compatibiltiy impact for these changes, it's a completely free optimisation

There's still plenty of work that could be done, but this is a nice, very low risk set of changes. More will follow in the coming days/weeks.