### PR TITLE
Selectively add bias modifier so bump-map is signed

### DIFF
--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -2958,8 +2958,9 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
         if (m_PSVersion >= D3DPS_VERSION(1, 4))
         {
 
-            // If the bump-map input texture is not a standard Xbox bump-map texture format, apply a bias
-            // Fixes an issue where JSRF that uses unsigned texture as an input to texbem
+            // If the bump-map texture format is X_D3DFMT_X8L8V8U8 or  X_D3DFMT_L6V5U5 we need to apply a bias
+            // This happens because these formats are an alias of unsigned texture formats.
+            // Fixes an issue with the JSRF boost-dash effect
             // NOTE: This assumes that this shader will only ever be used for the input bumpmap texture
             // If this causes regressions in other titles, we'll need to be smarter about this
             // and include the texture formats in the shader hash, somehow.
@@ -2967,7 +2968,7 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             extern XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::X_D3DPixelContainer *pXboxPixelContainer);
             auto format = GetXboxPixelContainerFormat(XTL::EmuD3DActiveTexture[0]);
             bool bias = false;
-            if (format != XTL::X_D3DFMT_V8U8 && format != XTL::X_D3DFMT_V16U16) {
+            if (format == XTL::X_D3DFMT_X8L8V8U8 || format == XTL::X_D3DFMT_L6V5U5) {
                 bias = true;
             }
 

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -2957,18 +2957,38 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
 
         if (m_PSVersion >= D3DPS_VERSION(1, 4))
         {
+
+            // If the bump-map input texture is not a standard Xbox bump-map texture format, apply a bias
+            // Fixes an issue where JSRF that uses unsigned texture as an input to texbem
+            // NOTE: This assumes that this shader will only ever be used for the input bumpmap texture
+            // If this causes regressions in other titles, we'll need to be smarter about this
+            // and include the texture formats in the shader hash, somehow.
+            extern XTL::X_D3DBaseTexture* XTL::EmuD3DActiveTexture[TEXTURE_STAGES];
+            extern XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::X_D3DPixelContainer *pXboxPixelContainer);
+            auto format = GetXboxPixelContainerFormat(XTL::EmuD3DActiveTexture[0]);
+            bool bias = false;
+            if (format != XTL::X_D3DFMT_V8U8 && format != XTL::X_D3DFMT_V16U16) {
+                bias = true;
+            }
+
             Ins.Initialize(PO_MAD);
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_R);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT00, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_R);
-            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+
+            if (bias) {
+                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+            }
+
             Ins.Parameters[2].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + Stage, MASK_R);
             InsertIns.emplace_back(Ins);
             Ins.Initialize(PO_MAD);
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_R);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT10, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_G);
-            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+            if (bias) {
+                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+            }
             Ins.Parameters[2].SetRegister(PARAM_R, 1, MASK_R);
             InsertIns.emplace_back(Ins);
             //
@@ -2976,14 +2996,18 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_G);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT01, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_R);
-            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+            if (bias) {
+                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+            }
             Ins.Parameters[2].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + Stage, MASK_G);
             InsertIns.emplace_back(Ins);
             Ins.Initialize(PO_MAD);
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_G);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT11, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_G);
-            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+            if (bias) {
+                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+            }
             Ins.Parameters[2].SetRegister(PARAM_R, 1, MASK_G);
             InsertIns.emplace_back(Ins);
 

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -2961,12 +2961,14 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_R);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT00, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_R);
+            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
             Ins.Parameters[2].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + Stage, MASK_R);
             InsertIns.emplace_back(Ins);
             Ins.Initialize(PO_MAD);
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_R);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT10, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_G);
+            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
             Ins.Parameters[2].SetRegister(PARAM_R, 1, MASK_R);
             InsertIns.emplace_back(Ins);
             //
@@ -2974,12 +2976,14 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_G);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT01, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_R);
+            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
             Ins.Parameters[2].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + Stage, MASK_G);
             InsertIns.emplace_back(Ins);
             Ins.Initialize(PO_MAD);
             Ins.Output[0].SetRegister(PARAM_R, 1, MASK_G);
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT11, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_G);
+            Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
             Ins.Parameters[2].SetRegister(PARAM_R, 1, MASK_G);
             InsertIns.emplace_back(Ins);
 


### PR DESCRIPTION
This builds upon #1592 to fix JSRF without breaking the XDK Samples, it's a little bit of a hack, but it has been tested and improves the regressions from #1592 without re-breaking JSRF.

The issue stems from the fact that the bump-map formats X_D3DFMT_L6V5U5 and X_D3DFMT_X8L8V8U8 share an identical format specifier as the texture formats X_D3DFMT_X8L8V8U8 and X_D3DFMT_L6V5U5.

The fix applies a bias to those two input types when used in texbem or texbeml operations, to allow them to be (correctly) interpreted as signed bump-map surfaces.