### PR TITLE
Shader improvements (Pixel Shader 2.0)

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -5953,6 +5953,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_BumpEnv_8)
         case 26:    // X_D3DTSS_BUMPENVLSCALE
 			hRet = g_pD3DDevice->SetTextureStageState(Stage, D3DTSS_BUMPENVLSCALE, Value);
             break;
+        case 27:    // X_D3DTSS_BUMPENVLOFFSET
+            hRet = g_pD3DDevice->SetTextureStageState(Stage, D3DTSS_BUMPENVLOFFSET, Value);
+            break;
     }
 
 	//DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetTextureStageState");
@@ -5994,6 +5997,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_BumpEnv)
             break;
         case 26:    // X_D3DTSS_BUMPENVLSCALE
 			hRet = g_pD3DDevice->SetTextureStageState(Stage, D3DTSS_BUMPENVLSCALE, Value);
+            break;
+        case 27:    // X_D3DTSS_BUMPENVLOFFSET
+			hRet = g_pD3DDevice->SetTextureStageState(Stage, D3DTSS_BUMPENVLOFFSET, Value);
             break;
     }
 
@@ -7403,14 +7409,14 @@ void EmuUpdateActiveTextureStages()
 
 void XTL::CxbxUpdateNativeD3DResources()
 {
-	EmuUpdateActiveTextureStages();
+    EmuUpdateActiveTextureStages();
 
 	// If Pixel Shaders are not disabled, process them
 	if (!g_DisablePixelShaders) {
 		XTL::DxbxUpdateActivePixelShader();
 	}
 
-	XTL::EmuUpdateDeferredStates();
+    XTL::EmuUpdateDeferredStates();
 /* TODO : Port these :
 	DxbxUpdateActiveVertexShader();
 	DxbxUpdateActiveTextures();

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -5820,7 +5820,7 @@ bool PSH_XBOX_SHADER::FixOverusedRegisters()
                     InsertIntermediate(&Ins, InsertPos);
                     ++InsertPos;
 
-                    ReplaceInputRegisterFromIndexOnwards(InsertPos, Intermediate[i].Parameters[p].Type, Intermediate[i].Parameters[p].Address, PARAM_R, output, InsertPos);
+                    ReplaceInputRegisterFromIndexOnwards(InsertPos, Intermediate[InsertPos].Parameters[p].Type, Intermediate[InsertPos].Parameters[p].Address, PARAM_R, output, InsertPos);
                     Result = true;
                     break;
                 }
@@ -5840,7 +5840,7 @@ bool PSH_XBOX_SHADER::FixOverusedRegisters()
                     InsertIntermediate(&Ins, InsertPos);
                     ++InsertPos;
 
-                    ReplaceInputRegisterFromIndexOnwards(InsertPos, Intermediate[i].Parameters[p].Type, Intermediate[i].Parameters[p].Address, PARAM_R, output, InsertPos);
+                    ReplaceInputRegisterFromIndexOnwards(InsertPos, Intermediate[InsertPos].Parameters[p].Type, Intermediate[InsertPos].Parameters[p].Address, PARAM_R, output, InsertPos);
                     Result = true;
                     break;
                 }

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -4098,7 +4098,7 @@ bool PSH_XBOX_SHADER::IsValidNativeOutputRegister(PSH_ARGUMENT_TYPE aRegType, in
     bool valid = (PARAM_R == aRegType) && (MaxRegisterCount(PARAM_R) > index);
 
     if (m_PSVersion <= D3DPS_VERSION(1, 3))
-        valid = valid || ((PARAM_T == aRegType) && (MaxRegisterCount(PARAM_R) > index));
+        valid = valid || ((PARAM_T == aRegType) && (MaxRegisterCount(PARAM_T) > index));
 
     return valid;
 }

--- a/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PixelShader.cpp
@@ -1206,25 +1206,25 @@ float PSH_IMD_ARGUMENT::GetConstValue()
   float Result = Multiplier;
 
   // y = 1-x     -> 0..1 >    1..0
-  if ((Modifiers & (1 << ARGMOD_INVERT)) > 0)    Result = 1.0f-Result;
+  if (HasModifier(ARGMOD_INVERT))    Result = 1.0f-Result;
 
   // y = -x      -> 0..1 >    0..-1
-  if ((Modifiers & (1 << ARGMOD_NEGATE)) > 0)    Result = -Result;
+  if (HasModifier(ARGMOD_NEGATE))    Result = -Result;
 
   // y =  x-0.5  -> 0..1 > -0.5..0.5
-  if ((Modifiers & (1 << ARGMOD_BIAS)) > 0)      Result = Result-0.5f;
+  if (HasModifier (ARGMOD_BIAS))      Result = Result-0.5f;
 
   // y =  x*2    -> 0..1 >    0..2
-  if ((Modifiers & (1 << ARGMOD_SCALE_X2)) > 0)  Result = Result*2.0f;
+  if (HasModifier(ARGMOD_SCALE_X2))  Result = Result*2.0f;
 
   // y = (x*2)-1 -> 0..1 >   -1..1
-  if ((Modifiers & (1 << ARGMOD_SCALE_BX2)) > 0) Result = (Result*2.0f)-1.0f;
+  if (HasModifier(ARGMOD_SCALE_BX2)) Result = (Result*2.0f)-1.0f;
 
   // y =  x*4    -> 0..1 >    0..4
-  if ((Modifiers & (1 << ARGMOD_SCALE_X4)) > 0)  Result = Result*4.0f;
+  if (HasModifier(ARGMOD_SCALE_X4))  Result = Result*4.0f;
 
   // y =  x/2    -> 0..1 >    0..0.5
-  if ((Modifiers & (1 << ARGMOD_SCALE_D2)) > 0)  Result = Result/2.0f;
+  if (HasModifier(ARGMOD_SCALE_D2))  Result = Result/2.0f;
 
   return Result;
 } // GetConstValue
@@ -1362,7 +1362,7 @@ std::string PSH_IMD_ARGUMENT::ToString()
   if (UsesRegister())
   {
     for (DWORD Modifier = ARGMOD_IDENTITY; Modifier < ARGMOD_BLUE_REPLICATE; Modifier++)
-      if ((1 << Modifier) & Modifiers) {
+      if (HasModifier((PSH_ARG_MODIFIER)Modifier)) {
 		char buffer[256];
 		Result = std::string(buffer, sprintf(buffer, PSH_ARG_MODIFIER_Str[Modifier], Result.c_str()));
 	  }
@@ -1597,7 +1597,7 @@ bool PSH_IMD_ARGUMENT::Decode(const DWORD Value, DWORD aMask, TArgumentType Argu
 
 void PSH_IMD_ARGUMENT::Invert()
 {
-  if ((Modifiers & (1 << ARGMOD_INVERT)) == 0)
+  if (!HasModifier(ARGMOD_INVERT))
     Modifiers = Modifiers | (1 << ARGMOD_INVERT);
   else
     Modifiers = Modifiers & ~(1 << ARGMOD_INVERT);
@@ -1605,7 +1605,7 @@ void PSH_IMD_ARGUMENT::Invert()
 
 void PSH_IMD_ARGUMENT::Negate()
 {
-  if ((Modifiers & (1 << ARGMOD_NEGATE)) == 0)
+  if (!HasModifier(ARGMOD_NEGATE))
     Modifiers = Modifiers | (1 << ARGMOD_NEGATE);
   else
     Modifiers = Modifiers & ~(1 << ARGMOD_NEGATE);
@@ -4071,7 +4071,7 @@ bool PSH_XBOX_SHADER::FinalizeShader()
       return false;
 
     // Is the left argument inverted and the right not (or the other way around) ?
-    if ((ParamLeft->Modifiers & (1 << ARGMOD_INVERT)) != (ParamRight->Modifiers & (1 << ARGMOD_INVERT)))
+    if (ParamLeft->HasModifier(ARGMOD_INVERT) != ParamRight->HasModifier(ARGMOD_INVERT))
     {
       // In that case, already move the arguments over to AddOpcode so we create a LRP :
       AddOpcode->Parameters[0] = *ParamLeft;

--- a/src/CxbxKrnl/EmuD3D8/State.cpp
+++ b/src/CxbxKrnl/EmuD3D8/State.cpp
@@ -304,7 +304,7 @@ void XTL::EmuUpdateDeferredStates()
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_COLOROP, D3DTOP_LERP);
 					break;
 				case X_D3DTOP_BUMPENVMAP:
-					g_pD3DDevice->SetTextureStageState(v, D3DTSS_COLOROP, D3DTOP_MULTIPLYADD);
+					g_pD3DDevice->SetTextureStageState(v, D3DTSS_COLOROP, D3DTOP_BUMPENVMAP);
 					break;
 				case X_D3DTOP_BUMPENVMAPLUMINANCE:
 					g_pD3DDevice->SetTextureStageState(v, D3DTSS_COLOROP, D3DTOP_BUMPENVMAPLUMINANCE);

--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1161,9 +1161,6 @@ static boolean VshAddInstructionILU_R(VSH_SHADER_INSTRUCTION *pInstruction,
         return FALSE;
     }
 
-	// Dxbx note : Scalar instructions read from C, but use X instead of W, fix that :
-	DxbxFixupScalarParameter(pInstruction, pShader, &pInstruction->C);
-
 	pIntermediate = VshNewIntermediate(pShader);
     pIntermediate->IsCombined = IsCombined;
 
@@ -1230,6 +1227,9 @@ static void VshConvertToIntermediate(VSH_SHADER_INSTRUCTION *pInstruction,
     //   +ILU
     //   +ILU
     boolean IsCombined = FALSE;
+
+    // Dxbx note : Scalar instructions read from C, but use X instead of W, fix that :
+    DxbxFixupScalarParameter(pInstruction, pShader, &pInstruction->C);
 
     if(VshAddInstructionMAC_R(pInstruction, pShader, IsCombined))
     {


### PR DESCRIPTION
Initial implementation of updates to pixel shader compilation to use version 2.0
- Replace usage of instruction and argument modifiers
- Replace unsupported 'texm*' instructions
- Fix register usages that exceed instruction limits
