### PR TITLE
Fix shader constants: It's per-function not per-XDK

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3705,10 +3705,10 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant)
 		LOG_FUNC_END;
 
 /*#ifdef _DEBUG_TRACK_VS_CONST
-    for (uint32 i = 0; i < ConstantCount; i++)
+    for (uint32_t i = 0; i < ConstantCount; i++)
     {
-        printf("SetVertexShaderConstant, c%d (c%d) = { %f, %f, %f, %f }\n",
-               Register - 96 + i, Register + i,
+        printf("SetVertexShaderConstant, c%d  = { %f, %f, %f, %f }\n",
+               Register + i,
                *((float*)pConstantData + 4 * i),
                *((float*)pConstantData + 4 * i + 1),
                *((float*)pConstantData + 4 * i + 2),
@@ -3716,12 +3716,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant)
     }
 #endif*/ // _DEBUG_TRACK_VS_CONST
 
-	// TODO: HACK: Since Xbox vertex shader constants range from -96 to 96, during conversion
-	// some shaders need to add 96 to use ranges 0 to 192.  This fixes 3911 - 4361 games and XDK
-	// samples, but breaks Turok.
-	// See D3DDevice_GetVertexShaderConstant
-	if(g_LibVersion_D3D8 <= 4361)
-		Register += 96;
+    // Xbox vertex shader constants range from -96 to 96
+    // The host does not support negative, so we adjust to 0-192
+	Register += 96;
 
     HRESULT hRet;
 	hRet = g_pD3DDevice->SetVertexShaderConstantF(
@@ -3749,7 +3746,10 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant1)
 {
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
-    EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register, pConstantData, 1);
+    // The XDK uses a macro to automatically adjust to 0-192 range
+    // but D3DDevice_SetVertexShaderConstant expects -96-96 range
+    // so we adjust before forwarding
+    EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - 96, pConstantData, 1);
 }
 
 // ******************************************************************
@@ -3763,9 +3763,10 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant1Fast)
 {
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
-	// Redirect to the standard version.
-
-    EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register, pConstantData, 1);
+    // The XDK uses a macro to automatically adjust to 0-192 range
+    // but D3DDevice_SetVertexShaderConstant expects -96-96 range
+    // so we adjust before forwarding
+    EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - 96, pConstantData, 1);
 }
 
 // ******************************************************************
@@ -3779,7 +3780,10 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstant4)
 {
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
-	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register, pConstantData, 4);
+    // The XDK uses a macro to automatically adjust to 0-192 range
+    // but D3DDevice_SetVertexShaderConstant expects -96-96 range
+    // so we adjust before forwarding
+	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - 96, pConstantData, 4);
 }
 
 // ******************************************************************
@@ -3794,7 +3798,10 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline)
 {
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
-	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register, pConstantData, ConstantCount / 4);
+    // The XDK uses a macro to automatically adjust to 0-192 range
+    // but D3DDevice_SetVertexShaderConstant expects -96-96 range
+    // so we adjust before forwarding
+	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - 96, pConstantData, ConstantCount / 4);
 }
 
 // ******************************************************************
@@ -3809,9 +3816,10 @@ VOID __fastcall XTL::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInlineFast)
 {
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
 
-	// Redirect to the standard version.
-
-	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register, pConstantData, ConstantCount / 4);
+    // The XDK uses a macro to automatically adjust to 0-192 range
+    // but D3DDevice_SetVertexShaderConstant expects -96-96 range
+    // so we adjust before forwarding
+	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - 96, pConstantData, ConstantCount / 4);
 }
 
 // LTCG specific D3DDevice_SetTexture function...
@@ -8292,12 +8300,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderConstant)
 		LOG_FUNC_ARG(ConstantCount)
 		LOG_FUNC_END;
 
-	// TODO: HACK: Since Xbox vertex shader constants range from -96 to 96, during conversion
-	// some shaders need to add 96 to use ranges 0 to 192.  This fixes 3911 - 4361 games and XDK
-	// samples, but breaks Turok.
-	// See D3DDevice_SetVertexShaderConstant
-	if (g_LibVersion_D3D8 <= 4361)
-		Register += 96;
+	// Xbox vertex shader constants range from -96 to 96
+    // The host does not support negative, so we adjust to 0-192
+	Register += 96;
 
 	HRESULT hRet = g_pD3DDevice->GetVertexShaderConstantF
     (
@@ -9217,11 +9222,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetPixelShaderConstant_4)
     //    LOG_FUNC_ARG(ConstantCount)
     //    LOG_FUNC_END;
     EmuLog(LOG_LEVEL::DEBUG, "D3DDevice_SetPixelShaderConstant_4(Register : %d pConstantData : %08X ConstantCount : %d);", Register, pConstantData, ConstantCount);
-
-    // TODO: This hack is necessary for Vertex Shaders on XDKs prior to 4361, but if this
-    // causes problems with pixel shaders, feel free to comment out the hack below.
-    if(g_LibVersion_D3D8 <= 4361)
-        Register += 96;
 
 	HRESULT hRet = g_pD3DDevice->SetPixelShaderConstantF
     (


### PR DESCRIPTION
Previously, Cxbx-R interpreted shaders from earlier XDKs as requiring +96 and later XDKS not, but this is incorrect.

After disassembling various games, it can be seen that instead, it goes per-function.

The standard D3DDevice_SetVertexShaderConstant function *always* takes constants ranging -96 to 96 on the Xbox, so we need to apply a +96 bias to convert to the host representation.

This also matches how the shaders are mapped to nv2a registers 0-196.

The functions that we implemented as forwards to D3DDevice_SetVertexShaderConstant take registers in the range 0-196. (already in NV2A register range). This is a perforamce optimization on the Xbox side: Later XDKs use a macro to adjust the range at compile time (using these functions) instead of run-time.

It's safe to implement these as forwards, but rather than implementing a per-XDK version check, we can simply subtract 96 to convert the range back into the expected range for D3DDevice_SetVertexShaderConstant.