### PR TITLE
Hotfix: Audio non-stop loop bug

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -3020,21 +3020,27 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_FlushEx)
 
         hRet = XTL::EMUPATCH(CDirectSoundStream_Flush)(pThis);
 
+    }
     // Remaining flags require X_DSSFLUSHEX_ASYNC to be include.
-    } else if ((dwFlags & X_DSSFLUSHEX_ASYNC) > 0) {
+    else if ((dwFlags & X_DSSFLUSHEX_ASYNC) > 0) {
 
         pThis->EmuFlags |= DSE_FLAG_FLUSH_ASYNC;
         pThis->Xb_rtFlushEx = rtTimeStamp;
 
         // Set or remove flags (This is the only place it will set/remove other than Flush perform remove the flags.)
         if ((dwFlags & X_DSSFLUSHEX_ENVELOPE) > 0) {
-            pThis->EmuFlags |= DSE_FLAG_ENVELOPE;
-        } else {
-            pThis->EmuFlags ^= DSE_FLAG_ENVELOPE;
+            if (rtTimeStamp == 0LL) {
+                xboxkrnl::LARGE_INTEGER getTime;
+                xboxkrnl::KeQuerySystemTime(&getTime);
+                pThis->Xb_rtFlushEx = getTime.QuadPart;
+            }
+            pThis->Xb_rtFlushEx += (pThis->Xb_EnvolopeDesc.dwRelease * 512) / 48000;
         }
+
         if ((dwFlags & X_DSSFLUSHEX_ENVELOPE2) > 0) {
             pThis->EmuFlags |= DSE_FLAG_ENVELOPE2;
-        } else {
+        }
+        else {
             pThis->EmuFlags ^= DSE_FLAG_ENVELOPE2;
         }
     }

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -244,8 +244,6 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
     OUT LPDIRECTSOUND8* ppDirectSound,
     LPUNKNOWN       pUnknown)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pguidDeviceId)
 		LOG_FUNC_ARG_OUT(ppDirectSound)
@@ -373,8 +371,6 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSound_AddRef)
 (
     LPDIRECTSOUND8          pThis)
 {
-    
-
     return 1;
 
     enterCriticalSection;
@@ -395,8 +391,6 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSound_Release)
 (
     LPDIRECTSOUND8          pThis)
 {
-    
-
     return 0;
 
     enterCriticalSection;
@@ -422,8 +416,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_GetSpeakerConfig)
     X_CDirectSound*         pThis,
     OUT PDWORD                  pdwSpeakerConfig)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -445,8 +437,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SynchPlayback)
 (
     LPDIRECTSOUND8          pThis)
 {
-    
-
 	LOG_FUNC_ONE_ARG(pThis);
 
     return XTL::EMUPATCH(CDirectSound_SynchPlayback)(pThis);
@@ -463,8 +453,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_DownloadEffectsImage)
     PVOID           pImageLoc,      // TODO: Use this param
     PVOID*          ppImageDesc)    // TODO: Use this param
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -489,8 +477,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_DownloadEffectsImage)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(DirectSoundDoWork)()
 {
-    
-
     if (!g_bDSoundCreateCalled) {
         return;
     }
@@ -594,8 +580,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetOrientation)
     FLOAT           zTop,
     DWORD           dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -635,8 +619,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetDistanceFactor)
     FLOAT           fDistanceFactor,
     DWORD           dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(fDistanceFactor)
@@ -655,8 +637,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetRolloffFactor)
     FLOAT           fRolloffFactor,
     DWORD           dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(fRolloffFactor)
@@ -675,8 +655,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetDopplerFactor)
     FLOAT           fDopplerFactor,
     DWORD           dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(fDopplerFactor)
@@ -695,8 +673,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetI3DL2Listener)
     X_DSI3DL2LISTENER      *pds3dl,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -723,8 +699,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetMixBinHeadroom)
     DWORD                   dwMixBinMask,
     DWORD                   dwHeadroom)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -748,8 +722,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBins)
     LPDIRECTSOUND8          pThis,
     PVOID                   pMixBins)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -774,8 +746,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_12)
     DWORD                   dwMixBinMask,
     const LONG*             alVolumes)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -803,8 +773,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMixBinVolumes_8)
     X_CDirectSoundBuffer*   pThis,
     X_LPDSMIXBINS           pMixBins)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pMixBins)
