### PR TITLE
Preserve caller esp value

### DIFF
--- a/src/core/kernel/support/EmuFS.cpp
+++ b/src/core/kernel/support/EmuFS.cpp
@@ -426,6 +426,7 @@ __declspec(naked) void EmuFS_MovFs00Esp()
 		push eax
 		mov eax, fs : [TIB_ArbitraryDataSlot]
 		mov [eax], esp
+		add [eax], 8 // account esp changes from pushed registers and return address
 		pop eax
 		call UnlockFS
 		ret


### PR DESCRIPTION
We patch instructions like `mov fs esp`
But `esp` is modified by calling the patch and pushing registers

This PR reverses `esp` changes before storing it in the emulated `fs`

Regressing titles:
PoP2 (black screen on boot)
Mechassault (black screen on boot)
Mercenaries (hang on boot)
