### PR TITLE
Call DefWindowProc when WM_KEYDOWN, WM_SYSKEYDOWN are not handled

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1619,6 +1619,10 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
             {
                 ToggleFauxFullscreen(hWnd);
             }
+            else
+            {
+                return DefWindowProc(hWnd, msg, wParam, lParam);
+            }
         }
         break;
 
@@ -1654,6 +1658,10 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
             {
                 if(g_iWireframe++ == 2)
                     g_iWireframe = 0;
+            }
+            else
+            {
+                return DefWindowProc(hWnd, msg, wParam, lParam);
             }
         }
         break;

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -381,8 +381,12 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
             {
                 SendMessage(m_hwndChild, uMsg, wParam, lParam);
             }
+            else
+            {
+				return DefWindowProc(hwnd, uMsg, wParam, lParam);
+            }
         };
-		break; // added per PVS suggestion.
+        break; // added per PVS suggestion.
 
         case WM_PAINT:
         {
@@ -513,6 +517,10 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
                     if(m_hwndChild != NULL)
                     {
                         SendMessage(m_hwndChild, uMsg, wParam, lParam);
+                    }
+                    else
+                    {
+                        DefWindowProc(hwnd, uMsg, wParam, lParam);
                     }
                 }
             }


### PR DESCRIPTION
This enables key combos not handled by CxBx to pass through, including some system functions.

Previously, `Alt` couldn't be used to access the menu bar, `Alt-F4` did not close, etc.