### PR TITLE
HLE overlay fix for Turok

### DIFF
--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp.unused-patches
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp.unused-patches
@@ -3002,3 +3002,16 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetBackMaterial)
 		hRet = D3D_OK;
 	}
 }
+
+// ******************************************************************
+// * patch: D3DDevice_SetRenderState_YuvEnable
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(D3DDevice_SetRenderState_YuvEnable)
+(
+    BOOL Enable
+)
+{
+	LOG_FUNC_ONE_ARG(Enable);
+
+    g_bColorSpaceConvertYuvToRgb = (Enable != FALSE);
+}

--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.h
@@ -1271,14 +1271,6 @@ VOID WINAPI EMUPATCH(D3DDevice_SetRenderState_ShadowFunc)
 );
 
 // ******************************************************************
-// * patch: D3DDevice_SetRenderState_YuvEnable
-// ******************************************************************
-VOID WINAPI EMUPATCH(D3DDevice_SetRenderState_YuvEnable)
-(
-    BOOL Enable
-);
-
-// ******************************************************************
 // * patch: D3DDevice_SetTransform
 // ******************************************************************
 VOID WINAPI EMUPATCH(D3DDevice_SetTransform)

--- a/src/core/HLE/D3D8/XbPushBuffer.cpp
+++ b/src/core/HLE/D3D8/XbPushBuffer.cpp
@@ -325,6 +325,13 @@ extern void pgraph_handle_method(
 // LLE NV2A
 extern NV2ADevice* g_NV2A;
 
+uint32_t HLE_read_NV2A_pgraph_register(const int reg)
+{
+	NV2AState* dev = g_NV2A->GetDeviceState();
+	PGRAPHState *pg = &(dev->pgraph);
+	return pg->regs[reg];
+}
+
 void HLE_write_NV2A_vertex_attribute_slot(unsigned slot, uint32_t parameter)
 {
 	// Write value to LLE NV2A device

--- a/src/core/HLE/Patches.cpp
+++ b/src/core/HLE/Patches.cpp
@@ -168,7 +168,6 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_SetRenderState_TextureFactor", XTL::EMUPATCH(D3DDevice_SetRenderState_TextureFactor), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetRenderState_TwoSidedLighting", XTL::EMUPATCH(D3DDevice_SetRenderState_TwoSidedLighting), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetRenderState_VertexBlend", XTL::EMUPATCH(D3DDevice_SetRenderState_VertexBlend), PATCH_HLE_D3D),
-	PATCH_ENTRY("D3DDevice_SetRenderState_YuvEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_YuvEnable), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetRenderState_ZBias", XTL::EMUPATCH(D3DDevice_SetRenderState_ZBias), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetRenderState_ZEnable", XTL::EMUPATCH(D3DDevice_SetRenderState_ZEnable), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetRenderTarget", XTL::EMUPATCH(D3DDevice_SetRenderTarget), PATCH_HLE_D3D),

--- a/src/devices/video/EmuNV2A_PGRAPH.cpp
+++ b/src/devices/video/EmuNV2A_PGRAPH.cpp
@@ -1264,6 +1264,12 @@ void pgraph_handle_method(NV2AState *d,
 			SET_MASK(pg->regs[NV_PGRAPH_CONTROL_0],
 				NV_PGRAPH_CONTROL_0_Z_PERSPECTIVE_ENABLE,
 				z_perspective);
+
+			int color_space_convert =
+				GET_MASK(parameter, NV097_SET_CONTROL0_COLOR_SPACE_CONVERT);
+			SET_MASK(pg->regs[NV_PGRAPH_CONTROL_0],
+				NV_PGRAPH_CONTROL_0_CSCONVERT,
+				color_space_convert);
 			break;
 		}
 

--- a/src/devices/video/nv2a_int.h
+++ b/src/devices/video/nv2a_int.h
@@ -477,6 +477,7 @@
 #   define NV_PGRAPH_CONTROL_0_RED_WRITE_ENABLE                 (1 << 27)
 #   define NV_PGRAPH_CONTROL_0_GREEN_WRITE_ENABLE               (1 << 28)
 #   define NV_PGRAPH_CONTROL_0_BLUE_WRITE_ENABLE                (1 << 29)
+#   define NV_PGRAPH_CONTROL_0_CSCONVERT                        (3 << 30)
 #define NV_PGRAPH_CONTROL_1                              0x00001950
 #   define NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE              (1 << 0)
 #   define NV_PGRAPH_CONTROL_1_STENCIL_FUNC                     0x000000F0
@@ -1110,6 +1111,7 @@
 #       define NV097_SET_CONTROL0_STENCIL_WRITE_ENABLE            (1 << 0)
 #       define NV097_SET_CONTROL0_Z_FORMAT                        (1 << 12)
 #       define NV097_SET_CONTROL0_Z_PERSPECTIVE_ENABLE            (1 << 16)
+#       define NV097_SET_CONTROL0_COLOR_SPACE_CONVERT             (0xF << 28)
 #   define NV097_SET_FOG_MODE                                 0x0000029C
 #       define NV097_SET_FOG_MODE_V_LINEAR                        0x2601
 #       define NV097_SET_FOG_MODE_V_EXP                           0x800


### PR DESCRIPTION
This was done by reading color-space conversion from PGRAPH (for which handling was added to NV097_SET_CONTROL0). This allowed removal of the D3DDevice_SetRenderState_YuvEnable patch.

Note, that we're still not doing anything special regarding color-space conversions; This is just an accuracy change.

This fixes #1435.

PS : Now that we're reading more and more state from PGRAPH (even under HLE GPU) we really need a push-buffer flush function!