@@ -824,8 +792,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetPosition)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -854,8 +820,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetVelocity)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -883,8 +847,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetAllParameters)
     LPCDS3DLISTENER         pDS3DListenerParameters,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -907,8 +869,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_CommitDeferredSettings)
 (
     X_CDirectSound*         pThis)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_ONE_ARG(pThis);
@@ -928,8 +888,6 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
     X_DSBUFFERDESC*         pdsbd,
     OUT X_CDirectSoundBuffer**  ppBuffer)
 {
-    
-
     // Research reveal DirectSound creation check is part of the requirement.
     if (!g_pDSound8 && !g_bDSoundCreateCalled) {
         HRESULT hRet;
@@ -1017,8 +975,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CreateSoundBuffer)
     OUT X_CDirectSoundBuffer**  ppBuffer,
     LPUNKNOWN               pUnkOuter)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pdsbd)
@@ -1038,8 +994,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetBufferData)
     LPVOID                  pvBufferData,
     DWORD                   dwBufferBytes)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -1127,8 +1081,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPlayRegion)
     DWORD                   dwPlayStart,
     DWORD                   dwPlayLength)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1180,8 +1132,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Lock)
     LPDWORD                 pdwAudioBytes2,
     DWORD                   dwFlags)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1254,8 +1204,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Unlock)
     DWORD                   pdwAudioBytes2
     )
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -1301,8 +1249,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetHeadroom)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwHeadroom)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwHeadroom)
@@ -1321,8 +1267,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetLoopRegion)
     DWORD                   dwLoopStart,
     DWORD                   dwLoopLength)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1363,8 +1307,6 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Release)
 (
     X_CDirectSoundBuffer*   pThis)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_ONE_ARG(pThis);
@@ -1410,8 +1352,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPitch)
     X_CDirectSoundBuffer*   pThis,
     LONG                    lPitch)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(lPitch)
@@ -1428,8 +1368,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetStatus)
     X_CDirectSoundBuffer*   pThis,
     OUT LPDWORD             pdwStatus)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1471,8 +1409,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetCurrentPosition)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwNewPosition)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1503,8 +1439,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetCurrentPosition)
     OUT PDWORD                  pdwCurrentPlayCursor,
     OUT PDWORD                  pdwCurrentWriteCursor)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG_OUT(pdwCurrentPlayCursor)
@@ -1524,8 +1458,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Play)
     DWORD                   dwReserved2,
     DWORD                   dwFlags)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1588,8 +1520,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Stop)
 (
     X_CDirectSoundBuffer*   pThis)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_ONE_ARG(pThis);
@@ -1616,8 +1546,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_StopEx)
     REFERENCE_TIME          rtTimeStamp,
     DWORD                   dwFlags)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -1693,8 +1621,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetVolume)
     X_CDirectSoundBuffer*   pThis,
     LONG                    lVolume)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(lVolume)
@@ -1712,8 +1638,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetFrequency)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwFrequency)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwFrequency)
@@ -1730,8 +1654,6 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
     X_DSSTREAMDESC*         pdssd,
     OUT X_CDirectSoundStream**  ppStream)
 {
-    
-
     // Research reveal DirectSound creation check is part of the requirement.
     if (!g_pDSound8 && !g_bDSoundCreateCalled) {
         HRESULT hRet;
@@ -1831,8 +1753,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CreateSoundStream)
     OUT X_CDirectSoundStream**  ppStream,
     PVOID                   pUnknown)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pdssd)
@@ -1848,8 +1768,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CreateSoundStream)
 // ******************************************************************
 VOID WINAPI XTL::EMUPATCH(CMcpxStream_Dummy_0x10)(DWORD dwDummy1, DWORD dwDummy2)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1874,8 +1792,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetVolume)
     X_CDirectSoundStream*   pThis,
     LONG                    lVolume)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(lVolume)
