### PR TITLE
Split Symbol scanning and patching phases

### DIFF
--- a/build/win32/Cxbx.vcxproj
+++ b/build/win32/Cxbx.vcxproj
@@ -248,6 +248,7 @@
     <ClInclude Include="..\..\src\CxbxKrnl\gloffscreen\glextensions.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\gloffscreen\gloffscreen.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\HLEIntercept.h" />
+    <ClInclude Include="..\..\src\CxbxKrnl\HLEPatches.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\LibRc4.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\PhysicalMemory.h" />
     <ClInclude Include="..\..\src\CxbxKrnl\PoolManager.h" />
@@ -504,6 +505,7 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\src\CxbxKrnl\HLEPatches.cpp" />
     <ClCompile Include="..\..\src\CxbxKrnl\KernelThunk.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/build/win32/Cxbx.vcxproj.filters
+++ b/build/win32/Cxbx.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClCompile Include="..\..\src\Common\Win32\IPCWindows.cpp">
       <Filter>Cross Platform\Win32</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\CxbxKrnl\HLEPatches.cpp">
+      <Filter>Emulator</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Cxbx\DlgControllerConfig.h">
@@ -627,6 +630,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Common\IPCHybrid.hpp">
       <Filter>Cross Platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\CxbxKrnl\HLEPatches.h">
+      <Filter>Emulator</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -34,8 +34,6 @@
 #ifndef CXBX_H
 #define CXBX_H
 
-#define FUNC_EXPORTS __pragma(comment(linker, "/EXPORT:" __FUNCTION__ "=" __FUNCDNAME__))
-
 /*! \name primitive typedefs */
 /*! \{ */
 typedef signed int     sint;

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -2470,7 +2470,7 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice_4)
     X_D3DPRESENT_PARAMETERS     *pPresentationParameters
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pPresentationParameters)
@@ -2525,7 +2525,7 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice_16)
     X_D3DPRESENT_PARAMETERS     *pPresentationParameters
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Adapter)
@@ -2578,7 +2578,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetIndices)
 	UINT                BaseVertexIndex
 )
 {
-	FUNC_EXPORTS
+
 
 		LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pIndexData)
@@ -2605,7 +2605,7 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice)
     IDirect3DDevice           **ppReturnedDeviceInterface
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Adapter)
@@ -2657,7 +2657,7 @@ HRESULT WINAPI XTL::EMUPATCH(Direct3D_CreateDevice)
 VOID WINAPI XTL::EMUPATCH(D3DDevice_GetDisplayFieldStatus)(X_D3DFIELD_STATUS *pFieldStatus)
 {
 	// NOTE: This can be unpatched only when NV2A does it's own VBlank and HLE _Swap function is unpatched
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pFieldStatus);
 
@@ -2699,7 +2699,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetDisplayFieldStatus)(X_D3DFIELD_STATUS *pF
 // ******************************************************************
 PDWORD WINAPI XTL::EMUPATCH(D3DDevice_BeginPush)(DWORD Count)
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Count);
 
@@ -2724,7 +2724,7 @@ PDWORD WINAPI XTL::EMUPATCH(D3DDevice_BeginPush)(DWORD Count)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_BeginPush2)(DWORD Count, DWORD** ppPush)
 {
-	FUNC_EXPORTS
+
 
 		LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Count)
@@ -2750,7 +2750,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_BeginPush2)(DWORD Count, DWORD** ppPush)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_EndPush)(DWORD *pPush)
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pPush);
 
@@ -2770,7 +2770,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_EndPush)(DWORD *pPush)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_BeginVisibilityTest)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -2784,7 +2784,7 @@ HRESULT __stdcall XTL::EMUPATCH(D3DDevice_EndVisibilityTest_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD                       Index;
 
@@ -2803,7 +2803,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndVisibilityTest)
     DWORD                       Index
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Index);
 
@@ -2817,7 +2817,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndVisibilityTest)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_SetBackBufferScale)(FLOAT x, FLOAT y)
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(x)
@@ -2837,7 +2837,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult)
     ULONGLONG                  *pTimeStamp
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Index)
@@ -2864,7 +2864,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_LoadVertexShader_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
     DWORD                       Handle;
     DWORD                       Address;
@@ -2884,7 +2884,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShader_4)
     DWORD                       Address
 )
 {
-	FUNC_EXPORTS
+
 
 	DWORD           Handle;
 	__asm mov Handle, eax;
@@ -2919,7 +2919,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShader)
     DWORD                       Address
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -2948,7 +2948,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SelectVertexShader_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
     DWORD                       Handle;
     DWORD                       Address;
@@ -2969,7 +2969,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SelectVertexShader_4)
     DWORD                       Address
 )
 {
-	FUNC_EXPORTS
+
 
 	DWORD           Handle;
 	__asm mov Handle, eax;
@@ -2986,7 +2986,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShader)
     DWORD                       Address
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -3052,7 +3052,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetGammaRamp)
     CONST X_D3DGAMMARAMP   *pRamp
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(dwFlags)
@@ -3085,7 +3085,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetGammaRamp)
     X_D3DGAMMARAMP     *pRamp
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pRamp);
 
@@ -3114,7 +3114,7 @@ XTL::X_D3DSurface* WINAPI XTL::EMUPATCH(D3DDevice_GetBackBuffer2)
     INT                 BackBuffer
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(BackBuffer);
 
@@ -3246,7 +3246,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetBackBuffer)
     X_D3DSurface      **ppBackBuffer
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_GetBackBuffer2");
 
@@ -3301,7 +3301,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
     CONST X_D3DVIEWPORT8 *pViewport
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pViewport);
 
@@ -3360,7 +3360,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_GetViewportOffsetAndScale_0)
 (
 )
 {
-	//FUNC_EXPORTS;
+	//
 
     D3DXVECTOR4 *pOffset;
     D3DXVECTOR4 *pScale;
@@ -3382,7 +3382,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetViewportOffsetAndScale)
 	X_D3DXVECTOR4 *pScale
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pOffset)
@@ -3454,7 +3454,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SetShaderConstantMode_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	XTL::X_VERTEXSHADERCONSTANTMODE param;
 	__asm {
@@ -3472,7 +3472,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetShaderConstantMode)
     XTL::X_VERTEXSHADERCONSTANTMODE Mode
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Mode);
 
@@ -3490,7 +3490,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
     DWORD           Usage
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pDeclaration)
@@ -3700,7 +3700,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant_8)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	static uint32 returnAddr;
 
@@ -3728,7 +3728,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant)
     DWORD       ConstantCount
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Register)
@@ -3779,7 +3779,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant1)
     CONST PVOID pConstantData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
@@ -3795,7 +3795,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant1Fast)
     CONST PVOID pConstantData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
@@ -3813,7 +3813,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant4)
     CONST PVOID pConstantData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
@@ -3830,7 +3830,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline)
     DWORD       ConstantCount
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
@@ -3847,7 +3847,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInlineFast)
     DWORD       ConstantCount
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
@@ -3867,7 +3867,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTexture_4)
 	X_D3DBaseTexture  *pTexture
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD           Stage;
 	__asm mov Stage, eax;
@@ -3894,7 +3894,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTexture)
 	X_D3DBaseTexture  *pTexture
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Stage)
@@ -3918,7 +3918,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SwitchTexture)
     DWORD           Format
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Method)
@@ -3993,7 +3993,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_Begin)
     X_D3DPRIMITIVETYPE     PrimitiveType
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(PrimitiveType);
 
@@ -4012,7 +4012,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData2f)
     FLOAT   b
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexData4f");
 
@@ -4032,7 +4032,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData2s)
     SHORT   b
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexData4f");
 
@@ -4082,7 +4082,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f)
     FLOAT   d
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Register)
@@ -4348,7 +4348,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4ub)
 	BYTE	d
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexData4f");
 
@@ -4372,7 +4372,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4s)
 	SHORT	d
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexData4f");
 
@@ -4410,7 +4410,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexDataColor)
     D3DCOLOR    Color
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetVertexData4f");
 
@@ -4427,7 +4427,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexDataColor)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_End)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -4448,7 +4448,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_RunPushBuffer)
     X_D3DFixup            *pFixup
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pPushBuffer)
@@ -4471,7 +4471,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_Clear)
     DWORD           Stencil
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Count)
@@ -4548,7 +4548,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_Present)
     PVOID       pDummy2
 )
 {
-	FUNC_EXPORTS
+
 
 	// LOG_FORWARD("D3DDevice_Swap");
 	LOG_FUNC_BEGIN
@@ -4570,7 +4570,7 @@ DWORD XTL::EMUPATCH(D3DDevice_Swap_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	uint32_t param;
 	__asm {
@@ -4588,7 +4588,7 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
 	DWORD Flags
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Flags);
 
@@ -5532,7 +5532,7 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
 	X_D3DResource      *pThis
 	)
 {
-	FUNC_EXPORTS
+
 		LOG_FUNC_ONE_ARG(pThis);
 
 	// Backup the key now, as the Xbox resource may be wiped out by the following release call!
@@ -5574,7 +5574,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_EnableOverlay)
     BOOL Enable
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Enable);
 	
@@ -5597,7 +5597,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_UpdateOverlay)
 	D3DCOLOR      ColorKey
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pSurface)
@@ -5635,7 +5635,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_UpdateOverlay)
 // ******************************************************************
 BOOL WINAPI XTL::EMUPATCH(D3DDevice_GetOverlayUpdateStatus)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();    
 
@@ -5650,7 +5650,7 @@ BOOL WINAPI XTL::EMUPATCH(D3DDevice_GetOverlayUpdateStatus)()
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_BlockUntilVerticalBlank)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -5666,7 +5666,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVerticalBlankCallback)
     D3DVBLANKCALLBACK pCallback
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pCallback);
 
@@ -5680,7 +5680,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SetTextureState_TexCoordIndex_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD Stage;
 	DWORD Value;
@@ -5700,7 +5700,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_TexCoordIndex_4)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	DWORD           Stage;
 	__asm mov Stage, esi;
@@ -5733,7 +5733,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_TexCoordIndex)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Stage)
@@ -5762,7 +5762,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_TwoSidedLighting)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -5777,7 +5777,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_BackFillMode)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -5800,7 +5800,7 @@ VOID XTL::EMUPATCH(D3DDevice_SetTextureState_BorderColor_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD Stage;
 	DWORD Value;
@@ -5821,7 +5821,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_BorderColor_4)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
     DWORD Stage;
 	__asm mov Stage, eax;
@@ -5846,7 +5846,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_BorderColor)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Stage)
@@ -5865,7 +5865,7 @@ VOID XTL::EMUPATCH(D3DDevice_SetTextureState_ColorKeyColor_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD Stage;
 	DWORD Value;
@@ -5885,7 +5885,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_ColorKeyColor_4)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
     DWORD Stage;
 	__asm mov Stage, eax;
@@ -5902,7 +5902,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_ColorKeyColor)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Stage)
@@ -5922,7 +5922,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_BumpEnv_8)
     DWORD                      Value
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD           Stage;
 	__asm mov Stage, eax;
