### PR TITLE
Fix an oversight where the scaled viewport values were not used

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3197,6 +3197,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
 		XboxViewPort.MinZ = pViewport->MinZ;
 		XboxViewPort.MaxZ = pViewport->MaxZ;
 
+		// Write the scaled viewport data back to the host viewport structure
+		HostViewPort = XboxViewPort;
+
 		if (g_ScaleViewport) {
 			// Get current host render target dimensions
 			DWORD HostRenderTarget_Width;


### PR DESCRIPTION
This has no known impact, but it was an oversight I spotted while testing something else.

SetViewPort should clip the viewport dimensions to the backbuffer size, this operation was done, but the result was simply discarded in normal operation.

This fixed that minor oversight.