### PR TITLE
Implement CDirectSoundStream_GetInfo

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -8572,7 +8572,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetScreenSpaceOffset)
 		LOG_FUNC_ARG(y)
 		LOG_FUNC_END;
 
-    EmuLog(LOG_LEVEL::WARNING, "EmuD3DDevice_SetScreenSpaceOffset ignored");
+    // No need to log this, it's safe to ignore.
+    //EmuLog(LOG_LEVEL::WARNING, "EmuD3DDevice_SetScreenSpaceOffset ignored");
 }
 
 // ******************************************************************

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -1931,14 +1931,11 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetInfo)
 		LOG_FUNC_ARG_OUT(pInfo)
 		LOG_FUNC_END;
 
-    // TODO: A (real) implementation?
-    EmuLog(LOG_LEVEL::WARNING, "EmuDirectSound_CDirectSoundStream_GetInfo is not yet supported!");
-
     if (pInfo) {
-        pInfo->dwFlags = XMO_STREAMF_FIXED_SAMPLE_SIZE;
-        pInfo->dwInputSize = 0x40000;
-        pInfo->dwOutputSize = 0x40000;
-        pInfo->dwMaxLookahead = 0x4000;
+        pInfo->dwFlags = XMO_STREAMF_FIXED_SAMPLE_SIZE | XMO_STREAMF_INPUT_ASYNC;
+        pInfo->dwInputSize = pThis->EmuBufferDesc.lpwfxFormat->nBlockAlign;
+        pInfo->dwOutputSize = 0;
+        pInfo->dwMaxLookahead = std::max(static_cast<uint32_t>(pThis->EmuBufferDesc.lpwfxFormat->nChannels * pThis->EmuBufferDesc.lpwfxFormat->wBitsPerSample / 8) * 32, static_cast<uint32_t>(pThis->EmuBufferDesc.lpwfxFormat->nBlockAlign) * 2);
     }
 
     leaveCriticalSection;

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -226,7 +226,7 @@ inline void GeneratePCMFormat(
                 lpwfxFormatHost->nChannels = 2;
                 lpwfxFormatHost->nSamplesPerSec = 44100;
                 lpwfxFormatHost->wBitsPerSample = 8;
-                lpwfxFormatHost->nBlockAlign = (lpwfxFormatHost->wBitsPerSample / 8 * lpwfxFormatHost->nChannels);
+                lpwfxFormatHost->nBlockAlign = lpwfxFormatHost->nChannels * lpwfxFormatHost->wBitsPerSample / 8;
                 lpwfxFormatHost->nAvgBytesPerSec = lpwfxFormatHost->nSamplesPerSec * lpwfxFormatHost->nBlockAlign;
             }
             else {
@@ -249,7 +249,7 @@ inline void GeneratePCMFormat(
                 }
 
                 if (lpwfxFormatHost->nBlockAlign == 0) {
-                    lpwfxFormatHost->nBlockAlign = (lpwfxFormatHost->wBitsPerSample / 8 * lpwfxFormatHost->nChannels);
+                    lpwfxFormatHost->nBlockAlign = lpwfxFormatHost->nChannels * lpwfxFormatHost->wBitsPerSample / 8;
                 }
 
                 if (lpwfxFormatHost->nSamplesPerSec == 0) {


### PR DESCRIPTION
This fixes an issue in many titles where the game fires a breakpoint exception and/or crashes after calling GetInfo(); on a DirectSoundStream.

This implementation has been confirmed correct and will give valid responses so long as the lpwfxFormat definition is setup with the correct values.

Test Cases:
Crash Bandicoot: The Wrath of Cortex
Shin Megami Tensei: Nine
Likely *many* other titles.