### PR TITLE
Fix a crash when using more mip-map levels than D3D9 supports

### DIFF
--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.cpp
@@ -3961,6 +3961,26 @@ extern void HLE_write_NV2A_vertex_attribute_slot(unsigned slot, uint32_t paramet
 extern uint32_t HLE_read_NV2A_vertex_attribute_slot(unsigned VertexSlot); // Declared in PushBuffer.cpp
 
 // ******************************************************************
+// * patch: D3DDevice_SetVertexData4f_16
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f_16)
+(
+	FLOAT   a,
+	FLOAT   b,
+	FLOAT   c,
+	FLOAT   d
+)
+{
+	// This is an LTCG specific version of SetVertexData4f where the first param is passed in edi
+	int Register = 0;
+	__asm{
+		mov Register, edi
+	}
+
+	EMUPATCH(D3DDevice_SetVertexData4f)(Register, a, b, c, d);
+}
+
+// ******************************************************************
 // * patch: D3DDevice_SetVertexData4f
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexData4f)

--- a/src/core/HLE/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/HLE/D3D8/Direct3D9/Direct3D9.h
@@ -672,6 +672,17 @@ VOID WINAPI EMUPATCH(D3DDevice_SetVertexData4f)
 );
 
 // ******************************************************************
+// * patch: D3DDevice_SetVertexData4f_16
+// ******************************************************************
+VOID WINAPI EMUPATCH(D3DDevice_SetVertexData4f_16)
+(
+	FLOAT   a,
+	FLOAT   b,
+	FLOAT   c,
+	FLOAT   d
+);
+
+// ******************************************************************
 // * patch: D3DDevice_SetVertexData4ub
 // ******************************************************************
 VOID WINAPI EMUPATCH(D3DDevice_SetVertexData4ub)

--- a/src/core/HLE/Patches.cpp
+++ b/src/core/HLE/Patches.cpp
@@ -200,6 +200,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_SetVertexData2f", XTL::EMUPATCH(D3DDevice_SetVertexData2f), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexData2s", XTL::EMUPATCH(D3DDevice_SetVertexData2s), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexData4f", XTL::EMUPATCH(D3DDevice_SetVertexData4f), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexData4f_16", XTL::EMUPATCH(D3DDevice_SetVertexData4f_16), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexData4s", XTL::EMUPATCH(D3DDevice_SetVertexData4s), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexData4ub", XTL::EMUPATCH(D3DDevice_SetVertexData4ub), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexDataColor", XTL::EMUPATCH(D3DDevice_SetVertexDataColor), PATCH_HLE_D3D),


### PR DESCRIPTION
This allows Shin Megami Tensei: Nine to progress slightly further.

It's still not playable, as 3D elements don't render, but at least it doesn't crash Cxbx-R anymore.
Note that this is an LTCG title and likely to remain problematic for some time...

