### PR TITLE
Bumpmap bias tweaks

### DIFF
--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -2958,7 +2958,7 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
         if (m_PSVersion >= D3DPS_VERSION(1, 4))
         {
 
-            // If the bump-map texture format is X_D3DFMT_X8L8V8U8 or  X_D3DFMT_L6V5U5 we need to apply a bias
+            // If the bump-map texture format is X_D3DFMT_X8L8V8U8 or X_D3DFMT_L6V5U5 we need to apply a bias
             // This happens because these formats are an alias of unsigned texture formats.
             // Fixes an issue with the JSRF boost-dash effect
             // NOTE: This assumes that this shader will only ever be used for the input bumpmap texture
@@ -2966,9 +2966,11 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             // and include the texture formats in the shader hash, somehow.
             extern XTL::X_D3DBaseTexture* XTL::EmuD3DActiveTexture[TEXTURE_STAGES];
             extern XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::X_D3DPixelContainer *pXboxPixelContainer);
-            auto format = GetXboxPixelContainerFormat(XTL::EmuD3DActiveTexture[0]);
+            auto format = GetXboxPixelContainerFormat(XTL::EmuD3DActiveTexture[inputStage]);
             bool bias = false;
-            if (format == XTL::X_D3DFMT_X8L8V8U8 || format == XTL::X_D3DFMT_L6V5U5) {
+			auto biasModifier = (1 << ARGMOD_SCALE_BX2);
+			// TODO L6V5U5 format is converted incorrectly if not supported by the device
+            if (format == XTL::X_D3DFMT_X8L8V8U8 /*|| format == XTL::X_D3DFMT_L6V5U5*/) {
                 bias = true;
             }
 
@@ -2978,7 +2980,7 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_R);
 
             if (bias) {
-                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+                Ins.Parameters[1].Modifiers = biasModifier;
             }
 
             Ins.Parameters[2].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + Stage, MASK_R);
@@ -2988,7 +2990,7 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT10, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_G);
             if (bias) {
-                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+                Ins.Parameters[1].Modifiers = biasModifier;
             }
             Ins.Parameters[2].SetRegister(PARAM_R, 1, MASK_R);
             InsertIns.emplace_back(Ins);
@@ -2998,7 +3000,7 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT01, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_R);
             if (bias) {
-                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+                Ins.Parameters[1].Modifiers = biasModifier;
             }
             Ins.Parameters[2].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + Stage, MASK_G);
             InsertIns.emplace_back(Ins);
@@ -3007,7 +3009,7 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             Ins.Parameters[0].SetScaleBemLumRegister(XTL::D3DTSS_BUMPENVMAT11, Stage, Recompiled);
             Ins.Parameters[1].SetRegister(PARAM_R, PSH_XBOX_MAX_R_REGISTER_COUNT + inputStage, MASK_G);
             if (bias) {
-                Ins.Parameters[1].Modifiers = (1 << ARGMOD_BIAS);
+                Ins.Parameters[1].Modifiers = biasModifier;
             }
             Ins.Parameters[2].SetRegister(PARAM_R, 1, MASK_G);
             InsertIns.emplace_back(Ins);


### PR DESCRIPTION
Use inputStage for bias check:
We were always checking stage 0 but the stage can vary

SCALE_BX2 instead of BIAS:
Makes the bump effect more extreme than it is now.
The comparison of bias and bx2 is done with hacked together support for L6V5U5 conversion.
The reference shot is a bit blurry, but bx2 seems definitely closer to it

<details>
<summary>Bias / Bx2 comparison</summary>

Reference Image (despite the blurriness note the highlights in the bottom right)
![image](https://user-images.githubusercontent.com/3938312/56869577-f5842f80-69c7-11e9-81d6-126738b7f10c.png)

Hardware bias (-0.5, 0.5)
![hardware_bumpearth_bias](https://user-images.githubusercontent.com/9897874/57189959-07864500-6f69-11e9-8211-aa5e858915c1.PNG)

Hardware bx2 (-1, 1)
![hardware_bumpearth_bx2](https://user-images.githubusercontent.com/9897874/57189968-2258b980-6f69-11e9-9707-edc8a877f3b4.PNG)

Software with no bias hack
![image](https://user-images.githubusercontent.com/9897874/57170575-dff88500-6e61-11e9-95da-6eb81026b7d6.png)

JSRF (Makes the blur more extreme)
![jsrf_texbemstage](https://user-images.githubusercontent.com/9897874/57189903-26380c00-6f68-11e9-9285-2ec1887e243b.PNG)

</details>

Disable L6V5U5 biasing (for now):
If L6V5U5 is supported by hardware it is already ranged (-1, 1), so the bias breaks the sample.
Not sure this is the correct host format to ultimately use though