### PR TITLE
Always apply scalar swizzle fix

### DIFF
--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -1509,9 +1509,12 @@ static boolean VshConvertShader(VSH_XBOX_SHADER *pShader,
 
 			// Fix when mad or mov to a scaler input does not use a replicate swizzle
 			// MAD Test case: Panzer Dragoon Orta
-			// MOV Test case: DOA3
-			if ((pIntermediate->InstructionType == IMD_MAC && pIntermediate->MAC == MAC_MAD) ||
-				(pIntermediate->InstructionType == IMD_MAC && pIntermediate->MAC == MAC_MOV)) {
+			// MOV Test case: DOA3, Mechassault (Const)
+			// MUL Test case: Amped
+			// TODO Previously we applied this fix for specified instructions
+			// When should we not apply the correction?
+			if (true)
+			{
 				// Clear all but the first swizzle for each parameter
 				// TODO: Is this sufficient? Perhaps we need to be smart about which swizzle to select
 				for (int param = 0; param < 3; param++) {


### PR DESCRIPTION
We fix up swizzling when writing into scalar output registers (`oPts`, `oFog`)
This PR removes the selective application of the fix.
This fixes visual issues in Mechassault
And something in Amped (no visible difference to me)
Both of these games `MUL` into scalar registers, so perhaps we keep things selective and just add MUL?

![image](https://user-images.githubusercontent.com/9897874/58377420-52c5cd80-7fd4-11e9-888c-2fe1a86a6d7a.png)

![image](https://user-images.githubusercontent.com/9897874/58377414-3a55b300-7fd4-11e9-8afd-3be831900ec2.png)
