### PR TITLE
Unpatch XMountAlternateTitleA and XMountAlternateTitleA

### DIFF
--- a/src/CxbxKrnl/EmuKrnlNt.cpp
+++ b/src/CxbxKrnl/EmuKrnlNt.cpp
@@ -1397,13 +1397,12 @@ XBSYSAPI EXPORTNUM(215) xboxkrnl::NTSTATUS NTAPI xboxkrnl::NtQuerySymbolicLinkOb
 	} else {
 		if (LinkTarget != NULL)
 		{
-			if (LinkTarget->Length > LinkTarget->MaximumLength)
-			{
-				ret = STATUS_BUFFER_TOO_SMALL;
-				LinkTarget->Length = LinkTarget->MaximumLength;
+			if (LinkTarget->MaximumLength >= symbolicLinkObject->XboxSymbolicLinkPath.length() + sizeof(char)) {
+				copy_string_to_PSTRING_to(symbolicLinkObject->XboxSymbolicLinkPath, LinkTarget);
 			}
-
-			copy_string_to_PSTRING_to(symbolicLinkObject->XboxSymbolicLinkPath, LinkTarget);
+			else {
+				ret = STATUS_BUFFER_TOO_SMALL;
+			}
 		}
 
 		if (ReturnedLength != NULL)

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -1854,47 +1854,6 @@ DWORD WINAPI XTL::EMUPATCH(XMountMUA)
 }
 
 // ******************************************************************
-// * patch: XMountAlternateTitleA
-// ******************************************************************
-DWORD WINAPI XTL::EMUPATCH(XMountAlternateTitleA)
-(
-	LPCSTR		lpRootPath,               
-	DWORD		dwAltTitleId,               
-	PCHAR		pchDrive               
-)
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(lpRootPath)
-		LOG_FUNC_ARG(dwAltTitleId)
-		LOG_FUNC_ARG(pchDrive)
-		LOG_FUNC_END;
-
-	// TODO: Anything?
-	LOG_UNIMPLEMENTED();
-
-	RETURN(ERROR_SUCCESS);
-}
-
-// ******************************************************************
-// * patch: XUnmountAlternateTitleA
-// ******************************************************************
-DWORD WINAPI XTL::EMUPATCH(XUnmountAlternateTitleA)
-(
-	CHAR chDrive
-)
-{
-	FUNC_EXPORTS
-
-	LOG_FUNC_ONE_ARG(chDrive);
-
-	LOG_UNIMPLEMENTED();
-
-	RETURN(ERROR_SUCCESS);
-}
-
-// ******************************************************************
 // * patch: XGetDeviceEnumerationStatus
 // ******************************************************************
 DWORD WINAPI XTL::EMUPATCH(XGetDeviceEnumerationStatus)()

--- a/src/CxbxKrnl/EmuXapi.h
+++ b/src/CxbxKrnl/EmuXapi.h
@@ -910,9 +910,9 @@ int WINAPI EMUPATCH(lstrcmpiW)
 // ******************************************************************
 DWORD WINAPI EMUPATCH(XMountMUA)
 (
-	DWORD dwPort,                  
-	DWORD dwSlot,                  
-	PCHAR pchDrive               
+	DWORD dwPort,
+	DWORD dwSlot,
+	PCHAR pchDrive
 );
 
 // ******************************************************************
@@ -920,25 +920,25 @@ DWORD WINAPI EMUPATCH(XMountMUA)
 // ******************************************************************
 DWORD WINAPI EMUPATCH(XMountMURootA)
 (
-	DWORD dwPort,                  
-	DWORD dwSlot,                  
-	PCHAR pchDrive               
+	DWORD dwPort,
+	DWORD dwSlot,
+	PCHAR pchDrive
 );
 
 // ******************************************************************
 // * patch: XMountAlternateTitleA
 // ******************************************************************
-DWORD WINAPI EMUPATCH(XMountAlternateTitleA)
+/*DWORD WINAPI EMUPATCH(XMountAlternateTitleA)
 (
-	LPCSTR		lpRootPath,               
-	DWORD		dwAltTitleId,               
-	PCHAR		pchDrive               
-);
+	LPCSTR lpRootPath,
+	DWORD  dwAltTitleId,
+	PCHAR  pchDrive
+);*/
 
 // ******************************************************************
 // * patch: XUnmountAlternateTitleA
 // ******************************************************************
-DWORD WINAPI EMUPATCH(XUnmountAlternateTitleA)(CHAR chDrive);
+//DWORD WINAPI EMUPATCH(XUnmountAlternateTitleA)(CHAR chDrive);
 
 // ******************************************************************
 // * patch: MoveFileA


### PR DESCRIPTION
Plus fix NtQuerySymbolicLinkObject function.

Tested against:
* Lego Star Wars 2
* Dead or Alive Xtreme Beach Volleyball (possible resolve)