### PR TITLE
Prevent dead-lock in VMManager::AllocateContiguous

### DIFF
--- a/src/CxbxKrnl/VMManager.cpp
+++ b/src/CxbxKrnl/VMManager.cpp
@@ -1003,13 +1003,13 @@ VAddr VMManager::AllocateContiguous(size_t Size, PAddr LowestAddress, PAddr High
 	HigherPfn = HighestAddress >> PAGE_SHIFT;
 	PfnAlignment = Alignment >> PAGE_SHIFT;
 
-	if (!IsMappable(PteNumber, true, false)) { goto Fail; }
 	if (HigherPfn > m_MaxContiguousPfn) { HigherPfn = m_MaxContiguousPfn; }
 	if (LowerPfn > HigherPfn) { LowerPfn = HigherPfn; }
 	if (!PfnAlignment) { PfnAlignment = 1; }
 
 	Lock();
 
+	if (!IsMappable(PteNumber, true, false)) { goto Fail; }
 	if (!RemoveFree(PteNumber, &pfn, PfnAlignment, LowerPfn, HigherPfn)) { goto Fail; }
 	addr = CONTIGUOUS_MEMORY_BASE + (pfn << PAGE_SHIFT);
 


### PR DESCRIPTION
Done by moving the if-IsMappable-goto-Fail line down below the Lock() call, so that we won't Unlock an unlocked critical section (which according to MS documentation, will cause a deadlock on the next call to EnterCriticaSection).

Source https://docs.microsoft.com/en-us/windows/desktop/api/synchapi/nf-synchapi-leavecriticalsection :
"If a thread calls LeaveCriticalSection when it does not have ownership of the specified critical section object, an error occurs that may cause another thread using EnterCriticalSection to wait indefinitely."