### PR TITLE
Use SimpleIni class for symbol cache file

### DIFF
--- a/resource/Cxbx.rc
+++ b/resource/Cxbx.rc
@@ -579,10 +579,10 @@ BEGIN
             MENUITEM "Store with Executable",       ID_SETTINGS_CONFIG_DLOCCURDIR,MFT_STRING,MFS_ENABLED
             MENUITEM "Custom",                      ID_SETTINGS_CONFIG_DLOCCUSTOM,MFT_STRING,MFS_ENABLED
         END
-        POPUP "&HLE Cache",                     65535,MFT_STRING,MFS_ENABLED
+        POPUP "&Symbol Cache",                     65535,MFT_STRING,MFS_ENABLED
         BEGIN
-            MENUITEM "&Clear entire HLE Cache",     ID_CACHE_CLEARHLECACHE_ALL,MFT_STRING,MFS_ENABLED
-            MENUITEM "&Rescan title HLE Cache",     ID_CACHE_CLEARHLECACHE_CURRENT,MFT_STRING,MFS_ENABLED
+            MENUITEM "&Clear entire Symbol Cache",     ID_CACHE_CLEARHLECACHE_ALL,MFT_STRING,MFS_ENABLED
+            MENUITEM "&Rescan title Symbol Cache",     ID_CACHE_CLEARHLECACHE_CURRENT,MFT_STRING,MFS_ENABLED
         END
         MENUITEM MFT_SEPARATOR
         POPUP "&LLE (Experimental)",            65535,MFT_STRING,MFS_ENABLED

--- a/src/Cxbx/WndMain.cpp
+++ b/src/Cxbx/WndMain.cpp
@@ -76,9 +76,9 @@ static int splashLogoWidth, splashLogoHeight;
 
 bool g_SaveOnExit = true;
 
-void ClearHLECache(const char sStorageLocation[MAX_PATH])
+void ClearSymbolCache(const char sStorageLocation[MAX_PATH])
 {
-	std::string cacheDir = std::string(sStorageLocation) + "\\HLECache\\";
+	std::string cacheDir = std::string(sStorageLocation) + "\\SymbolCache\\";
 	std::string fullpath = cacheDir + "*.ini";
 
 	WIN32_FIND_DATA data;
@@ -90,7 +90,7 @@ void ClearHLECache(const char sStorageLocation[MAX_PATH])
 			if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
 				fullpath = cacheDir + data.cFileName;
 
-				if (!DeleteFile(fullpath.c_str())) {
+				if (!std::experimental::filesystem::remove(fullpath)) {
 					break;
 				}
 			}
@@ -1049,14 +1049,14 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 
 			case ID_CACHE_CLEARHLECACHE_ALL:
 			{
-				ClearHLECache(g_Settings->GetDataLocation().c_str());
-				MessageBox(m_hwnd, "The entire HLE Cache has been cleared.", "Cxbx-Reloaded", MB_OK);
+				ClearSymbolCache(g_Settings->GetDataLocation().c_str());
+				MessageBox(m_hwnd, "The entire Symbol Cache has been cleared.", "Cxbx-Reloaded", MB_OK);
 			}
 			break;
 
 			case ID_CACHE_CLEARHLECACHE_CURRENT:
 			{
-				std::string cacheDir = g_Settings->GetDataLocation() + "\\HLECache\\";
+				std::string cacheDir = g_Settings->GetDataLocation() + "\\SymbolCache\\";
 
 				// Hash the loaded XBE's header, use it as a filename
 				uint32_t uiHash = XXHash32::hash((void*)&m_Xbe->m_Header, sizeof(Xbe::Header), 0);
@@ -1066,8 +1066,8 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				sstream << cacheDir << szTitleName << "-" << std::hex << uiHash << ".ini";
 				std::string fullpath = sstream.str();
 
-				if (DeleteFile(fullpath.c_str())) {
-					MessageBox(m_hwnd, "This title's HLE Cache entry has been cleared.", "Cxbx-Reloaded", MB_OK);
+				if (std::experimental::filesystem::remove(fullpath)) {
+					MessageBox(m_hwnd, "This title's Symbol Cache entry has been cleared.", "Cxbx-Reloaded", MB_OK);
 				}
 			}
 			break;

--- a/src/core/HLE/Intercept.cpp
+++ b/src/core/HLE/Intercept.cpp
@@ -29,7 +29,11 @@
 // *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
+// *  (c) 2016-2018 Luke Usher <luke.usher@outlook.com>
+// *  (c) 2016-2018 Patrick van Logchem <pvanlogchem@gmail.com>
 // *  (c) 2017-2018 RadWolfie
+// *  (c) 2017-2018 jarupxx
+// *  (c) 2018 x1nixmzeng
 // *
 // *  All rights reserved
 // *


### PR DESCRIPTION
refs #1416 

The following changes in this pull request are:
* Replace Windows API to SimpleIni class usage.
* Remove some keys no longer going to be used.
* Store symbol cache files into SymbolCache directory instead of HLECache.
* Replace spaces to tabs indent in edited functions.
* Add missing copyright authors

Before: 
[Blood Wake-376abe0f.ini](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/files/2347009/Blood.Wake-376abe0f.ini.txt)
After:
[Blood Wake-376abe0f.ini](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/files/2347010/Blood.Wake-376abe0f.ini.txt)

