### PR TITLE
Fix Universal Error Message Output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ file (GLOB CXBXR_HEADER_EMU
  "${CXBXR_ROOT_DIR}/src/core/hle/XAPI/Xapi.h"
  "${CXBXR_ROOT_DIR}/src/core/hle/XGRAPHIC/XGraphic.h"
  "${CXBXR_ROOT_DIR}/src/core/hle/XONLINE/XOnline.h"
+ "${CXBXR_ROOT_DIR}/src/core/kernel/common/strings.hpp"
  "${CXBXR_ROOT_DIR}/src/core/kernel/exports/EmuKrnlAvModes.h"
  "${CXBXR_ROOT_DIR}/src/core/kernel/exports/EmuKrnlKe.h"
  "${CXBXR_ROOT_DIR}/src/core/kernel/exports/EmuKrnlKi.h"

--- a/resource/Cxbx.rc
+++ b/resource/Cxbx.rc
@@ -654,17 +654,6 @@ BEGIN
     MENUITEM " ",                           ID_LOG,MFT_STRING,MFS_ENABLED
 END
 
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// String Table
-//
-
-STRINGTABLE
-BEGIN
-    IDS_UEM                 "Your Xbox requires service.\n\nPlease call Xbox Customer Support.\n\n\nIhre Xbox muss gewartet werden.\n\nBitte den Xbox-Kundendienst anrufen.\n\n\nLa consola Xbox requiere asistencia técnica.\n\nLlame al servicio de soporte al cliente de la Xbox.\n\n\nXbox ha bisogno di manutenzione.\n\nChiamare l'Assistenza Clienti di Xbox.\n\n\nVotre Xbox ne fonctionne pas correctement.\n\nVeuillez contacter le Support à la clientèle Xbox.\n\n\n不具合が生じました。お手数ですが、\n\nXboxカスタマー　サポートにお問い合わせください。"
-END
-
 #endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -51,6 +51,7 @@ namespace xboxkrnl
 #include "devices\video\nv2a.h" // For GET_MASK, NV_PGRAPH_CONTROL_0
 #include "gui\ResCxbx.h"
 #include "WalkIndexBuffer.h"
+#include "core/kernel/common/strings.hpp" // For uem_str
 
 #include <assert.h>
 #include <process.h>
@@ -542,18 +543,17 @@ void DrawUEM(HWND hWnd)
 
 	SetTextColor(hMemDC, RGB(0, 204, 0));
 
-	wchar_t buff[500];
-	LoadStringW(GetModuleHandle(NULL), IDS_UEM, buff, sizeof(buff) / sizeof(wchar_t));
-	std::wstring wstr(buff);
+	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> UTF8toUTF16;
+	std::wstring utf16str = UTF8toUTF16.from_bytes(uem_str);
 
 	// Unfortunately, DrawTextW doesn't support vertical alignemnt, so we have to do the calculation
 	// ourselves. See here: https://social.msdn.microsoft.com/Forums/vstudio/en-US/abd89aae-16a0-41c6-8db6-b119ea90b42a/win32-drawtext-how-center-in-vertical-with-new-lines-and-tabs?forum=vclanguage
 
 	RECT rect = { 0, 0, 640, 480 };
 	RECT textrect = { 0, 0, 640, 480 };
-	DrawTextW(hMemDC, wstr.c_str(), wstr.length(), &textrect, DT_CALCRECT);
+	DrawTextW(hMemDC, utf16str.c_str(), utf16str.length(), &textrect, DT_CALCRECT);
 	rect.top = (rect.bottom - textrect.bottom) / 2;
-	DrawTextW(hMemDC, wstr.c_str(), wstr.length(), &rect, DT_CENTER);
+	DrawTextW(hMemDC, utf16str.c_str(), utf16str.length(), &rect, DT_CENTER);
 
 
 	// Draw the Xbox error code

--- a/src/core/kernel/common/strings.hpp
+++ b/src/core/kernel/common/strings.hpp
@@ -1,0 +1,38 @@
+// ******************************************************************
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// *
+// *  (c) 2018          ergo720
+// *  (c) 2018-2019     RadWolfie
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+#include <string>
+
+// The file is saved as UTF-8 format, some strings may not output correctly at runtime.
+// To work around this, you will need to use std::wstring_convert class
+// or any UTF-8 to UTF-16 conversion function.
+
+// Universal Error Message (UEM)
+static std::string uem_str = "Your Xbox requires service.\n\nPlease call Xbox Customer Support.\n"
+                             "\n\nIhre Xbox muss gewartet werden.\n\nBitte den Xbox-Kundendienst anrufen.\n"
+                             "\n\nLa consola Xbox requiere asistencia técnica.\n\nLlame al servicio de soporte al cliente de la Xbox.\n"
+                             "\n\nXbox ha bisogno di manutenzione.\n\nChiamare l'Assistenza Clienti di Xbox.\n"
+                             "\n\nVotre Xbox ne fonctionne pas correctement.\n\nVeuillez contacter le Support à la clientèle Xbox.\n"
+                             "\n\n不具合が生じました。お手数ですが、\n\nXboxカスタマー　サポートにお問い合わせください。";

--- a/src/gui/ResCxbx.h
+++ b/src/gui/ResCxbx.h
@@ -17,7 +17,6 @@
 #define IDD_ABOUT                       119
 #define IDR_CONTRIBUTORS                121
 #define IDR_COPYING                     122
-#define IDS_UEM                         123
 #define IDD_CONTROLLER_HOST_MAPPING     131
 #define IDD_VIRTUAL_SBC_FEEDBACK        133
 #define IDD_NETWORK_CFG                 134


### PR DESCRIPTION
While this pull request may not change anything, except it will fix the loader branch's UEM window issue when `cxbxr-emu.dll` try to output missing UEM message.