### PR TITLE
Ignore D3DVSDT_NONE

### DIFF
--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -2247,12 +2247,19 @@ static void VshConvertToken_STREAMDATA_REG(
 		break;
 	case X_D3DVSDT_NONE: // 0x02:
 		DbgVshPrintf("D3DVSDT_NONE /* xbox ext. */");
-		HostVertexElementDataType = D3DDECLTYPE_UNUSED;
-		// NeedPatching = TRUE; // TODO : This seems to cause regressions?
+		// Ignore token
 		break;
 	default:
 		DbgVshPrintf("Unknown data type for D3DVSD_REG: 0x%02X\n", XboxVertexElementDataType);
 		break;
+	}
+
+	DbgVshPrintf("),\n");
+
+	// On X_D3DVSDT_NONE skip this token
+	if (XboxVertexElementDataType == X_D3DVSDT_NONE)
+	{
+		return;
 	}
 
 	// save patching information
@@ -2278,12 +2285,6 @@ static void VshConvertToken_STREAMDATA_REG(
 
     pPatchData->pCurrentVertexShaderStreamInfo->HostVertexStride += HostVertexElementByteSize;
 
-    DbgVshPrintf("),\n");
-
-    if(HostVertexElementDataType == D3DDECLTYPE_UNUSED)
-    {
-        EmuLog(LOG_LEVEL::WARNING, "/* WARNING: Fatal type mismatch, no fitting type! */");
-    }
 }
 
 static void VshConvertToken_STREAMDATA(


### PR DESCRIPTION
This PR skips outputting anything when encountering `D3DVSDT_NONE`
Before, we output a vertex element with type `D3DDECLTYPE_UNUSED`, which results in a crash

`D3DDECLTYPE_UNUSED` is supposed to be used for certain `D3DDECL_METHOD` values:
https://docs.microsoft.com/en-us/windows/desktop/direct3d9/d3ddecltype

Here is are some example xbox decl from Soldier of Fortune II:
```
DWORD dwVSHDecl[] =
{
	D3DVSD_STREAM(0),
		D3DVSD_REG(0, D3DVSDT_FLOAT3),
	// NeedPatching: 0
	D3DVSD_STREAM(1),
		D3DVSD_REG(1, D3DVSDT_NONE /* xbox ext. */),
	// NeedPatching: 0
	D3DVSD_STREAM(2),
		D3DVSD_REG(2, D3DVSDT_FLOAT2),
	// NeedPatching: 0
	D3DVSD_STREAM(3),
		D3DVSD_REG(3, D3DVSDT_NONE /* xbox ext. */),
	// NeedPatching: 0
	D3DVSD_STREAM(4),
		D3DVSD_REG(4, D3DVSDT_D3DCOLOR),
	// NeedPatching: 0
	D3DVSD_STREAM(5),
		D3DVSD_REG(5, D3DVSDT_NONE /* xbox ext. */),
	// NeedPatching: 0
	D3DVSD_END()
};
DWORD dwVSHDecl[] =
{
	D3DVSD_STREAM(0),
		D3DVSD_REG(0, D3DVSDT_FLOAT3),
	// NeedPatching: 0
	D3DVSD_STREAM(1),
		D3DVSD_REG(1, D3DVSDT_NONE /* xbox ext. */),
	// NeedPatching: 0
	D3DVSD_STREAM(2),
		D3DVSD_REG(2, D3DVSDT_FLOAT2),
	// NeedPatching: 0
	D3DVSD_STREAM(3),
		D3DVSD_REG(3, D3DVSDT_NONE /* xbox ext. */),
	// NeedPatching: 0
	D3DVSD_STREAM(4),
		D3DVSD_REG(4, D3DVSDT_NONE /* xbox ext. */),
	// NeedPatching: 0
	D3DVSD_STREAM(5),
		D3DVSD_REG(5, D3DVSDT_NONE /* xbox ext. */),
	// NeedPatching: 0
	D3DVSD_END()
};
```
It looks to me like each stream is declared one-by-one in order, but some streams don't contain any data , so get  `D3DVSDT_NONE` as a placeholder
So suspect we should ignore it

Ignoring allows Soldier of Fortune II to boot, otherwise it hits "Setting Vertex Declaration Failed"