### PR TITLE
Implement STOS, Inline OutputDebugStringA & Fix Vertex Declaration oversight

### DIFF
--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -3267,7 +3267,7 @@ bool EmuX86_DecodeException(LPEXCEPTION_POINTERS e)
 				while (counter != 0) {
 					if (EmuX86_Opcode_STOS(e, info)) {
 						counter--;
-						break;
+						continue;
 					}
 
 					goto opcode_error;

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -3272,6 +3272,7 @@ bool EmuX86_DecodeException(LPEXCEPTION_POINTERS e)
 
 					goto opcode_error;
 				}
+				break;
 			}
 			case I_SUB:
 				if (EmuX86_Opcode_SUB(e, info)) break;

--- a/src/CxbxKrnl/EmuX86.cpp
+++ b/src/CxbxKrnl/EmuX86.cpp
@@ -1502,6 +1502,8 @@ bool EmuX86_Opcode_STOS(LPEXCEPTION_POINTERS e, _DInst& info)
 		e->ContextRecord->Esi += size;
 		e->ContextRecord->Edi += size;
 	}
+
+	return true;
 }
 
 bool EmuX86_Opcode_SUB(LPEXCEPTION_POINTERS e, _DInst& info)

--- a/src/core/HLE/D3D8/XbD3D8Types.h
+++ b/src/core/HLE/D3D8/XbD3D8Types.h
@@ -516,7 +516,7 @@ typedef struct _CxbxVertexShader
     // we save them to be able to return them when necessary.
     UINT                  Size;
     DWORD                *pDeclaration;
-	DWORD                 OriginalDeclarationSize;
+	DWORD                 OriginalDeclarationCount;
 	XTL::LPDIRECT3DVERTEXDECLARATION9 pHostDeclaration;
 	DWORD                 HostDeclarationSize;
     DWORD                *pFunction;

--- a/src/core/HLE/D3D8/XbVertexShader.cpp
+++ b/src/core/HLE/D3D8/XbVertexShader.cpp
@@ -1768,7 +1768,7 @@ CxbxVertexShaderPatch;
 #define DEF_VSH_END 0xFFFFFFFF
 #define DEF_VSH_NOP 0x00000000
 
-static DWORD VshGetDeclarationSize(DWORD *pDeclaration)
+static DWORD VshGetDeclarationCount(DWORD *pDeclaration)
 {
     DWORD Pos = 0;
     while (*(pDeclaration + Pos) != DEF_VSH_END)
@@ -2361,7 +2361,7 @@ DWORD XTL::EmuRecompileVshDeclaration
 (
     DWORD                *pDeclaration,
 	D3DVERTEXELEMENT    **ppRecompiledDeclaration,
-    DWORD                *pOriginalDeclarationSize,
+    DWORD                *pOriginalDeclarationCount,
 	DWORD                *pHostDeclarationSize,
     boolean               IsFixedFunction,
     CxbxVertexShaderInfo *pVertexShaderInfo
@@ -2378,18 +2378,17 @@ DWORD XTL::EmuRecompileVshDeclaration
     // 0x00000000 - nop (means that this value is ignored)
 
     // Calculate size of declaration
-    DWORD DeclarationSize = VshGetDeclarationSize(pDeclaration);
-	*pOriginalDeclarationSize = DeclarationSize;
-
+    DWORD DeclarationCount = VshGetDeclarationCount(pDeclaration);
 	// For Direct3D9, we need to reserve at least twice the number of elements, as one token can generate two registers (in and out) :
-	DeclarationSize *= sizeof(D3DVERTEXELEMENT) * 2;
+	DWORD HostDeclarationSize = DeclarationCount * sizeof(D3DVERTEXELEMENT) * 2;
+	*pOriginalDeclarationCount = DeclarationCount;
+	*pHostDeclarationSize = HostDeclarationSize;
+	
+	D3DVERTEXELEMENT *pRecompiled = (D3DVERTEXELEMENT *)malloc(HostDeclarationSize);
+	memset(pRecompiled, 0, HostDeclarationSize);
 
-	D3DVERTEXELEMENT *pRecompiled = (D3DVERTEXELEMENT *)malloc(DeclarationSize);
-	memset(pRecompiled, 0, DeclarationSize);
-
-	uint8_t *pRecompiledBufferOverflow = ((uint8_t*)pRecompiled) + DeclarationSize;
+	uint8_t *pRecompiledBufferOverflow = ((uint8_t*)pRecompiled) + HostDeclarationSize;
     *ppRecompiledDeclaration = pRecompiled;
-    *pHostDeclarationSize = DeclarationSize;
 
     CxbxVertexShaderPatch PatchData = { 0 };
 	PatchData.pVertexShaderInfoToSet = pVertexShaderInfo;


### PR DESCRIPTION
This *may* fix some of the recent regressions after the d3d-tweaks PR was merged...
Please make sure to test before merged