### PR TITLE
Remove DBG_PRINTF_EX

### DIFF
--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -85,7 +85,7 @@ extern bool g_bIsRetail;
 /*! indicates ability to save on exit (needed for settings reset) */
 extern bool g_SaveOnExit;
 
-/*! runtime DBG_PRINTF toggle boolean */
+/*! runtime logging toggle boolean */
 extern volatile bool g_bPrintfOn;
 
 #ifdef _MSC_VER

--- a/src/common/EmuEEPROM.cpp
+++ b/src/common/EmuEEPROM.cpp
@@ -38,7 +38,6 @@ namespace xboxkrnl
 #include <shlobj.h> // For HANDLE, CreateFile, CreateFileMapping, MapViewOfFile
 #include <random>
 
-#include "Cxbx.h" // For DBG_PRINTF_EX
 #include "EmuEEPROM.h" // For EEPROMInfo, EEPROMInfos
 #include "core\kernel\support\Emu.h" // For EmuWarning
 #include "..\..\src\devices\LED.h" // For SetLEDSequence
@@ -122,7 +121,7 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 			/* hTemplateFile */nullptr);
 		if (hFileEEPROM == INVALID_HANDLE_VALUE)
 		{
-			DBG_PRINTF_EX(LOG_PREFIX_INIT, "Couldn't create EEPROM.bin file!\n");
+			EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Couldn't create EEPROM.bin file!\n");
 			return nullptr;
 		}
 	}
@@ -140,7 +139,7 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 		/**/nullptr);
 	if (hFileMappingEEPROM == NULL)
 	{
-		DBG_PRINTF_EX(LOG_PREFIX_INIT, "Couldn't create EEPROM.bin file mapping!\n");
+		EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Couldn't create EEPROM.bin file mapping!\n");
 		return nullptr;
 	}
 
@@ -161,7 +160,7 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
 		/* dwFileOffsetLow */0,
 		EEPROM_SIZE);
 	if (pEEPROM == nullptr) {
-		DBG_PRINTF_EX(LOG_PREFIX_INIT, "Couldn't map EEPROM.bin into memory!\n");
+		EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Couldn't map EEPROM.bin into memory!\n");
 		return nullptr;
 	}
 
@@ -177,12 +176,12 @@ xboxkrnl::XBOX_EEPROM *CxbxRestoreEEPROM(char *szFilePath_EEPROM_bin)
         // This must be done last to include all initialized data in the CRC
         gen_section_CRCs(pEEPROM);
 
-		DBG_PRINTF_EX(LOG_PREFIX_INIT, "Initialized default EEPROM\n");
+		EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Initialized default EEPROM\n");
 	}
 	else
 	{
 		XboxFactoryGameRegion = pEEPROM->EncryptedSettings.GameRegion;
-		DBG_PRINTF_EX(LOG_PREFIX_INIT, "Loaded EEPROM.bin\n");
+		EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Loaded EEPROM.bin\n");
 	}
 
 	// Read the HDD (and eventually also the online) keys stored in the eeprom file. Users can input them in the eeprom menu

--- a/src/common/Logging.h
+++ b/src/common/Logging.h
@@ -393,13 +393,6 @@ extern thread_local std::string _logThreadPrefix;
 #pragma warning(disable : 4477)
 #endif
 
-#define DBG_PRINTF_EX(cxbxr_module, fmt, ...) { \
-		LOG_CHECK_ENABLED_EX(cxbxr_module, LOG_LEVEL::DEBUG) { \
-			CXBX_CHECK_INTEGRITY(); \
-			if(g_bPrintfOn) printf("[0x%.4X] %s"##fmt, GetCurrentThreadId(), g_EnumModules2String[to_underlying(cxbxr_module)], ##__VA_ARGS__); \
-		} \
-     }
-
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/src/core/kernel/exports/EmuKrnlKe.cpp
+++ b/src/core/kernel/exports/EmuKrnlKe.cpp
@@ -329,8 +329,7 @@ void InitDpcThread()
 
 	InitializeCriticalSection(&(g_DpcData.Lock));
 	InitializeListHead(&(g_DpcData.DpcQueue));
