### PR TITLE
Fix random crashes in Panzer Dragoon Orta

### DIFF
--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -119,9 +119,6 @@ extern bool g_bIsRetail;
 /*! indicates ability to save on exit (needed for settings reset) */
 extern bool g_SaveOnExit;
 
-/*! maximum number of threads cxbx can handle */
-#define MAXIMUM_XBOX_THREADS 256
-
 /*! runtime DBG_PRINTF toggle boolean */
 extern volatile bool g_bPrintfOn;
 

--- a/src/CxbxKrnl/EmuKrnlPs.cpp
+++ b/src/CxbxKrnl/EmuKrnlPs.cpp
@@ -306,7 +306,7 @@ XBSYSAPI EXPORTNUM(255) xboxkrnl::NTSTATUS NTAPI xboxkrnl::PsCreateSystemThreadE
     {
         DWORD dwThreadId = 0, dwThreadWait;
         bool bWait = true;
-		HANDLE hStartedEvent = CreateEvent(NULL, FALSE, FALSE, TEXT("PCSTProxyEvent"));
+		HANDLE hStartedEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 		if (hStartedEvent == NULL) {
 			std::string errorMessage = CxbxGetLastErrorString("PsCreateSystemThreadEx could not create PCSTProxyEvent");
 			CxbxKrnlCleanup(errorMessage.c_str());
@@ -324,13 +324,10 @@ XBSYSAPI EXPORTNUM(255) xboxkrnl::NTSTATUS NTAPI xboxkrnl::PsCreateSystemThreadE
         *ThreadHandle = (HANDLE)_beginthreadex(NULL, KernelStackSize, PCSTProxy, iPCSTProxyParam, NULL, (uint*)&dwThreadId);
 		// Note : DO NOT use iPCSTProxyParam anymore, since ownership is transferred to the proxy (which frees it too)
 
-		// Give the thread chance to start
-		Sleep(100);
-
 		DBG_PRINTF("Waiting for Xbox proxy thread to start...\n");
 
         while (bWait) {
-            dwThreadWait = WaitForSingleObject(hStartedEvent, 300);
+            dwThreadWait = WaitForSingleObject(hStartedEvent, INFINITE);
             switch (dwThreadWait) {
                 case WAIT_TIMEOUT: { // The time-out interval elapsed, and the object's state is nonsignaled.
 					EmuLog(LOG_LEVEL::WARNING, "Timeout while waiting for Xbox proxy thread to start...\n");

--- a/src/devices/video/EmuNV2A_PGRAPH.cpp
+++ b/src/devices/video/EmuNV2A_PGRAPH.cpp
@@ -2355,7 +2355,9 @@ void pgraph_handle_method(NV2AState *d,
 					assert(pg->inline_array_length == 0);
 					assert(pg->inline_elements_length == 0);
 
-					pgraph_draw_arrays(d);
+					if (pgraph_draw_arrays != nullptr) {
+						pgraph_draw_arrays(d);
+					}
 				} else if (pg->inline_buffer_length) {
 
 					NV2A_GL_DPRINTF(false, "Inline Buffer");
@@ -2364,7 +2366,9 @@ void pgraph_handle_method(NV2AState *d,
 					assert(pg->inline_array_length == 0);
 					assert(pg->inline_elements_length == 0);
 
-					pgraph_draw_inline_buffer(d);
+					if (pgraph_draw_inline_buffer != nullptr) {
+						pgraph_draw_inline_buffer(d);
+					}
 				} else if (pg->inline_array_length) {
 
 					NV2A_GL_DPRINTF(false, "Inline Array");
@@ -2373,7 +2377,9 @@ void pgraph_handle_method(NV2AState *d,
 					assert(pg->inline_buffer_length == 0);
 					assert(pg->inline_elements_length == 0);
 
-					pgraph_draw_inline_array(d);
+					if (pgraph_draw_inline_array != nullptr) {
+						pgraph_draw_inline_array(d);
+					}
 				} else if (pg->inline_elements_length) {
 
 					NV2A_GL_DPRINTF(false, "Inline Elements");
@@ -2382,7 +2388,9 @@ void pgraph_handle_method(NV2AState *d,
 					assert(pg->inline_buffer_length == 0);
 					assert(pg->inline_array_length == 0);
 
-					pgraph_draw_inline_elements(d);
+					if (pgraph_draw_inline_elements != nullptr) {
+						pgraph_draw_inline_elements(d);
+					}
 				} else {
 					NV2A_GL_DPRINTF(true, "EMPTY NV097_SET_BEGIN_END");
 					assert(false);
@@ -2393,7 +2401,9 @@ void pgraph_handle_method(NV2AState *d,
 
 				pg->primitive_mode = parameter;
 
-				pgraph_draw_state_update(d);
+				if (pgraph_draw_state_update != nullptr) {
+					pgraph_draw_state_update(d);
+				}
 
 				pg->inline_elements_length = 0;
 				pg->inline_array_length = 0;
@@ -2675,7 +2685,9 @@ void pgraph_handle_method(NV2AState *d,
 
 		case NV097_CLEAR_SURFACE: {
 			pg->clear_surface = parameter;
-			pgraph_draw_clear(d);
+			if (pgraph_draw_clear != nullptr) {
+				pgraph_draw_clear(d);
+			}
 			break;
 		}
 


### PR DESCRIPTION
This has been confirmed to fix the crashing and thread synchronization issues in Panzer Dragoon Orta

With this, it's now possible to play the game to completion, with or without the All Cores speed hack.