### PR TITLE
Fix VS 2019 Compiler

### DIFF
--- a/src/devices/EmuNVNet.h
+++ b/src/devices/EmuNVNet.h
@@ -24,6 +24,8 @@
 // ******************************************************************
 #pragma once
 
+#include <string>
+
 #include "PCIDevice.h" // For PCIDevice
 
 // NVNET Register Definitions


### PR DESCRIPTION
Very low risk merge.

This fix allow Visual Studio 2019 to able compile. Since source code's included header(s) did not include string.