### PR TITLE
Fix D3DDevice_Begin/D3DDevice_EndPush length calculation

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -109,9 +109,7 @@ static bool                         g_bHasStencil = false;  // Does device have 
 static DWORD						g_dwPrimPerFrame = 0;	// Number of primitives within one frame
 
 // primary push buffer
-static uint32_t  g_dwPrimaryPBCount = 0;
 static uint32_t *g_pPrimaryPB = nullptr;
-
 
 struct {
 	XTL::X_D3DSurface Surface;
@@ -2615,7 +2613,6 @@ PDWORD WINAPI XTL::EMUPATCH(D3DDevice_BeginPush)(DWORD Count)
 
     DWORD *pRet = new DWORD[Count];
 
-    g_dwPrimaryPBCount = Count;
     g_pPrimaryPB = (uint32_t*)pRet;
 
     return pRet;
@@ -2641,7 +2638,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_BeginPush2)(DWORD Count, DWORD** ppPush)
 
 	DWORD *pRet = new DWORD[Count];
 
-	g_dwPrimaryPBCount = Count;
 	g_pPrimaryPB = (uint32_t*)pRet;
 
 	*ppPush=pRet;

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -2658,7 +2658,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_EndPush)(DWORD *pPush)
 		EmuLog(LOG_LEVEL::WARNING, "D3DDevice_EndPush called without preceding D3DDevice_BeginPush?!");
 	else
 	{
-		EmuExecutePushBufferRaw(g_pPrimaryPB, g_dwPrimaryPBCount * sizeof(DWORD));
+        // Note: We don't use the count from BeginPush because that specifies the *maximum* count
+        // rather than the count actually in the pushbuffer. 
+		EmuExecutePushBufferRaw(g_pPrimaryPB, (uintptr_t)pPush - (uintptr_t)g_pPrimaryPB);
 
 		delete[] g_pPrimaryPB;
 		g_pPrimaryPB = nullptr;


### PR DESCRIPTION
With this fix, Rallisport Challenge is in-game even in Release builds.
Any title that uses BeginPush/EndPush is potentially effected, so it'l be good to retry any game that previously complained about PushBuffer issues.