### PR TITLE
General Tweaks/Improvements.

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -149,6 +149,8 @@ typedef long                            NTSTATUS;
 
 #define NT_SUCCESS(Status)              ((NTSTATUS) (Status) >= 0)
 #define STATUS_SUCCESS                   ((DWORD   )0x00000000L)
+#define STATUS_ABANDONED                 ((DWORD   )0x00000080L)
+#define STATUS_MUTANT_LIMIT_EXCEEDED     ((DWORD   )0xC0000191L)
 #ifndef STATUS_PENDING
 #define STATUS_PENDING                   ((DWORD   )0x00000103L)
 #endif
@@ -1607,11 +1609,13 @@ typedef struct _KFLOATING_SAVE
 }
 KFLOATING_SAVE, *PKFLOATING_SAVE;
 
+#define DISPATCHER_OBJECT_TYPE_MASK 0x7
 // ******************************************************************
 // * KOBJECTS
 // ******************************************************************
 typedef enum _KOBJECTS
 {
+	EventSynchronizationObject = 1,
 	MutantObject = 2,
 	QueueObject = 4,
 	SemaphoreObject = 5,

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -1737,7 +1737,7 @@ PS_STATISTICS, *PPS_STATISTICS;
 // ******************************************************************
 typedef struct _RTL_CRITICAL_SECTION
 {
-    DWORD               Unknown[4];                                     // 0x00
+	DISPATCHER_HEADER	Event;			                                // 0x00
     LONG                LockCount;                                      // 0x10
     LONG                RecursionCount;                                 // 0x14
     HANDLE              OwningThread;                                   // 0x18

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -1741,7 +1741,7 @@ PS_STATISTICS, *PPS_STATISTICS;
 // ******************************************************************
 typedef struct _RTL_CRITICAL_SECTION
 {
-	DISPATCHER_HEADER	Event;			                                // 0x00
+	DISPATCHER_HEADER   Event;                                          // 0x00
     LONG                LockCount;                                      // 0x10
     LONG                RecursionCount;                                 // 0x14
     HANDLE              OwningThread;                                   // 0x18

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -70,6 +70,7 @@ namespace xboxkrnl
 #include "devices\EEPROMDevice.h" // For g_EEPROM
 #include "devices\Xbox.h" // For InitXboxHardware()
 #include "devices\LED.h" // For LED::Sequence
+#include "devices\SMCDevice.h" // For SMC Access
 #include "EmuSha.h" // For the SHA1 functions
 #include "Timer.h" // For Timer_Init
 #include "..\Common\Input\InputConfig.h" // For the InputDeviceManager
@@ -1487,6 +1488,9 @@ __declspec(noreturn) void CxbxKrnlInit
 	}
 
 	InitXboxHardware(HardwareModel::Revision1_5); // TODO : Make configurable
+
+	// Read Xbox video mode from the SMC, store it in HalBootSMCVideoMode
+	xboxkrnl::HalReadSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_AV_PACK, FALSE, &xboxkrnl::HalBootSMCVideoMode);
 
 	if (bLLE_USB) {
 #if 0 // Reenable this when LLE USB actually works

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -1508,6 +1508,10 @@ __declspec(noreturn) void CxbxKrnlInit
 	// Read Xbox video mode from the SMC, store it in HalBootSMCVideoMode
 	xboxkrnl::HalReadSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_AV_PACK, FALSE, &xboxkrnl::HalBootSMCVideoMode);
 
+	// TODO: move much of this stuff to xboxkrnl::init();
+	extern xboxkrnl::LIST_ENTRY KiWaitInListHead;
+	InitializeListHead(&KiWaitInListHead);
+
 	if (bLLE_USB) {
 #if 0 // Reenable this when LLE USB actually works
 		int ret;

--- a/src/CxbxKrnl/EmuFile.cpp
+++ b/src/CxbxKrnl/EmuFile.cpp
@@ -363,14 +363,11 @@ NTSTATUS CxbxConvertFilePath(
 
 	// Check if we where called from a File-handling API :
 	if (!aFileAPIName.empty()) {
-		// Disabled, see CxbxKrnl.cpp (search Chihiro) for more details
-#if 0
 		if (RelativePath.compare(DriveMbrom) == 0) {
 			*RootDirectory = CxbxBasePathHandle;
 			HostPath = CxbxBasePath;
 			RelativePath = MediaBoardRomFile;
-		} else
-#endif if (!partitionHeader) {
+		} else if (!partitionHeader) {
 			// Check if the path starts with a volume indicator :
 			if ((RelativePath.length() >= 2) && (RelativePath[1] == ':')) {
 				// Look up the symbolic link information using the drive letter :

--- a/src/CxbxKrnl/EmuFile.cpp
+++ b/src/CxbxKrnl/EmuFile.cpp
@@ -456,12 +456,12 @@ NTSTATUS CxbxConvertFilePath(
 
 		if (g_bPrintfOn) {
 			DbgPrintf(LOG_PREFIX, "%s Corrected path...\n", aFileAPIName.c_str());
-			printf("  Org:\"%s\"\n", OriginalPath.c_str());
+			DbgPrintf(LOG_PREFIX, "  Org:\"%s\"\n", OriginalPath.c_str());
 			if (_strnicmp(HostPath.c_str(), CxbxBasePath.c_str(), CxbxBasePath.length()) == 0) {
-				printf("  New:\"$CxbxPath\\%s%s\"\n", (HostPath.substr(CxbxBasePath.length(), std::string::npos)).c_str(), RelativePath.c_str());
+				DbgPrintf(LOG_PREFIX, "  New:\"$CxbxPath\\%s%s\"\n", (HostPath.substr(CxbxBasePath.length(), std::string::npos)).c_str(), RelativePath.c_str());
 			}
 			else
-				printf("  New:\"$XbePath\\%s\"\n", RelativePath.c_str());
+				DbgPrintf(LOG_PREFIX, "  New:\"$XbePath\\%s\"\n", RelativePath.c_str());
 		}
 	}
 	else

--- a/src/CxbxKrnl/EmuFile.h
+++ b/src/CxbxKrnl/EmuFile.h
@@ -59,6 +59,7 @@ namespace NtDll
 // TODO : Move to a better suited file
 //std::ostream& operator<<(std::ostream& os, const NtDll::NTSTATUS& value);
 
+extern const std::string MediaBoardRomFile;
 extern const std::string DrivePrefix;
 extern const std::string DriveSerial;
 extern const std::string DriveCdRom0;

--- a/src/CxbxKrnl/EmuKrnlAv.cpp
+++ b/src/CxbxKrnl/EmuKrnlAv.cpp
@@ -120,17 +120,29 @@ VOID ARX_WR(VOID *Ptr, xboxkrnl::UCHAR i, xboxkrnl::UCHAR d)
 }
 
 
-
-
 // Global Variable(s)
 PVOID g_pPersistedData = NULL;
 ULONG AvpCurrentMode = 0;
 
+ULONG AvSMCVideoModeToAVPack(ULONG VideoMode)
+{
+	switch (VideoMode)
+	{
+	case 0x0: return AV_PACK_SCART;
+	case 0x1: return AV_PACK_HDTV;
+	case 0x2: return AV_PACK_VGA;
+	case 0x3: return AV_PACK_RFU;
+	case 0x4: return AV_PACK_SVIDEO;
+	case 0x6: return AV_PACK_STANDARD;
+	}
+
+	return AV_PACK_NONE;
+}
+
+
 ULONG AvQueryAvCapabilities()
 {
-	// This is the only AV mode we currently emulate, so we can hardcode the return value
-	// TODO: Once we add the ability to change av pack, read HalSmcVideoMode) and convert it to a AV_PACK_*
-	ULONG avpack = AV_PACK_HDTV;
+	ULONG avpack = AvSMCVideoModeToAVPack(xboxkrnl::HalBootSMCVideoMode);
 	ULONG type;
 	ULONG resultSize;
 

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -130,14 +130,14 @@ xboxkrnl::ULONGLONG LARGE_INTEGER2ULONGLONG(xboxkrnl::LARGE_INTEGER value)
 
 void FASTCALL KiWaitSatisfyAll
 (
-	IN xboxkrnl::PRKWAIT_BLOCK WaitBlock
+	IN xboxkrnl::PKWAIT_BLOCK WaitBlock
 )
 {
 	using namespace xboxkrnl;
 
 	PKMUTANT Object;
 	PRKTHREAD Thread;
-	PRKWAIT_BLOCK WaitBlock1;
+	PKWAIT_BLOCK WaitBlock1;
 
 	WaitBlock1 = WaitBlock;
 	Thread = WaitBlock1->Thread;
@@ -1611,7 +1611,7 @@ XBSYSAPI EXPORTNUM(145) xboxkrnl::LONG NTAPI xboxkrnl::KeSetEvent
 	if (IsListEmpty(&Event->Header.WaitListHead) != FALSE) {
 		Event->Header.SignalState = 1;
 	} else {
-		PRKWAIT_BLOCK WaitBlock = CONTAINING_RECORD(Event->Header.WaitListHead.Flink, KWAIT_BLOCK, WaitListEntry);
+		PKWAIT_BLOCK WaitBlock = CONTAINING_RECORD(Event->Header.WaitListHead.Flink, KWAIT_BLOCK, WaitListEntry);
 		if ((Event->Header.Type == NotificationEvent) ||
 			(WaitBlock->WaitType != WaitAny)) {
 			if (OldState == 0) {
@@ -2025,7 +2025,7 @@ XBSYSAPI EXPORTNUM(158) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForMultipleObje
 				}
 
 				// Setup a timer for the thread
-				PRKTIMER Timer = &Thread->Timer;
+				PKTIMER Timer = &Thread->Timer;
 				PKWAIT_BLOCK WaitTimer = &Thread->TimerWaitBlock;
 				WaitBlock->NextWaitBlock = WaitTimer;
 				Timer->Header.WaitListHead.Flink = &WaitTimer->WaitListEntry;
@@ -2204,7 +2204,7 @@ XBSYSAPI EXPORTNUM(159) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForSingleObject
 				}
 
 				// Setup a timer for the thread
-				PRKTIMER Timer = &Thread->Timer;
+				PKTIMER Timer = &Thread->Timer;
 				PKWAIT_BLOCK WaitTimer = &Thread->TimerWaitBlock;
 				WaitBlock->NextWaitBlock = WaitTimer;
 				Timer->Header.WaitListHead.Flink = &WaitTimer->WaitListEntry;

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -2048,7 +2048,7 @@ XBSYSAPI EXPORTNUM(158) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForMultipleObje
 			WaitBlock = &WaitBlockArray[0];
 			do {
 				ObjectMutant = (PKMUTANT)WaitBlock->Object;
-				InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
+				//InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
 				WaitBlock = WaitBlock->NextWaitBlock;
 			} while (WaitBlock != &WaitBlockArray[0]);
 
@@ -2060,7 +2060,7 @@ XBSYSAPI EXPORTNUM(158) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForMultipleObje
 			*/
 
 			// Insert the WaitBlock
-			InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
+			//InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
 
 			// If the current thread is processing a queue object, wake other treads using the same queue
 			PRKQUEUE Queue = (PRKQUEUE)Thread->Queue;
@@ -2231,7 +2231,7 @@ XBSYSAPI EXPORTNUM(159) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForSingleObject
 			*/
 
 			// Insert the WaitBlock
-			InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
+			//InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
 
 			// If the current thread is processing a queue object, wake other treads using the same queue
 			PRKQUEUE Queue = (PRKQUEUE)Thread->Queue;

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -75,14 +75,111 @@ typedef struct _DpcData {
 
 DpcData g_DpcData = { 0 }; // Note : g_DpcData is initialized in InitDpcAndTimerThread()
 
-std::map<xboxkrnl::PRKEVENT, HANDLE> g_KeEventHandles;
-
 xboxkrnl::ULONGLONG LARGE_INTEGER2ULONGLONG(xboxkrnl::LARGE_INTEGER value)
 {
 	// Weird construction because there doesn't seem to exist an implicit
 	// conversion of LARGE_INTEGER to ULONGLONG :
 	return *((PULONGLONG)&value);
 }
+
+#define KiWaitSatisfyMutant(_Object_, _Thread_) {                            \
+    (_Object_)->Header.SignalState -= 1;                                     \
+    if ((_Object_)->Header.SignalState == 0) {                               \
+        (_Object_)->OwnerThread = (_Thread_);                                \
+        if ((_Object_)->Abandoned == TRUE) {                                 \
+            (_Object_)->Abandoned = FALSE;                                   \
+            (_Thread_)->WaitStatus = STATUS_ABANDONED;                       \
+        }                                                                    \
+                                                                             \
+        InsertHeadList((_Thread_)->MutantListHead.Blink,                     \
+                       &(_Object_)->MutantListEntry);                        \
+    }                                                                        \
+}
+
+#define KiWaitSatisfyOther(_Object_) {                                       \
+    if (((_Object_)->Header.Type & DISPATCHER_OBJECT_TYPE_MASK) == EventSynchronizationObject) { \
+        (_Object_)->Header.SignalState = 0;                                  \
+                                                                             \
+    } else if ((_Object_)->Header.Type == SemaphoreObject) {                 \
+        (_Object_)->Header.SignalState -= 1;                                 \
+                                                                             \
+    }                                                                        \
+}
+
+#define KiWaitSatisfyAny(_Object_, _Thread_) {                               \
+    if (((_Object_)->Header.Type & DISPATCHER_OBJECT_TYPE_MASK) == EventSynchronizationObject) { \
+        (_Object_)->Header.SignalState = 0;                                  \
+                                                                             \
+    } else if ((_Object_)->Header.Type == SemaphoreObject) {                 \
+        (_Object_)->Header.SignalState -= 1;                                 \
+                                                                             \
+    } else if ((_Object_)->Header.Type == MutantObject) {                    \
+        (_Object_)->Header.SignalState -= 1;                                 \
+        if ((_Object_)->Header.SignalState == 0) {                           \
+            (_Object_)->OwnerThread = (_Thread_);                            \
+            if ((_Object_)->Abandoned == TRUE) {                             \
+                (_Object_)->Abandoned = FALSE;                               \
+                (_Thread_)->WaitStatus = STATUS_ABANDONED;                   \
+            }                                                                \
+                                                                             \
+            InsertHeadList((_Thread_)->MutantListHead.Blink,                 \
+                           &(_Object_)->MutantListEntry);                    \
+        }                                                                    \
+    }                                                                        \
+}
+
+void FASTCALL KiWaitSatisfyAll
+(
+	IN xboxkrnl::PRKWAIT_BLOCK WaitBlock
+)
+{
+	using namespace xboxkrnl;
+
+	PKMUTANT Object;
+	PRKTHREAD Thread;
+	PRKWAIT_BLOCK WaitBlock1;
+
+	WaitBlock1 = WaitBlock;
+	Thread = WaitBlock1->Thread;
+	do {
+		if (WaitBlock1->WaitKey != (CSHORT)STATUS_TIMEOUT) {
+			Object = (PKMUTANT)WaitBlock1->Object;
+			KiWaitSatisfyAny(Object, Thread);
+		}
+
+		WaitBlock1 = WaitBlock1->NextWaitBlock;
+	} while (WaitBlock1 != WaitBlock);
+
+	return;
+}
+
+#define TestForAlertPending(Alertable) \
+    if (Alertable) { \
+        if (Thread->Alerted[WaitMode] != FALSE) { \
+            Thread->Alerted[WaitMode] = FALSE; \
+            WaitStatus = STATUS_ALERTED; \
+            break; \
+        } else if ((WaitMode != KernelMode) && \
+                  (IsListEmpty(&Thread->ApcState.ApcListHead[UserMode])) == FALSE) { \
+            Thread->ApcState.UserApcPending = TRUE; \
+            WaitStatus = STATUS_USER_APC; \
+            break; \
+        } else if (Thread->Alerted[KernelMode] != FALSE) { \
+            Thread->Alerted[KernelMode] = FALSE; \
+            WaitStatus = STATUS_ALERTED; \
+            break; \
+        } \
+    } else if ((WaitMode != KernelMode) && (Thread->ApcState.UserApcPending)) { \
+        WaitStatus = STATUS_USER_APC; \
+        break; \
+    }
+
+#define KiInsertWaitList(_WaitMode, _Thread) {                  \
+    PLIST_ENTRY _ListHead;                                      \
+    _ListHead = &KiWaitInListHead;                              \
+    InsertTailList(_ListHead, &(_Thread)->WaitListEntry);       \
+}
+
 
 // ******************************************************************
 // * KeGetPcr()
@@ -647,22 +744,6 @@ XBSYSAPI EXPORTNUM(108) xboxkrnl::VOID NTAPI xboxkrnl::KeInitializeEvent
 	Event->Header.Size = sizeof(KEVENT) / sizeof(LONG);
 	Event->Header.SignalState = SignalState;
 	InitializeListHead(&(Event->Header.WaitListHead)); 
-
-
-	// Create a Windows event, to be used in KeWaitForObject
-	// TODO: This doesn't check for events that are already initialized
-	// This shouldn't happen, except on shoddily coded titles so we
-	// ignore it for now
-	HANDLE hostEvent;
-	if (Type == NotificationEvent)
-	{
-		hostEvent = CreateEvent(NULL, TRUE, SignalState, NULL);
-	}
-	else {
-		hostEvent = CreateEvent(NULL, FALSE, SignalState, NULL);
-	}
-
-	g_KeEventHandles[Event] = hostEvent;
 }
 
 // ******************************************************************
@@ -1053,17 +1134,29 @@ XBSYSAPI EXPORTNUM(123) xboxkrnl::LONG NTAPI xboxkrnl::KePulseEvent
 		LOG_FUNC_ARG(Wait)
 		LOG_FUNC_END;
 
-	// Fetch the host event and signal it, if present
-	if (g_KeEventHandles.find(Event) == g_KeEventHandles.end()) {
-		EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KePulseEvent called on a non-existant event!");
-	}
-	else {
-		PulseEvent(g_KeEventHandles[Event]);
+	KIRQL OldIrql;
+	KiLockDispatcherDatabase(&OldIrql);
+	LONG OldState = Event->Header.SignalState;
+	if ((OldState == 0) && (IsListEmpty(&Event->Header.WaitListHead) == FALSE)) {
+		Event->Header.SignalState = 1;
+		// TODO: KiWaitTest(Event, Increment);
+		// For now, we just sleep to give other threads time to wake
+		// KiWaitTest and related functions require correct thread scheduling to implement first
+		// This will have to wait until CPU emulation at v1.0
+		Sleep(1);
 	}
 
-	LOG_UNIMPLEMENTED();
+	Event->Header.SignalState = 0;
 
-	RETURN(0);
+	if (Wait != FALSE) {
+		PRKTHREAD Thread = KeGetCurrentThread();
+		Thread->WaitIrql = OldIrql;
+		Thread->WaitNext = Wait;
+	} else {
+		KiUnlockDispatcherDatabase(OldIrql);
+	}
+
+	RETURN(OldState);
 }
 
 XBSYSAPI EXPORTNUM(124) xboxkrnl::LONG NTAPI xboxkrnl::KeQueryBasePriorityThread
@@ -1375,20 +1468,14 @@ XBSYSAPI EXPORTNUM(138) xboxkrnl::LONG NTAPI xboxkrnl::KeResetEvent
 {
 	LOG_FUNC_ONE_ARG(Event);
 
-	// TODO : Untested & incomplete
-	LONG ret = Event->Header.SignalState;
+	KIRQL OldIrql;
+	KiLockDispatcherDatabase(&OldIrql);
+
+	LONG OldState = Event->Header.SignalState;
 	Event->Header.SignalState = 0;
 
-	// Fetch the host event and signal it, if present
-	if (g_KeEventHandles.find(Event) == g_KeEventHandles.end()) {
-		EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KeResetEvent called on a non-existant event!");
-	}
-	else {
-		ResetEvent(g_KeEventHandles[Event]);
-	}
-
-
-	return ret;
+	KiUnlockDispatcherDatabase(OldIrql);
+	return OldState;	
 }
 
 // ******************************************************************
@@ -1517,29 +1604,40 @@ XBSYSAPI EXPORTNUM(145) xboxkrnl::LONG NTAPI xboxkrnl::KeSetEvent
 		LOG_FUNC_ARG(Wait)
 		LOG_FUNC_END;
 
-	// TODO : Untested & incomplete
-	LONG ret = Event->Header.SignalState;
-	Event->Header.SignalState = TRUE;
+	KIRQL OldIrql;
+	KiLockDispatcherDatabase(&OldIrql);
 
-	// Fetch the host event and signal it, if present
-	if (g_KeEventHandles.find(Event) == g_KeEventHandles.end()) {
-		EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KeSetEvent called on a non-existant event. Creating it!");
-		// TODO: Find out why some XDKs do not call KeInitializeEvent first
-
-		//We can check the event type from the internal structure, see https://www.geoffchappell.com/studies/windows/km/ntoskrnl/structs/kobjects.htm?tx=111
-		if ((Event->Header.Type & 0x7F) == 0x01)
-		{
-			KeInitializeEvent(Event, NotificationEvent, TRUE);
-		}
-		else {
-			KeInitializeEvent(Event, SynchronizationEvent, TRUE);
-		}
-
+	LONG OldState = Event->Header.SignalState;
+	if (IsListEmpty(&Event->Header.WaitListHead) != FALSE) {
+		Event->Header.SignalState = 1;
 	} else {
-		SetEvent(g_KeEventHandles[Event]);
+		PRKWAIT_BLOCK WaitBlock = CONTAINING_RECORD(Event->Header.WaitListHead.Flink, KWAIT_BLOCK, WaitListEntry);
+		if ((Event->Header.Type == NotificationEvent) ||
+			(WaitBlock->WaitType != WaitAny)) {
+			if (OldState == 0) {
+				Event->Header.SignalState = 1;
+				// TODO: KiWaitTest(Event, Increment);
+				// For now, we just sleep to give other threads time to wake
+				// See KePulseEvent
+				Sleep(1);
+			}
+		} else {
+			// TODO: KiUnwaitThread(WaitBlock->Thread, (NTSTATUS)WaitBlock->WaitKey, Increment);
+			// For now, we just sleep to give other threads time to wake
+			// See KePulseEvent
+			Sleep(1);
+		}
 	}
 
-	RETURN(ret);
+	if (Wait != FALSE) {
+		PRKTHREAD Thread = KeGetCurrentThread();
+		Thread->WaitNext = Wait;
+		Thread->WaitIrql = OldIrql;
+	} else {
+		KiUnlockDispatcherDatabase(OldIrql);
+	}
+
+	RETURN(OldState);
 }
 
 XBSYSAPI EXPORTNUM(146) xboxkrnl::VOID NTAPI xboxkrnl::KeSetEventBoostPriority
@@ -1552,8 +1650,26 @@ XBSYSAPI EXPORTNUM(146) xboxkrnl::VOID NTAPI xboxkrnl::KeSetEventBoostPriority
 		LOG_FUNC_ARG(Event)
 		LOG_FUNC_ARG(Thread)
 		LOG_FUNC_END;
+	KIRQL OldIrql;
+	KiLockDispatcherDatabase(&OldIrql);
 
-	LOG_UNIMPLEMENTED();
+	if (IsListEmpty(&Event->Header.WaitListHead) != FALSE) {
+		Event->Header.SignalState = 1;
+	} else {
+		PRKTHREAD WaitThread = CONTAINING_RECORD(Event->Header.WaitListHead.Flink, KWAIT_BLOCK, WaitListEntry)->Thread;
+
+		if (Thread != nullptr) {
+			*Thread = WaitThread;
+		}
+
+		WaitThread->Quantum = WaitThread->ApcState.Process->ThreadQuantum;
+		// TODO: KiUnwaitThread(WaitThread, STATUS_SUCCESS, 1);
+		// For now, we just sleep to give other threads time to wake
+		// See KePulseEvent
+		Sleep(1);
+	}
+
+	KiUnlockDispatcherDatabase(OldIrql);
 }
 
 XBSYSAPI EXPORTNUM(147) xboxkrnl::KPRIORITY NTAPI xboxkrnl::KeSetPriorityProcess
@@ -1772,6 +1888,24 @@ const xboxkrnl::ULONG CLOCK_TIME_INCREMENT = 0x2710;
 // ******************************************************************
 XBSYSAPI EXPORTNUM(157) xboxkrnl::ULONG xboxkrnl::KeTimeIncrement = CLOCK_TIME_INCREMENT;
 
+
+xboxkrnl::PLARGE_INTEGER FASTCALL KiComputeWaitInterval(
+	IN xboxkrnl::PLARGE_INTEGER OriginalTime,
+	IN xboxkrnl::PLARGE_INTEGER DueTime,
+	IN OUT xboxkrnl::PLARGE_INTEGER NewTime
+)
+{
+	if (OriginalTime->QuadPart >= 0) {
+		return OriginalTime;
+
+	}
+	else {
+		NewTime->QuadPart = xboxkrnl::KeQueryInterruptTime();
+		NewTime->QuadPart -= DueTime->QuadPart;
+		return NewTime;
+	}
+}
+
 // ******************************************************************
 // * 0x009E - KeWaitForMultipleObjects()
 // ******************************************************************
@@ -1798,52 +1932,193 @@ XBSYSAPI EXPORTNUM(158) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForMultipleObje
 		LOG_FUNC_ARG(WaitBlockArray)
 		LOG_FUNC_END;
 
-	NTSTATUS ret = STATUS_SUCCESS;
+	// If the lock is not already held, lock it
+	PRKTHREAD Thread = KeGetCurrentThread();
+	if (Thread->WaitNext) {
+		Thread->WaitNext = FALSE;
+	}
+	else {
+		KiLockDispatcherDatabase(&Thread->WaitIrql);
+	}
 
-	// Take the input and build two arrays: One of handles created by our kernel and one for not
-	// Handles created by our kernel need to be forwarded to WaitForMultipleObjects while handles
-	// created by Windows need to be forwarded to NtDll::KeWaitForMultipleObjects
-	std::vector<HANDLE> nativeObjects;
-	std::vector<HANDLE> ntdllObjects;
-
-	for (uint i = 0; i < Count; i++) {
-		DbgPrintf(LOG_PREFIX, "Object: 0x%08X\n", Object[i]);
-		if (g_KeEventHandles.find((PKEVENT)Object[i]) == g_KeEventHandles.end()) {
-			ntdllObjects.push_back(Object[i]);
-		} else {
-			nativeObjects.push_back(g_KeEventHandles[(PRKEVENT)Object[i]]);
+	// Wait Loop
+	// This loop ends 
+	PLARGE_INTEGER OriginalTime = Timeout;
+	LARGE_INTEGER DueTime, NewTime;
+	KWAIT_BLOCK StackWaitBlock;
+	PKWAIT_BLOCK WaitBlock = &StackWaitBlock;
+	BOOLEAN WaitSatisfied;
+	NTSTATUS WaitStatus;
+	PKMUTANT ObjectMutant;
+	do {
+		// Check if we need to let an APC run. This should immediately trigger APC interrupt via a call to UnlockDispatcherDatabase
+		if (Thread->ApcState.KernelApcPending && (Thread->WaitIrql < APC_LEVEL)) {
+			KiUnlockDispatcherDatabase(Thread->WaitIrql);
 		}
+		else {
+			WaitSatisfied = TRUE;
+			Thread->WaitStatus = STATUS_SUCCESS;
+
+			for (LONG Index = 0; Index < Count; Index += 1) {
+				ObjectMutant = (PKMUTANT)Object[Index];
+				if (WaitType == WaitAny) {
+					if (ObjectMutant->Header.Type == MutantObject) {
+						// If the object is a mutant object and it has been acquired MINGLONG times, raise an exception
+						// If the mutant is signalled, we can satisfy the wait
+						if ((ObjectMutant->Header.SignalState > 0) || (Thread == ObjectMutant->OwnerThread)) {
+							if (ObjectMutant->Header.SignalState != MINLONG) {
+								KiWaitSatisfyMutant(ObjectMutant, Thread);
+								WaitStatus = (NTSTATUS)(Thread->WaitStatus);
+								goto NoWait;
+							}
+							else {
+								KiUnlockDispatcherDatabase(Thread->WaitIrql);
+								ExRaiseStatus(STATUS_MUTANT_LIMIT_EXCEEDED);
+							}
+						}
+					}
+					else if (ObjectMutant->Header.SignalState) {
+						// Otherwise, if the signal state is > 0, we can still just satisfy the wait
+						KiWaitSatisfyOther(ObjectMutant);
+						WaitStatus = STATUS_SUCCESS;
+						goto NoWait;
+					}
+				} else {
+					if (ObjectMutant->Header.Type == MutantObject) {
+						if ((Thread == ObjectMutant->OwnerThread) &&	(ObjectMutant->Header.SignalState == MINLONG)) {
+							KiUnlockDispatcherDatabase(Thread->WaitIrql);
+							ExRaiseStatus(STATUS_MUTANT_LIMIT_EXCEEDED);
+						} else if ((ObjectMutant->Header.SignalState <= 0) && (Thread != ObjectMutant->OwnerThread)) {
+							WaitSatisfied = FALSE;
+						}
+					} else if (ObjectMutant->Header.SignalState <= 0) {
+						WaitSatisfied = FALSE;
+					}
+				}
+
+
+				// If we reached here, the wait could not be satisfied immediately, so we must setup a WaitBlock
+				WaitBlock = &WaitBlockArray[Index];
+				WaitBlock->Object = ObjectMutant;
+				WaitBlock->WaitKey = (CSHORT)(Index);
+				WaitBlock->WaitType = WaitType;
+				WaitBlock->Thread = Thread;
+				WaitBlock->NextWaitBlock = &WaitBlockArray[Index + 1];
+			}
+
+			// Check if the wait can be satisfied immediately
+			if ((WaitType == WaitAll) && (WaitSatisfied)) {
+				WaitBlock->NextWaitBlock = &WaitBlockArray[0];
+				KiWaitSatisfyAll(WaitBlock);
+				WaitStatus = (NTSTATUS)Thread->WaitStatus;
+				goto NoWait;
+			}	
+
+			TestForAlertPending(Alertable);
+
+			// Handle a Timeout if specified
+			if (Timeout != nullptr) {
+				// If the timeout is 0, do not wait
+				if (!(Timeout->u.LowPart | Timeout->u.HighPart)) {
+					WaitStatus = (NTSTATUS)(STATUS_TIMEOUT);
+					goto NoWait;
+				}
+
+				// Setup a timer for the thread
+				PRKTIMER Timer = &Thread->Timer;
+				PKWAIT_BLOCK WaitTimer = &Thread->TimerWaitBlock;
+				WaitBlock->NextWaitBlock = WaitTimer;
+				Timer->Header.WaitListHead.Flink = &WaitTimer->WaitListEntry;
+				Timer->Header.WaitListHead.Blink = &WaitTimer->WaitListEntry;
+				WaitTimer->NextWaitBlock = WaitBlock;
+				if (KiInsertTreeTimer(Timer, *Timeout) == FALSE) {
+					WaitStatus = (NTSTATUS)STATUS_TIMEOUT;
+					goto NoWait;
+				}
+
+				DueTime.QuadPart = Timer->DueTime.QuadPart;
+			}
+			else {
+				WaitBlock->NextWaitBlock = WaitBlock;
+			}
+
+			WaitBlock->NextWaitBlock = &WaitBlockArray[0];
+			WaitBlock = &WaitBlockArray[0];
+			do {
+				ObjectMutant = (PKMUTANT)WaitBlock->Object;
+				InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
+				WaitBlock = WaitBlock->NextWaitBlock;
+			} while (WaitBlock != &WaitBlockArray[0]);
+
+
+			/*
+			TODO: We can't implement this and the return values until we have our own thread schedular
+			For now, we'll have to implement waiting here instead of the schedular.
+			This code can all be enabled once we have CPU emulation and our own schedular in v1.0
+
+			// Insert the WaitBlock
+			InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
+
+			// If the current thread is processing a queue object, wake other treads using the same queue
+			PRKQUEUE Queue = (PRKQUEUE)Thread->Queue;
+			if (Queue != NULL) {
+			KiActivateWaiterQueue(Queue);
+			}
+
+			// Insert the thread into the Wait List
+			Thread->Alertable = Alertable;
+			Thread->WaitMode = WaitMode;
+			Thread->WaitReason = (UCHAR)WaitReason;
+			Thread->WaitTime = KiQueryLowTickCount();
+			Thread->State = Waiting;
+			KiInsertWaitList(WaitMode, Thread);
+
+			WaitStatus = (NTSTATUS)KiSwapThread();
+
+			if (WaitStatus == STATUS_USER_APC) {
+			// TODO: KiDeliverUserApc();
+			}
+
+			// If the thread was not awakened for an APC, return the Wait Status
+			if (WaitStatus != STATUS_KERNEL_APC) {
+			return WaitStatus;
+			}
+			*/
+
+			// TODO: Remove this after we have our own schedular and the above is implemented
+			Sleep(10);
+
+			// Reduce the timout if necessary
+			if (Timeout != nullptr) {
+				Timeout = KiComputeWaitInterval(OriginalTime, &DueTime, &NewTime);
+			}
+		}
+
+		// Raise IRQL to DISPATCH_LEVEL and lock the database
+		KiLockDispatcherDatabase(&Thread->WaitIrql);
+	} while (TRUE);
+
+	// The waiting thead has been alerted, or an APC needs to be delivered
+	// So unlock the dispatcher database, lower the IRQ and return the status
+	KiUnlockDispatcherDatabase(Thread->WaitIrql);
+	if (WaitStatus == STATUS_USER_APC) {
+		//TODO: KiDeliverUserApc();
 	}
 
-	if (ntdllObjects.size() > 0) {
-		// TODO : What should we do with the (currently ignored)
-		//        WaitReason, WaitMode, WaitBlockArray?
+	RETURN(WaitStatus);
 
-		// Unused arguments : WaitReason, WaitMode, WaitBlockArray
-		ret = NtDll::NtWaitForMultipleObjects(
-			ntdllObjects.size(),
-			&ntdllObjects[0],
-			(NtDll::OBJECT_WAIT_TYPE)WaitType,
-			Alertable,
-			(NtDll::PLARGE_INTEGER)Timeout);
+NoWait:
+	// The wait was satisfied without actually waiting
+	// Unlock the database and return the status
+	//TODO: KiAdjustQuantumThread(Thread);
 
-		if (FAILED(ret))
-			EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KeWaitForMultipleObjects failed! (%s)", NtStatusToString(ret));
-	}
-	
-	if (nativeObjects.size() > 0) {
-		ret = NtDll::NtWaitForMultipleObjects(
-			nativeObjects.size(),
-			&nativeObjects[0],
-			(NtDll::OBJECT_WAIT_TYPE)WaitType,
-			Alertable,
-			(NtDll::PLARGE_INTEGER)Timeout);
+	KiUnlockDispatcherDatabase(Thread->WaitIrql);
 
-		if (FAILED(ret))
-			EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KeWaitForMultipleObjects failed! (%s)", NtStatusToString(ret));
+	if (WaitStatus == STATUS_USER_APC) {
+		// TODO: KiDeliverUserApc();
 	}
 
-	RETURN(ret);
+	RETURN(WaitStatus);
 }
 
 // ******************************************************************
@@ -1858,16 +2133,160 @@ XBSYSAPI EXPORTNUM(159) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForSingleObject
 	IN PLARGE_INTEGER Timeout OPTIONAL
 )
 {
-	LOG_FORWARD("KeWaitForMultipleObjects");
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Object)
+		LOG_FUNC_ARG(WaitReason)
+		LOG_FUNC_ARG(WaitMode)
+		LOG_FUNC_ARG(Alertable)
+		LOG_FUNC_ARG(Timeout)
+		LOG_FUNC_END;
 
-	return xboxkrnl::KeWaitForMultipleObjects(
-		/*Count=*/1,
-		&Object,
-		/*WaitType=*/WaitAll,
-		WaitReason,
-		WaitMode,
-		Alertable,
-		Timeout,
-		/*WaitBlockArray*/NULL
-	);
+	// If the lock is not already held, lock it
+	PRKTHREAD Thread = KeGetCurrentThread();
+	if (Thread->WaitNext) {
+		Thread->WaitNext = FALSE;
+	}
+	else {
+		KiLockDispatcherDatabase(&Thread->WaitIrql);
+	}
+
+	// Wait Loop
+	// This loop ends 
+	PLARGE_INTEGER OriginalTime = Timeout;
+	LARGE_INTEGER DueTime, NewTime;
+	KWAIT_BLOCK StackWaitBlock;
+	PKWAIT_BLOCK WaitBlock = &StackWaitBlock;
+	NTSTATUS WaitStatus;
+	do {
+		// Check if we need to let an APC run. This should immediately trigger APC interrupt via a call to UnlockDispatcherDatabase
+		if (Thread->ApcState.KernelApcPending && (Thread->WaitIrql < APC_LEVEL)) {
+			KiUnlockDispatcherDatabase(Thread->WaitIrql);
+		} else {
+			PKMUTANT ObjectMutant = (PKMUTANT)Object;
+			Thread->WaitStatus = STATUS_SUCCESS;
+
+			if (ObjectMutant->Header.Type == MutantObject) {
+				// If the object is a mutant object and it has been acquired MINGLONG times, raise an exception
+				// If the mutant is signalled, we can satisfy the wait
+				if ((ObjectMutant->Header.SignalState > 0) || (Thread == ObjectMutant->OwnerThread)) {
+					if (ObjectMutant->Header.SignalState != MINLONG) {
+						KiWaitSatisfyMutant(ObjectMutant, Thread);
+						WaitStatus = (NTSTATUS)(Thread->WaitStatus);
+						goto NoWait;
+					}
+					else {
+						KiUnlockDispatcherDatabase(Thread->WaitIrql);
+						ExRaiseStatus(STATUS_MUTANT_LIMIT_EXCEEDED);
+					}
+				}
+			}
+			else if (ObjectMutant->Header.SignalState) {
+				// Otherwise, if the signal state is > 0, we can still just satisfy the wait
+				KiWaitSatisfyOther(ObjectMutant);
+				WaitStatus = STATUS_SUCCESS;
+				goto NoWait;
+			}
+
+			// If we reached here, the wait could not be satisfied immediately, so we must setup a WaitBlock
+			WaitBlock->Object = Object;
+			WaitBlock->WaitKey = (CSHORT)(STATUS_SUCCESS);
+			WaitBlock->WaitType = WaitAny;
+			WaitBlock->Thread = Thread;
+
+			TestForAlertPending(Alertable);
+
+			// Handle a Timeout if specified
+			if (Timeout != nullptr) {
+				// If the timeout is 0, do not wait
+				if (!(Timeout->u.LowPart | Timeout->u.HighPart)) {
+					WaitStatus = (NTSTATUS)(STATUS_TIMEOUT);
+					goto NoWait;
+				}
+
+				// Setup a timer for the thread
+				PRKTIMER Timer = &Thread->Timer;
+				PKWAIT_BLOCK WaitTimer = &Thread->TimerWaitBlock;
+				WaitBlock->NextWaitBlock = WaitTimer;
+				Timer->Header.WaitListHead.Flink = &WaitTimer->WaitListEntry;
+				Timer->Header.WaitListHead.Blink = &WaitTimer->WaitListEntry;
+				WaitTimer->NextWaitBlock = WaitBlock;
+				if (KiInsertTreeTimer(Timer, *Timeout) == FALSE) {
+					WaitStatus = (NTSTATUS)STATUS_TIMEOUT;
+					goto NoWait;
+				}
+
+				DueTime.QuadPart = Timer->DueTime.QuadPart;
+			}
+			else {
+				WaitBlock->NextWaitBlock = WaitBlock;
+			}
+
+			/* 
+				TODO: We can't implement this and the return values until we have our own thread schedular
+				For now, we'll have to implement waiting here instead of the schedular.
+				This code can all be enabled once we have CPU emulation and our own schedular in v1.0
+
+				// Insert the WaitBlock
+				InsertTailList(&ObjectMutant->Header.WaitListHead, &WaitBlock->WaitListEntry);
+
+				// If the current thread is processing a queue object, wake other treads using the same queue
+				PRKQUEUE Queue = (PRKQUEUE)Thread->Queue;
+				if (Queue != NULL) {
+					KiActivateWaiterQueue(Queue);
+				}
+
+				// Insert the thread into the Wait List
+				Thread->Alertable = Alertable;
+				Thread->WaitMode = WaitMode;
+				Thread->WaitReason = (UCHAR)WaitReason;
+				Thread->WaitTime = KiQueryLowTickCount();
+				Thread->State = Waiting;
+				KiInsertWaitList(WaitMode, Thread);
+
+				WaitStatus = (NTSTATUS)KiSwapThread();
+
+				if (WaitStatus == STATUS_USER_APC) {
+					// TODO: KiDeliverUserApc();
+				}
+
+				// If the thread was not awakened for an APC, return the Wait Status
+				if (WaitStatus != STATUS_KERNEL_APC) {
+					return WaitStatus;
+				}
+			*/
+
+			// TODO: Remove this after we have our own schedular and the above is implemented
+			Sleep(10);
+
+			// Reduce the timout if necessary
+			if (Timeout != nullptr) {
+				Timeout = KiComputeWaitInterval(OriginalTime, &DueTime,	&NewTime);
+			}
+		}
+
+		// Raise IRQL to DISPATCH_LEVEL and lock the database
+		KiLockDispatcherDatabase(&Thread->WaitIrql);
+	} while (TRUE);
+
+	// The waiting thead has been alerted, or an APC needs to be delivered
+	// So unlock the dispatcher database, lower the IRQ and return the status
+	KiUnlockDispatcherDatabase(Thread->WaitIrql);
+	if (WaitStatus == STATUS_USER_APC) {
+		//TODO: KiDeliverUserApc();
+	}
+
+	RETURN(WaitStatus);
+
+NoWait:
+	// The wait was satisfied without actually waiting
+	// Unlock the database and return the status
+	//TODO: KiAdjustQuantumThread(Thread);
+
+	KiUnlockDispatcherDatabase(Thread->WaitIrql);
+
+	if (WaitStatus == STATUS_USER_APC) {
+		// TODO: KiDeliverUserApc();
+	}
+
+	RETURN(WaitStatus);
 }

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -2020,7 +2020,7 @@ XBSYSAPI EXPORTNUM(158) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForMultipleObje
 
 			// Handle a Timeout if specified
 			if (Timeout != nullptr) {
-				// If the timeout is 0, do not `
+				// If the timeout is 0, do not wait
 				if (!(Timeout->u.LowPart | Timeout->u.HighPart)) {
 					WaitStatus = (NTSTATUS)(STATUS_TIMEOUT);
 					goto NoWait;

--- a/src/CxbxKrnl/EmuKrnlKe.cpp
+++ b/src/CxbxKrnl/EmuKrnlKe.cpp
@@ -2088,7 +2088,7 @@ XBSYSAPI EXPORTNUM(158) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForMultipleObje
 			//}
 
 			// TODO: Remove this after we have our own schedular and the above is implemented
-			Sleep(10);
+			Sleep(0);
 
 			// Reduce the timout if necessary
 			if (Timeout != nullptr) {
@@ -2096,8 +2096,10 @@ XBSYSAPI EXPORTNUM(158) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForMultipleObje
 			}
 		}
 
-		// Raise IRQL to DISPATCH_LEVEL and lock the database
-		KiLockDispatcherDatabase(&Thread->WaitIrql);
+		// Raise IRQL to DISPATCH_LEVEL and lock the database (only if it's not already at this level)
+		if (KeGetCurrentIrql() != DISPATCH_LEVEL) {
+			KiLockDispatcherDatabase(&Thread->WaitIrql);
+		}
 	} while (TRUE);
 
 	// The waiting thead has been alerted, or an APC needs to be delivered
@@ -2260,7 +2262,7 @@ XBSYSAPI EXPORTNUM(159) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForSingleObject
 			} */
 
 			// TODO: Remove this after we have our own schedular and the above is implemented
-			Sleep(10);
+			Sleep(0);
 
 			// Reduce the timout if necessary
 			if (Timeout != nullptr) {
@@ -2269,7 +2271,9 @@ XBSYSAPI EXPORTNUM(159) xboxkrnl::NTSTATUS NTAPI xboxkrnl::KeWaitForSingleObject
 		}
 
 		// Raise IRQL to DISPATCH_LEVEL and lock the database
-		KiLockDispatcherDatabase(&Thread->WaitIrql);
+		if (KeGetCurrentIrql() != DISPATCH_LEVEL) {
+			KiLockDispatcherDatabase(&Thread->WaitIrql);
+		}
 	} while (TRUE);
 
 	// The waiting thead has been alerted, or an APC needs to be delivered

