### PR TITLE
Allow XBE Section preload to fail

### DIFF
--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1231,7 +1231,7 @@ void CxbxKrnlMain(int argc, char* argv[])
 			if ((sectionHeaders[i].Flags & XBEIMAGE_SECTION_PRELOAD) != 0) {
 				NTSTATUS result = xboxkrnl::XeLoadSection(&sectionHeaders[i]);
 				if (FAILED(result)) {
-					CxbxKrnlCleanupEx(LOG_PREFIX_INIT, "Failed to preload XBE section: %s", CxbxKrnl_Xbe->m_szSectionName[i]);
+					EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::WARNING, "Failed to preload XBE section: %s", CxbxKrnl_Xbe->m_szSectionName[i]);
 				}
 			}
 		}

--- a/src/core/kernel/memory-manager/VMManager.cpp
+++ b/src/core/kernel/memory-manager/VMManager.cpp
@@ -1746,6 +1746,7 @@ xboxkrnl::NTSTATUS VMManager::XbAllocateVirtualMemory(VAddr* addr, ULONG ZeroBit
 
 	// Attempt to commit the requested range with VirtualAlloc *before* setting up and reserving the PT
 	// This allows an early-out in a failure scenario (Test Case: Star Wars Battlefront DVD Demo: LA-018 v1.02)
+    // We don't commit the requested range if it's within our placeholder, since that was already allocated earlier
 	if (AlignedCapturedBase >= XBE_MAX_VA)
 	{
 		if (!VirtualAlloc((void*)AlignedCapturedBase, AlignedCapturedSize, MEM_COMMIT,


### PR DESCRIPTION
Since all sections in all Xbes are usually marked as preload, the Xbox
kernel attempts to load them all.

In some titles (for example, Lego Star Wars DVD demo) the whole XBE is
too large to fit in RAM, and it is *expected* for the preload to fail.

Previously, when hit with this scenario, Cxbx-R would hard crash.

Now it mirrors hardware behavior and gracefully continues, skipping the
failed Xbe section.

Q: Why is this the case?
A: It's possible (and proven) that with titles such as the Lego Star Wars
DVD Demo, *all* game data is contained within the XBE file, rather than
on-disc as raw files. Naturally, these are too big to fit into the Xbox
RAM, so certain large sections fail to allocate, and are skipped
entirely by the Xbox Kernel.

The game then reads data from these sections by *not* loading them to
memory, but parsing the section *headers* to do raw file-io and read the
Xbe file as a binary blob, parsing the virtual filesystem.

This change allows Lego Star Wars DVD Demo (and other large Xbe titles)
to boot.

Lego Star Wars DVD Demo doesn't work yet, however, as it attempts a
dashboard update and fails, but it no longer crashes the whole emulator.