### PR TITLE
Improve LockFS performance

### DIFF
--- a/src/core/kernel/support/EmuFS.cpp
+++ b/src/core/kernel/support/EmuFS.cpp
@@ -128,12 +128,12 @@ __declspec(naked) void LockFS()
 		// Backup Registers
 		pushfd
 		pushad
+		jmp entry
 
 		// Spin until we can aquire the lock
 		spinlock :
-		call SwitchToThread // Give other threads chance to run, prevents hogging entire timeslice waiting for spinlock
-							// We do this here loop because SwitchToThread will overwrite eax, so it cannot go below
-							// It's not worth wasting the extra cycles of pushing/popping eax to the stack around this call
+		call SwitchToThread // Give other threads a chance to run if we couldn't get the lock
+		entry:
 		mov eax, 1
 		xchg eax, fs_lock
 		test eax, eax


### PR DESCRIPTION
Follow up to #1673 
Only call `SwitchToThread` after we fail to obtain `fs_lock`

* Transworld Surf goes in game again
* Fixes DoAX and Outrun 2006 stutter and low fps during startup and in menus (sub 30fps to 60fps)

PoP2 still fine