@@ -5968,7 +5968,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTextureState_BumpEnv)
     DWORD                      Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Stage)
@@ -6008,7 +6008,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_FrontFace)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6023,7 +6023,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_LogicOp)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6038,7 +6038,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_NormalizeNormals)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6054,7 +6054,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_TextureFactor)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6070,7 +6070,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_ZBias)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6091,7 +6091,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_EdgeAntiAlias)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6110,7 +6110,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_FillMode)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6138,7 +6138,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_FogColor)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6154,7 +6154,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_Dxt1NoiseEnable)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6170,7 +6170,7 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetRenderState_Simple)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Method)
@@ -6384,8 +6384,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_VertexBlend)
     DWORD Value
 )
 {
-    FUNC_EXPORTS
-
     LOG_FUNC_ONE_ARG(Value);
 
     // convert from Xbox direct3d to PC direct3d enumeration
@@ -6412,7 +6410,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_PSTextureModes)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_ONE_ARG(Value);
 
 	XTL::TemporaryPixelShaderRenderStates[XTL::X_D3DRS_PSTEXTUREMODES] = Value;
@@ -6426,7 +6424,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_CullMode)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6459,7 +6457,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_LineWidth)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6476,7 +6474,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_StencilFail)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6492,7 +6490,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_OcclusionCullEnable)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6507,7 +6505,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_StencilCullEnable)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6522,7 +6520,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_RopZCmpAlwaysRead)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6537,7 +6535,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_RopZRead)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6552,7 +6550,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_DoNotCullUncompressed)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6567,7 +6565,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_ZEnable)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6583,7 +6581,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_StencilEnable)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6599,7 +6597,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleAntiAlias)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6615,7 +6613,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleMask)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6631,7 +6629,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleMode)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6646,7 +6644,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleRenderTargetMode)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6661,7 +6659,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_ShadowFunc)
     DWORD Value
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Value);
 
@@ -6691,7 +6689,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_YuvEnable)
     BOOL Enable
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Enable);
 
@@ -6704,7 +6702,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SetTransform_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	D3DTRANSFORMSTATETYPE param1;
 	CONST D3DMATRIX *param2;
@@ -6726,7 +6724,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetTransform)
     CONST D3DMATRIX      *pMatrix
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(State)
@@ -6769,7 +6767,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_MultiplyTransform)
 	CONST D3DMATRIX      *pMatrix
 )
 {
-	FUNC_EXPORTS
+
 
 		LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(State)
@@ -6792,7 +6790,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetTransform)
     D3DMATRIX            *pMatrix
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(State)
@@ -6818,7 +6816,7 @@ VOID WINAPI XTL::EMUPATCH(Lock2DSurface)
 	DWORD                Flags
 	)
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pPixelContainer)
@@ -6852,7 +6850,7 @@ VOID WINAPI XTL::EMUPATCH(Lock3DSurface)
 	DWORD				Flags
 	)
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pPixelContainer)
@@ -6881,7 +6879,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetStreamSource_4)
     UINT                Stride
 )
 {
-	FUNC_EXPORTS
+
 
     UINT                StreamNumber;
     X_D3DVertexBuffer  *pStreamData;
@@ -6918,7 +6916,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetStreamSource_8)
     UINT                Stride
 )
 {
-	FUNC_EXPORTS
+
 
     UINT                StreamNumber;
 
@@ -6954,7 +6952,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetStreamSource)
     UINT                Stride
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(StreamNumber)
@@ -6981,7 +6979,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShader)
     DWORD Handle
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Handle);
 
@@ -7443,7 +7441,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPixelShader_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD           Handle;
 	__asm mov Handle, eax;
@@ -7467,7 +7465,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPixelShader)
 	DWORD           Handle
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_ONE_ARG(Handle);
 
 	// Call the Xbox function to make sure D3D structures get set
@@ -7488,7 +7486,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
     UINT               VertexCount
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(PrimitiveType)
@@ -7590,7 +7588,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVerticesUP)
     UINT                VertexStreamZeroStride
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(PrimitiveType)
@@ -7639,7 +7637,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
     CONST PWORD         pIndexData
 )
 {
-	FUNC_EXPORTS
+
 
 	// Test-cases : XDK samples (Cartoon, Gamepad)
 	// Note : In gamepad.xbe, the gamepad is drawn by D3DDevice_DrawIndexedVertices
@@ -7699,7 +7697,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
     UINT                VertexStreamZeroStride
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(PrimitiveType)
@@ -7825,7 +7823,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetLight)
     X_D3DLIGHT8     *pLight
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Index)
@@ -7845,7 +7843,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_SetLight)
     CONST X_D3DLIGHT8 *pLight
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Index)
@@ -7866,7 +7864,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetMaterial)
     CONST X_D3DMATERIAL8 *pMaterial
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pMaterial);
 
@@ -7883,7 +7881,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_LightEnable)
     BOOL             bEnable
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Index)
@@ -7932,7 +7930,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DCubeTexture_GetCubeMapSurface)
 	X_D3DSurface**		ppCubeMapSurface
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -7965,7 +7963,7 @@ XTL::X_D3DSurface* WINAPI XTL::EMUPATCH(D3DCubeTexture_GetCubeMapSurface2)
 	UINT				Level
 )
 {
-	FUNC_EXPORTS
+
 
 		LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -7995,7 +7993,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderTarget)
     X_D3DSurface    *pNewZStencil
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pRenderTarget)
@@ -8078,7 +8076,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SetPalette_4)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	static uint32 returnAddr;
 
@@ -8105,7 +8103,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPalette)
     X_D3DPalette *pPalette
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Stage)
@@ -8137,7 +8135,7 @@ VOID WINAPI XTL::EMUPATCH(D3DPalette_Lock)
 	DWORD           Flags
 )
 {
-	FUNC_EXPORTS
+
 	
 	LOG_FUNC_BEGIN
 	LOG_FUNC_ARG(pThis)
@@ -8165,7 +8163,7 @@ XTL::D3DCOLOR * WINAPI XTL::EMUPATCH(D3DPalette_Lock2)
 	DWORD           Flags
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 	LOG_FUNC_ARG(pThis)
@@ -8192,7 +8190,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_SetFlickerFilter_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD         Filter;
 
@@ -8211,7 +8209,7 @@ void WINAPI XTL::EMUPATCH(D3DDevice_SetFlickerFilter)
     DWORD         Filter
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Filter);
 
@@ -8226,7 +8224,7 @@ void WINAPI XTL::EMUPATCH(D3DDevice_SetSoftDisplayFilter)
     BOOL Enable
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Enable);
 
@@ -8242,7 +8240,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderSize)
     UINT* pSize
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -8264,7 +8262,7 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_DeleteVertexShader_0)
 (
 )
 {
-	FUNC_EXPORTS;
+;
 
 	DWORD Handle;
 
@@ -8284,7 +8282,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DeleteVertexShader)
 	DWORD Handle
 	)
 {
-	FUNC_EXPORTS
+
 
 		LOG_FUNC_ONE_ARG(Handle);
 
@@ -8332,7 +8330,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShaderDirect)
     DWORD                    Address
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pVAF)
@@ -8350,7 +8348,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetShaderConstantMode)
     DWORD *pMode
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pMode);
         
@@ -8368,7 +8366,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShader)
     DWORD *pHandle
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pHandle);
 
@@ -8388,7 +8386,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderConstant)
     DWORD ConstantCount
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Register)
@@ -8423,7 +8421,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderInputDirect)
     X_STREAMINPUT           *pStreamInputs
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pVAF)
@@ -8448,7 +8446,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderInput)
     X_STREAMINPUT      *pStreamInputs
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pHandle)
@@ -8471,7 +8469,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderInput)
     X_STREAMINPUT     *pStreamInputs
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -8498,7 +8496,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_RunVertexStateShader)
     CONST FLOAT *pData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Address)
@@ -8522,7 +8520,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShaderProgram)
     DWORD        Address
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pFunction)
@@ -8578,7 +8576,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderType)
     DWORD *pType
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -8606,7 +8604,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderDeclaration)
     DWORD *pSizeOfData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -8654,7 +8652,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderFunction)
     DWORD *pSizeOfData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -8701,7 +8699,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_SetDepthClipPlanes)
     DWORD Flags
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Near)
@@ -8765,7 +8763,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_SetDepthClipPlanes)
 // ******************************************************************
 DWORD WINAPI XTL::EMUPATCH(D3DDevice_InsertFence)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -8785,7 +8783,7 @@ BOOL WINAPI XTL::EMUPATCH(D3DDevice_IsFencePending)
     DWORD Fence
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Fence);
 
@@ -8803,7 +8801,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_BlockOnFence)
     DWORD Fence
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Fence);
 
@@ -8819,7 +8817,7 @@ VOID WINAPI XTL::EMUPATCH(D3DResource_BlockUntilNotBusy)
     X_D3DResource *pThis
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pThis);
 
@@ -8836,7 +8834,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetScreenSpaceOffset)
     FLOAT y
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(x)
@@ -8856,7 +8854,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_InsertCallback)
 	DWORD				Context
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Type)
@@ -8882,7 +8880,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_DrawRectPatch)
 	CONST D3DRECTPATCH_INFO *pRectPatchInfo
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -8908,7 +8906,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_DrawTriPatch)
 	CONST D3DTRIPATCH_INFO* pTriPatchInfo
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Handle)
@@ -8933,7 +8931,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetProjectionViewportMatrix)
 	D3DXMATRIX *pProjectionViewport
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pProjectionViewport);
 
@@ -8989,7 +8987,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetProjectionViewportMatrix)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_SetStateVB)( ULONG Unknown1 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Unknown1);
 
@@ -9004,7 +9002,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetStateVB)( ULONG Unknown1 )
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_SetStateUP)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -9020,7 +9018,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetStateUP)()
 // ******************************************************************
 void WINAPI XTL::EMUPATCH(D3DDevice_SetStipple)( DWORD* pPattern )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pPattern);
 
@@ -9037,7 +9035,7 @@ void WINAPI XTL::EMUPATCH(D3DDevice_SetSwapCallback)
 	D3DSWAPCALLBACK		pCallback
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pCallback);
 
@@ -9049,7 +9047,7 @@ void WINAPI XTL::EMUPATCH(D3DDevice_SetSwapCallback)
 // ******************************************************************
 HRESULT WINAPI XTL::EMUPATCH(D3DDevice_PersistDisplay)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -9080,7 +9078,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_PrimeVertexCache)
 	WORD *pIndexData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(VertexCount)
@@ -9099,7 +9097,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_SampleAlpha)
 	DWORD dwSampleAlpha
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(dwSampleAlpha);
 
@@ -9122,7 +9120,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetModelView)
 	CONST D3DMATRIX *pComposite
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pModelView)
@@ -9139,7 +9137,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetModelView)
 // ******************************************************************
 void WINAPI XTL::EMUPATCH(D3DDevice_FlushVertexCache)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -9151,7 +9149,7 @@ void WINAPI XTL::EMUPATCH(D3DDevice_FlushVertexCache)()
 // ******************************************************************
 HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetModelView)(D3DXMATRIX* pModelView)
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pModelView);
 
