### PR TITLE
Fixed the argc checks in winmain and CxbxKrnl.cpp

### DIFF
--- a/src/Cxbx/WinMain.cpp
+++ b/src/Cxbx/WinMain.cpp
@@ -84,7 +84,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		bKernel = true;
 
 		// Perform check if command line contain gui's hWnd value.
-		if (__argc > 2) {
+		if (__argc > 3) {
 			hWnd = (HWND)std::stoi(__argv[3], nullptr, 10);
 
 			hWnd = IsWindow(hWnd) ? hWnd : nullptr;

--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -869,19 +869,19 @@ void CxbxKrnlMain(int argc, char* argv[])
 
 	// Get DCHandle :
 	HWND hWnd = 0;
-	if (argc > 2) {
+	if (argc > 3) {
 		hWnd = (HWND)std::atoi(argv[3]);
 	}
 
 	// Get KernelDebugMode :
 	DebugMode DbgMode = DebugMode::DM_NONE;
-	if (argc > 3) {
+	if (argc > 4) {
 		DbgMode = (DebugMode)std::atoi(argv[4]);
 	}
 
 	// Get KernelDebugFileName :
 	std::string DebugFileName = "";
-	if (argc > 4) {
+	if (argc > 5) {
 		DebugFileName = argv[5];
 	}
 


### PR DESCRIPTION
WinMain.cpp and CxbxKrnl.cpp were checking the value of argc before using the value compared against to get a value out of argv. The value that was checked against was not the correct value though so these optional arguments were not being treated as optional and if left out the emulator would not start correctly in kernel mode.