### PR TITLE
NV2A : Fixed PGRAPH light handlers

### DIFF
--- a/src/devices/video/EmuNV2A_PGRAPH.cpp
+++ b/src/devices/video/EmuNV2A_PGRAPH.cpp
@@ -2082,8 +2082,7 @@ void pgraph_handle_method(NV2AState *d,
 		}
 
 		/* Handles NV097_SET_BACK_LIGHT_* */
-		CASE_78(NV097_SET_BACK_LIGHT_AMBIENT_COLOR, 4): {
-			// NV097_SET_BACK_LIGHT_SPECULAR_COLOR 0x00000C18 - 0x00000C00 + 0x1C8 = 0x1E0; /4= 78d
+		CASE_128(NV097_SET_BACK_LIGHT_AMBIENT_COLOR, 4): {
 			slot = (method - NV097_SET_BACK_LIGHT_AMBIENT_COLOR) / 4;
 			unsigned int part = NV097_SET_BACK_LIGHT_AMBIENT_COLOR / 4 + slot % 16;
 			slot /= 16; /* [Light index] */
@@ -2111,8 +2110,7 @@ void pgraph_handle_method(NV2AState *d,
 			break;
 		}
 		/* Handles all the light source props except for NV097_SET_BACK_LIGHT_* */
-		CASE_253(NV097_SET_LIGHT_AMBIENT_COLOR, 4): {
-			// NV097_SET_LIGHT_LOCAL_ATTENUATION 0x00001068 - 0x00001000 + 0x38C = 0x3F4; /4= 253d
+		CASE_256(NV097_SET_LIGHT_AMBIENT_COLOR, 4): {
 			slot = (method - NV097_SET_LIGHT_AMBIENT_COLOR) / 4;
 			unsigned int part = NV097_SET_LIGHT_AMBIENT_COLOR / 4 + slot % 32;
 			slot /= 32; /* [Light index] */

--- a/src/devices/video/nv2a.h
+++ b/src/devices/video/nv2a.h
@@ -131,18 +131,10 @@ static int ffs(register int valu)
 #define CASE_32(v, step) CASE_16(v, step) : CASE_16(v + (step) * 16, step)
 #define CASE_64(v, step) CASE_32(v, step) : CASE_32(v + (step) * 32, step)
 #define CASE_128(v, step) CASE_64(v, step) : CASE_64(v + (step) * 64, step)
+#define CASE_256(v, step) CASE_128(v, step) : CASE_128(v + (step) * 128, step)
 
 // Non-power-of-two CASE statements
 #define CASE_3(v, step) CASE_2(v, step) : CASE_1(v + (step) * 2, step)
-#define CASE_12(v, step) CASE_8(v, step) : CASE_4(v + (step) * 8, step)
-#define CASE_13(v, step) CASE_8(v, step) : CASE_3(v + (step) * 8, step)
-#define CASE_28(v, step) CASE_16(v, step) : CASE_12(v + (step) * 16, step)
-#define CASE_29(v, step) CASE_16(v, step) : CASE_13(v + (step) * 16, step)
-#define CASE_61(v, step) CASE_32(v, step) : CASE_29(v + (step) * 32, step)
-#define CASE_78(v, step) CASE_64(v, step) : CASE_12(v + (step) * 64, step)
-#define CASE_125(v, step) CASE_64(v, step) : CASE_61(v + (step) * 64, step)
-#define CASE_132(v, step) CASE_128(v, step) : CASE_4(v + (step) * 128, step)
-#define CASE_253(v, step) CASE_128(v, step) : CASE_125(v + (step) * 128, step)
 
 #define NV2A_DEVICE(obj) \
     OBJECT_CHECK(NV2AState, (obj), "nv2a")


### PR DESCRIPTION
The case statement wasn't covering the final few light slots, potentially causing black spots here and there (specifically in scenes that use all 8 lights).