@@ -9174,7 +9172,7 @@ DWORD PushBuffer[64 * 1024 / sizeof(DWORD)];
 // ******************************************************************
 void WINAPI XTL::EMUPATCH(D3D_SetCommonDebugRegisters)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -9190,7 +9188,7 @@ void WINAPI XTL::EMUPATCH(D3D_SetCommonDebugRegisters)()
 // ******************************************************************
 BOOL WINAPI XTL::EMUPATCH(D3DDevice_IsBusy)()
 {
-	FUNC_EXPORTS
+
 
 		LOG_FUNC();
 
@@ -9205,7 +9203,7 @@ BOOL WINAPI XTL::EMUPATCH(D3DDevice_IsBusy)()
 // ******************************************************************
 void WINAPI XTL::EMUPATCH(D3D_BlockOnTime)( DWORD Unknown1, int Unknown2 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(Unknown1)
@@ -9231,7 +9229,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderTargetFast)
     DWORD			Flags
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FORWARD("D3DDevice_SetRenderTarget");
 
@@ -9248,7 +9246,7 @@ void WINAPI XTL::EMUPATCH(D3D_LazySetPointParams)
 	void* Device
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(Device);
 
@@ -9263,7 +9261,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetMaterial)
 	X_D3DMATERIAL8* pMaterial
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pMaterial);
 
@@ -9291,8 +9289,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPixelShaderConstant_4)
     CONST PVOID pConstantData
 )
 {
-    FUNC_EXPORTS
-
     DWORD       Register;
     DWORD       ConstantCount;
 

--- a/src/CxbxKrnl/EmuDSound.cpp
+++ b/src/CxbxKrnl/EmuDSound.cpp
@@ -244,7 +244,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
     OUT LPDIRECTSOUND8* ppDirectSound,
     LPUNKNOWN       pUnknown)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pguidDeviceId)
@@ -373,7 +373,7 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSound_AddRef)
 (
     LPDIRECTSOUND8          pThis)
 {
-    FUNC_EXPORTS;
+    
 
     return 1;
 
@@ -395,7 +395,7 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSound_Release)
 (
     LPDIRECTSOUND8          pThis)
 {
-    FUNC_EXPORTS;
+    
 
     return 0;
 
@@ -422,7 +422,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_GetSpeakerConfig)
     X_CDirectSound*         pThis,
     OUT PDWORD                  pdwSpeakerConfig)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -445,7 +445,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SynchPlayback)
 (
     LPDIRECTSOUND8          pThis)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_ONE_ARG(pThis);
 
@@ -463,7 +463,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_DownloadEffectsImage)
     PVOID           pImageLoc,      // TODO: Use this param
     PVOID*          ppImageDesc)    // TODO: Use this param
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -489,7 +489,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_DownloadEffectsImage)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(DirectSoundDoWork)()
 {
-    FUNC_EXPORTS;
+    
 
     if (!g_bDSoundCreateCalled) {
         return;
@@ -593,7 +593,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetOrientation)
     FLOAT           zTop,
     DWORD           dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -634,7 +634,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetDistanceFactor)
     FLOAT           fDistanceFactor,
     DWORD           dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -654,7 +654,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetRolloffFactor)
     FLOAT           fRolloffFactor,
     DWORD           dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -674,7 +674,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetDopplerFactor)
     FLOAT           fDopplerFactor,
     DWORD           dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -694,7 +694,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetI3DL2Listener)
     X_DSI3DL2LISTENER      *pds3dl,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -722,7 +722,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetMixBinHeadroom)
     DWORD                   dwMixBinMask,
     DWORD                   dwHeadroom)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -747,7 +747,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBins)
     LPDIRECTSOUND8          pThis,
     PVOID                   pMixBins)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -773,7 +773,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_12)
     DWORD                   dwMixBinMask,
     const LONG*             alVolumes)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -802,7 +802,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_8)
     X_CDirectSoundBuffer*   pThis,
     X_LPDSMIXBINS           pMixBins)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -823,7 +823,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetPosition)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -853,7 +853,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetVelocity)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -882,7 +882,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetAllParameters)
     LPCDS3DLISTENER         pDS3DListenerParameters,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -906,7 +906,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_CommitDeferredSettings)
 (
     X_CDirectSound*         pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -927,7 +927,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
     X_DSBUFFERDESC*         pdsbd,
     OUT X_CDirectSoundBuffer**  ppBuffer)
 {
-    FUNC_EXPORTS;
+    
 
     // Research reveal DirectSound creation check is part of the requirement.
     if (!g_pDSound8 && !g_bDSoundCreateCalled) {
@@ -1016,7 +1016,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CreateSoundBuffer)
     OUT X_CDirectSoundBuffer**  ppBuffer,
     LPUNKNOWN               pUnkOuter)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1037,7 +1037,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
     LPVOID                  pvBufferData,
     DWORD                   dwBufferBytes)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1126,7 +1126,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPlayRegion)
     DWORD                   dwPlayStart,
     DWORD                   dwPlayLength)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1179,7 +1179,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Lock)
     LPDWORD                 pdwAudioBytes2,
     DWORD                   dwFlags)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1253,7 +1253,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Unlock)
     DWORD                   pdwAudioBytes2
     )
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1300,7 +1300,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetHeadroom)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwHeadroom)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1320,7 +1320,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetLoopRegion)
     DWORD                   dwLoopStart,
     DWORD                   dwLoopLength)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1362,7 +1362,7 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Release)
 (
     X_CDirectSoundBuffer*   pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1409,7 +1409,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPitch)
     X_CDirectSoundBuffer*   pThis,
     LONG                    lPitch)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1427,7 +1427,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetStatus)
     X_CDirectSoundBuffer*   pThis,
     OUT LPDWORD             pdwStatus)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1470,7 +1470,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetCurrentPosition)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwNewPosition)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1502,7 +1502,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetCurrentPosition)
     OUT PDWORD                  pdwCurrentPlayCursor,
     OUT PDWORD                  pdwCurrentWriteCursor)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1523,7 +1523,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Play)
     DWORD                   dwReserved2,
     DWORD                   dwFlags)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1587,7 +1587,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Stop)
 (
     X_CDirectSoundBuffer*   pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1615,7 +1615,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_StopEx)
     REFERENCE_TIME          rtTimeStamp,
     DWORD                   dwFlags)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1692,7 +1692,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetVolume)
     X_CDirectSoundBuffer*   pThis,
     LONG                    lVolume)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1711,7 +1711,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetFrequency)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwFrequency)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1729,7 +1729,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
     X_DSSTREAMDESC*         pdssd,
     OUT X_CDirectSoundStream**  ppStream)
 {
-    FUNC_EXPORTS;
+    
 
     // Research reveal DirectSound creation check is part of the requirement.
     if (!g_pDSound8 && !g_bDSoundCreateCalled) {
@@ -1830,7 +1830,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CreateSoundStream)
     OUT X_CDirectSoundStream**  ppStream,
     PVOID                   pUnknown)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1847,7 +1847,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CreateSoundStream)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(CMcpxStream_Dummy_0x10)(DWORD dwDummy1, DWORD dwDummy2)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1873,7 +1873,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetVolume)
     X_CDirectSoundStream*   pThis,
     LONG                    lVolume)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -1893,7 +1893,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetRolloffFactor)
     FLOAT                   fRolloffFactor,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1919,7 +1919,7 @@ ULONG WINAPI XTL::EMUPATCH(CDirectSoundStream_AddRef)
 (
     X_CDirectSoundStream*   pThis)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_ONE_ARG(pThis);
 
@@ -1933,7 +1933,7 @@ ULONG WINAPI XTL::EMUPATCH(CDirectSoundStream_Release)
 (
     X_CDirectSoundStream*   pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -1980,7 +1980,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetInfo)
     X_CDirectSoundStream*   pThis,
     OUT LPXMEDIAINFO            pInfo)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2012,7 +2012,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetStatus)
     X_CDirectSoundStream*   pThis,
     OUT DWORD*              pdwStatus)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2071,7 +2071,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Process)
     PXMEDIAPACKET           pInputBuffer,
     PXMEDIAPACKET           pOutputBuffer)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2152,7 +2152,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Discontinuity)
 (
     X_CDirectSoundStream*   pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2186,7 +2186,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
 (
     X_CDirectSoundStream*   pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2212,7 +2212,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_SynchPlayback)
 (
     LPDIRECTSOUND8 pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2256,7 +2256,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Pause)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwPause)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2275,7 +2275,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetHeadroom)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwHeadroom)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2296,7 +2296,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetConeAngles)
     DWORD                   dwOutsideConeAngle,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2317,7 +2317,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetConeOutsideVolume)
     LONG                    lConeOutsideVolume,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2337,7 +2337,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetAllParameters)
     X_DS3DBUFFER*           pc3DBufferParameters,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2357,7 +2357,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMaxDistance)
     D3DVALUE                flMaxDistance,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2377,7 +2377,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMinDistance)
     D3DVALUE                fMinDistance,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2399,7 +2399,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetVelocity)
     D3DVALUE                z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2423,7 +2423,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetConeOrientation)
     D3DVALUE                z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2447,7 +2447,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetPosition)
     D3DVALUE                z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2468,7 +2468,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFrequency)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwFrequency)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2486,7 +2486,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBins)
     X_CDirectSoundStream*   pThis,
     PVOID                   pMixBins)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2512,7 +2512,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMaxDistance)
     FLOAT                   flMaxDistance,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2532,7 +2532,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMinDistance)
     FLOAT                   flMinDistance,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2552,7 +2552,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetRolloffFactor)
     FLOAT                   flRolloffFactor,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2580,7 +2580,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetDistanceFactor)
     FLOAT                   flDistanceFactor,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2605,7 +2605,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetConeAngles)
     DWORD                   dwOutsideConeAngle,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2628,7 +2628,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetConeOrientation)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2650,7 +2650,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetConeOutsideVolume)
     LONG                    lConeOutsideVolume,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2672,7 +2672,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPosition)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2696,7 +2696,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetVelocity)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2718,7 +2718,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetDopplerFactor)
     FLOAT                   flDopplerFactor,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2738,7 +2738,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetI3DL2Source)
     X_DSI3DL2BUFFER*        pds3db,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2768,7 +2768,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMode)
     DWORD                   dwMode,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -2788,7 +2788,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetFormat)
     X_CDirectSoundBuffer*   pThis,
     LPCWAVEFORMATEX         pwfxFormat)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2814,7 +2814,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF)
 (
     void)
 {
-    FUNC_EXPORTS;
+    
 
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
@@ -2830,7 +2830,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF)
 (
     void)
 {
-    FUNC_EXPORTS;
+    
 
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
@@ -2846,7 +2846,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF4Channel)
 (
     void)
 {
-    FUNC_EXPORTS;
+    
 
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
@@ -2862,7 +2862,7 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF4Channel)
 (
     void)
 {
-    FUNC_EXPORTS;
+    
 
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
@@ -2879,7 +2879,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetLFO) //Low Frequency Oscillat
     LPDIRECTSOUNDBUFFER8    pThis,
     LPCDSLFODESC            pLFODesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2905,7 +2905,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetLFO)
     X_CDirectSoundStream*   pThis,
     LPCDSLFODESC            pLFODesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2932,7 +2932,7 @@ VOID WINAPI XTL::EMUPATCH(XAudioCreateAdpcmFormat)
     DWORD                  nSamplesPerSec,
     LPXBOXADPCMWAVEFORMAT  pwfx)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2965,7 +2965,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetRolloffCurve)
     DWORD                   dwPointCount,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -2994,7 +2994,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_EnableHeadphones)
     LPDIRECTSOUND8      pThis,
     BOOL                fEnabled)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3018,7 +3018,7 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSoundBuffer_AddRef)
 (
     X_CDirectSoundBuffer*   pThis)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_ONE_ARG(pThis);
 
