### PR TITLE
Fixup for HLE DSound's GetCaps

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -400,13 +400,13 @@ inline void DSoundGenericUnlock(
 }
 
 // Temporary creation since we need IDIRECTSOUNDBUFFER8, not IDIRECTSOUNDBUFFER class.
-inline void DSoundBufferCreate(LPDSBUFFERDESC pDSBufferDesc, LPDIRECTSOUNDBUFFER8 &pDSBuffer)
+inline HRESULT DSoundBufferCreate(LPDSBUFFERDESC pDSBufferDesc, LPDIRECTSOUNDBUFFER8 &pDSBuffer)
 {
     LPDIRECTSOUNDBUFFER pTempBuffer;
     HRESULT hRetDS = g_pDSound8->CreateSoundBuffer(pDSBufferDesc, &pTempBuffer, NULL);
 
     if (hRetDS != DS_OK) {
-        CxbxKrnlCleanup("CreateSoundBuffer error: 0x%08X", hRetDS);
+        //CxbxKrnlCleanup("CreateSoundBuffer error: 0x%08X", hRetDS);
     } else {
         hRetDS = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&(pDSBuffer));
         pTempBuffer->Release();
@@ -414,6 +414,7 @@ inline void DSoundBufferCreate(LPDSBUFFERDESC pDSBufferDesc, LPDIRECTSOUNDBUFFER
             CxbxKrnlCleanup("Create IDirectSoundBuffer8 error: 0x%08X", hRetDS);
         }
     }
+    return hRetDS;
 }
 inline void DSound3DBufferCreate(LPDIRECTSOUNDBUFFER8 pDSBuffer, LPDIRECTSOUND3DBUFFER8 &pDS3DBuffer) {
     HRESULT hRetDS3D = pDSBuffer->QueryInterface(IID_IDirectSound3DBuffer, (LPVOID*)&(pDS3DBuffer));


### PR DESCRIPTION
**!!DO NOT MERGE PLEASE!!**
**NOTE: 3 commits will be removed since being move into #1534**

The following fixes contains:
* DirectSound's GetCaps function for accurate dwFree2DBuffers and dwFree3DBuffers counters.
  * Research from experiment lle audio turns out GetCaps' values are from software end, not from hardware directly.
  * NOTE: SGE counter and memAlloc are not accurate. Hopefully titles are not relying on this information.

Partial fixed #1132