### PR TITLE
Fix Virtua Cop 3 (Chihiro)

### DIFF
--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
@@ -3433,6 +3433,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 
 	// Now, we can create the host vertex shader
 	CxbxVertexShader* hostVertexShader = (CxbxVertexShader*)malloc(sizeof(CxbxVertexShader));
+	memset(hostVertexShader, 0, sizeof(CxbxVertexShader));
 
     LPD3DXBUFFER pRecompiledBuffer = NULL;
     DWORD        *pRecompiledDeclaration = NULL;

--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
@@ -3414,6 +3414,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 	XB_trampoline(HRESULT, WINAPI, D3DDevice_CreateVertexShader, (CONST DWORD*, CONST DWORD*, DWORD*, DWORD));
 	HRESULT hRet = XB_D3DDevice_CreateVertexShader(pDeclaration, pFunction, pHandle, Usage);
 	if (FAILED(hRet)) {
+		LOG_TEST_CASE("XB_D3DDevice_CreateVertexShader failed");
 		RETURN(hRet);
 	}
 
@@ -8091,18 +8092,21 @@ VOID __stdcall XTL::EMUPATCH(D3DDevice_DeleteVertexShader_0)
 VOID WINAPI XTL::EMUPATCH(D3DDevice_DeleteVertexShader)
 (
 	DWORD Handle
-	)
+)
 {
-		LOG_FUNC_ONE_ARG(Handle);
+	LOG_FUNC_ONE_ARG(Handle);
+
+	XB_trampoline(void, WINAPI, D3DDevice_DeleteVertexShader, (DWORD));
+	XB_D3DDevice_DeleteVertexShader(Handle);
 
 	// Handle is always address of an Xbox VertexShader struct, or-ed with 1 (X_D3DFVF_RESERVED0)
 	// It's reference count is lowered. If it reaches zero (0), the struct is freed.
+	
 
 	DWORD HostVertexShaderHandle = 0;
 
 	if (VshHandleIsVertexShader(Handle))
 	{
-		X_D3DVertexShader *pD3DVertexShader = VshHandleToXboxVertexShader(Handle);
 		CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 
 		if (pVertexShader->pHostDeclaration) {
@@ -8121,7 +8125,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DeleteVertexShader)
 
 		free(pVertexShader);
 		SetCxbxVertexShader(Handle, nullptr);
-		g_VMManager.Deallocate((VAddr)pD3DVertexShader);
 	}
 
 	// Don't attempt to release invalid null handles

--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
@@ -3427,7 +3427,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 
     // create emulated shader struct
     X_D3DVertexShader *pD3DVertexShader = (X_D3DVertexShader*)g_VMManager.AllocateZeroed(sizeof(X_D3DVertexShader));
-    CxbxVertexShader     *pVertexShader = (CxbxVertexShader*)g_VMManager.AllocateZeroed(sizeof(CxbxVertexShader));
+    CxbxVertexShader     *pVertexShader = (CxbxVertexShader*)malloc(sizeof(CxbxVertexShader));
 
     // TODO: Intelligently fill out these fields as necessary
 
@@ -3548,7 +3548,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 
     free(pRecompiledDeclaration);
 
-    pVertexShader->pDeclaration = (DWORD*)g_VMManager.Allocate(OriginalDeclarationCount * sizeof(DWORD));
+    pVertexShader->pDeclaration = (DWORD*)malloc(OriginalDeclarationCount * sizeof(DWORD));
     memcpy(pVertexShader->pDeclaration, pDeclaration, OriginalDeclarationCount * sizeof(DWORD));
 
     pVertexShader->FunctionSize = 0;
@@ -3562,7 +3562,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
     {
         if(pFunction != NULL)
         {
-            pVertexShader->pFunction = (DWORD*)g_VMManager.Allocate(VertexShaderSize);
+            pVertexShader->pFunction = (DWORD*)malloc(VertexShaderSize);
             memcpy(pVertexShader->pFunction, pFunction, VertexShaderSize);
             pVertexShader->FunctionSize = VertexShaderSize;
         }
@@ -8119,16 +8119,16 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DeleteVertexShader)
 		}
 
 		HostVertexShaderHandle = pVertexShader->Handle;