@@ -1894,8 +1810,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetRolloffFactor)
     FLOAT                   fRolloffFactor,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -1920,8 +1834,6 @@ ULONG WINAPI XTL::EMUPATCH(CDirectSoundStream_AddRef)
 (
     X_CDirectSoundStream*   pThis)
 {
-    
-
 	LOG_FUNC_ONE_ARG(pThis);
 
     return HybridDirectSoundBuffer_AddRef(pThis->EmuDirectSoundBuffer8);
@@ -1934,8 +1846,6 @@ ULONG WINAPI XTL::EMUPATCH(CDirectSoundStream_Release)
 (
     X_CDirectSoundStream*   pThis)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_ONE_ARG(pThis);
@@ -1981,8 +1891,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetInfo)
     X_CDirectSoundStream*   pThis,
     OUT LPXMEDIAINFO            pInfo)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2013,8 +1921,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetStatus)
     X_CDirectSoundStream*   pThis,
     OUT DWORD*              pdwStatus)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -2072,8 +1978,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Process)
     PXMEDIAPACKET           pInputBuffer,
     PXMEDIAPACKET           pOutputBuffer)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2153,8 +2057,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Discontinuity)
 (
     X_CDirectSoundStream*   pThis)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_ONE_ARG(pThis);
@@ -2187,8 +2089,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Flush)
 (
     X_CDirectSoundStream*   pThis)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_ONE_ARG(pThis);
@@ -2213,8 +2113,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_SynchPlayback)
 (
     LPDIRECTSOUND8 pThis)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_ONE_ARG(pThis);
@@ -2257,8 +2155,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_Pause)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwPause)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwPause)
@@ -2281,8 +2177,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetHeadroom)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwHeadroom)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwHeadroom)
@@ -2302,8 +2196,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetConeAngles)
     DWORD                   dwOutsideConeAngle,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwInsideConeAngle)
@@ -2323,8 +2215,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetConeOutsideVolume)
     LONG                    lConeOutsideVolume,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(lConeOutsideVolume)
@@ -2343,8 +2233,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetAllParameters)
     X_DS3DBUFFER*           pc3DBufferParameters,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pc3DBufferParameters)
@@ -2363,8 +2251,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMaxDistance)
     D3DVALUE                flMaxDistance,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(flMaxDistance)
@@ -2383,8 +2269,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMinDistance)
     D3DVALUE                fMinDistance,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(fMinDistance)
@@ -2405,8 +2289,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetVelocity)
     D3DVALUE                z,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(x)
@@ -2429,8 +2311,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetConeOrientation)
     D3DVALUE                z,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(x)
@@ -2453,8 +2333,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetPosition)
     D3DVALUE                z,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(x)
@@ -2474,8 +2352,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFrequency)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwFrequency)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwFrequency)
@@ -2492,8 +2368,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBins)
     X_CDirectSoundStream*   pThis,
     PVOID                   pMixBins)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2518,8 +2392,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMaxDistance)
     FLOAT                   flMaxDistance,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(flMaxDistance)
@@ -2538,8 +2410,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMinDistance)
     FLOAT                   flMinDistance,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(flMinDistance)
@@ -2558,8 +2428,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetRolloffFactor)
     FLOAT                   flRolloffFactor,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2586,8 +2454,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetDistanceFactor)
     FLOAT                   flDistanceFactor,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2611,8 +2477,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetConeAngles)
     DWORD                   dwOutsideConeAngle,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwInsideConeAngle)
@@ -2634,8 +2498,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetConeOrientation)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(x)
@@ -2656,8 +2518,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetConeOutsideVolume)
     LONG                    lConeOutsideVolume,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(lConeOutsideVolume)
@@ -2678,8 +2538,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetPosition)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(x)
@@ -2702,8 +2560,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetVelocity)
     FLOAT                   z,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(x)
@@ -2724,8 +2580,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetDopplerFactor)
     FLOAT                   flDopplerFactor,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(flDopplerFactor)
@@ -2744,8 +2598,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetI3DL2Source)
     X_DSI3DL2BUFFER*        pds3db,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2774,8 +2626,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetMode)
     DWORD                   dwMode,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwMode)
