### PR TITLE
Check surface parent format matches surface format before creating it

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4677,7 +4677,10 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 	case XTL::X_D3DRTYPE_SURFACE: {
 		XTL::X_D3DSurface *pXboxSurface = (XTL::X_D3DSurface *)pResource;
 		XTL::X_D3DTexture *pParentXboxTexture = (pXboxSurface) ? (XTL::X_D3DTexture *)pXboxSurface->Parent : xbnullptr;
-		if (pParentXboxTexture) {
+
+		// Don't init the Parent if the Surface and Surface Parent formats differ
+		// Happens in some Outrun 2006 SetRenderTarget calls
+		if (pParentXboxTexture && (pXboxSurface->Format == pParentXboxTexture->Format)) {
 			XTL::IDirect3DBaseTexture *pParentHostBaseTexture = GetHostBaseTexture(pParentXboxTexture, D3DUsage, iTextureStage);
 			switch (pParentHostBaseTexture->GetType()) {
 			case XTL::D3DRTYPE_VOLUMETEXTURE: {


### PR DESCRIPTION
Outrun 2006 has an issue where both surfaces passed to SetRenderTarget have the same parent
And one surface matches the parent format, and one doesn't
Might help with some of #1064 but needs testing