### PR TITLE
Pixel shader upgrading

### DIFF
--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -4229,7 +4229,7 @@ bool PSH_XBOX_SHADER::FixArgumentModifiers()
         int InsertPos = i;
         // Detect modifiers on constant and arguments
 		for (int p = 0; p < 7 && p < PSH_OPCODE_DEFS[Cur->Opcode]._In; p++) {
-			if ((Cur->Parameters[p].Type == PARAM_C || (Cur->Parameters[p].UsesRegister()))
+			if ((Cur->Parameters[p].Type == PARAM_C || Cur->Parameters[p].UsesRegister())
 				&& ((Cur->Parameters[p].Modifiers & ~(1 << ARGMOD_NEGATE)) != 0)) {
 
                 PSH_INTERMEDIATE_FORMAT Ins = {};

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -7241,6 +7241,8 @@ inline void GetOutputFlags
 	}
 	case PS_COMBINEROUTPUT_SHIFTLEFT_1_BIAS: // 0x18L
 	{
+		using namespace XTL;
+		LOG_TEST_CASE("PS_COMBINEROUTPUT_SHIFTLEFT_1_BIAS");
 		printf("PS_COMBINEROUTPUT_SHIFTLEFT_1_BIAS"); // y = (x - 0.5)*2
 
 		//strcpy(szInstMod, "_x2");
@@ -7255,6 +7257,8 @@ inline void GetOutputFlags
 	}
 	case PS_COMBINEROUTPUT_SHIFTLEFT_2: // 0x20L
 	{
+		using namespace XTL;
+		LOG_TEST_CASE("PS_COMBINEROUTPUT_SHIFTLEFT_2");
 		printf("PS_COMBINEROUTPUT_SHIFTLEFT_2");  // y = x*4
 		strcpy(szInstMod, "_x4");
 		break;
@@ -7262,6 +7266,8 @@ inline void GetOutputFlags
 	// case PS_COMBINEROUTPUT_SHIFTLEFT_2_BIAS: // 0x28L, // y = (x - 0.5)*4
 	case PS_COMBINEROUTPUT_SHIFTRIGHT_1: // 0x30L
 	{
+		using namespace XTL;
+		LOG_TEST_CASE("PS_COMBINEROUTPUT_SHIFTRIGHT_1");
 		printf("PS_COMBINEROUTPUT_SHIFTRIGHT_1"); // y = x/2
 		strcpy(szInstMod, "_d2");
 		break;


### PR DESCRIPTION
A minor bit of maintenance on our pixel shader generation code;
* Removed support for shader models older than 2.0 while keeping existing functionality intact.
* Fixed combiner output flags parsing (it didn't use a bitmask before)
* Separate decoding of register combiner registers from generation of pixel shaders.

Only the second might solve some corner-cases, the others won't cause any functional change.