--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -2066,17 +2066,15 @@ XBSYSAPI EXPORTNUM(233) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
     IN  PLARGE_INTEGER   Timeout
 )
 {
-	LOG_FORWARD("KeWaitForMultipleObjects");
+	LOG_FORWARD("NtWaitForMultipleObjectsEx");
 
-	return xboxkrnl::KeWaitForMultipleObjects(
+	return xboxkrnl::NtWaitForMultipleObjectsEx(
 		/*Count=*/1,
 		&Handle,
 		/*WaitType=*/WaitAll,
-		/*WaitReason=*/WrUserRequest,
 		/*WaitMode=*/KernelMode,
 		Alertable,
-		Timeout,
-		/*WaitBlockArray*/NULL
+		Timeout
 	);
 }
 
@@ -2091,17 +2089,15 @@ XBSYSAPI EXPORTNUM(234) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForSingleObject
 	IN  PLARGE_INTEGER  Timeout
 )
 {
-	LOG_FORWARD("KeWaitForMultipleObjects");
+	LOG_FORWARD("NtWaitForMultipleObjectsEx");
 
-	return xboxkrnl::KeWaitForMultipleObjects(
+	return xboxkrnl::NtWaitForMultipleObjectsEx(
 		/*Count=*/1,
 		&Handle,
 		/*WaitType=*/WaitAll,
-		/*WaitReason=*/WrUserRequest,
 		WaitMode,
 		Alertable,
-		Timeout,
-		/*WaitBlockArray*/NULL
+		Timeout
 	);
 }
 
@@ -2118,17 +2114,21 @@ XBSYSAPI EXPORTNUM(235) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtWaitForMultipleObje
 	IN  PLARGE_INTEGER  Timeout
 )
 {
-	LOG_FORWARD("KeWaitForMultipleObjects");
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Count)
+		LOG_FUNC_ARG(Handles)
+		LOG_FUNC_ARG(WaitType)
+		LOG_FUNC_ARG(WaitMode)
+		LOG_FUNC_ARG(Alertable)
+		LOG_FUNC_ARG(Timeout)
+		LOG_FUNC_END;
 
