### PR TITLE
Detect and fix the situation when EmuD3DDeferrdRenderState is derived incorrectly

### DIFF
--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
@@ -3220,11 +3220,17 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
 {
 	LOG_FUNC_ONE_ARG(pViewport);
 
-	D3DVIEWPORT HostViewPort = *pViewport;
-
 	// Always call the Xbox SetViewPort to update D3D Internal State
 	XB_trampoline(VOID, WINAPI, D3DDevice_SetViewport, (CONST X_D3DVIEWPORT8 *));
 	XB_D3DDevice_SetViewport(pViewport);
+
+	// Host does not support pViewPort = nullptr
+	if (pViewport == nullptr) {
+		LOG_TEST_CASE("pViewport = null");
+		return;
+	}
+
+	D3DVIEWPORT HostViewPort = *pViewport;
 
 	if (g_pXboxRenderTarget) {
 		// Get current Xbox render target dimensions

--- a/src/core/HLE/Intercept.cpp
+++ b/src/core/HLE/Intercept.cpp
@@ -306,6 +306,7 @@ void EmuD3D_Init_DeferredStates()
     if (g_SymbolAddresses.find("D3DDeferredRenderState") != g_SymbolAddresses.end()) {
         XTL::EmuD3DDeferredRenderState = (DWORD*)g_SymbolAddresses["D3DDeferredRenderState"];
     }
+
     if (g_SymbolAddresses.find("D3DDeferredTextureState") != g_SymbolAddresses.end()) {
         XTL::EmuD3DDeferredTextureState = (DWORD*)g_SymbolAddresses["D3DDeferredTextureState"];
     }


### PR DESCRIPTION
This may be re-worked in the future to drive D3D__RenderStates directly, without requiring extensive changes, potentially leading to the unpatching of all RenderState, and Pixel Shader functions!