### PR TITLE
HOTFIX: GenerateMixBinDefault Check for lpwfxFormat is null pointer

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -251,7 +251,7 @@ inline void GenerateMixBinDefault(
         }
         else {
             // If format is PCM/XADPCM, then use stereo mixbin as default.
-            if (lpwfxFormat->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
+            if (lpwfxFormat == xbnullptr || lpwfxFormat->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
                 counter = 2;
                 for (i = 0; i < counter; i++) {
                     xb_mixbinArray[i].dwMixBin = i;


### PR DESCRIPTION
After discussion with other dev, I had discover a design flaw for not checking lpwfxFormat if has a null pointer or not.