### PR TITLE
Fix multisampling

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1946,10 +1946,10 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 						g_EmuCDPD.HostPresentationParameters.BackBufferCount = 1;
 					}
 
-                    // We ignore multisampling completely for now
+					// We disable multisampling on the host backbuffer completely for now
 					// It causes issues with backbuffer locking.
-					// NOTE: It is possible to fix multisampling by having the host backbuffer normal size, the Xbox backbuffer being multisamples
-					// and scaling that way, but that can be done as a future PR
+					// NOTE: multisampling is still implemented by having the host backbuffer normal size
+ 					// the Xbox backbuffer being multisampled and scaled during blit
 					g_EmuCDPD.HostPresentationParameters.MultiSampleType = XTL::D3DMULTISAMPLE_NONE;
 					g_EmuCDPD.HostPresentationParameters.MultiSampleQuality = 0;
 
@@ -2414,9 +2414,6 @@ void Direct3D_CreateDevice_Start
 	XTL::X_D3DPRESENT_PARAMETERS     *pPresentationParameters
 )
 {
-	// HACK: Disable multisampling... See comment in CreateDevice proxy for more info
-	pPresentationParameters->MultiSampleType = XTL::X_D3DMULTISAMPLE_NONE;
-
 	// create default device *before* calling Xbox Direct3D_CreateDevice trampline
 	// to avoid hitting EMUPATCH'es that need a valid g_pD3DDevice
 	{


### PR DESCRIPTION
Thanks to PR #1595, we can now fix multisampling in Xbox titles. This has a *zero* performance impact too!

Please note that due to a limitation of host Direct3D, this only works as while the 'Render to Host Backbuffer' is disabled.

Before:
![before_1](https://user-images.githubusercontent.com/740003/57014034-1afe7c80-6c06-11e9-9a18-86e1d7d2bf21.png)
![before_2](https://user-images.githubusercontent.com/740003/57014037-1cc84000-6c06-11e9-87fb-4ac824163add.png)

After:

![after_1](https://user-images.githubusercontent.com/740003/57014040-1fc33080-6c06-11e9-98fb-bc6e30a16dbb.png)
![after_2](https://user-images.githubusercontent.com/740003/57014041-20f45d80-6c06-11e9-8718-81f65688882d.png)
