### PR TITLE
Revert "Prevent NVNet hogging cpu"

### DIFF
--- a/src/devices/EmuNVNet.cpp
+++ b/src/devices/EmuNVNet.cpp
@@ -489,8 +489,7 @@ static void NVNetRecvThreadProc(NvNetState_t *s)
 		int size = g_NVNet->PCAPReceive(packet, 65536);
 		if (size > 0) {
 			EmuNVNet_DMAPacketToGuest(packet, size);
-		}
-		Sleep(1);
+		}	
 	}
 }
 


### PR DESCRIPTION
This fixes networking desync introduced by additional sleeps: Performance impact is minimal.

Thanks Driveclub & friends for testing/reporting