### PR TITLE
Prevent NVNet hogging cpu

### DIFF
--- a/src/devices/EmuNVNet.cpp
+++ b/src/devices/EmuNVNet.cpp
@@ -486,7 +486,8 @@ static void NVNetRecvThreadProc(NvNetState_t *s)
 		int size = g_NVNet->PCAPReceive(packet, 65536);
 		if (size > 0) {
 			EmuNVNet_DMAPacketToGuest(packet, size);
-		}	
+		}
+		Sleep(1);
 	}
 }
 


### PR DESCRIPTION
Just a minor change, to prevent the NVNet emulation from hogging 100% cpu, low impact.