### PR TITLE
Fix file path to use RootDirectory properly.

### DIFF
--- a/src/CxbxKrnl/EmuFile.cpp
+++ b/src/CxbxKrnl/EmuFile.cpp
@@ -494,7 +494,7 @@ NTSTATUS CxbxObjectAttributesToNT(
 	}
 
 	// Is there a filename API given?
-	if (aFileAPIName.size() > 0)
+	if (aFileAPIName.size() > 0 && (int)RootDirectory <= 0)
 	{
 		// Then interpret the ObjectName as a filename, and update it to host relative :
 		NTSTATUS result = CxbxConvertFilePath(ObjectName, /*OUT*/RelativeHostPath, /*OUT*/&RootDirectory, aFileAPIName, partitionHeader);

--- a/src/CxbxKrnl/EmuFile.cpp
+++ b/src/CxbxKrnl/EmuFile.cpp
@@ -373,7 +373,7 @@ NTSTATUS CxbxConvertFilePath(
 				if ((RelativePath.length() > 0) && (RelativePath[0] == ':'))
 					RelativePath.erase(0, 1);  // xbmp needs this, as it accesses 'e::\'
 			}
-            else if (RelativePath[0] == '$') {
+			else if (RelativePath[0] == '$') {
 				if (RelativePath.compare(0, 5, "$HOME") == 0) // "xbmp" needs this
 				{
 					NtSymbolicLinkObject = FindNtSymbolicLinkObjectByRootHandle(g_hCurDir);

--- a/src/CxbxKrnl/EmuFile.h
+++ b/src/CxbxKrnl/EmuFile.h
@@ -166,7 +166,7 @@ struct NativeObjectAttributes {
 };
 
 NTSTATUS CxbxObjectAttributesToNT(xboxkrnl::POBJECT_ATTRIBUTES ObjectAttributes, NativeObjectAttributes& nativeObjectAttributes, std::string aFileAPIName = "", bool partitionHeader = false);
-NTSTATUS CxbxConvertFilePath(std::string RelativeXboxPath, OUT std::wstring &RelativeHostPath, OUT NtDll::HANDLE *RootDirectory, std::string aFileAPIName = "", bool partitionHeader = false);
+NTSTATUS CxbxConvertFilePath(std::string RelativeXboxPath, OUT std::wstring &RelativeHostPath, IN OUT NtDll::HANDLE *RootDirectory, std::string aFileAPIName = "", bool partitionHeader = false);
 
 // ******************************************************************
 // * Wrapper of a handle object

--- a/src/CxbxKrnl/EmuKrnlHal.cpp
+++ b/src/CxbxKrnl/EmuKrnlHal.cpp
@@ -539,7 +539,7 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 			std::string XbePath = TitlePath;
 			// Convert Xbox XBE Path to Windows Path
 			{
-				HANDLE rootDirectoryHandle;
+				HANDLE rootDirectoryHandle = nullptr;
 				std::wstring wXbePath;
 				// We pretend to come from NtCreateFile to force symbolic link resolution
 				CxbxConvertFilePath(TitlePath, wXbePath, &rootDirectoryHandle, "NtCreateFile");


### PR DESCRIPTION
Turok Evolution can now finally be able to save the game progress.

`RootDirectory` handle is very important role when a title pass down with non-null handle in the structure. We should never ignore it at the end.

Ideally should not cause any regression.

Requesting @LukeUsher for review. Since I had moved his `BaseNamedObjects` check to last. Originally, it was at front. I'm not sure if it needs to be at front or not.