@@ -2794,8 +2644,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetFormat)
     X_CDirectSoundBuffer*   pThis,
     LPCWAVEFORMATEX         pwfxFormat)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2820,8 +2668,6 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF)
 (
     void)
 {
-    
-
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
@@ -2836,8 +2682,6 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF)
 (
     void)
 {
-    
-
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
@@ -2852,8 +2696,6 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseFullHRTF4Channel)
 (
     void)
 {
-    
-
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
@@ -2868,8 +2710,6 @@ void WINAPI XTL::EMUPATCH(DirectSoundUseLightHRTF4Channel)
 (
     void)
 {
-    
-
     //NOTE: enter/leave criticalsection is not required! Titles are calling it before DirectSoundCreate.
 
 	LOG_FUNC();
@@ -2885,8 +2725,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetLFO) //Low Frequency Oscillat
     LPDIRECTSOUNDBUFFER8    pThis,
     LPCDSLFODESC            pLFODesc)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2911,8 +2749,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetLFO)
     X_CDirectSoundStream*   pThis,
     LPCDSLFODESC            pLFODesc)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -2938,8 +2774,6 @@ VOID WINAPI XTL::EMUPATCH(XAudioCreateAdpcmFormat)
     DWORD                  nSamplesPerSec,
     LPXBOXADPCMWAVEFORMAT  pwfx)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -2971,8 +2805,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetRolloffCurve)
     DWORD                   dwPointCount,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3000,8 +2832,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_EnableHeadphones)
     LPDIRECTSOUND8      pThis,
     BOOL                fEnabled)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3024,8 +2854,6 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSoundBuffer_AddRef)
 (
     X_CDirectSoundBuffer*   pThis)
 {
-    
-
 	LOG_FUNC_ONE_ARG(pThis);
 
     return HybridDirectSoundBuffer_AddRef(pThis->EmuDirectSoundBuffer8);
@@ -3040,8 +2868,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Pause)
     X_CDirectSoundBuffer*   pThis,
     DWORD                   dwPause)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwPause)
@@ -3097,8 +2923,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetOutputLevels)
     OUT X_DSOUTPUTLEVELS*       pOutputLevels,
     BOOL                    bResetPeakValues)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3126,8 +2950,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetEG)
     X_CDirectSoundStream*   pThis,
     LPVOID                  pEnvelopeDesc)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3153,8 +2975,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_FlushEx)
     REFERENCE_TIME          rtTimeStamp,
     DWORD                   dwFlags)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3203,8 +3023,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMode)
     DWORD                   dwMode,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(dwMode)
@@ -3224,8 +3042,6 @@ HRESULT WINAPI XTL::EMUPATCH(XAudioDownloadEffectsImage)
     DWORD       dwFlags,
     LPVOID*     ppImageDesc)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3250,8 +3066,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetFilter)
     LPVOID              pThis,
     X_DSFILTERDESC*     pFilterDesc)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3276,8 +3090,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFilter)
     X_CDirectSoundStream*   pThis,
     X_DSFILTERDESC*         pFilterDesc)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3304,8 +3116,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_PlayEx)
     REFERENCE_TIME        rtTimeStamp,
     DWORD                 dwFlags)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3334,8 +3144,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetCaps)
     X_CDirectSound*     pThis,
     OUT X_DSCAPS*           pDSCaps)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3369,8 +3177,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetPitch)
     X_CDirectSoundStream*   pThis,
     LONG                    lPitch)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(lPitch)
@@ -3384,8 +3190,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetPitch)
 // ******************************************************************
 DWORD WINAPI XTL::EMUPATCH(DirectSoundGetSampleTime)()
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC();
@@ -3407,8 +3211,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_12)
     DWORD                   dwMixBinMask,
     const LONG*             alVolumes)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3436,8 +3238,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetMixBinVolumes_8)
     X_CDirectSoundStream*   pThis,
     X_LPDSMIXBINS           pMixBins)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pMixBins)
@@ -3455,8 +3255,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetI3DL2Source)
     X_DSI3DL2BUFFER*        pds3db,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3485,8 +3283,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetAllParameters)
     X_DS3DBUFFER*            pc3DBufferParameters,
     DWORD                    dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(pc3DBufferParameters)