@@ -3034,7 +3034,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Pause)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwPause)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -3064,7 +3064,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_PauseEx)
     REFERENCE_TIME          rtTimestamp,
     DWORD                   dwPause)
 {
-      FUNC_EXPORTS;
+      
 
         enterCriticalSection;
 
@@ -3091,7 +3091,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetOutputLevels)
     OUT X_DSOUTPUTLEVELS*       pOutputLevels,
     BOOL                    bResetPeakValues)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3120,7 +3120,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetEG)
     X_CDirectSoundStream*   pThis,
     LPVOID                  pEnvelopeDesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3147,7 +3147,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_FlushEx)
     REFERENCE_TIME          rtTimeStamp,
     DWORD                   dwFlags)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3197,7 +3197,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMode)
     DWORD                   dwMode,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -3218,7 +3218,7 @@ HRESULT WINAPI XTL::EMUPATCH(XAudioDownloadEffectsImage)
     DWORD       dwFlags,
     LPVOID*     ppImageDesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3244,7 +3244,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetFilter)
     LPVOID              pThis,
     X_DSFILTERDESC*     pFilterDesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3270,7 +3270,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFilter)
     X_CDirectSoundStream*   pThis,
     X_DSFILTERDESC*         pFilterDesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3298,7 +3298,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_PlayEx)
     REFERENCE_TIME        rtTimeStamp,
     DWORD                 dwFlags)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3328,7 +3328,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetCaps)
     X_CDirectSound*     pThis,
     OUT X_DSCAPS*           pDSCaps)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3363,7 +3363,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetPitch)
     X_CDirectSoundStream*   pThis,
     LONG                    lPitch)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -3378,7 +3378,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetPitch)
 // ******************************************************************
 DWORD WINAPI XTL::EMUPATCH(DirectSoundGetSampleTime)()
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3401,7 +3401,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12)
     DWORD                   dwMixBinMask,
     const LONG*             alVolumes)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3430,7 +3430,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
     X_CDirectSoundStream*   pThis,
     X_LPDSMIXBINS           pMixBins)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -3449,7 +3449,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetI3DL2Source)
     X_DSI3DL2BUFFER*        pds3db,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3479,7 +3479,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetAllParameters)
     X_DS3DBUFFER*            pc3DBufferParameters,
     DWORD                    dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -3498,7 +3498,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFormat)
     X_CDirectSoundStream*   pThis,
     LPCWAVEFORMATEX         pwfxFormat)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3532,7 +3532,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetOutputBuffer)
     X_CDirectSoundBuffer*   pThis,
     X_CDirectSoundBuffer*   pOutputBuffer)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3560,7 +3560,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetOutputBuffer)
     X_CDirectSoundStream*   pThis,
     X_CDirectSoundBuffer*   pOutputBuffer)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3588,7 +3588,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileCreateMediaObjectEx)
     HANDLE      hFile,
     OUT void**      ppMediaObject)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3614,7 +3614,7 @@ HRESULT WINAPI XTL::EMUPATCH(XWaveFileCreateMediaObject)
     LPCWAVEFORMATEX*        ppwfxFormat,
     OUT void**              ppMediaObject) //XFileMediaObject, include XMediaObject interface
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3639,7 +3639,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetEG)
     X_CDirectSoundBuffer*   pThis,
     LPVOID                  pEnvelopeDesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3668,7 +3668,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetEffectData)
     OUT LPVOID          pvData,
     DWORD           dwDataSize)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3703,7 +3703,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetNotificationPositions)
     DWORD                   dwNotifyCount,
     LPCDSBPOSITIONNOTIFY    paNotifies)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3753,7 +3753,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetRolloffCurve)
     DWORD                   dwPointCount,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3783,7 +3783,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetEffectData)
     DWORD   dwDataSize,
     DWORD   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3813,7 +3813,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Use3DVoiceData)
     LPVOID      pThis,
     LPUNKNOWN   pUnknown)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -3839,7 +3839,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileCreateMediaObjectAsync)
     DWORD       dwMaxPackets,
     OUT void**      ppMediaObject)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3869,7 +3869,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Seek)
     DWORD               dwOrigin,
     LPDWORD             pdwAbsolute)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3893,7 +3893,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Seek)
 // NOTE: Does not require a patch.
 VOID WINAPI XTL::EMUPATCH(XFileMediaObject_DoWork)(X_XFileMediaObject* pThis)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3913,7 +3913,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_GetStatus)
     X_XFileMediaObject* pThis,
     OUT LPDWORD             pdwStatus)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3938,7 +3938,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_GetInfo)
     X_XFileMediaObject* pThis,
     OUT XMEDIAINFO*         pInfo)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3964,7 +3964,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Process)
     LPXMEDIAPACKET      pInputBuffer,
     LPXMEDIAPACKET      pOutputBuffer)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -3989,7 +3989,7 @@ ULONG WINAPI XTL::EMUPATCH(XFileMediaObject_AddRef)
 (
 	X_XFileMediaObject* pThis)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -4014,7 +4014,7 @@ ULONG WINAPI XTL::EMUPATCH(XFileMediaObject_Release)
 (
 	X_XFileMediaObject* pThis)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -4042,7 +4042,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileMediaObject_Discontinuity)
 (
 	X_XFileMediaObject *pThis)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -4063,7 +4063,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetSpeakerConfig)
     X_CDirectSound*     pThis,
     OUT LPDWORD*        pdwSpeakerConfig)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -4087,7 +4087,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CommitDeferredSettings)
 (
     X_CDirectSound*     pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -4111,7 +4111,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CommitEffectData)
 (
     X_CDirectSound*     pThis)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -4135,7 +4135,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_PauseEx)
     REFERENCE_TIME          rtTimestamp,
     DWORD                   dwPause)
 {
-      FUNC_EXPORTS;
+      
 
         enterCriticalSection;
 
@@ -4168,7 +4168,7 @@ HRESULT WINAPI XTL::EMUPATCH(XFileCreateMediaObject)
     DWORD           dwFlagsAndAttributes,
     OUT void**      ppMediaObject)
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -4198,7 +4198,7 @@ HRESULT WINAPI XTL::EMUPATCH(XWaveFileCreateMediaObjectEx)
     HANDLE              hFile,
     OUT void**          ppMediaObject) //XWaveFileMediaObject, include XFileMediaObject and XMediaObject interfaces
 {
-    //FUNC_EXPORTS;
+    //
 
     enterCriticalSection;
 
@@ -4224,7 +4224,7 @@ HRESULT WINAPI XTL::EMUPATCH(XAudioSetEffectData)
     void*               pDesc,
     void*               pRawDesc)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -4250,7 +4250,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetDistanceFactor)
     FLOAT                   flDistanceFactor,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
@@ -4270,7 +4270,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetDopplerFactor)
     FLOAT                   flDopplerFactor,
     DWORD                   dwApply)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4289,7 +4289,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetVoiceProperties)
     X_CDirectSoundBuffer*   pThis,
     OUT void*               pVoiceProps)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -4313,7 +4313,7 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetVoiceProperties)
     X_CDirectSoundStream*   pThis,
     OUT void*               pVoiceProps)
 {
-    FUNC_EXPORTS;
+    
 
     enterCriticalSection;
 
@@ -4337,7 +4337,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetVolume)
     X_CDirectSoundStream*   pThis,
     LONG                    lVolume)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4356,7 +4356,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetPitch)
     X_CDirectSoundStream*   pThis,
     LONG                    lPitch)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4373,7 +4373,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetLFO)
 (
     X_CDirectSoundStream*   pThis,
     LPCDSLFODESC            pLFODesc) {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4391,7 +4391,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetEG)
     X_CDirectSoundStream*   pThis,
     LPVOID                  pEnvelopeDesc)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4409,7 +4409,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetFilter)
     X_CDirectSoundStream*   pThis,
     X_DSFILTERDESC*         pFilterDesc)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4427,7 +4427,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetHeadroom)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwHeadroom)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4445,7 +4445,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetFrequency)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwFrequency)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
@@ -4463,7 +4463,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetMixBins)
     X_CDirectSoundStream*   pThis,
     PVOID                   pMixBins)
 {
-    FUNC_EXPORTS;
+    
 
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)

--- a/src/CxbxKrnl/EmuDSound.h
+++ b/src/CxbxKrnl/EmuDSound.h
@@ -618,6 +618,8 @@ class X_XFileMediaObject
         UINT                EmuRefCount;
 };
 
+extern "C" {
+
 // ******************************************************************
 // * patch: DirectSoundCreate
 // ******************************************************************
@@ -1939,3 +1941,4 @@ HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetMixBins)
     X_CDirectSoundStream*   pThis,
     PVOID                   pMixBins);
 #endif
+}

--- a/src/CxbxKrnl/EmuXG.cpp
+++ b/src/CxbxKrnl/EmuXG.cpp
@@ -76,7 +76,7 @@ VOID WINAPI XTL::EMUPATCH(XGSwizzleRect)
     DWORD         BytesPerPixel
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pSource)
 		LOG_FUNC_ARG(Pitch)
@@ -297,7 +297,7 @@ VOID WINAPI XTL::EMUPATCH(XGSetTextureHeader)
 //	void			**ppFont
 //)
 //{
-//		FUNC_EXPORTS
+//	
 //
 //		LOG_FUNC_BEGIN
 //			LOG_FUNC_ARG(pFontData)

--- a/src/CxbxKrnl/EmuXOnline.cpp
+++ b/src/CxbxKrnl/EmuXOnline.cpp
@@ -52,7 +52,7 @@ int WINAPI XTL::EMUPATCH(WSAStartup)
     WSADATA    *lpWSAData
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(wVersionRequested)
@@ -76,7 +76,7 @@ INT WINAPI XTL::EMUPATCH(XNetStartup)
     const PVOID pDummy
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(pDummy);
 