-	return xboxkrnl::KeWaitForMultipleObjects(
+	return NtDll::NtWaitForMultipleObjects(
 		Count,
 		Handles,
-		WaitType,
-		/*WaitReason=*/WrUserRequest,
-		WaitMode,
+		(NtDll::OBJECT_WAIT_TYPE)WaitType,
 		Alertable,
-		Timeout,
-		/*WaitBlockArray*/NULL);
+		(NtDll::PLARGE_INTEGER)Timeout);
 }
 
 // ******************************************************************

--- a/src/CxbxKrnl/EmuKrnlPs.cpp
+++ b/src/CxbxKrnl/EmuKrnlPs.cpp
@@ -327,13 +327,13 @@ XBSYSAPI EXPORTNUM(255) xboxkrnl::NTSTATUS NTAPI xboxkrnl::PsCreateSystemThreadE
 		// Give the thread chance to start
 		Sleep(100);
 
-        EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KRNL: Waiting for Xbox proxy thread to start...\n");
+		DbgPrintf(LOG_PREFIX, "Waiting for Xbox proxy thread to start...\n");
 
         while (bWait) {
             dwThreadWait = WaitForSingleObject(hStartedEvent, 300);
             switch (dwThreadWait) {
                 case WAIT_TIMEOUT: { // The time-out interval elapsed, and the object's state is nonsignaled.
-					EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KRNL: Timeout while waiting for Xbox proxy thread to start...\n");
+					EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "Timeout while waiting for Xbox proxy thread to start...\n");
                     bWait = false;
                     break;
                 }
@@ -346,7 +346,7 @@ XBSYSAPI EXPORTNUM(255) xboxkrnl::NTSTATUS NTAPI xboxkrnl::PsCreateSystemThreadE
 					if (dwThreadWait == WAIT_FAILED) // The function has failed
 						bWait = false;
 
-					std::string ErrorStr = CxbxGetLastErrorString("KRNL: While waiting for Xbox proxy thread to start");
+					std::string ErrorStr = CxbxGetLastErrorString("While waiting for Xbox proxy thread to start");
 					EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "%s\n", ErrorStr.c_str());
 					break;
                 }
