### PR TITLE
Log non-texture resources passed to GetHostTexture

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -939,6 +939,17 @@ XTL::IDirect3DBaseTexture *GetHostBaseTexture(XTL::X_D3DResource *pXboxResource,
 
 XTL::IDirect3DTexture *GetHostTexture(XTL::X_D3DResource *pXboxResource, int iTextureStage = 0)
 {
+	if (pXboxResource == NULL)
+		return nullptr;
+
+	if (GetXboxCommonResourceType(pXboxResource) != X_D3DCOMMON_TYPE_TEXTURE) {
+		// Burnout and Outrun 2006 hit this case (retrieving a surface instead of a texture)
+		// TODO : Surfaces can be set in the texture stages, instead of textures
+		// We'll need to wrap the surface somehow before using it as a texture
+		LOG_TEST_CASE("GetHostBaseTexture called on a non-texture object");
+		return nullptr;
+	}
+
 	return (XTL::IDirect3DTexture *)GetHostBaseTexture(pXboxResource, 0, iTextureStage);
 
 	// TODO : Check for 1 face (and 2 dimensions)?


### PR DESCRIPTION
Outrun 2006 goes in-game