### PR TITLE
Workaround & LOG_TEST_CASE for missing DestroyResource patch

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5576,45 +5576,37 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
 
 	// Was the Xbox resource freed?
 	if (uRet == 0) {
-		// We should free any variables storing the resource when freed
-        // HACK: For now, we skip the release when the resource has a non-zero internal ref count
-		// We also skip the release if we still have a cached variable containing this value
-        // This is a (small) memory leak, but prevents incorrectly freeing an in-use resource
-        // This is a *temporary* work around until solving https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1665
+	
+        // Generate some test cases so we know what to investigate/re-test after
+		// solving https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1665
 		if ((pThis->Common & X_D3DCOMMON_INTREFCOUNT_MASK) != 0) {
-			LOG_TEST_CASE("Skipping Release of resource with a non-zero internal reference count");
-			RETURN(uRet);
+			LOG_TEST_CASE("Release of resource with a non-zero internal reference count");
 		}
 
 		if (pThis == g_pXboxRenderTarget) {
-            LOG_TEST_CASE("Skipping release of active Xbox Render Target");
-            RETURN(uRet);
-            //g_pXboxRenderTarget = nullptr;
+            LOG_TEST_CASE("Release of active Xbox Render Target");
+            g_pXboxRenderTarget = nullptr;
 		}
 
 		if (pThis == g_pXboxDepthStencil) {
-            LOG_TEST_CASE("Skipping release of active Xbox Depth Stencil");
-            RETURN(uRet);
-            //g_pXboxDepthStencil = nullptr;
+            LOG_TEST_CASE("Release of active Xbox Depth Stencil");
+            g_pXboxDepthStencil = nullptr;
 		}
 
 		if (pThis == g_XboxBackBufferSurface) {
-            LOG_TEST_CASE("Skipping release of active Xbox Render Target");
-            RETURN(uRet);
-            //g_XboxBackBufferSurface = nullptr;
+            LOG_TEST_CASE("Release of active Xbox Render Target");
+            g_XboxBackBufferSurface = nullptr;
 		}
 
         if (pThis == g_XboxDefaultDepthStencilSurface) {
-            LOG_TEST_CASE("Skipping release of default Xbox Depth Stencil");
-            RETURN(uRet);
-            //g_XboxDefaultDepthStencilSurface = nullptr;
+            LOG_TEST_CASE("Release of default Xbox Depth Stencil");
+            g_XboxDefaultDepthStencilSurface = nullptr;
         }
 
 		for (int i = 0; i < TEXTURE_STAGES; i++) {
             if (pThis == EmuD3DActiveTexture[i]) {
-                LOG_TEST_CASE("Skipping release of active Xbox Texture");
-                RETURN(uRet);
-                //EmuD3DActiveTexture[i] = nullptr;
+                LOG_TEST_CASE("Release of active Xbox Texture");
+                EmuD3DActiveTexture[i] = nullptr;
             }
 		}
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5577,10 +5577,15 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
 	// Was the Xbox resource freed?
 	if (uRet == 0) {
 		// We should free any variables storing the resource when freed
-        // HACK: For now, we skip the release and issue a LOG_TEST_CASE
+        // HACK: For now, we skip the release when the resource has a non-zero internal ref count
+		// We also skip the release if we still have a cached variable containing this value
         // This is a (small) memory leak, but prevents incorrectly freeing an in-use resource
-        // This is a *temporary* work around until solving
-        // https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1665
+        // This is a *temporary* work around until solving https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1665
+		if ((pThis->Common & X_D3DCOMMON_INTREFCOUNT_MASK) != 0) {
+			LOG_TEST_CASE("Skipping Release of resource with a non-zero internal reference count");
+			RETURN(uRet);
+		}
+
 		if (pThis == g_pXboxRenderTarget) {
             LOG_TEST_CASE("Skipping release of active Xbox Render Target");
             RETURN(uRet);

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5576,33 +5576,48 @@ ULONG WINAPI XTL::EMUPATCH(D3DResource_Release)
 
 	// Was the Xbox resource freed?
 	if (uRet == 0) {
-		// If this was a cached render target or depth surface, clear the cache variable too!
+		// We should free any variables storing the resource when freed
+        // HACK: For now, we skip the release and issue a LOG_TEST_CASE
+        // This is a (small) memory leak, but prevents incorrectly freeing an in-use resource
+        // This is a *temporary* work around until solving
+        // https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1665
 		if (pThis == g_pXboxRenderTarget) {
-			g_pXboxRenderTarget = nullptr;
+            LOG_TEST_CASE("Skipping release of active Xbox Render Target");
+            RETURN(uRet);
+            //g_pXboxRenderTarget = nullptr;
 		}
 
 		if (pThis == g_pXboxDepthStencil) {
-			g_pXboxDepthStencil = nullptr;
+            LOG_TEST_CASE("Skipping release of active Xbox Depth Stencil");
+            RETURN(uRet);
+            //g_pXboxDepthStencil = nullptr;
 		}
 
 		if (pThis == g_XboxBackBufferSurface) {
-			g_XboxBackBufferSurface = nullptr;
+            LOG_TEST_CASE("Skipping release of active Xbox Render Target");
+            RETURN(uRet);
+            //g_XboxBackBufferSurface = nullptr;
 		}
 
         if (pThis == g_XboxDefaultDepthStencilSurface) {
-            g_XboxDefaultDepthStencilSurface = nullptr;
+            LOG_TEST_CASE("Skipping release of default Xbox Depth Stencil");
+            RETURN(uRet);
+            //g_XboxDefaultDepthStencilSurface = nullptr;
         }
 
 		for (int i = 0; i < TEXTURE_STAGES; i++) {
-			if (pThis == EmuD3DActiveTexture[i])
-				EmuD3DActiveTexture[i] = nullptr;
+            if (pThis == EmuD3DActiveTexture[i]) {
+                LOG_TEST_CASE("Skipping release of active Xbox Texture");
+                RETURN(uRet);
+                //EmuD3DActiveTexture[i] = nullptr;
+            }
 		}
 
 		// Also release the host copy (if it exists!)
 		FreeHostResource(key); 
 	}
 
-    return uRet;
+    RETURN(uRet);
 }
 
 // ******************************************************************


### PR DESCRIPTION
This is a temporary workaround until https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1665 can be solved.

Added a LOG_TEST_CASE so we can track occurances so we know what to retest once we do finally patch DestroyResource (we're waiting on XbSymbolDatabase for that)