@@ -3504,8 +3300,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetFormat)
     X_CDirectSoundStream*   pThis,
     LPCWAVEFORMATEX         pwfxFormat)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3538,8 +3332,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetOutputBuffer)
     X_CDirectSoundBuffer*   pThis,
     X_CDirectSoundBuffer*   pOutputBuffer)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3566,8 +3358,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetOutputBuffer)
     X_CDirectSoundStream*   pThis,
     X_CDirectSoundBuffer*   pOutputBuffer)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3645,8 +3435,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetEG)
     X_CDirectSoundBuffer*   pThis,
     LPVOID                  pEnvelopeDesc)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3674,8 +3462,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetEffectData)
     OUT LPVOID          pvData,
     DWORD           dwDataSize)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3709,8 +3495,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_SetNotificationPositions)
     DWORD                   dwNotifyCount,
     LPCDSBPOSITIONNOTIFY    paNotifies)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3759,8 +3543,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetRolloffCurve)
     DWORD                   dwPointCount,
     DWORD                   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3789,8 +3571,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_SetEffectData)
     DWORD   dwDataSize,
     DWORD   dwApply)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -3819,8 +3599,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Use3DVoiceData)
     LPVOID      pThis,
     LPUNKNOWN   pUnknown)
 {
-    
-
     enterCriticalSection;
 
 	LOG_FUNC_BEGIN
@@ -4069,8 +3847,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetSpeakerConfig)
     X_CDirectSound*     pThis,
     OUT LPDWORD*        pdwSpeakerConfig)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -4093,8 +3869,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CommitDeferredSettings)
 (
     X_CDirectSound*     pThis)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_ONE_ARG(pThis);
@@ -4117,8 +3891,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_CommitEffectData)
 (
     X_CDirectSound*     pThis)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_ONE_ARG(pThis);
@@ -4230,8 +4002,6 @@ HRESULT WINAPI XTL::EMUPATCH(XAudioSetEffectData)
     void*               pDesc,
     void*               pRawDesc)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -4256,8 +4026,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetDistanceFactor)
     FLOAT                   flDistanceFactor,
     DWORD                   dwApply)
 {
-    
-
 	LOG_FUNC_BEGIN
 		LOG_FUNC_ARG(pThis)
 		LOG_FUNC_ARG(flDistanceFactor)
@@ -4276,8 +4044,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_SetDopplerFactor)
     FLOAT                   flDopplerFactor,
     DWORD                   dwApply)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(flDopplerFactor)
@@ -4295,8 +4061,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetVoiceProperties)
     X_CDirectSoundBuffer*   pThis,
     OUT void*               pVoiceProps)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -4319,8 +4083,6 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetVoiceProperties)
     X_CDirectSoundStream*   pThis,
     OUT void*               pVoiceProps)
 {
-    
-
     enterCriticalSection;
 
     LOG_FUNC_BEGIN
@@ -4343,8 +4105,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetVolume)
     X_CDirectSoundStream*   pThis,
     LONG                    lVolume)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(lVolume)
@@ -4362,8 +4122,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetPitch)
     X_CDirectSoundStream*   pThis,
     LONG                    lPitch)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(lPitch)
@@ -4379,8 +4137,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetLFO)
 (
     X_CDirectSoundStream*   pThis,
     LPCDSLFODESC            pLFODesc) {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(pLFODesc)
@@ -4397,8 +4153,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetEG)
     X_CDirectSoundStream*   pThis,
     LPVOID                  pEnvelopeDesc)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(pEnvelopeDesc)
@@ -4415,8 +4169,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetFilter)
     X_CDirectSoundStream*   pThis,
     X_DSFILTERDESC*         pFilterDesc)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(pFilterDesc)
@@ -4433,8 +4185,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetHeadroom)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwHeadroom)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(dwHeadroom)
@@ -4451,8 +4201,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetFrequency)
     X_CDirectSoundStream*   pThis,
     DWORD                   dwFrequency)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(dwFrequency)
@@ -4469,8 +4217,6 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundStream_SetMixBins)
     X_CDirectSoundStream*   pThis,
     PVOID                   pMixBins)
 {
-    
-
     LOG_FUNC_BEGIN
         LOG_FUNC_ARG(pThis)
         LOG_FUNC_ARG(pMixBins)

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.hpp
@@ -104,6 +104,23 @@ struct X_DSBUFFERDESC
     DWORD           dwInputMixBin;
 };
 
