### PR TITLE
Fix a bug where the smashing drive fix was actually ignored

### DIFF
--- a/src/core/hle/D3D8/XbState.cpp
+++ b/src/core/hle/D3D8/XbState.cpp
@@ -102,7 +102,7 @@ void UpdateDeferredRenderStates()
                     if (fogValue < 0.0f) {
                         LOG_TEST_CASE("FOGSTART/FOGEND below 0");
                         fogValue = std::abs(fogValue);
-                        Value = *(DWORD*)&Value;
+                        Value = *(DWORD*)&fogValue;
                     }
                 } break;
                 case XTL::X_D3DRS_FOGENABLE:


### PR DESCRIPTION
Quick fix because the wrong value was being used in the smashing drive fix