### PR TITLE
Fix xbe loading when section filesize is zero

### DIFF
--- a/src/common/xbe/Xbe.cpp
+++ b/src/common/xbe/Xbe.cpp
@@ -737,9 +737,13 @@ void *Xbe::FindSection(char *zsSectionName)
 void* Xbe::FindSection(xboxkrnl::PXBEIMAGE_SECTION section)
 {
 	for (uint32 v = 0; v < m_Header.dwSections; v++) {
-		if (m_SectionHeader[v].dwRawAddr == section->FileAddress && (m_SectionHeader[v].dwVirtualAddr > 0 && m_SectionHeader[v].dwVirtualSize > 0)) {
-			return m_bzSection[v];
+		if (m_SectionHeader[v].dwVirtualAddr > 0 && m_SectionHeader[v].dwVirtualSize > 0) {
+			if (m_SectionHeader[v].dwRawAddr == section->FileAddress && m_SectionHeader[v].dwVirtualAddr == (uint32)(section->VirtualAddress)
+				&& m_SectionHeader[v].dwVirtualSize == section->VirtualSize) {
+				return m_bzSection[v];
+			}
 		}
+
 	}
 
 	return NULL;


### PR DESCRIPTION
This case was hit by a custom build xbe I wrote which has a file section size of zero. In this case, when ```void* Xbe::FindSection(xboxkrnl::PXBEIMAGE_SECTION section)```  is called by ```XeLoadSection``` to load the “.text” section of my xbe, it actually returns the address of section “.textbss”. This is because that section has a file size of zero, which results in the two sections sharing the same starting file address (0x1000) and so our function grabs the address of “.textbss”. Then, ```XeLoadSection``` proceeds to memcpy from the incorrect section address that has been returned, hence the problem.

Xbe dump
```
Section Name                     : 0x00010506 (".textbss")
Flags                            : 0x00000007 (Writable) (Preload) (Executable) 
Virtual Address                  : 0x00011000
Virtual Size                     : 0x0001681C
Raw Address                      : 0x00001000
Size of Raw                      : 0x00000000
Section Name Address             : 0x00010506
Section Reference Count          : 0x00000000
Head Shared Reference Count Addr : 0x000104F8
Tail Shared Reference Count Addr : 0x000104FA
Section Digest                   : 9069CA78E7450A285173431B3E52C5C25299E473

Section Name                     : 0x0001050F (".text")
Flags                            : 0x00000006 (Preload) (Executable) 
Virtual Address                  : 0x00027820
Virtual Size                     : 0x00022B34
Raw Address                      : 0x00001000
Size of Raw                      : 0x00022B34
Section Name Address             : 0x0001050F
Section Reference Count          : 0x00000000
Head Shared Reference Count Addr : 0x000104FA
Tail Shared Reference Count Addr : 0x000104FC
Section Digest                   : B65B2131C02095ADCB7F2DDB3BB2FAFD4B5E7415
```