@@ -97,7 +97,7 @@ SOCKET WINAPI XTL::EMUPATCH(socket)
     int   protocol
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(af)
@@ -120,7 +120,7 @@ int WINAPI XTL::EMUPATCH(connect)
 	int namelen
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(s)
@@ -144,7 +144,7 @@ int WINAPI XTL::EMUPATCH(send)
 	int flags
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(s)
@@ -169,7 +169,7 @@ int WINAPI XTL::EMUPATCH(recv)
 	int flags
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(s)
@@ -193,7 +193,7 @@ int WINAPI XTL::EMUPATCH(bind)
 	int namelen
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(s)
@@ -217,7 +217,7 @@ int WINAPI XTL::EMUPATCH(listen)
 	int backlog
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(s)
@@ -241,7 +241,7 @@ int WINAPI XTL::EMUPATCH(ioctlsocket)
 	u_long FAR *argp
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(s)
@@ -289,7 +289,7 @@ HRESULT WINAPI XTL::EMUPATCH(XOnlineLogon)
     HANDLE	pHandle
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pUsers)

--- a/src/CxbxKrnl/EmuXapi.cpp
+++ b/src/CxbxKrnl/EmuXapi.cpp
@@ -271,7 +271,7 @@ VOID WINAPI XTL::EMUPATCH(XInitDevices)
 	PXDEVICE_PREALLOC_TYPE	PreallocTypes
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(dwPreallocTypeCount)
@@ -390,7 +390,7 @@ DWORD WINAPI XTL::EMUPATCH(XGetDevices)
     PXPP_DEVICE_TYPE DeviceType
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(DeviceType);
 
@@ -439,7 +439,7 @@ BOOL WINAPI XTL::EMUPATCH(XGetDeviceChanges)
     PDWORD           pdwRemovals
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(DeviceType)
@@ -513,7 +513,7 @@ HANDLE WINAPI XTL::EMUPATCH(XInputOpen)
     IN PX_XINPUT_POLLING_PARAMETERS   pPollingParameters OPTIONAL
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(DeviceType)
@@ -620,7 +620,7 @@ VOID WINAPI XTL::EMUPATCH(XInputClose)
     IN HANDLE hDevice
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(hDevice);
 
@@ -673,7 +673,7 @@ DWORD WINAPI XTL::EMUPATCH(XInputPoll)
     IN HANDLE hDevice
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(hDevice);
 
@@ -748,7 +748,7 @@ DWORD WINAPI XTL::EMUPATCH(XInputGetCapabilities)
     OUT PX_XINPUT_CAPABILITIES pCapabilities
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hDevice)
@@ -1028,7 +1028,7 @@ DWORD WINAPI XTL::EMUPATCH(XInputGetState)
     OUT PX_XINPUT_STATE  pState
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hDevice)
@@ -1119,7 +1119,7 @@ DWORD WINAPI XTL::EMUPATCH(XInputSetState)
     IN OUT PX_XINPUT_FEEDBACK pFeedback
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hDevice)
@@ -1251,7 +1251,7 @@ BOOL WINAPI XTL::EMUPATCH(SetThreadPriorityBoost)
     BOOL    DisablePriorityBoost
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hThread)
@@ -1275,7 +1275,7 @@ BOOL WINAPI XTL::EMUPATCH(SetThreadPriority)
     int     nPriority
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hThread)
@@ -1299,7 +1299,7 @@ int WINAPI XTL::EMUPATCH(GetThreadPriority)
     HANDLE  hThread
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(hThread);
 
@@ -1320,7 +1320,7 @@ BOOL WINAPI XTL::EMUPATCH(GetExitCodeThread)
     LPDWORD lpExitCode
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hThread)
@@ -1445,7 +1445,7 @@ LPVOID WINAPI XTL::EMUPATCH(CreateFiber)
 	LPVOID					lpParameter
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(dwStackSize)
@@ -1471,7 +1471,7 @@ VOID WINAPI XTL::EMUPATCH(DeleteFiber)
 	LPVOID					lpFiber
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_ONE_ARG((DWORD)DeleteFiber);
 
 	DeleteFiber(lpFiber);
@@ -1485,7 +1485,7 @@ VOID WINAPI XTL::EMUPATCH(SwitchToFiber)
 	LPVOID lpFiber 
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_ONE_ARG(lpFiber);
 
 	SwitchToFiber(lpFiber);
@@ -1499,7 +1499,7 @@ LPVOID WINAPI XTL::EMUPATCH(ConvertThreadToFiber)
 	LPVOID lpParameter
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_ONE_ARG(lpParameter);
 		
 	LPVOID pRet = ConvertThreadToFiber(lpParameter);
@@ -1515,7 +1515,7 @@ BOOL WINAPI XTL::EMUPATCH(QueryPerformanceCounter)
 	LARGE_INTEGER * lpPerformanceCount
 )
 {
-	FUNC_EXPORTS;
+
 	
 	lpPerformanceCount->QuadPart = xboxkrnl::KeQueryPerformanceCounter();
 	return TRUE;
@@ -1679,7 +1679,7 @@ DWORD WINAPI XTL::EMUPATCH(XGetLaunchInfo)
 	PLAUNCH_DATA	pLaunchData
 )
 {
-	FUNC_EXPORTS
+
 
 	// TODO : This patch can be removed once we're sure all XAPI library
 	// functions indirectly reference our xboxkrnl::LaunchDataPage variable.
@@ -1728,7 +1728,7 @@ VOID WINAPI XTL::EMUPATCH(XSetProcessQuantumLength)
     DWORD dwMilliseconds
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_ONE_ARG(dwMilliseconds);
 
 	// TODO: Implement?
@@ -1746,7 +1746,7 @@ DWORD WINAPI XTL::EMUPATCH(SignalObjectAndWait)
 	BOOL	bAlertable
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hObjectToSignal)
 		LOG_FUNC_ARG(hObjectToWaitOn)
@@ -1771,7 +1771,7 @@ MMRESULT WINAPI XTL::EMUPATCH(timeSetEvent)
 	UINT			fuEvent
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(uDelay)
@@ -1794,7 +1794,7 @@ MMRESULT WINAPI XTL::EMUPATCH(timeKillEvent)
 	UINT uTimerID  
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_ONE_ARG(uTimerID);
 
@@ -1814,7 +1814,7 @@ VOID WINAPI XTL::EMUPATCH(RaiseException)
 	CONST ULONG_PTR *lpArguments		   // array of arguments
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(dwExceptionCode)
@@ -1839,7 +1839,7 @@ DWORD WINAPI XTL::EMUPATCH(XMountMUA)
 	PCHAR pchDrive               
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(dwPort)
@@ -1858,7 +1858,7 @@ DWORD WINAPI XTL::EMUPATCH(XMountMUA)
 // ******************************************************************
 DWORD WINAPI XTL::EMUPATCH(XGetDeviceEnumerationStatus)()
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC();
 
@@ -1876,7 +1876,7 @@ DWORD WINAPI XTL::EMUPATCH(XInputGetDeviceDescription)
     PVOID	pDescription
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(hDevice)
@@ -1899,7 +1899,7 @@ DWORD WINAPI XTL::EMUPATCH(XMountMURootA)
 	PCHAR pchDrive               
 )
 {
-	FUNC_EXPORTS
+
 
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(dwPort)
@@ -1921,7 +1921,7 @@ VOID WINAPI XTL::EMUPATCH(OutputDebugStringA)
 	IN LPCSTR lpOutputString
 )
 {
-	FUNC_EXPORTS
+
 	LOG_FUNC_ONE_ARG(lpOutputString);
 	printf("OutputDebugStringA: %s\n", lpOutputString);
 }

--- a/src/CxbxKrnl/HLEPatches.cpp
+++ b/src/CxbxKrnl/HLEPatches.cpp
@@ -394,7 +394,6 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("XMountMUA", XTL::EMUPATCH(XMountMUA), PATCH_ALWAYS),
 	PATCH_ENTRY("XMountMURootA", XTL::EMUPATCH(XMountMURootA), PATCH_ALWAYS),
 	PATCH_ENTRY("XSetProcessQuantumLength", XTL::EMUPATCH(XSetProcessQuantumLength), PATCH_ALWAYS),
-	PATCH_ENTRY("XUnmountAlternateTitleA", XTL::EMUPATCH(XUnmountAlternateTitleA), PATCH_ALWAYS),
 	PATCH_ENTRY("timeKillEvent", XTL::EMUPATCH(timeKillEvent), PATCH_ALWAYS),
 	PATCH_ENTRY("timeSetEvent", XTL::EMUPATCH(timeSetEvent), PATCH_ALWAYS),
 };