-		g_VMManager.Deallocate((VAddr)pVertexShader->pDeclaration);
+		free(pVertexShader->pDeclaration);
 
 		if (pVertexShader->pFunction)
 		{
-			g_VMManager.Deallocate((VAddr)pVertexShader->pFunction);
+			free(pVertexShader->pFunction);
 		}
 
 		FreeVertexDynamicPatch(pVertexShader);
 
-		g_VMManager.Deallocate((VAddr)pVertexShader);
+		free(pVertexShader);
 		g_VMManager.Deallocate((VAddr)pD3DVertexShader);
 	}
 

--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
@@ -2834,7 +2834,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShader_4)
 	// D3DDevice_LoadVertexShader pushes the program contained in the Xbox VertexShader struct to the NV2A
     if(Address < 136 && VshHandleIsVertexShader(Handle))
     {
-		CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+		CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
         for (DWORD i = Address; i < pVertexShader->Size; i++)
         {
             // TODO: This seems very fishy
@@ -2862,7 +2862,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShader)
 	// Address is the slot (offset) from which the program must be written onwards (as whole DWORDS)
 	// D3DDevice_LoadVertexShader pushes the program contained in the Xbox VertexShader struct to the NV2A
     if(Address < 136) {
-        CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+        CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 		if (pVertexShader) {
 			for (DWORD i = Address; i < pVertexShader->Size; i++) {
 				// TODO: This seems very fishy
@@ -2930,7 +2930,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShader)
 
     if(VshHandleIsVertexShader(Handle))
     {
-        CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+        CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 		hRet = g_pD3DDevice->SetVertexDeclaration(pVertexShader->pHostDeclaration);
 		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexDeclaration(VshHandleIsVertexShader)");
 		hRet = g_pD3DDevice->SetVertexShader((XTL::IDirect3DVertexShader9*)pVertexShader->Handle);
@@ -3410,36 +3410,28 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 		LOG_FUNC_ARG_TYPE(X_D3DUSAGE, Usage)
 		LOG_FUNC_END;
 
+	// First, we must call the Xbox CreateVertexShader function and check for success
+	XB_trampoline(HRESULT, WINAPI, D3DDevice_CreateVertexShader, (CONST DWORD*, CONST DWORD*, DWORD*, DWORD));
+	HRESULT hRet = XB_D3DDevice_CreateVertexShader(pDeclaration, pFunction, pHandle, Usage);
+	if (FAILED(hRet)) {
+		RETURN(hRet);
+	}
+
 	if (g_pD3DDevice == nullptr) {
 		LOG_TEST_CASE("D3DDevice_CreateVertexShader called before Direct3D_CreateDevice");
 		// We lie to allow the game to continue for now, but it probably won't work well
 		return STATUS_SUCCESS;
 	}
 
-	// Allocates an Xbox VertexShader struct
-	// Sets reference count to 1
-	// Puts Usage in VertexShader->Flags
-	// If pFunction is not null, it points to DWORDS shader type, length and a binary compiled xbox vertex shader
-	// If pDeclaration is not null, it's parsed, resulting in a number of constants
-	// Parse results are pushed to the push buffer
-	// Sets other fields
-	// pHandle recieves the addres of the new shader, or-ed with 1 (D3DFVF_RESERVED0)
-
-    // create emulated shader struct
-    X_D3DVertexShader *pD3DVertexShader = (X_D3DVertexShader*)g_VMManager.AllocateZeroed(sizeof(X_D3DVertexShader));
-    CxbxVertexShader     *pVertexShader = (CxbxVertexShader*)malloc(sizeof(CxbxVertexShader));
-
-    // TODO: Intelligently fill out these fields as necessary
-
     // HACK: TODO: support this situation
-    if(pDeclaration == NULL)
-    {
+    if(pDeclaration == NULL) {
+		LOG_TEST_CASE("Vertex shader without declaration");
         *pHandle = NULL;
-
-        
-
         return D3D_OK;
     }
+
+	// Now, we can create the host vertex shader
+	CxbxVertexShader* hostVertexShader = (CxbxVertexShader*)malloc(sizeof(CxbxVertexShader));
 
     LPD3DXBUFFER pRecompiledBuffer = NULL;
     DWORD        *pRecompiledDeclaration = NULL;
@@ -3449,23 +3441,23 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
     DWORD        HostDeclarationSize = 0;
     DWORD        Handle = 0;
 
-    HRESULT hRet = XTL::EmuRecompileVshDeclaration((DWORD*)pDeclaration,
+    hRet = XTL::EmuRecompileVshDeclaration((DWORD*)pDeclaration,
                                                    (XTL::D3DVERTEXELEMENT9**)&pRecompiledDeclaration,
 												   &OriginalDeclarationCount,
                                                    &HostDeclarationSize,
                                                    pFunction == NULL,
-                                                   &pVertexShader->VertexShaderInfo);
+                                                   &hostVertexShader->VertexShaderInfo);
 
 
 	// Create the vertex declaration
-	hRet = g_pD3DDevice->CreateVertexDeclaration((XTL::D3DVERTEXELEMENT9*)pRecompiledDeclaration, &pVertexShader->pHostDeclaration);
+	hRet = g_pD3DDevice->CreateVertexDeclaration((XTL::D3DVERTEXELEMENT9*)pRecompiledDeclaration, &hostVertexShader->pHostDeclaration);
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateVertexDeclaration");
 
 	if (FAILED(hRet)) {
 		// NOTE: This is a fatal error because it ALWAYS triggers a crash within DrawVertices if not set
 		CxbxKrnlCleanup("Failed to create Vertex Declaration");
 	}
-	g_pD3DDevice->SetVertexDeclaration(pVertexShader->pHostDeclaration);
+	g_pD3DDevice->SetVertexDeclaration(hostVertexShader->pHostDeclaration);
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexDeclaration");
 
 	if (SUCCEEDED(hRet) && pFunction)
@@ -3544,43 +3536,42 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 	}
 
     // Save the status, to remove things later
-    pVertexShader->Status = hRet;
+	hostVertexShader->Status = hRet;
 
     free(pRecompiledDeclaration);
 
-    pVertexShader->pDeclaration = (DWORD*)malloc(OriginalDeclarationCount * sizeof(DWORD));
-    memcpy(pVertexShader->pDeclaration, pDeclaration, OriginalDeclarationCount * sizeof(DWORD));
+	hostVertexShader->pDeclaration = (DWORD*)malloc(OriginalDeclarationCount * sizeof(DWORD));
+    memcpy(hostVertexShader->pDeclaration, pDeclaration, OriginalDeclarationCount * sizeof(DWORD));
 
-    pVertexShader->FunctionSize = 0;
-    pVertexShader->pFunction = NULL;
-    pVertexShader->Type = X_VST_NORMAL;
-    pVertexShader->Size = (VertexShaderSize - sizeof(VSH_SHADER_HEADER)) / VSH_INSTRUCTION_SIZE_BYTES;
-	pVertexShader->OriginalDeclarationCount = OriginalDeclarationCount;
-    pVertexShader->HostDeclarationSize = HostDeclarationSize;
+	hostVertexShader->FunctionSize = 0;
+	hostVertexShader->pFunction = NULL;
+	hostVertexShader->Type = X_VST_NORMAL;
+	hostVertexShader->Size = (VertexShaderSize - sizeof(VSH_SHADER_HEADER)) / VSH_INSTRUCTION_SIZE_BYTES;
+	hostVertexShader->OriginalDeclarationCount = OriginalDeclarationCount; 
+    hostVertexShader->HostDeclarationSize = HostDeclarationSize;
 
     if(SUCCEEDED(hRet))
     {
         if(pFunction != NULL)
         {
-            pVertexShader->pFunction = (DWORD*)malloc(VertexShaderSize);
-            memcpy(pVertexShader->pFunction, pFunction, VertexShaderSize);
-            pVertexShader->FunctionSize = VertexShaderSize;
+			hostVertexShader->pFunction = (DWORD*)malloc(VertexShaderSize);
+            memcpy(hostVertexShader->pFunction, pFunction, VertexShaderSize);
+			hostVertexShader->FunctionSize = VertexShaderSize;
         }
         else
         {
-            pVertexShader->pFunction = NULL;
-            pVertexShader->FunctionSize = 0;
+			hostVertexShader->pFunction = NULL;
+			hostVertexShader->FunctionSize = 0;
         }
-        pVertexShader->Handle = Handle;
+		hostVertexShader->Handle = Handle;
     }
     else
     {
-        pVertexShader->Handle = D3DFVF_XYZ | D3DFVF_TEX0;
+        hostVertexShader->Handle = D3DFVF_XYZ | D3DFVF_TEX0;
     }
 
-    pD3DVertexShader->Handle = (DWORD)pVertexShader;
-
-	*pHandle = (DWORD)pD3DVertexShader | D3DFVF_RESERVED0; // DON'T collide with PHYSICAL_MAP_BASE (see VshHandleIsFVF and VshHandleIsVertexShader)
+	// Register the host Vertex Shader
+	SetCxbxVertexShader(*pHandle, hostVertexShader);
 
     if(FAILED(hRet))
     {
@@ -6885,7 +6876,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShader)
     }
 
 	if (VshHandleIsVertexShader(Handle)) {
- 		CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+ 		CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 		hRet = g_pD3DDevice->SetVertexDeclaration(pVertexShader->pHostDeclaration);
 		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexDeclaration");
 		hRet = g_pD3DDevice->SetVertexShader((XTL::IDirect3DVertexShader9*)pVertexShader->Handle);
@@ -8072,7 +8063,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderSize)
 	// Handle is always address of an Xbox VertexShader struct, or-ed with 1 (X_D3DFVF_RESERVED0)
 
     if (pSize) {
-        CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+        CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
         *pSize = pVertexShader ? pVertexShader->Size : 0;
     }
 }
@@ -8112,7 +8103,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DeleteVertexShader)
 	if (VshHandleIsVertexShader(Handle))
 	{
 		X_D3DVertexShader *pD3DVertexShader = VshHandleToXboxVertexShader(Handle);
-		CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+		CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 
 		if (pVertexShader->pHostDeclaration) {
 			pVertexShader->pHostDeclaration->Release();
@@ -8129,6 +8120,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DeleteVertexShader)
 		FreeVertexDynamicPatch(pVertexShader);
 
 		free(pVertexShader);
+		SetCxbxVertexShader(Handle, nullptr);
 		g_VMManager.Deallocate((VAddr)pD3DVertexShader);
 	}
 
@@ -8343,7 +8335,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShaderProgram)
 		return;
 	}
 