-
-	DBG_PRINTF_EX(CXBXR_MODULE::INIT, "Creating DPC event\n");
+	EmuLogEx(CXBXR_MODULE::INIT, LOG_LEVEL::DEBUG, "Creating DPC event\n");
 	g_DpcData.DpcEvent = CreateEvent(/*lpEventAttributes=*/nullptr, /*bManualReset=*/FALSE, /*bInitialState=*/FALSE, /*lpName=*/nullptr);
 }
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1462,7 +1462,7 @@ __declspec(noreturn) void CxbxKrnlInit
 	CxbxRegisterDeviceHostPath(DeviceHarddisk0Partition7, CxbxBasePath + "Partition7");
 
 	// Create default symbolic links :
-	DBG_PRINTF_EX(LOG_PREFIX_INIT, "Creating default symbolic links.\n");
+	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Creating default symbolic links.\n");
 	{
 		// TODO: DriveD should always point to the Xbe Path
 		// This is the only symbolic link the Xbox Kernel sets, the rest are set by the application, usually via XAPI.
@@ -1526,7 +1526,7 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	// Make sure the Xbox1 code runs on one core (as the box itself has only 1 CPU,
 	// this will better aproximate the environment with regard to multi-threading) :
-	DBG_PRINTF_EX(LOG_PREFIX_INIT, "Determining CPU affinity.\n");
+	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Determining CPU affinity.\n");
 	{
 		if (!GetProcessAffinityMask(g_CurrentProcessHandle, &g_CPUXbox, &g_CPUOthers))
 			CxbxKrnlCleanupEx(LOG_PREFIX_INIT, "GetProcessAffinityMask failed.");
@@ -1545,7 +1545,7 @@ __declspec(noreturn) void CxbxKrnlInit
 	}
 
 	// initialize graphics
-	DBG_PRINTF_EX(LOG_PREFIX_INIT, "Initializing render window.\n");
+	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Initializing render window.\n");
 	XTL::CxbxInitWindow(true);
 
 	// Now process the boot flags to see if there are any special conditions to handle
@@ -1592,7 +1592,7 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	if (!bLLE_GPU)
 	{
-		DBG_PRINTF_EX(LOG_PREFIX_INIT, "Initializing Direct3D.\n");
+		EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Initializing Direct3D.\n");
 		XTL::EmuD3DInit();
 	}
 	
@@ -1634,13 +1634,13 @@ __declspec(noreturn) void CxbxKrnlInit
 	TimerObject* KernelClockThr = Timer_Create(CxbxKrnlClockThread, nullptr, "Kernel clock thread", &g_CPUOthers);
 	Timer_Start(KernelClockThr, SCALE_MS_IN_NS);
 
-	DBG_PRINTF_EX(LOG_PREFIX_INIT, "Calling XBE entry point...\n");
+	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Calling XBE entry point...\n");
 	CxbxLaunchXbe(Entry);
 
 	// FIXME: Wait for Cxbx to exit or error fatally
 	Sleep(INFINITE);
 
-	DBG_PRINTF_EX(LOG_PREFIX_INIT, "XBE entry point returned\n");
+	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "XBE entry point returned\n");
 	fflush(stdout);
 
 	//	EmuShared::Cleanup();   FIXME: commenting this line is a bad workaround for issue #617 (https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/617)