@@ -358,7 +358,7 @@ XBSYSAPI EXPORTNUM(255) xboxkrnl::NTSTATUS NTAPI xboxkrnl::PsCreateSystemThreadE
 		hStartedEvent = NULL;
 
 		// Log ThreadID identical to how GetCurrentThreadID() is rendered :
-		EmuLog(LOG_PREFIX, LOG_LEVEL::WARNING, "KRNL: Created Xbox proxy thread. Handle : 0x%X, ThreadId : [0x%.4X]\n", *ThreadHandle, dwThreadId);
+		DbgPrintf(LOG_PREFIX, "Created Xbox proxy thread. Handle : 0x%X, ThreadId : [0x%.4X]\n", *ThreadHandle, dwThreadId);
 
 		CxbxKrnlRegisterThread(*ThreadHandle);
 

--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -655,18 +655,20 @@ XBSYSAPI EXPORTNUM(277) xboxkrnl::VOID NTAPI xboxkrnl::RtlEnterCriticalSection
     }
     else {
         if(CriticalSection->OwningThread != thread) {
-            NTSTATUS result;
-            result = KeWaitForSingleObject(
-                (PVOID)CriticalSection,
-                (KWAIT_REASON)0,
-                (KPROCESSOR_MODE)0,
-                (BOOLEAN)0,
-                (PLARGE_INTEGER)0
-            );
-            if(!NT_SUCCESS(result))
-            {
-                CxbxKrnlCleanup(LOG_PREFIX, "Waiting for event of a critical section returned %lx.", result);
-            };
+			if (CriticalSection->OwningThread != nullptr) {
+				NTSTATUS result;
+				result = KeWaitForSingleObject(
+					(PVOID)CriticalSection,
+					(KWAIT_REASON)0,
+					(KPROCESSOR_MODE)0,
+					(BOOLEAN)0,
+					(PLARGE_INTEGER)0
+				);
+				if (!NT_SUCCESS(result))
+				{
+					CxbxKrnlCleanup(LOG_PREFIX, "Waiting for event of a critical section returned %lx.", result);
+				};
+			}
             CriticalSection->OwningThread = thread;
             CriticalSection->RecursionCount = 1;
         }

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -79,8 +79,8 @@ void SMCDevice::Init()
 {
 	m_PICVersionStringIndex = 0;
 	buffer[SMC_COMMAND_AV_PACK] = 1; // AV_PACK_HDTV: see http://xboxdevwiki.net/PIC#The_AV_Pack
-									 // We can't use the existing constant because SMC flags and kernel flags
-								     // different values!
+	                                 // We can't use the existing constant because SMC flags and kernel flags
+	                                 // different values!
 	buffer[SMC_COMMAND_LED_SEQUENCE] = LED::GREEN;
 	buffer[SMC_COMMAND_SCRATCH] = 0; // http://xboxdevwiki.net/PIC#Scratch_register_values
 }

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -104,10 +104,10 @@ uint8_t SMCDevice::ReadByte(uint8_t command)
 	case SMC_COMMAND_VERSION: // 0x01 PIC version string
 		// See http://xboxdevwiki.net/PIC#PIC_version_string
 		switch (m_revision) {
-		case SCMRevision::P01: buffer[0] = "P01"[m_PICVersionStringIndex]; break;
-		case SCMRevision::P2L: buffer[0] = "P05"[m_PICVersionStringIndex]; break; // ??
-		case SCMRevision::D01: buffer[0] = "DXB"[m_PICVersionStringIndex]; break;
-		case SCMRevision::D05: buffer[0] = "D05"[m_PICVersionStringIndex]; break; // ??
+		case SCMRevision::P01: buffer[1] = "P01"[m_PICVersionStringIndex]; break;
+		case SCMRevision::P2L: buffer[1] = "P05"[m_PICVersionStringIndex]; break; // ??
+		case SCMRevision::D01: buffer[1] = "DXB"[m_PICVersionStringIndex]; break;
+		case SCMRevision::D05: buffer[1] = "D05"[m_PICVersionStringIndex]; break; // ??
 		// default: UNREACHABLE(m_revision);
 		}
 

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -78,7 +78,9 @@ SMCDevice::SMCDevice(SCMRevision revision)
 void SMCDevice::Init()
 {
 	m_PICVersionStringIndex = 0;
-	buffer[SMC_COMMAND_AV_PACK] = AV_PACK_HDTV; // see http://xboxdevwiki.net/PIC#The_AV_Pack
+	buffer[SMC_COMMAND_AV_PACK] = 1; // AV_PACK_HDTV: see http://xboxdevwiki.net/PIC#The_AV_Pack
+									 // We can't use the existing constant because SMC flags and kernel flags
+								     // different values!
 	buffer[SMC_COMMAND_LED_SEQUENCE] = LED::GREEN;
 	buffer[SMC_COMMAND_SCRATCH] = 0; // http://xboxdevwiki.net/PIC#Scratch_register_values
 }


### PR DESCRIPTION
1. KeEvent functionality, including KeWaitForSingleObject and KeWaitForMultipleObjects no longer forward to Windows. This solves the fatal error that could occur when waiting for a critical section, as well as prevents several deadlock issues.
2. Fixes an issue where the SMC Version String was read incorrectly
3. Reads AVPack from SMC, instead of hard-coding in the kernel
4. Fix an issue where some titles would crash when accessing a CR register
5. Experimental (but disabled and VERY incomplete) support for Chihiro Media Board ROM(AKA Segaboot)