### PR TITLE
Fix alter echo hang + remove force high priority

### DIFF
--- a/src/CxbxKrnl/CxbxKrnl.cpp
+++ b/src/CxbxKrnl/CxbxKrnl.cpp
@@ -1515,12 +1515,6 @@ __declspec(noreturn) void CxbxKrnlInit
 		}
 	}
 
-	// Set process priority to higher than default
-	// Gives a significant performance boost, even without the 'all cores' hack
-	// We could use HIGH or even REALTIME priority for a higher boost, but that would decrease host OS responsiveness
-	// TODO: Make this user configurable?
-	SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
-
 	// initialize graphics
 	DBG_PRINTF_EX(LOG_PREFIX_INIT, "Initializing render window.\n");
 	XTL::CxbxInitWindow(true);

--- a/src/devices/video/EmuNV2A_PCRTC.cpp
+++ b/src/devices/video/EmuNV2A_PCRTC.cpp
@@ -55,6 +55,25 @@ DEVICE_READ32(PCRTC)
 	case NV_PCRTC_START:
 		result = d->pcrtc.start;
 		break;
+	case 0x00000808: { // Register name unknown, NV_PCRTC_SCANLINE?, this returns the current scanline 
+		// Test case: Alter Echo
+		// Hack: Increment on every call, up-to the framebuffer height, satisfying titles waiting for any value
+		// TODO: Implement this in a better/more accurate way
+		static int scanline = 0;
+
+		// Derive frame_height from hardware registers
+		int frame_height = ((int)d->prmcio.cr[NV_CIO_CR_VDE_INDEX])
+			| (((int)d->prmcio.cr[NV_CIO_CR_OVL_INDEX] & 0x02) >> 1 << 8)
+			| (((int)d->prmcio.cr[NV_CIO_CR_OVL_INDEX] & 0x40) >> 6 << 9)
+			| (((int)d->prmcio.cr[NV_CIO_CRE_LSR_INDEX] & 0x02) >> 1 << 10);
+		frame_height++;
+
+		if (scanline > frame_height + 100 /* Increase range by 100 to allow overflow into VBlank*/) {
+			scanline = 0;
+		}
+
+		result = scanline++;
+	} break;
 	default: 
 		result = 0;
 		//DEVICE_READ32_REG(pcrtc); // Was : DEBUG_READ32_UNHANDLED(PCRTC);

--- a/src/devices/video/EmuNV2A_PCRTC.cpp
+++ b/src/devices/video/EmuNV2A_PCRTC.cpp
@@ -55,20 +55,15 @@ DEVICE_READ32(PCRTC)
 	case NV_PCRTC_START:
 		result = d->pcrtc.start;
 		break;
-	case NV_PCRTC_RASTER:
+	case NV_PCRTC_RASTER: {
 		// Test case: Alter Echo
 		// Hack: Increment on every call, up-to the framebuffer height, satisfying titles waiting for any value
 		// TODO: Implement this in a better/more accurate way
 		static int scanline = 0;
 
-		// Derive frame_height from hardware registers
-		int frame_height = ((int)d->prmcio.cr[NV_CIO_CR_VDE_INDEX])
-			| (((int)d->prmcio.cr[NV_CIO_CR_OVL_INDEX] & 0x02) >> 1 << 8)
-			| (((int)d->prmcio.cr[NV_CIO_CR_OVL_INDEX] & 0x40) >> 6 << 9)
-			| (((int)d->prmcio.cr[NV_CIO_CRE_LSR_INDEX] & 0x02) >> 1 << 10);
-		frame_height++;
-
-		if (scanline > frame_height + 100 /* Increase range by 100 to allow overflow into VBlank*/) {
+		// The exact range of the timer needs verifying on hardware, but it must exceed the frame-height to account for VBlank time
+		// For now, we use a constant of 100 and Alter Echo seems happy enough.
+		if (scanline > NV2ADevice::GetFrameHeight(d) + 100) {
 			scanline = 0;
 		}
 

--- a/src/devices/video/EmuNV2A_PCRTC.cpp
+++ b/src/devices/video/EmuNV2A_PCRTC.cpp
@@ -55,7 +55,7 @@ DEVICE_READ32(PCRTC)
 	case NV_PCRTC_START:
 		result = d->pcrtc.start;
 		break;
-	case 0x00000808: { // Register name unknown, NV_PCRTC_SCANLINE?, this returns the current scanline 
+	case NV_PCRTC_RASTER:
 		// Test case: Alter Echo
 		// Hack: Increment on every call, up-to the framebuffer height, satisfying titles waiting for any value
 		// TODO: Implement this in a better/more accurate way

--- a/src/devices/video/nv2a.h
+++ b/src/devices/video/nv2a.h
@@ -71,6 +71,9 @@ public:
 	void MMIOWrite(int barIndex, uint32_t addr, uint32_t value, unsigned size);
 
 	static void UpdateHostDisplay(NV2AState *d);
+
+	static int GetFrameWidth(NV2AState *d);
+	static int GetFrameHeight(NV2AState *d);
 private:
 	NV2AState *m_nv2a_state;
 };

--- a/src/devices/video/nv2a_regs.h
+++ b/src/devices/video/nv2a_regs.h
@@ -691,7 +691,6 @@
 #define NV_PCRTC_CONFIG                                  0x00000804
 #define NV_PCRTC_RASTER                                  0x00000808
 
-
 #define NV_PVIDEO_DEBUG_2                                0x00000088
 #define NV_PVIDEO_DEBUG_3                                0x0000008C
 #define NV_PVIDEO_INTR                                   0x00000100

--- a/src/devices/video/nv2a_regs.h
+++ b/src/devices/video/nv2a_regs.h
@@ -689,6 +689,7 @@
 #   define NV_PCRTC_INTR_EN_0_VBLANK                            (1 << 0)
 #define NV_PCRTC_START                                   0x00000800
 #define NV_PCRTC_CONFIG                                  0x00000804
+#define NV_PCRTC_RASTER                                  0x00000808
 
 
 #define NV_PVIDEO_DEBUG_2                                0x00000088


### PR DESCRIPTION
The Alter Echo hang was caused by the title using D3DDevice_GetRasterStatus.
This function read from an unimplemented register, which returns the current scanline.

As we don't track this information at present, it has been implemented as a dumb counter, it's not accurate by any means, but enough to get Alter Echo working.

![image](https://user-images.githubusercontent.com/740003/47533803-0cc55180-d8ad-11e8-8738-c46248c9ed61.png)
