### PR TITLE
Fix for vertex declaration failures

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
+++ b/src/CxbxKrnl/EmuD3D8/VertexShader.cpp
@@ -1914,7 +1914,7 @@ static DWORD VshConvertToken_CONSTMEM(
 
 	// TODO
 
-    return Count;
+    return Count * 4 + 1;
 }
 
 static void VshConvertToken_TESSELATOR(


### PR DESCRIPTION
Initial fix for vertex declaration failures due to incorrectly handled CONST declaration Step size.
- Update step size calculation to return the correct number of DWORD values to skip
