### PR TITLE
Separate D3D8 Build Version Away from General Build Version

### DIFF
--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -44,6 +44,10 @@ static_assert(false, "Please implement support for cross-platform's user profile
 
 std::string g_exec_filepath;
 
+// Individual library version
+uint16_t g_LibVersion_D3D8 = 0;
+uint16_t g_LibVersion_DSOUND = 0;
+
 // NOTE: Update settings_version when add/edit/delete setting's structure.
 const unsigned int settings_version = 4;
 

--- a/src/common/Settings.hpp
+++ b/src/common/Settings.hpp
@@ -32,6 +32,10 @@
 
 extern std::string g_exec_filepath;
 
+// Individual library version
+extern uint16_t g_LibVersion_D3D8;
+extern uint16_t g_LibVersion_DSOUND;
+
 #define szSettings_alloc_error "ERROR: Unable to allocate Settings class."
 
 // Cxbx-Reloaded's data storage location.

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -127,9 +127,6 @@ XTL::D3DCAPS					    g_D3DCaps = {};         // Direct3D Caps
 // wireframe toggle
 static int                          g_iWireframe    = 0;
 
-// build version
-extern uint32_t                     g_BuildVersion;
-
 typedef uint64_t resource_key_t;
 
 extern void UpdateFPSCounter();
@@ -3632,7 +3629,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant)
 	// some shaders need to add 96 to use ranges 0 to 192.  This fixes 3911 - 4361 games and XDK
 	// samples, but breaks Turok.
 	// See D3DDevice_GetVertexShaderConstant
-	if(g_BuildVersion <= 4361)
+	if(g_LibVersion_D3D8 <= 4361)
 		Register += 96;
 
     HRESULT hRet;
@@ -8171,7 +8168,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderConstant)
 	// some shaders need to add 96 to use ranges 0 to 192.  This fixes 3911 - 4361 games and XDK
 	// samples, but breaks Turok.
 	// See D3DDevice_SetVertexShaderConstant
-	if (g_BuildVersion <= 4361)
+	if (g_LibVersion_D3D8 <= 4361)
 		Register += 96;
 
 	HRESULT hRet = g_pD3DDevice->GetVertexShaderConstantF
@@ -9095,7 +9092,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPixelShaderConstant_4)
 
     // TODO: This hack is necessary for Vertex Shaders on XDKs prior to 4361, but if this
     // causes problems with pixel shaders, feel free to comment out the hack below.
-    if(g_BuildVersion <= 4361)
+    if(g_LibVersion_D3D8 <= 4361)
         Register += 96;
 
 	HRESULT hRet = g_pD3DDevice->SetPixelShaderConstantF

--- a/src/core/hle/D3D8/XbState.cpp
+++ b/src/core/hle/D3D8/XbState.cpp
@@ -35,9 +35,8 @@
 DWORD *XTL::EmuD3DDeferredRenderState = nullptr;
 DWORD *XTL::EmuD3DDeferredTextureState = nullptr;
 
-extern uint32_t g_BuildVersion;
-
 #include "core\hle\Intercept.hpp" // For g_SymbolAddresses
+#include "common/Settings.hpp"    // For g_LibVersion_D3D8
 
 void VerifyAndFixEmuDeferredRenderStateOffset()
 {
@@ -62,7 +61,7 @@ void VerifyAndFixEmuDeferredRenderStateOffset()
     // Calculate index of D3DRS_CULLMODE for this XDK. We start counting from the first deferred state (D3DRS_FOGENABLE)
     DWORD CullModeIndex = 0;
     for (int i = XTL::X_D3DRS_FOGENABLE; i < XTL::X_D3DRS_CULLMODE; i++) {
-        if (XTL::DxbxRenderStateInfo[i].V <= g_BuildVersion) {
+        if (XTL::DxbxRenderStateInfo[i].V <= g_LibVersion_D3D8) {
             CullModeIndex++;
         }
     }
@@ -82,7 +81,7 @@ void UpdateDeferredRenderStates()
         // Loop through all deferred render states
         for (unsigned int RenderState = XTL::X_D3DRS_FOGENABLE; RenderState <= XTL::X_D3DRS_PRESENTATIONINTERVAL; RenderState++) {
             // If the current state is not present within our desired XDK, skip it
-            if (XTL::DxbxRenderStateInfo[RenderState].V >= g_BuildVersion) {
+            if (XTL::DxbxRenderStateInfo[RenderState].V >= g_LibVersion_D3D8) {
                 continue;
             }
 
@@ -175,7 +174,7 @@ DWORD GetDeferredTextureStateFromIndex(DWORD State)
 {
     // On early XDKs, we need to shuffle the values around a little
     // TODO: Verify which XDK version this change occurred at
-    if (g_BuildVersion <= 3948) {
+    if (g_LibVersion_D3D8 <= 3948) {
         // Values range 0-9 (D3DTSS_COLOROP to D3DTSS_TEXTURETRANSFORMFLAGS) become 12-21
         if (State <= 9) {
             return State + 12;
@@ -229,7 +228,7 @@ DWORD TranslateXDKSpecificD3DTOP(DWORD Value)
     // TODO: Determine when exactly these values changed
     // So far, 4134 is the earliest version we've seen using these mappings
     // But this may change
-    if (g_BuildVersion >= 4134) {
+    if (g_LibVersion_D3D8 >= 4134) {
         // For these XDKs, the mapping has been confirmed to match our internal mapping
         return Value;
     }


### PR DESCRIPTION
Doing this method will allow D3D8 library version not to select general build version.

Plus prepare DSOUND build version to be use for #1649 pull request. I had confirmed DSOUND's 4039 detection is functional.