### PR TITLE
Fix a deadlock in KiTimerExpiration caused by KeWaitForSingleObject

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -1580,6 +1580,7 @@ typedef enum _KOBJECTS
 	MutantObject = 2,
 	QueueObject = 4,
 	SemaphoreObject = 5,
+	ThreadObject = 6,
 	TimerNotificationObject = 8,
 	TimerSynchronizationObject = 9,
 	ApcObject = 0x12,
@@ -1961,7 +1962,7 @@ typedef struct _KTHREAD
 	/* 0x55/85 */ CHAR WaitMode;
 	/* 0x56/86 */ CHAR WaitNext;
 	/* 0x57/87 */ CHAR WaitReason;
-	/* 0x58/88 */ PVOID WaitBlockList;
+	/* 0x58/88 */ PKWAIT_BLOCK WaitBlockList;
 	/* 0x5C/92 */ LIST_ENTRY WaitListEntry;
 	/* 0x64/100 */ ULONG WaitTime;
 	/* 0x68/104 */ ULONG KernelApcDisable;

--- a/src/core/kernel/exports/EmuKrnl.cpp
+++ b/src/core/kernel/exports/EmuKrnl.cpp
@@ -102,7 +102,12 @@ xboxkrnl::BOOLEAN RemoveEntryList(xboxkrnl::PLIST_ENTRY pEntry)
 		_EX_Flink->Blink = _EX_Blink;
 	}
 
-	return (_EX_Flink == _EX_Blink);
+	if (_EX_Blink != nullptr && _EX_Flink != nullptr) {
+		return (_EX_Flink == _EX_Blink);
+	}
+	// If we reach here then it means we have erroneously been called on a detached element. In this case,
+	// always report FALSE to avoid possible side effects
+	return FALSE;
 }
 
 xboxkrnl::PLIST_ENTRY RemoveHeadList(xboxkrnl::PLIST_ENTRY pListHead)

--- a/src/core/kernel/exports/EmuKrnlKe.h
+++ b/src/core/kernel/exports/EmuKrnlKe.h
@@ -27,8 +27,14 @@
 
 namespace xboxkrnl
 {
-	VOID NTAPI KeSetSystemTime(
+	VOID NTAPI KeSetSystemTime
+	(
 		IN  PLARGE_INTEGER NewTime,
 		OUT PLARGE_INTEGER OldTime
+	);
+
+	VOID NTAPI KeInitializeTimer
+	(
+		IN PKTIMER Timer
 	);
 }

--- a/src/core/kernel/exports/EmuKrnlKi.h
+++ b/src/core/kernel/exports/EmuKrnlKi.h
@@ -18,6 +18,7 @@
 // *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
 // *
 // *  (c) 2018 Patrick van Logchem <pvanlogchem@gmail.com>
+// *  (c) 2019 ergo720
 // *
 // *  All rights reserved
 // *
@@ -48,7 +49,7 @@ namespace xboxkrnl
 	typedef struct _KI_TIMER_LOCK
 	{
 		std::recursive_mutex Mtx;
-		bool Acquired;
+		int Acquired;
 	} KI_TIMER_LOCK;
 
 
@@ -58,70 +59,84 @@ namespace xboxkrnl
 
 	VOID KiTimerUnlock();
 
-	VOID KiClockIsr(
+	VOID KiClockIsr
+	(
 		IN unsigned int ScalingFactor
 	);
 
-	VOID NTAPI KiCheckTimerTable(
+	VOID NTAPI KiCheckTimerTable
+	(
 		IN ULARGE_INTEGER CurrentTime
 	);
 
-	VOID KxInsertTimer(
+	VOID KxInsertTimer
+	(
 		IN PKTIMER Timer,
 		IN ULONG Hand
 	);
 
-	VOID FASTCALL KiCompleteTimer(
-		IN PKTIMER Timer,
-		IN ULONG Hand
-		);
-
-	VOID KiRemoveEntryTimer(
+	VOID FASTCALL KiCompleteTimer
+	(
 		IN PKTIMER Timer,
 		IN ULONG Hand
 	);
 
-	VOID KxRemoveTreeTimer(
+	VOID KiRemoveEntryTimer
+	(
+		IN PKTIMER Timer,
+		IN ULONG Hand
+	);
+
+	VOID KxRemoveTreeTimer
+	(
 		IN PKTIMER Timer
 	);
 
-	BOOLEAN FASTCALL KiInsertTimerTable(
+	BOOLEAN FASTCALL KiInsertTimerTable
+	(
 		IN PKTIMER Timer,
 		IN ULONG Hand
 	);
 
-	BOOLEAN FASTCALL KiInsertTreeTimer(
+	BOOLEAN FASTCALL KiInsertTreeTimer
+	(
 		IN PKTIMER Timer,
 		IN LARGE_INTEGER Interval
 	);
 
-	ULONG KiComputeTimerTableIndex(
+	ULONG KiComputeTimerTableIndex
+	(
 		IN ULONGLONG Interval
 	);
 
-	BOOLEAN KiComputeDueTime(
+	BOOLEAN KiComputeDueTime
+	(
 		IN PKTIMER Timer,
 		IN LARGE_INTEGER DueTime,
 		OUT PULONG Hand
 	);
 
-	BOOLEAN FASTCALL KiSignalTimer(
+	BOOLEAN FASTCALL KiSignalTimer
+	(
 		IN PKTIMER Timer
 	);
 
-	VOID NTAPI KiTimerExpiration(
+	VOID NTAPI KiTimerExpiration
+	(
 		IN PKDPC Dpc,
 		IN PVOID DeferredContext,
 		IN PVOID SystemArgument1,
 		IN PVOID SystemArgument2
 	);
 
-	VOID FASTCALL KiTimerListExpire(
+	VOID FASTCALL KiTimerListExpire
+	(
 		IN PLIST_ENTRY ExpiredListHead,
 		IN KIRQL OldIrql
 	);
 
-	VOID FASTCALL KiWaitSatisfyAll(
+	VOID FASTCALL KiWaitSatisfyAll
+	(
 		IN PKWAIT_BLOCK WaitBlock
 	);
 };


### PR DESCRIPTION
This was meant for LLE USB, but the deadlock can also happen on current develop so it's beneficial to upstream.