### PR TITLE
Fix black screen in some titles when switching resolutions during gameplay

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3207,13 +3207,31 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
 		DWORD top = std::max((int)pViewport->Y, 0);
 		DWORD right = std::min((int)pViewport->X + (int)pViewport->Width, (int)XboxRenderTarget_Width);
 		DWORD bottom = std::min((int)pViewport->Y + (int)pViewport->Height, (int)XboxRenderTarget_Height);
+		DWORD width = right - left;
+		DWORD height = bottom - top;
 
 		XboxViewPort.X = left;
 		XboxViewPort.Y = top;
-		XboxViewPort.Width = right - left;
-		XboxViewPort.Height = bottom - top;
+		XboxViewPort.Width = width;
+		XboxViewPort.Height = height;
 		XboxViewPort.MinZ = pViewport->MinZ;
 		XboxViewPort.MaxZ = pViewport->MaxZ;
+
+		// This operation is often used to change the display resolution without calling SetRenderTarget!
+		// This works by updating the underlying Width & Height of the Xbox surface, without reallocating the data
+		// Because of this, we need to validate that the associated host resource still matches the dimensions of the Xbox Render Target
+		// If not, we must force them to be re-created
+		// TEST CASE: Chihiro Factory Test Program
+		DWORD HostRenderTarget_Width = 0, HostRenderTarget_Height = 0;
+		GetHostRenderTargetDimensions(&HostRenderTarget_Width, &HostRenderTarget_Height);
+		if (HostRenderTarget_Width != XboxRenderTarget_Width || HostRenderTarget_Height != XboxRenderTarget_Height) {
+			LOG_TEST_CASE("RenderTarget width/height changed without calling SetRenderTarget");
+			FreeHostResource(GetHostResourceKey(g_pXboxRenderTarget)); g_pD3DDevice->SetRenderTarget(0, GetHostSurface(g_pXboxRenderTarget, D3DUSAGE_RENDERTARGET));
+			FreeHostResource(GetHostResourceKey(g_pXboxDepthStencil)); g_pD3DDevice->SetDepthStencilSurface(GetHostSurface(g_pXboxRenderTarget, D3DUSAGE_DEPTHSTENCIL));
+		}
+						
+		// Store the updated viewport data ready to pass to host SetViewPort
+		HostViewPort = XboxViewPort;
 
 		if (g_ScaleViewport) {
 			// Get current host render target dimensions

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3238,7 +3238,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
 		// Store the updated viewport data ready to pass to host SetViewPort
 		HostViewPort = XboxViewPort;
 
-		// We *must* scale the viewport when using the DirectHostBackBuffert hack for the backbuffer render target
+		// We *must* scale the viewport when using the DirectHostBackBuffer hack for the backbuffer render target
+		// Otherwise, we only get partial screen updates
 		if (g_ScaleViewport || (g_DirectHostBackBufferAccess && g_pXboxRenderTarget == g_XboxBackBufferSurface)) {
 			// Get current host render target dimensions
 			DWORD HostRenderTarget_Width;
@@ -3253,8 +3254,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
 				// TODO : Fix test-case Shenmue 2 (which halves height, leaving the bottom half unused)
 				HostViewPort.MinZ = XboxViewPort.MinZ; // No need scale Z for now
 				HostViewPort.MaxZ = XboxViewPort.MaxZ;
-			}
-			else {
+			} else {
 				EmuLog(LOG_LEVEL::WARNING, "GetHostRenderTargetDimensions failed - SetViewport sets Xbox viewport instead!");
 			}
 		}

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3226,12 +3226,20 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
 		GetHostRenderTargetDimensions(&HostRenderTarget_Width, &HostRenderTarget_Height);
 		if (HostRenderTarget_Width != XboxRenderTarget_Width || HostRenderTarget_Height != XboxRenderTarget_Height) {
 			LOG_TEST_CASE("RenderTarget width/height changed without calling SetRenderTarget");
-			FreeHostResource(GetHostResourceKey(g_pXboxRenderTarget)); g_pD3DDevice->SetRenderTarget(0, GetHostSurface(g_pXboxRenderTarget, D3DUSAGE_RENDERTARGET));
-			FreeHostResource(GetHostResourceKey(g_pXboxDepthStencil)); g_pD3DDevice->SetDepthStencilSurface(GetHostSurface(g_pXboxRenderTarget, D3DUSAGE_DEPTHSTENCIL));
+
+			// NOTE: If the host backbuffer hack is enabled, we must skip this operation for the back buffer, otherwise everything will break
+			// In that situation, there's nothing we can do without causing damage. 
+			if (!g_DirectHostBackBufferAccess && g_pXboxRenderTarget != g_XboxBackBufferSurface) {
+				FreeHostResource(GetHostResourceKey(g_pXboxRenderTarget)); g_pD3DDevice->SetRenderTarget(0, GetHostSurface(g_pXboxRenderTarget, D3DUSAGE_RENDERTARGET));
+				FreeHostResource(GetHostResourceKey(g_pXboxDepthStencil)); g_pD3DDevice->SetDepthStencilSurface(GetHostSurface(g_pXboxRenderTarget, D3DUSAGE_DEPTHSTENCIL));
+			}
 		}
 						
 		// Store the updated viewport data ready to pass to host SetViewPort
-		HostViewPort = XboxViewPort;
+		// Again, we can only do this when the host backbuffer hack is disabled, otherwise, we break
+		if (!g_DirectHostBackBufferAccess && g_pXboxRenderTarget != g_XboxBackBufferSurface) {
+			HostViewPort = XboxViewPort;
+		}
 
 		if (g_ScaleViewport) {
 			// Get current host render target dimensions

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3236,12 +3236,10 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetViewport)
 		}
 						
 		// Store the updated viewport data ready to pass to host SetViewPort
-		// Again, we can only do this when the host backbuffer hack is disabled, otherwise, we break
-		if (!g_DirectHostBackBufferAccess && g_pXboxRenderTarget != g_XboxBackBufferSurface) {
-			HostViewPort = XboxViewPort;
-		}
+		HostViewPort = XboxViewPort;
 
-		if (g_ScaleViewport) {
+		// We *must* scale the viewport when using the DirectHostBackBuffert hack for the backbuffer render target
+		if (g_ScaleViewport || (g_DirectHostBackBufferAccess && g_pXboxRenderTarget == g_XboxBackBufferSurface)) {
 			// Get current host render target dimensions
 			DWORD HostRenderTarget_Width;
 			DWORD HostRenderTarget_Height;


### PR DESCRIPTION
This contains a bug fix that can be seen on the MS dashboard (Clipped viewport values were never copied back to HostViewPort)

And one that was a previously unknown behavior (changing backbuffer width/height without a call to SetRenderTarget)
a LOG_TEST_CASE has been added for the new behavior, and a fix has been applied by destroying the existing host render target, and creating a new one.

Known PR Test Cases:
 - MS Dashboard 'Video Mode' settings menu (When switching between 'widescreen', 'letterbox', 'normal')
 - Chihiro Factory Test Program (requires chihiro-work branch)