+// ******************************************************************
+// * X_DSENVELOPEDESC
+// ******************************************************************
+struct X_DSENVOLOPEDESC
+{
+    DWORD           dwEnvelopGenerator;
+    DWORD           dwMode;
+    DWORD           dwDelay;
+    DWORD           dwAttack;
+    DWORD           dwHold;
+    DWORD           dwDecay;
+    DWORD           dwRelease;
+    DWORD           dwSustain;
+    LONG            lPitchScale;
+    LONG            lFilterCutOff;
+};
+
 typedef VOID(CALLBACK *LPFNXMOCALLBACK)(LPVOID pStreamContext, LPVOID pPacketContext, DWORD dwStatus);
 
 // ******************************************************************
@@ -387,9 +404,11 @@ struct X_CDirectSoundBuffer
     DSoundBuffer_Lock       Host_lock;
     DSoundBuffer_Lock       X_lock;
     REFERENCE_TIME          Xb_rtPauseEx;
+    REFERENCE_TIME          Xb_rtStopEx;
     LONG                    Xb_Volume;
     LONG                    Xb_VolumeMixbin;
     DWORD                   Xb_dwHeadroom;
+    X_DSENVOLOPEDESC        Xb_EnvolopeDesc;
 };
 
 #define WAVE_FORMAT_XBOX_ADPCM 0x0069
@@ -541,6 +560,7 @@ class X_CDirectSoundStream
         LONG                                    Xb_Volume;
         LONG                                    Xb_VolumeMixbin;
         DWORD                                   Xb_dwHeadroom;
+        X_DSENVOLOPEDESC                        Xb_EnvolopeDesc;
 };
 
 // ******************************************************************
@@ -1493,7 +1513,7 @@ HRESULT WINAPI EMUPATCH(IDirectSound_GetOutputLevels)
 HRESULT WINAPI EMUPATCH(CDirectSoundStream_SetEG)
 (
     X_CDirectSoundStream*   pThis,
-    LPVOID                  pEnvelopeDesc
+    X_DSENVOLOPEDESC*       pEnvelopeDesc
 );
 
 // ******************************************************************
@@ -1659,7 +1679,7 @@ HRESULT WINAPI EMUPATCH(XWaveFileCreateMediaObject)
 HRESULT WINAPI EMUPATCH(IDirectSoundBuffer_SetEG)
 (
     X_CDirectSoundBuffer*   pThis,
-    LPVOID                  pEnvelopeDesc
+    X_DSENVOLOPEDESC*       pEnvelopeDesc
 );
 
 // ******************************************************************
@@ -1907,7 +1927,7 @@ HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetLFO)
 HRESULT WINAPI EMUPATCH(IDirectSoundStream_SetEG)
 (
     X_CDirectSoundStream*   pThis,
-    LPVOID                  pEnvelopeDesc);
+    X_DSENVOLOPEDESC*       pEnvelopeDesc);
 
 // ******************************************************************
 // * patch: IDirectSoundStream_SetFilter

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -433,7 +433,8 @@ inline void DSound3DBufferCreate(LPDIRECTSOUNDBUFFER8 pDSBuffer, LPDIRECTSOUND3D
     pThis->Xb_rtPauseEx = 0LL; \
     pThis->Xb_Volume = 0L; \
     pThis->Xb_VolumeMixbin = 0L; \
-    pThis->Xb_dwHeadroom = 600; // default for 2D voice
+    pThis->Xb_dwHeadroom = 600; /* default for 2D voice */ \
+    pThis->Xb_EnvolopeDesc = { 0 };
     //pThis->EmuBufferDesc = { 0 }; // Enable this when become necessary.
     /*
     pThis->EmuLockPtr1 = xbnullptr; \


### PR DESCRIPTION
Mainly fix toward audio non-stop loop bug when it should be stopped or "released" by EG's input. Affected titles using Envelope Generator, aka EG, which is part of DSP. However, it does not include fade-out or any special EG values throughout the audio. Think of it as a hotfix.

The following fixes contains:
* DirectSoundBuffer's StopEx
  * Implement envelope's release stage timer, however does not have a fade out volume.
* DirectSoundStream_FlushEx
  * Include envelope's release stage timer, also does not include fade out volume.

This pull request is to separate #1532 due to longer ongoing investigation for GetCaps.