--- a/src/CxbxKrnl/HLEPatches.cpp
+++ b/src/CxbxKrnl/HLEPatches.cpp
@@ -1,0 +1,447 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+// ******************************************************************
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->Win32->CxbxKrnl->HLEPatches.cpp
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2018 Luke Usher <luke.usher@outlook.com>
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+#include "CxbxKrnl.h"
+#include "Emu.h"
+#include "EmuXTL.h"
+#include "HLEPatches.h"
+#include "HLEIntercept.h"
+
+#include <map>
+#include <unordered_map>
+#include <subhook.h>
+
+typedef struct {
+	const void* patchFunc;		// Function pointer of the patch in Cxbx-R codebase
+	const uint32_t flags;		// Patch Flags
+} xbox_patch_t;
+
+const uint32_t PATCH_ALWAYS = 1 << 0;
+const uint32_t PATCH_HLE_D3D = 1 << 1;
+const uint32_t PATCH_HLE_DSOUND = 1 << 2;
+const uint32_t PATCH_HLE_OHCI = 1 << 3;
+
+#define PATCH_ENTRY(Name, Func, Flags) \
+    { Name, { &Func, Flags} }
+
+// Map of Xbox Patch names to Emulator Patches
+// A std::string is used as it's possible for a symbol to have multiple names
+// This allows for the eventual importing of Dxbx symbol files and even IDA signatures too!
+std::map<const std::string, const xbox_patch_t> g_PatchTable = {
+	// Direct3D
+	PATCH_ENTRY("D3DCubeTexture_GetCubeMapSurface", XTL::EMUPATCH(D3DCubeTexture_GetCubeMapSurface), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DCubeTexture_GetCubeMapSurface2", XTL::EMUPATCH(D3DCubeTexture_GetCubeMapSurface2), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_Begin", XTL::EMUPATCH(D3DDevice_Begin), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_BeginPush", XTL::EMUPATCH(D3DDevice_BeginPush), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_BeginPush2", XTL::EMUPATCH(D3DDevice_BeginPush2), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_BeginVisibilityTest", XTL::EMUPATCH(D3DDevice_BeginVisibilityTest), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_BlockOnFence", XTL::EMUPATCH(D3DDevice_BlockOnFence), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_BlockUntilVerticalBlank", XTL::EMUPATCH(D3DDevice_BlockUntilVerticalBlank), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_Clear", XTL::EMUPATCH(D3DDevice_Clear), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_CreateVertexShader", XTL::EMUPATCH(D3DDevice_CreateVertexShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DeleteVertexShader", XTL::EMUPATCH(D3DDevice_DeleteVertexShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DeleteVertexShader_0", XTL::EMUPATCH(D3DDevice_DeleteVertexShader_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DrawIndexedVertices", XTL::EMUPATCH(D3DDevice_DrawIndexedVertices), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DrawIndexedVerticesUP", XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DrawRectPatch", XTL::EMUPATCH(D3DDevice_DrawRectPatch), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DrawTriPatch", XTL::EMUPATCH(D3DDevice_DrawTriPatch), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DrawVertices", XTL::EMUPATCH(D3DDevice_DrawVertices), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DrawVerticesUP", XTL::EMUPATCH(D3DDevice_DrawVerticesUP), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_EnableOverlay", XTL::EMUPATCH(D3DDevice_EnableOverlay), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_End", XTL::EMUPATCH(D3DDevice_End), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_EndPush", XTL::EMUPATCH(D3DDevice_EndPush), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_EndVisibilityTest", XTL::EMUPATCH(D3DDevice_EndVisibilityTest), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_EndVisibilityTest_0", XTL::EMUPATCH(D3DDevice_EndVisibilityTest_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_FlushVertexCache", XTL::EMUPATCH(D3DDevice_FlushVertexCache), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetBackBuffer", XTL::EMUPATCH(D3DDevice_GetBackBuffer), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetBackBuffer2", XTL::EMUPATCH(D3DDevice_GetBackBuffer2), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetDisplayFieldStatus", XTL::EMUPATCH(D3DDevice_GetDisplayFieldStatus), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetGammaRamp", XTL::EMUPATCH(D3DDevice_GetGammaRamp), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetLight", XTL::EMUPATCH(D3DDevice_GetLight), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetMaterial", XTL::EMUPATCH(D3DDevice_GetMaterial), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetModelView", XTL::EMUPATCH(D3DDevice_GetModelView), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetOverlayUpdateStatus", XTL::EMUPATCH(D3DDevice_GetOverlayUpdateStatus), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetProjectionViewportMatrix", XTL::EMUPATCH(D3DDevice_GetProjectionViewportMatrix), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetShaderConstantMode", XTL::EMUPATCH(D3DDevice_GetShaderConstantMode), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetTransform", XTL::EMUPATCH(D3DDevice_GetTransform), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVertexShader", XTL::EMUPATCH(D3DDevice_GetVertexShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVertexShaderConstant", XTL::EMUPATCH(D3DDevice_GetVertexShaderConstant), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVertexShaderDeclaration", XTL::EMUPATCH(D3DDevice_GetVertexShaderDeclaration), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVertexShaderFunction", XTL::EMUPATCH(D3DDevice_GetVertexShaderFunction), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVertexShaderInput", XTL::EMUPATCH(D3DDevice_GetVertexShaderInput), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVertexShaderSize", XTL::EMUPATCH(D3DDevice_GetVertexShaderSize), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVertexShaderType", XTL::EMUPATCH(D3DDevice_GetVertexShaderType), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetViewportOffsetAndScale", XTL::EMUPATCH(D3DDevice_GetViewportOffsetAndScale), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetVisibilityTestResult", XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_InsertCallback", XTL::EMUPATCH(D3DDevice_InsertCallback), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_InsertFence", XTL::EMUPATCH(D3DDevice_InsertFence), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_IsBusy", XTL::EMUPATCH(D3DDevice_IsBusy), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_IsFencePending", XTL::EMUPATCH(D3DDevice_IsFencePending), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_LightEnable", XTL::EMUPATCH(D3DDevice_LightEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_LoadVertexShader", XTL::EMUPATCH(D3DDevice_LoadVertexShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_LoadVertexShaderProgram", XTL::EMUPATCH(D3DDevice_LoadVertexShaderProgram), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_LoadVertexShader_0", XTL::EMUPATCH(D3DDevice_LoadVertexShader_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_LoadVertexShader_4", XTL::EMUPATCH(D3DDevice_LoadVertexShader_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_MultiplyTransform", XTL::EMUPATCH(D3DDevice_MultiplyTransform), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_PersistDisplay", XTL::EMUPATCH(D3DDevice_PersistDisplay), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_Present", XTL::EMUPATCH(D3DDevice_Present), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_PrimeVertexCache", XTL::EMUPATCH(D3DDevice_PrimeVertexCache), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_RunPushBuffer", XTL::EMUPATCH(D3DDevice_RunPushBuffer), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_RunVertexStateShader", XTL::EMUPATCH(D3DDevice_RunVertexStateShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SelectVertexShader", XTL::EMUPATCH(D3DDevice_SelectVertexShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SelectVertexShaderDirect", XTL::EMUPATCH(D3DDevice_SelectVertexShaderDirect), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SelectVertexShader_0", XTL::EMUPATCH(D3DDevice_SelectVertexShader_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SelectVertexShader_4", XTL::EMUPATCH(D3DDevice_SelectVertexShader_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetBackBufferScale", XTL::EMUPATCH(D3DDevice_SetBackBufferScale), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetDepthClipPlanes", XTL::EMUPATCH(D3DDevice_SetDepthClipPlanes), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetFlickerFilter", XTL::EMUPATCH(D3DDevice_SetFlickerFilter), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetFlickerFilter_0", XTL::EMUPATCH(D3DDevice_SetFlickerFilter_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetGammaRamp", XTL::EMUPATCH(D3DDevice_SetGammaRamp), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetIndices", XTL::EMUPATCH(D3DDevice_SetIndices), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetLight", XTL::EMUPATCH(D3DDevice_SetLight), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetMaterial", XTL::EMUPATCH(D3DDevice_SetMaterial), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetModelView", XTL::EMUPATCH(D3DDevice_SetModelView), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetPalette", XTL::EMUPATCH(D3DDevice_SetPalette), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetPalette_4", XTL::EMUPATCH(D3DDevice_SetPalette_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetPixelShader", XTL::EMUPATCH(D3DDevice_SetPixelShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetPixelShaderConstant_4", XTL::EMUPATCH(D3DDevice_SetPixelShaderConstant_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetPixelShader_0", XTL::EMUPATCH(D3DDevice_SetPixelShader_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_BackFillMode", XTL::EMUPATCH(D3DDevice_SetRenderState_BackFillMode), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_CullMode", XTL::EMUPATCH(D3DDevice_SetRenderState_CullMode), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_DoNotCullUncompressed", XTL::EMUPATCH(D3DDevice_SetRenderState_DoNotCullUncompressed), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_Dxt1NoiseEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_Dxt1NoiseEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_EdgeAntiAlias", XTL::EMUPATCH(D3DDevice_SetRenderState_EdgeAntiAlias), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_FillMode", XTL::EMUPATCH(D3DDevice_SetRenderState_FillMode), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_FogColor", XTL::EMUPATCH(D3DDevice_SetRenderState_FogColor), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_FrontFace", XTL::EMUPATCH(D3DDevice_SetRenderState_FrontFace), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_LineWidth", XTL::EMUPATCH(D3DDevice_SetRenderState_LineWidth), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_LogicOp", XTL::EMUPATCH(D3DDevice_SetRenderState_LogicOp), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_MultiSampleAntiAlias", XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleAntiAlias), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_MultiSampleMask", XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleMask), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_MultiSampleMode", XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleMode), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_MultiSampleRenderTargetMode", XTL::EMUPATCH(D3DDevice_SetRenderState_MultiSampleRenderTargetMode), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_NormalizeNormals", XTL::EMUPATCH(D3DDevice_SetRenderState_NormalizeNormals), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_OcclusionCullEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_OcclusionCullEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_PSTextureModes", XTL::EMUPATCH(D3DDevice_SetRenderState_PSTextureModes), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_RopZCmpAlwaysRead", XTL::EMUPATCH(D3DDevice_SetRenderState_RopZCmpAlwaysRead), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_RopZRead", XTL::EMUPATCH(D3DDevice_SetRenderState_RopZRead), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_SampleAlpha", XTL::EMUPATCH(D3DDevice_SetRenderState_SampleAlpha), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_ShadowFunc", XTL::EMUPATCH(D3DDevice_SetRenderState_ShadowFunc), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_Simple", XTL::EMUPATCH(D3DDevice_SetRenderState_Simple), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_StencilCullEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_StencilCullEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_StencilEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_StencilEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_StencilFail", XTL::EMUPATCH(D3DDevice_SetRenderState_StencilFail), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_TextureFactor", XTL::EMUPATCH(D3DDevice_SetRenderState_TextureFactor), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_TwoSidedLighting", XTL::EMUPATCH(D3DDevice_SetRenderState_TwoSidedLighting), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_VertexBlend", XTL::EMUPATCH(D3DDevice_SetRenderState_VertexBlend), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_YuvEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_YuvEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_ZBias", XTL::EMUPATCH(D3DDevice_SetRenderState_ZBias), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderState_ZEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_ZEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderTarget", XTL::EMUPATCH(D3DDevice_SetRenderTarget), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetRenderTargetFast", XTL::EMUPATCH(D3DDevice_SetRenderTargetFast), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetScreenSpaceOffset", XTL::EMUPATCH(D3DDevice_SetScreenSpaceOffset), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetShaderConstantMode", XTL::EMUPATCH(D3DDevice_SetShaderConstantMode), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetShaderConstantMode_0", XTL::EMUPATCH(D3DDevice_SetShaderConstantMode_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetSoftDisplayFilter", XTL::EMUPATCH(D3DDevice_SetSoftDisplayFilter), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetStateUP", XTL::EMUPATCH(D3DDevice_SetStateUP), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetStateVB", XTL::EMUPATCH(D3DDevice_SetStateVB), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetStipple", XTL::EMUPATCH(D3DDevice_SetStipple), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetStreamSource", XTL::EMUPATCH(D3DDevice_SetStreamSource), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetStreamSource_4", XTL::EMUPATCH(D3DDevice_SetStreamSource_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetStreamSource_8", XTL::EMUPATCH(D3DDevice_SetStreamSource_8), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetSwapCallback", XTL::EMUPATCH(D3DDevice_SetSwapCallback), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTexture", XTL::EMUPATCH(D3DDevice_SetTexture), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_BorderColor", XTL::EMUPATCH(D3DDevice_SetTextureState_BorderColor), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_BorderColor_0", XTL::EMUPATCH(D3DDevice_SetTextureState_BorderColor_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_BorderColor_4", XTL::EMUPATCH(D3DDevice_SetTextureState_BorderColor_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_BumpEnv", XTL::EMUPATCH(D3DDevice_SetTextureState_BumpEnv), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_BumpEnv_8", XTL::EMUPATCH(D3DDevice_SetTextureState_BumpEnv_8), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_ColorKeyColor", XTL::EMUPATCH(D3DDevice_SetTextureState_ColorKeyColor), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_ColorKeyColor_0", XTL::EMUPATCH(D3DDevice_SetTextureState_ColorKeyColor_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_ColorKeyColor_4", XTL::EMUPATCH(D3DDevice_SetTextureState_ColorKeyColor_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_TexCoordIndex", XTL::EMUPATCH(D3DDevice_SetTextureState_TexCoordIndex), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_TexCoordIndex_0", XTL::EMUPATCH(D3DDevice_SetTextureState_TexCoordIndex_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTextureState_TexCoordIndex_4", XTL::EMUPATCH(D3DDevice_SetTextureState_TexCoordIndex_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTexture_4", XTL::EMUPATCH(D3DDevice_SetTexture_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTransform", XTL::EMUPATCH(D3DDevice_SetTransform), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTransform_0", XTL::EMUPATCH(D3DDevice_SetTransform_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexData2f", XTL::EMUPATCH(D3DDevice_SetVertexData2f), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexData2s", XTL::EMUPATCH(D3DDevice_SetVertexData2s), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexData4f", XTL::EMUPATCH(D3DDevice_SetVertexData4f), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexData4s", XTL::EMUPATCH(D3DDevice_SetVertexData4s), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexData4ub", XTL::EMUPATCH(D3DDevice_SetVertexData4ub), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexDataColor", XTL::EMUPATCH(D3DDevice_SetVertexDataColor), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShader", XTL::EMUPATCH(D3DDevice_SetVertexShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant", XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant1", XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant1), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant1Fast", XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant1Fast), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant4", XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant4), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstantNotInline", XTL::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstantNotInlineFast", XTL::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInlineFast), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant_8", XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant_8), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderInput", XTL::EMUPATCH(D3DDevice_SetVertexShaderInput), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderInputDirect", XTL::EMUPATCH(D3DDevice_SetVertexShaderInputDirect), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVerticalBlankCallback", XTL::EMUPATCH(D3DDevice_SetVerticalBlankCallback), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetViewport", XTL::EMUPATCH(D3DDevice_SetViewport), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_Swap", XTL::EMUPATCH(D3DDevice_Swap), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_Swap_0", XTL::EMUPATCH(D3DDevice_Swap_0), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SwitchTexture", XTL::EMUPATCH(D3DDevice_SwitchTexture), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_UpdateOverlay", XTL::EMUPATCH(D3DDevice_UpdateOverlay), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DPalette_Lock", XTL::EMUPATCH(D3DPalette_Lock), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DPalette_Lock2", XTL::EMUPATCH(D3DPalette_Lock2), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DResource_BlockUntilNotBusy", XTL::EMUPATCH(D3DResource_BlockUntilNotBusy), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DResource_Release", XTL::EMUPATCH(D3DResource_Release), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3D_BlockOnTime", XTL::EMUPATCH(D3D_BlockOnTime), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3D_LazySetPointParams", XTL::EMUPATCH(D3D_LazySetPointParams), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3D_SetCommonDebugRegisters", XTL::EMUPATCH(D3D_SetCommonDebugRegisters), PATCH_HLE_D3D),
+	PATCH_ENTRY("Direct3D_CreateDevice", XTL::EMUPATCH(Direct3D_CreateDevice), PATCH_HLE_D3D),
+	PATCH_ENTRY("Direct3D_CreateDevice_16", XTL::EMUPATCH(Direct3D_CreateDevice_16), PATCH_HLE_D3D),
+	PATCH_ENTRY("Direct3D_CreateDevice_4", XTL::EMUPATCH(Direct3D_CreateDevice_4), PATCH_HLE_D3D),
+	PATCH_ENTRY("Lock2DSurface", XTL::EMUPATCH(Lock2DSurface), PATCH_HLE_D3D),
+	PATCH_ENTRY("Lock3DSurface", XTL::EMUPATCH(Lock3DSurface), PATCH_HLE_D3D),
+
+	// DSOUND
+	PATCH_ENTRY("CDirectSoundStream_AddRef", XTL::EMUPATCH(CDirectSoundStream_AddRef), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_Discontinuity", XTL::EMUPATCH(CDirectSoundStream_Discontinuity), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_Flush", XTL::EMUPATCH(CDirectSoundStream_Flush), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_FlushEx", XTL::EMUPATCH(CDirectSoundStream_FlushEx), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_GetInfo", XTL::EMUPATCH(CDirectSoundStream_GetInfo), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_GetStatus", XTL::EMUPATCH(CDirectSoundStream_GetStatus), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_GetVoiceProperties", XTL::EMUPATCH(CDirectSoundStream_GetVoiceProperties), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_Pause", XTL::EMUPATCH(CDirectSoundStream_Pause), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_PauseEx", XTL::EMUPATCH(CDirectSoundStream_PauseEx), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_Process", XTL::EMUPATCH(CDirectSoundStream_Process), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_Release", XTL::EMUPATCH(CDirectSoundStream_Release), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetAllParameters", XTL::EMUPATCH(CDirectSoundStream_SetAllParameters), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetConeAngles", XTL::EMUPATCH(CDirectSoundStream_SetConeAngles), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetConeOrientation", XTL::EMUPATCH(CDirectSoundStream_SetConeOrientation), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetConeOutsideVolume", XTL::EMUPATCH(CDirectSoundStream_SetConeOutsideVolume), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetDistanceFactor", XTL::EMUPATCH(CDirectSoundStream_SetDistanceFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetDopplerFactor", XTL::EMUPATCH(CDirectSoundStream_SetDopplerFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetEG", XTL::EMUPATCH(CDirectSoundStream_SetEG), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetFilter", XTL::EMUPATCH(CDirectSoundStream_SetFilter), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetFormat", XTL::EMUPATCH(CDirectSoundStream_SetFormat), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetFrequency", XTL::EMUPATCH(CDirectSoundStream_SetFrequency), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetHeadroom", XTL::EMUPATCH(CDirectSoundStream_SetHeadroom), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetI3DL2Source", XTL::EMUPATCH(CDirectSoundStream_SetI3DL2Source), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetLFO", XTL::EMUPATCH(CDirectSoundStream_SetLFO), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetMaxDistance", XTL::EMUPATCH(CDirectSoundStream_SetMaxDistance), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetMinDistance", XTL::EMUPATCH(CDirectSoundStream_SetMinDistance), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetMixBinVolumes_12", XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetMixBinVolumes_8", XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetMixBins", XTL::EMUPATCH(CDirectSoundStream_SetMixBins), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetMode", XTL::EMUPATCH(CDirectSoundStream_SetMode), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetOutputBuffer", XTL::EMUPATCH(CDirectSoundStream_SetOutputBuffer), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetPitch", XTL::EMUPATCH(CDirectSoundStream_SetPitch), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetPosition", XTL::EMUPATCH(CDirectSoundStream_SetPosition), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetRolloffCurve", XTL::EMUPATCH(CDirectSoundStream_SetRolloffCurve), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetRolloffFactor", XTL::EMUPATCH(CDirectSoundStream_SetRolloffFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetVelocity", XTL::EMUPATCH(CDirectSoundStream_SetVelocity), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSoundStream_SetVolume", XTL::EMUPATCH(CDirectSoundStream_SetVolume), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSound_CommitDeferredSettings", XTL::EMUPATCH(CDirectSound_CommitDeferredSettings), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSound_GetSpeakerConfig", XTL::EMUPATCH(CDirectSound_GetSpeakerConfig), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CDirectSound_SynchPlayback", XTL::EMUPATCH(CDirectSound_SynchPlayback), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("CMcpxStream_Dummy_0x10", XTL::EMUPATCH(CMcpxStream_Dummy_0x10), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundCreate", XTL::EMUPATCH(DirectSoundCreate), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundCreateBuffer", XTL::EMUPATCH(DirectSoundCreateBuffer), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundCreateStream", XTL::EMUPATCH(DirectSoundCreateStream), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundDoWork", XTL::EMUPATCH(DirectSoundDoWork), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundGetSampleTime", XTL::EMUPATCH(DirectSoundGetSampleTime), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundUseFullHRTF", XTL::EMUPATCH(DirectSoundUseFullHRTF), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundUseFullHRTF4Channel", XTL::EMUPATCH(DirectSoundUseFullHRTF4Channel), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundUseLightHRTF", XTL::EMUPATCH(DirectSoundUseLightHRTF), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("DirectSoundUseLightHRTF4Channel", XTL::EMUPATCH(DirectSoundUseLightHRTF4Channel), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_AddRef", XTL::EMUPATCH(IDirectSoundBuffer_AddRef), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_GetCurrentPosition", XTL::EMUPATCH(IDirectSoundBuffer_GetCurrentPosition), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_GetStatus", XTL::EMUPATCH(IDirectSoundBuffer_GetStatus), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_GetVoiceProperties", XTL::EMUPATCH(IDirectSoundBuffer_GetVoiceProperties), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_Lock", XTL::EMUPATCH(IDirectSoundBuffer_Lock), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_Pause", XTL::EMUPATCH(IDirectSoundBuffer_Pause), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_PauseEx", XTL::EMUPATCH(IDirectSoundBuffer_PauseEx), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_Play", XTL::EMUPATCH(IDirectSoundBuffer_Play), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_PlayEx", XTL::EMUPATCH(IDirectSoundBuffer_PlayEx), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_Release", XTL::EMUPATCH(IDirectSoundBuffer_Release), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetAllParameters", XTL::EMUPATCH(IDirectSoundBuffer_SetAllParameters), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetBufferData", XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetConeAngles", XTL::EMUPATCH(IDirectSoundBuffer_SetConeAngles), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetConeOrientation", XTL::EMUPATCH(IDirectSoundBuffer_SetConeOrientation), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetConeOutsideVolume", XTL::EMUPATCH(IDirectSoundBuffer_SetConeOutsideVolume), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetCurrentPosition", XTL::EMUPATCH(IDirectSoundBuffer_SetCurrentPosition), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetDistanceFactor", XTL::EMUPATCH(IDirectSoundBuffer_SetDistanceFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetDopplerFactor", XTL::EMUPATCH(IDirectSoundBuffer_SetDopplerFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetEG", XTL::EMUPATCH(IDirectSoundBuffer_SetEG), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetFilter", XTL::EMUPATCH(IDirectSoundBuffer_SetFilter), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetFormat", XTL::EMUPATCH(IDirectSoundBuffer_SetFormat), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetFrequency", XTL::EMUPATCH(IDirectSoundBuffer_SetFrequency), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetHeadroom", XTL::EMUPATCH(IDirectSoundBuffer_SetHeadroom), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetI3DL2Source", XTL::EMUPATCH(IDirectSoundBuffer_SetI3DL2Source), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetLFO", XTL::EMUPATCH(IDirectSoundBuffer_SetLFO), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetLoopRegion", XTL::EMUPATCH(IDirectSoundBuffer_SetLoopRegion), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetMaxDistance", XTL::EMUPATCH(IDirectSoundBuffer_SetMaxDistance), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetMinDistance", XTL::EMUPATCH(IDirectSoundBuffer_SetMinDistance), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetMixBinVolumes_12", XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_12), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetMixBinVolumes_8", XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_8), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetMixBins", XTL::EMUPATCH(IDirectSoundBuffer_SetMixBins), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetMode", XTL::EMUPATCH(IDirectSoundBuffer_SetMode), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetNotificationPositions", XTL::EMUPATCH(IDirectSoundBuffer_SetNotificationPositions), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetOutputBuffer", XTL::EMUPATCH(IDirectSoundBuffer_SetOutputBuffer), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetPitch", XTL::EMUPATCH(IDirectSoundBuffer_SetPitch), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetPlayRegion", XTL::EMUPATCH(IDirectSoundBuffer_SetPlayRegion), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetPosition", XTL::EMUPATCH(IDirectSoundBuffer_SetPosition), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetRolloffCurve", XTL::EMUPATCH(IDirectSoundBuffer_SetRolloffCurve), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetRolloffFactor", XTL::EMUPATCH(IDirectSoundBuffer_SetRolloffFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetVelocity", XTL::EMUPATCH(IDirectSoundBuffer_SetVelocity), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_SetVolume", XTL::EMUPATCH(IDirectSoundBuffer_SetVolume), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_Stop", XTL::EMUPATCH(IDirectSoundBuffer_Stop), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_StopEx", XTL::EMUPATCH(IDirectSoundBuffer_StopEx), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_Unlock", XTL::EMUPATCH(IDirectSoundBuffer_Unlock), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundBuffer_Use3DVoiceData", XTL::EMUPATCH(IDirectSoundBuffer_Use3DVoiceData), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetEG", XTL::EMUPATCH(IDirectSoundStream_SetEG), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetFilter", XTL::EMUPATCH(IDirectSoundStream_SetFilter), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetFrequency", XTL::EMUPATCH(IDirectSoundStream_SetFrequency), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetHeadroom", XTL::EMUPATCH(IDirectSoundStream_SetHeadroom), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetLFO", XTL::EMUPATCH(IDirectSoundStream_SetLFO), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetMixBins", XTL::EMUPATCH(IDirectSoundStream_SetMixBins), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetPitch", XTL::EMUPATCH(IDirectSoundStream_SetPitch), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSoundStream_SetVolume", XTL::EMUPATCH(IDirectSoundStream_SetVolume), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_AddRef", XTL::EMUPATCH(IDirectSound_AddRef), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_CommitDeferredSettings", XTL::EMUPATCH(IDirectSound_CommitDeferredSettings), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_CommitEffectData", XTL::EMUPATCH(IDirectSound_CommitEffectData), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_CreateSoundBuffer", XTL::EMUPATCH(IDirectSound_CreateSoundBuffer), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_CreateSoundStream", XTL::EMUPATCH(IDirectSound_CreateSoundStream), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_DownloadEffectsImage", XTL::EMUPATCH(IDirectSound_DownloadEffectsImage), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_EnableHeadphones", XTL::EMUPATCH(IDirectSound_EnableHeadphones), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_GetCaps", XTL::EMUPATCH(IDirectSound_GetCaps), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_GetEffectData", XTL::EMUPATCH(IDirectSound_GetEffectData), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_GetOutputLevels", XTL::EMUPATCH(IDirectSound_GetOutputLevels), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_GetSpeakerConfig", XTL::EMUPATCH(IDirectSound_GetSpeakerConfig), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_Release", XTL::EMUPATCH(IDirectSound_Release), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetAllParameters", XTL::EMUPATCH(IDirectSound_SetAllParameters), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetDistanceFactor", XTL::EMUPATCH(IDirectSound_SetDistanceFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetDopplerFactor", XTL::EMUPATCH(IDirectSound_SetDopplerFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetEffectData", XTL::EMUPATCH(IDirectSound_SetEffectData), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetI3DL2Listener", XTL::EMUPATCH(IDirectSound_SetI3DL2Listener), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetMixBinHeadroom", XTL::EMUPATCH(IDirectSound_SetMixBinHeadroom), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetOrientation", XTL::EMUPATCH(IDirectSound_SetOrientation), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetPosition", XTL::EMUPATCH(IDirectSound_SetPosition), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetRolloffFactor", XTL::EMUPATCH(IDirectSound_SetRolloffFactor), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SetVelocity", XTL::EMUPATCH(IDirectSound_SetVelocity), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("IDirectSound_SynchPlayback", XTL::EMUPATCH(IDirectSound_SynchPlayback), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("XAudioCreateAdpcmFormat", XTL::EMUPATCH(XAudioCreateAdpcmFormat), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("XAudioDownloadEffectsImage", XTL::EMUPATCH(XAudioDownloadEffectsImage), PATCH_HLE_DSOUND),
+	PATCH_ENTRY("XAudioSetEffectData", XTL::EMUPATCH(XAudioSetEffectData), PATCH_HLE_DSOUND),
+
+	// OHCI
+	PATCH_ENTRY("XGetDeviceChanges", XTL::EMUPATCH(XGetDeviceChanges), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XGetDeviceEnumerationStatus", XTL::EMUPATCH(XGetDeviceEnumerationStatus), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XGetDevices", XTL::EMUPATCH(XGetDevices), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInitDevices", XTL::EMUPATCH(XInitDevices), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInputClose", XTL::EMUPATCH(XInputClose), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInputGetCapabilities", XTL::EMUPATCH(XInputGetCapabilities), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInputGetDeviceDescription", XTL::EMUPATCH(XInputGetDeviceDescription), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInputGetState", XTL::EMUPATCH(XInputGetState), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInputOpen", XTL::EMUPATCH(XInputOpen), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInputPoll", XTL::EMUPATCH(XInputPoll), PATCH_HLE_OHCI),
+	PATCH_ENTRY("XInputSetState", XTL::EMUPATCH(XInputSetState), PATCH_HLE_OHCI),
+
+	// XAPI
+	PATCH_ENTRY("ConvertThreadToFiber", XTL::EMUPATCH(ConvertThreadToFiber), PATCH_ALWAYS),
+	PATCH_ENTRY("CreateFiber", XTL::EMUPATCH(CreateFiber), PATCH_ALWAYS),
+	PATCH_ENTRY("DeleteFiber", XTL::EMUPATCH(DeleteFiber), PATCH_ALWAYS),
+	PATCH_ENTRY("GetExitCodeThread", XTL::EMUPATCH(GetExitCodeThread), PATCH_ALWAYS),
+	PATCH_ENTRY("GetThreadPriority", XTL::EMUPATCH(GetThreadPriority), PATCH_ALWAYS),
+	PATCH_ENTRY("OutputDebugStringA", XTL::EMUPATCH(OutputDebugStringA), PATCH_ALWAYS),
+	PATCH_ENTRY("QueryPerformanceCounter", XTL::EMUPATCH(QueryPerformanceCounter), PATCH_ALWAYS),
+	PATCH_ENTRY("RaiseException", XTL::EMUPATCH(RaiseException), PATCH_ALWAYS),
+	PATCH_ENTRY("SetThreadPriority", XTL::EMUPATCH(SetThreadPriority), PATCH_ALWAYS),
+	PATCH_ENTRY("SetThreadPriorityBoost", XTL::EMUPATCH(SetThreadPriorityBoost), PATCH_ALWAYS),
+	PATCH_ENTRY("SignalObjectAndWait", XTL::EMUPATCH(SignalObjectAndWait), PATCH_ALWAYS),
+	PATCH_ENTRY("SwitchToFiber", XTL::EMUPATCH(SwitchToFiber), PATCH_ALWAYS),
+	PATCH_ENTRY("XMountMUA", XTL::EMUPATCH(XMountMUA), PATCH_ALWAYS),
+	PATCH_ENTRY("XMountMURootA", XTL::EMUPATCH(XMountMURootA), PATCH_ALWAYS),
+	PATCH_ENTRY("XSetProcessQuantumLength", XTL::EMUPATCH(XSetProcessQuantumLength), PATCH_ALWAYS),
+	PATCH_ENTRY("XUnmountAlternateTitleA", XTL::EMUPATCH(XUnmountAlternateTitleA), PATCH_ALWAYS),
+	PATCH_ENTRY("timeKillEvent", XTL::EMUPATCH(timeKillEvent), PATCH_ALWAYS),
+	PATCH_ENTRY("timeSetEvent", XTL::EMUPATCH(timeSetEvent), PATCH_ALWAYS),
+};
+
+std::unordered_map<std::string, subhook::Hook> g_FunctionHooks;
+
+// NOTE: EmuInstallPatch do not get to be in XbSymbolDatabase, do the patches in Cxbx project only.
+inline void EmuInstallPatch(std::string FunctionName, xbaddr FunctionAddr)
+{
+	auto it = g_PatchTable.find(FunctionName);
+	if (it == g_PatchTable.end()) {
+		return;
+	}
+
+	auto patch = it->second;
+
+	if ((patch.flags & PATCH_HLE_D3D) && bLLE_GPU) {
+		printf("HLE: %s: Skipped (LLE GPU Enabled)\n", FunctionName.c_str());
+		return;
+	}
+
+	if ((patch.flags & PATCH_HLE_DSOUND) && bLLE_APU) {
+		printf("HLE: %s: Skipped (LLE APU Enabled)\n", FunctionName.c_str());
+		return;
+	}
+
+	if ((patch.flags & PATCH_HLE_OHCI) && bLLE_USB) {
+		printf("HLE: %s: Skipped (LLE OHCI Enabled)\n", FunctionName.c_str());
+		return;
+	}
+
+	g_FunctionHooks[FunctionName].Install((void*)(FunctionAddr), (void*)patch.patchFunc);
+	printf("HLE: %s Patched\n", FunctionName.c_str());
+}
+
+void EmuInstallPatches()
+{
+	for (const auto& it : g_SymbolAddresses) {
+		EmuInstallPatch(it.first, it.second);
+	}
+}
+
+void* GetPatchedFunctionTrampoline(std::string functionName)
+{
+	if (g_FunctionHooks.find(functionName) != g_FunctionHooks.end()) {
+		return g_FunctionHooks[functionName].GetTrampoline();
+	}
+
+	return nullptr;
+}

--- a/src/CxbxKrnl/HLEPatches.h
+++ b/src/CxbxKrnl/HLEPatches.h
@@ -1,0 +1,38 @@
+// ******************************************************************
+// *
+// *    .,-:::::    .,::      .::::::::.    .,::      .:
+// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;;
+// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['
+// *  $$$              Y$$$P     $$""""Y$$     Y$$$P
+// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,
+// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
+// *
+// *   Cxbx->Win32->CxbxKrnl->HLEPatches.h
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2018 Luke Usher <luke.usher@outlook.com>
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+#include <string>
+
+void EmuInstallPatches();
+void* GetPatchedFunctionTrampoline(std::string functionName);


### PR DESCRIPTION
This allows for both steps to be completely disconnected, easily allowing patches to be turned on or off based on a set of flags, as well as preventing the need to clear the HLE cache when switching from HLE->LLE.

This also allows patches to be seen/modified from a central location, no more searching through the codebase to determine if a function should be patched or not, and no more 'FUNC_EXPORTS/GetProcAddress' magic!

Currently, this is used for HLE only, but could really shine when extended to introduce optional detour based logging even when LLE is enabled.

For example, We could easily add a LLE_D3D_DETOUR flag, which when enabled, patches functions with a wrapper, which simply logs input and output, calling the original Xbox function via a trampoline.

This would be great for debugging, as we'd get a full call trace from the API level, even when not implementing HLE.

There's also the possibility of mixing in some patches even with LLE enabled: for a hybrid HLE/LLE solution of the same functionality, but there are no plans to implement that at this moment of time.

NOTE: This has been verified by comparing a list of exports with the patch table that all patches that had a FUNC_EXPORT are present. There will be ZERO compatibility impact for this change.