### PR TITLE
Quick patch to fix Depth-Buffer issues in Crash Bandicoot: The Wrath of Cortex

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -6392,6 +6392,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_ZEnable)
 {
 	LOG_FUNC_ONE_ARG(Value);
 
+	XB_trampoline(VOID, WINAPI, D3DDevice_SetRenderState_ZEnable, (DWORD));
+	XB_D3DDevice_SetRenderState_ZEnable(Value);
+
 	HRESULT hRet = g_pD3DDevice->SetRenderState(D3DRS_ZENABLE, Value);
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetRenderState");
 }


### PR DESCRIPTION
Calling the unpatched trampoline of the patched function is enough to solve the issue: This further enforces that unpatching these functions and reading from NV2A state is the right thing to do, work will continue on that as a separate branch.

Before:
![image](https://user-images.githubusercontent.com/740003/44946457-ab28bf80-adf4-11e8-999d-475194ba9cc2.png)

After:
![image](https://user-images.githubusercontent.com/740003/44946474-eb883d80-adf4-11e8-8fb9-cfe24ae7e095.png)



