### PR TITLE
Check XBE signature on Open

### DIFF
--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -1991,9 +1991,11 @@ void WndMain::OpenXbe(const char *x_filename)
         return;
     }
 	
-	if (!m_Xbe->CheckXbeSignature())
+	if (!m_Xbe->CheckXbeSignature() && !g_Settings->m_core.allowAdminPrivilege)
 	{
-		int ret = MessageBox(m_hwnd, "XBE signature check failed! It's possible that hackers have injected malicious code into this game.\n\nAre you sure you wish to continue?", "Cxbx-Reloaded", MB_ICONEXCLAMATION | MB_YESNO);
+		int ret = MessageBox(m_hwnd, "XBE signature check failed!\n"
+			"\nThis is dangerous, as maliciously modified Xbox titles could take control of your system.\n"
+			"\nAre you sure you want to continue?", "Cxbx-Reloaded", MB_ICONEXCLAMATION | MB_YESNO);
 		if (ret != IDYES)
 			return;
 	}

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -1990,7 +1990,14 @@ void WndMain::OpenXbe(const char *x_filename)
 
         return;
     }
-
+	
+	if (!m_Xbe->CheckXbeSignature())
+	{
+		int ret = MessageBox(m_hwnd, "XBE signature check failed! It's possible that hackers have injected malicious code into this game.\n\nAre you sure you wish to continue?", "Cxbx-Reloaded", MB_ICONEXCLAMATION | MB_YESNO);
+		if (ret != IDYES)
+			return;
+	}
+	
     // save this xbe to the list of recent xbe files
     if(m_XbeFilename[0] != '\0') {
         bool found = false;

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -1991,13 +1991,21 @@ void WndMain::OpenXbe(const char *x_filename)
         return;
     }
 	
-	if (!m_Xbe->CheckXbeSignature() && !g_Settings->m_core.allowAdminPrivilege)
+	if (!g_Settings->m_core.allowAdminPrivilege && !m_Xbe->CheckXbeSignature())
 	{
 		int ret = MessageBox(m_hwnd, "XBE signature check failed!\n"
 			"\nThis is dangerous, as maliciously modified Xbox titles could take control of your system.\n"
 			"\nAre you sure you want to continue?", "Cxbx-Reloaded", MB_ICONEXCLAMATION | MB_YESNO);
 		if (ret != IDYES)
+		{
+			delete m_Xbe; m_Xbe = nullptr;
+			
+			RedrawWindow(m_hwnd, NULL, NULL, RDW_INVALIDATE);
+			
+			UpdateCaption();
+			
 			return;
+		}
 	}
 	
     // save this xbe to the list of recent xbe files


### PR DESCRIPTION
Check XBE signature on open & allow users to disable this pop-up using the setting `allowAdminPrivilege`.

I think this will produce better overall compatibility reports of games as it incentivizes users to use unmodified games.