### PR TITLE
Fix bug in RtlAppendUnicodeStringToString 

### DIFF
--- a/src/CxbxKrnl/EmuKrnlRtl.cpp
+++ b/src/CxbxKrnl/EmuKrnlRtl.cpp
@@ -169,9 +169,8 @@ XBSYSAPI EXPORTNUM(262) xboxkrnl::NTSTATUS NTAPI xboxkrnl::RtlAppendUnicodeStrin
 			result = STATUS_BUFFER_TOO_SMALL;
 		}
 		else {
-			CHAR *dstBuf = (CHAR*)(Destination->Buffer + (Destination->Length / sizeof(WCHAR)));
-			CHAR *srcBuf = (CHAR*)(Source->Buffer);
-			memmove(dstBuf, srcBuf, srcLen);
+			WCHAR *dstBuf = (WCHAR*)(Destination->Buffer + (Destination->Length / sizeof(WCHAR)));
+			memmove(dstBuf, Source->Buffer, srcLen);
 			Destination->Length += srcLen;
 			if (Destination->Length < Destination->MaximumLength) {
 				dstBuf[srcLen / sizeof(WCHAR)] = UNICODE_NULL;


### PR DESCRIPTION
The terminating null character was being incorrectly set in two ways.

1. Since the original dstBuf pointer was a `CHAR*`, `dstBuf[srcLen / sizeof(WCHAR)] = UNICODE_NULL;` was setting the wrong byte to 0. srcLen is the count in bytes, not the count in `WCHAR`.
2. Again, because the original dstBuf pointer was a `CHAR*`, only a single byte of the `WCHAR` character was being set to 0, leaving the upper byte untouched. 

Changing dstBuf to correctly be a `WCHAR*` pointer fixes the bug. Also, srcBuf was unneeded as memmove does not care about the incoming pointer type.

Xbox test suite xbe which finds the bug: [default.zip](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/files/2592537/default.zip)
KrnlDebug file of Cxbx-R results with bugfix: [KrnlDebug.txt](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/files/2592538/KrnlDebug.txt)
Results file from running the xbox test suite xbe on real hardware: [kernel_tests.log](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/files/2592539/kernel_tests.log)



