### PR TITLE
Keep appveyor release artifact only

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,12 +23,12 @@ build_script:
   - cmd: cmake --build . --config %CONFIGURATION%
 
 after_build:
-  - cmd: |-
-      cd bin\%CONFIGURATION%
-      7z u %APPVEYOR_BUILD_FOLDER%\export\%CONFIGURATION%.zip ..\..\..\COPYING ..\..\..\README.md
-      7z u %APPVEYOR_BUILD_FOLDER%\export\%CONFIGURATION%.zip Cxbx.exe glew32.dll subhook.dll CxbxVSBC.dll
-      7z u %APPVEYOR_BUILD_FOLDER%\export\%CONFIGURATION%.zip cxbxr-debugger.exe capstone.dll cs_x86.dll
-
-artifacts:
-  - path: export/*.zip
+  - ps: |-
+      cd "bin\${env:CONFIGURATION}"
+      7z u "${env:CONFIGURATION}.zip" ..\..\..\COPYING ..\..\..\README.md
+      7z u "${env:CONFIGURATION}.zip" Cxbx.exe glew32.dll subhook.dll CxbxVSBC.dll
+      7z u "${env:CONFIGURATION}.zip" cxbxr-debugger.exe capstone.dll cs_x86.dll
+      If ($env:CONFIGURATION -eq 'Release') { 
+        Get-ChildItem .\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } 
+      }
 


### PR DESCRIPTION
Thanks to @GXTX assistance

Currently very low risk and prevent users access to debug build then file false positives.