### PR TITLE
Fix an issue where Debugging/Breakpoints did not work in Release builds

### DIFF
--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -119,6 +119,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   "
   LINK_FLAGS_RELEASE "
   /LTCG
+  /DEBUG
   "
  )
 


### PR DESCRIPTION
Ever since CMake was introduced, debugging & breakpoints with MSVC in Release Builds has been broken.

The cause was the loss of the /DEBUG linker flag: Causing no symbols to be generated in Release builds, meaning that Visual Studio could not resolve functions during debugging.