@@ -1698,7 +1698,7 @@ __declspec(noreturn) void CxbxKrnlCleanupEx(CXBXR_MODULE cxbxr_module, const cha
         vsprintf(szBuffer2, szErrorMessage, argp);
         va_end(argp);
 
-		CxbxPopupMessageEx(cxbxr_module, LOG_LEVEL::FATAL, CxbxMsgDlgIcon_Error, "Received Fatal Message:\n\n* %s\n", szBuffer2); // Will also DBG_PRINTF
+		CxbxPopupMessageEx(cxbxr_module, LOG_LEVEL::FATAL, CxbxMsgDlgIcon_Error, "Received Fatal Message:\n\n* %s\n", szBuffer2); // Will also EmuLogEx
     }
 
     printf("[0x%.4X] MAIN: Terminating Process\n", GetCurrentThreadId());

--- a/src/core/kernel/support/EmuFS.cpp
+++ b/src/core/kernel/support/EmuFS.cpp
@@ -492,7 +492,7 @@ void EmuInitFS()
 	fsInstructions.push_back({ { 0x64, 0xA1, 0x58, 0x00, 0x00, 0x00 }, &EmuFS_MovEaxFs58 });					// mov eax, large fs:58
 	fsInstructions.push_back({ { 0x64, 0xA3, 0x00, 0x00, 0x00, 0x00 }, &EmuFS_MovFs00Eax });					// mov large fs:0, eax
 
-	DBG_PRINTF_EX(CXBXR_MODULE::INIT, "Patching FS Register Accesses\n");
+	EmuLogEx(CXBXR_MODULE::INIT, LOG_LEVEL::DEBUG, "Patching FS Register Accesses\n");
 	DWORD sizeOfImage = CxbxKrnl_XbeHeader->dwSizeofImage;
 	long numberOfInstructions = fsInstructions.size();
 
@@ -502,7 +502,7 @@ void EmuInitFS()
 			continue;
 		}
 
-		DBG_PRINTF_EX(CXBXR_MODULE::INIT, "Searching for FS Instruction in section %s\n", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
+		EmuLogEx(CXBXR_MODULE::INIT, LOG_LEVEL::DEBUG, "Searching for FS Instruction in section %s\n", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
 		xbaddr startAddr = CxbxKrnl_Xbe->m_SectionHeader[sectionIndex].dwVirtualAddr;
 		xbaddr endAddr = startAddr + CxbxKrnl_Xbe->m_SectionHeader[sectionIndex].dwSizeofRaw;
 		for (xbaddr addr = startAddr; addr < endAddr; addr++)
@@ -519,7 +519,7 @@ void EmuInitFS()
 
 				if (memcmp((void*)addr, &fsInstructions[i].data[0], sizeOfData) == 0)
 				{
-					DBG_PRINTF_EX(CXBXR_MODULE::INIT, "Patching FS Instruction at 0x%.8X\n", addr);
+					EmuLogEx(CXBXR_MODULE::INIT, LOG_LEVEL::DEBUG, "Patching FS Instruction at 0x%.8X\n", addr);
 
 					// Write Call opcode
 					*(uint8_t*)addr = OPCODE_CALL_E8;
@@ -535,7 +535,7 @@ void EmuInitFS()
 		}
 	}
 	
-	DBG_PRINTF_EX(CXBXR_MODULE::INIT, "Done patching FS Register Accesses\n");
+	EmuLogEx(CXBXR_MODULE::INIT, LOG_LEVEL::DEBUG, "Done patching FS Register Accesses\n");
 }
 
 // generate fs segment selector
@@ -584,7 +584,7 @@ void EmuGenerateFS(Xbe::TLS *pTLS, void *pTLSData)
 							EmuLog(LOG_LEVEL::DEBUG, "0x%.8X:", (xbaddr)bByte);
                         }
 
-                        // Note : Use printf instead of DBG_PRINTF here, which prefixes with GetCurrentThreadId() :
+                        // Note : Use printf instead of EmuLog here, which prefixes with GetCurrentThreadId() :
                         printf(" %.2X", *bByte);
                     }
 


### PR DESCRIPTION
Removes the macro DBG_PRINTF_EX from the code base and also 3 instances of DBG_PRINTF left from https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/1629.