### PR TITLE
Fix a deadlock when some LTCG titles attempt to wait for vertical blank

### DIFF
--- a/src/devices/video/nv2a.cpp
+++ b/src/devices/video/nv2a.cpp
@@ -1209,12 +1209,12 @@ void NV2ADevice::Init()
 	// Setup the conditions/mutexes
 	pgraph_init(d);
 
-	// Only spawn VBlank thread when LLE is enabled
+	// Only init PVIDEO when LLE is enabled
 	if (d->pgraph.opengl_enabled) {
 		pvideo_init(d);
-
-		vblank_thread = std::thread(nv2a_vblank_thread, d);
 	}
+
+    vblank_thread = std::thread(nv2a_vblank_thread, d);
 
     qemu_mutex_init(&d->pfifo.pfifo_lock);
     qemu_cond_init(&d->pfifo.puller_cond);


### PR DESCRIPTION
With this, conker no longer hangs. It still doesn't work, however.

The cause was that some LTCG titles replace WaitForVerticalBlank with nothing more than a pure wait for interrupt stub, which means that interrupts must be working