-	CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(hCurrentShader);
+	CxbxVertexShader *pVertexShader = GetCxbxVertexShader(hCurrentShader);
 	if (pVertexShader != nullptr)
     {
 		DWORD hNewShader = 0;
@@ -8352,7 +8344,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_LoadVertexShaderProgram)
 		DWORD* pDeclaration = (DWORD*) malloc( pVertexShader->OriginalDeclarationCount * sizeof(DWORD) );
 		memmove( pDeclaration, pVertexShader->pDeclaration, pVertexShader->OriginalDeclarationCount * sizeof(DWORD));
 
-		// Create a new vertex shader with the new 
+		// Create a vertex shader with the new vertex program data
 		HRESULT hr = EMUPATCH(D3DDevice_CreateVertexShader)( pDeclaration, pFunction, &hNewShader, 0 );
 		free(pDeclaration);
 		if( FAILED( hr ) )
@@ -8385,7 +8377,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderType)
 	// *pType is set according to flags in the VertexShader struct
 
 	if (pType) {
-		CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+		CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 		if (pVertexShader) {
 			*pType = pVertexShader->Type;
 		}
@@ -8422,7 +8414,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderDeclaration)
 	HRESULT hRet = D3DERR_INVALIDCALL;
 
     if (pSizeOfData) {
-        CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+        CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 		if (pVertexShader) {
 			DWORD sizeOfData = pVertexShader->OriginalDeclarationCount * sizeof(DWORD);
 			if (*pSizeOfData < sizeOfData || !pData) {
@@ -8468,7 +8460,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderFunction)
 	HRESULT hRet = D3DERR_INVALIDCALL;
 
     if(pSizeOfData) {
-        CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+        CxbxVertexShader *pVertexShader = GetCxbxVertexShader(Handle);
 		if (pVertexShader) {
 			if (*pSizeOfData < pVertexShader->FunctionSize || !pData) {
 				*pSizeOfData = pVertexShader->FunctionSize;

--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
@@ -3580,7 +3580,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_CreateVertexShader)
 
     pD3DVertexShader->Handle = (DWORD)pVertexShader;
 
-	*pHandle = (DWORD)pD3DVertexShader; // DON'T collide with PHYSICAL_MAP_BASE (see VshHandleIsFVF and VshHandleIsVertexShader)
+	*pHandle = (DWORD)pD3DVertexShader | D3DFVF_RESERVED0; // DON'T collide with PHYSICAL_MAP_BASE (see VshHandleIsFVF and VshHandleIsVertexShader)
 
     if(FAILED(hRet))
     {

--- a/src/core/HLE/D3D8/XbPushBuffer.cpp
+++ b/src/core/HLE/D3D8/XbPushBuffer.cpp
@@ -189,7 +189,7 @@ DWORD CxbxGetStrideFromVertexShaderHandle(DWORD dwVertexShader)
 		// Test-case : SpyHunter 2 [4D57001B]
 		//LOG_TEST_CASE("Non-FVF Vertex Shaders not yet (completely) supported for PushBuffer emulation!");
 
-		CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(dwVertexShader);
+		CxbxVertexShader *pVertexShader = GetCxbxVertexShader(dwVertexShader);
 		if (pVertexShader) {
 			if (pVertexShader->VertexShaderInfo.NumberOfVertexStreams == 1) {
 				// Note : This assumes that the only stream in use will be stream zero :

--- a/src/core/HLE/D3D8/XbVertexBuffer.cpp
+++ b/src/core/HLE/D3D8/XbVertexBuffer.cpp
@@ -747,7 +747,7 @@ void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext, DWORD 
 		CxbxKrnlCleanup("Unknown primitive type: 0x%.02X\n", pDrawContext->XboxPrimitiveType);
 
     if (VshHandleIsVertexShader(pDrawContext->hVertexShader)) {
-        m_pVertexShaderInfo = &(MapXboxVertexShaderHandleToCxbxVertexShader(pDrawContext->hVertexShader)->VertexShaderInfo);
+        m_pVertexShaderInfo = &(GetCxbxVertexShader(pDrawContext->hVertexShader)->VertexShaderInfo);
     }
 
 	pDrawContext->VerticesInBuffer = GetVerticesInBuffer(

--- a/src/core/HLE/D3D8/XbVertexBuffer.cpp
+++ b/src/core/HLE/D3D8/XbVertexBuffer.cpp
@@ -246,7 +246,8 @@ UINT XTL::CxbxVertexBufferConverter::GetNbrStreams(CxbxDrawContext *pDrawContext
 
     if(VshHandleIsVertexShader(pDrawContext->hVertexShader)) {
         CxbxVertexShaderInfo *pVertexShaderInfo = GetCxbxVertexShaderInfo(pDrawContext->hVertexShader);
-		if (pVertexShaderInfo) {
+		if (pVertexShaderInfo && pVertexShaderInfo->NumberOfVertexStreams <= 16) {
+			LOG_TEST_CASE("NumberOfVertexStreams > 16");
 			return pVertexShaderInfo->NumberOfVertexStreams;
 		}
 
@@ -329,6 +330,11 @@ void XTL::CxbxVertexBufferConverter::ConvertStream
 
 	CxbxVertexShaderStreamInfo *pVertexShaderStreamInfo = nullptr;
 	if (m_pVertexShaderInfo != nullptr) {
+		if (uiStream > m_pVertexShaderInfo->NumberOfVertexStreams + 1) {
+			LOG_TEST_CASE("uiStream > NumberOfVertexStreams");
+			return;
+		}
+
 		pVertexShaderStreamInfo = &(m_pVertexShaderInfo->VertexStreams[uiStream]);
 	}
 

--- a/src/core/HLE/D3D8/XbVertexBuffer.cpp
+++ b/src/core/HLE/D3D8/XbVertexBuffer.cpp
@@ -246,9 +246,13 @@ UINT XTL::CxbxVertexBufferConverter::GetNbrStreams(CxbxDrawContext *pDrawContext
 
     if(VshHandleIsVertexShader(pDrawContext->hVertexShader)) {
         CxbxVertexShaderInfo *pVertexShaderInfo = GetCxbxVertexShaderInfo(pDrawContext->hVertexShader);
-		if (pVertexShaderInfo && pVertexShaderInfo->NumberOfVertexStreams <= 16) {
+		if (pVertexShaderInfo) {
+			if (pVertexShaderInfo->NumberOfVertexStreams <= 16) {
+				return pVertexShaderInfo->NumberOfVertexStreams;
+			}
+
+			// If we reached here, pVertexShaderInfo was set,but with invalid data
 			LOG_TEST_CASE("NumberOfVertexStreams > 16");
-			return pVertexShaderInfo->NumberOfVertexStreams;
 		}
 
 		return CountActiveD3DStreams();

--- a/src/core/HLE/D3D8/XbVertexBuffer.cpp
+++ b/src/core/HLE/D3D8/XbVertexBuffer.cpp
@@ -759,6 +759,10 @@ void XTL::CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext, DWORD 
 
     // Get the number of streams
     m_uiNbrStreams = GetNbrStreams(pDrawContext);
+	if (m_uiNbrStreams > 16) {
+		LOG_TEST_CASE("m_uiNbrStreams count > max number of streams");
+		m_uiNbrStreams = 16;
+	}
 
     for(UINT uiStream = 0; uiStream < m_uiNbrStreams; uiStream++) {
 		// TODO: Check for cached vertex buffer, and use it if possible

--- a/src/core/HLE/D3D8/XbVertexShader.cpp
+++ b/src/core/HLE/D3D8/XbVertexShader.cpp
@@ -2369,7 +2369,7 @@ DWORD XTL::EmuRecompileVshDeclaration
 	uint8_t *pRecompiledBufferOverflow = ((uint8_t*)pRecompiled) + HostDeclarationSize;
     *ppRecompiledDeclaration = pRecompiled;
 
-    CxbxVertexShaderPatch PatchData = { 0 };
+	CxbxVertexShaderPatch PatchData = { 0 };
 	PatchData.pVertexShaderInfoToSet = pVertexShaderInfo;
 
     DbgVshPrintf("DWORD dwVSHDecl[] =\n{\n");

--- a/src/core/HLE/D3D8/XbVertexShader.cpp
+++ b/src/core/HLE/D3D8/XbVertexShader.cpp
@@ -513,7 +513,7 @@ DWORD VshHandleGetRealHandle(DWORD aHandle)
 {
 	using namespace XTL;
 
-	CxbxVertexShader *pVertexShader = MapXboxVertexShaderHandleToCxbxVertexShader(aHandle);
+	CxbxVertexShader *pVertexShader = GetCxbxVertexShader(aHandle);
 	if (pVertexShader)
 	{
 		// assert(pVertexShader);
@@ -2566,7 +2566,7 @@ boolean VshHandleIsValidShader(DWORD Handle)
 #if 0
 	//printf( "VS = 0x%.08X\n", Handle );
 
-    XTL::CxbxVertexShader *pVertexShader = XTL::MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+    XTL::CxbxVertexShader *pVertexShader = XTL::GetCxbxVertexShader(Handle);
     if (pVertexShader) {
         if (pVertexShader->Status != 0)
         {
@@ -2597,7 +2597,7 @@ extern boolean XTL::IsValidCurrentShader(void)
 
 XTL::CxbxVertexShaderInfo *GetCxbxVertexShaderInfo(DWORD Handle)
 {
-    XTL::CxbxVertexShader *pVertexShader = XTL::MapXboxVertexShaderHandleToCxbxVertexShader(Handle);
+    XTL::CxbxVertexShader *pVertexShader = XTL::GetCxbxVertexShader(Handle);
 
     for (uint32 i = 0; i < pVertexShader->VertexShaderInfo.NumberOfVertexStreams; i++)
     {
@@ -2607,4 +2607,28 @@ XTL::CxbxVertexShaderInfo *GetCxbxVertexShaderInfo(DWORD Handle)
         }
     }
     return NULL;
+}
+
+std::unordered_map<DWORD, XTL::CxbxVertexShader*> g_CxbxVertexShaders;
+
+XTL::CxbxVertexShader* XTL::GetCxbxVertexShader(DWORD Handle)
+{
+	if (VshHandleIsVertexShader(Handle)) {
+		auto it = g_CxbxVertexShaders.find(Handle);
+		if (it != g_CxbxVertexShaders.end()) {
+			return it->second;
+		}
+	}
+
+	return nullptr;
+}
+
+void XTL::SetCxbxVertexShader(DWORD Handle, XTL::CxbxVertexShader* shader)
+{
+	auto it = g_CxbxVertexShaders.find(Handle);
+	if (it != g_CxbxVertexShaders.end() && it->second != nullptr && shader != nullptr) {
+		LOG_TEST_CASE("Overwriting existing Vertex Shader");
+	}
+
+	g_CxbxVertexShaders[Handle] = shader;
 }

--- a/src/core/HLE/D3D8/XbVertexShader.h
+++ b/src/core/HLE/D3D8/XbVertexShader.h
@@ -77,14 +77,9 @@ extern void FreeVertexDynamicPatch(CxbxVertexShader *pVertexShader);
 // Checks for failed vertex shaders, and shaders that would need patching
 extern boolean IsValidCurrentShader(void);
 
-// NOTE: Comparing with 0xFFFF breaks some titles (like Kingdom Under Fire)
-// The real Xbox checks the D3DFVF_RESERVED0 flag but we can't do that without 
-// breaking rendering in many titles: CreateVertexShader needs to be unpatched first.
-// Instead, we assume any vertex shaders will be allocated by our memory manager and
-// exist above the XBE reserved region, not great, but it'l do for now.
-inline boolean VshHandleIsFVF(DWORD Handle) { return (Handle > NULL) && (Handle <= XBE_MAX_VA); }
-inline boolean VshHandleIsVertexShader(DWORD Handle) { return (Handle > XBE_MAX_VA) ? TRUE : FALSE; }
-inline X_D3DVertexShader *VshHandleToXboxVertexShader(DWORD Handle) { return (X_D3DVertexShader *)Handle;}
+inline boolean VshHandleIsVertexShader(DWORD Handle) { return (Handle & D3DFVF_RESERVED0) ? TRUE : FALSE; }
+inline boolean VshHandleIsFVF(DWORD Handle) { return !VshHandleIsVertexShader(Handle); }
+inline X_D3DVertexShader *VshHandleToXboxVertexShader(DWORD Handle) { return (X_D3DVertexShader *)(Handle & ~D3DFVF_RESERVED0);}
 
 inline CxbxVertexShader *MapXboxVertexShaderHandleToCxbxVertexShader(DWORD Handle)
 {

--- a/src/core/HLE/D3D8/XbVertexShader.h
+++ b/src/core/HLE/D3D8/XbVertexShader.h
@@ -81,15 +81,7 @@ inline boolean VshHandleIsVertexShader(DWORD Handle) { return (Handle & D3DFVF_R
 inline boolean VshHandleIsFVF(DWORD Handle) { return !VshHandleIsVertexShader(Handle); }
 inline X_D3DVertexShader *VshHandleToXboxVertexShader(DWORD Handle) { return (X_D3DVertexShader *)(Handle & ~D3DFVF_RESERVED0);}
 
-inline CxbxVertexShader *MapXboxVertexShaderHandleToCxbxVertexShader(DWORD Handle)
-{
-	if (VshHandleIsVertexShader(Handle)) {
-		X_D3DVertexShader *pD3DVertexShader = VshHandleToXboxVertexShader(Handle);
-		//assert(pD3DVertexShader != nullptr);
-		return (CxbxVertexShader *)(pD3DVertexShader->Handle);
-	}
-
-	return nullptr;
-}
+extern CxbxVertexShader* GetCxbxVertexShader(DWORD Handle);
+extern void SetCxbxVertexShader(DWORD Handle, CxbxVertexShader* shader);
 
 #endif

--- a/src/devices/video/EmuNV2A_PCRTC.cpp
+++ b/src/devices/video/EmuNV2A_PCRTC.cpp
@@ -57,17 +57,29 @@ DEVICE_READ32(PCRTC)
 		break;
 	case NV_PCRTC_RASTER: {
 		// Test case: Alter Echo
-		// Hack: Increment on every call, up-to the framebuffer height, satisfying titles waiting for any value
-		// TODO: Implement this in a better/more accurate way
-		static int scanline = 0;
+		// Hack: Alternate between 0, mid-frame, and end-of-frame, this is enough to satisfy any title
+		// that waits for VBlank using D3DDevice_GetRasterStatus, but not harm performance as much as
+		// the previous implementation
 
-		// The exact range of the timer needs verifying on hardware, but it must exceed the frame-height to account for VBlank time
-		// For now, we use a constant of 100 and Alter Echo seems happy enough.
-		if (scanline > NV2ADevice::GetFrameHeight(d) + 100) {
-			scanline = 0;
+		static int stage = 0;
+
+		switch (stage) {
+		case 0:
+			result = 0;
+			break;
+		case 1:
+			result = NV2ADevice::GetFrameHeight(d) / 2;
+			break;
+		case 2:
+			result = NV2ADevice::GetFrameHeight(d) + 1;
+			break;
 		}
 
-		result = scanline++;
+		stage++;
+
+		if (stage > 2) {
+			stage = 0;
+		}
 	} break;
 	default: 
 		result = 0;


### PR DESCRIPTION
A selection of tweaks an improvements to the vertex buffer and shader conversion code, resuling in Virtua Cop 3 reaching in-game!

Note that Virtua Cop 3 is an (encrypted) Sega Chihiro title, and as such, will require decryption using https://github.com/JayFoxRox/Chihiro-Tools

![image](https://user-images.githubusercontent.com/740003/47618523-360ff880-dacc-11e8-91f4-c88632ddcaa1.png)
