### PR TITLE
Preserve caller esp value

### DIFF
--- a/src/core/kernel/support/EmuFS.cpp
+++ b/src/core/kernel/support/EmuFS.cpp
@@ -421,13 +421,16 @@ __declspec(naked) void EmuFS_MovFs00Esp()
 	// Note : eax must be preserved here, hence the push/pop
 	__asm
 	{
+		pushfd
 		call LockFS
 		call EmuFS_RefreshKPCR
 		push eax
 		mov eax, fs : [TIB_ArbitraryDataSlot]
 		mov [eax], esp
+		add [eax], 12 // account for esp changes from pushed registers and return address
 		pop eax
 		call UnlockFS
+		popfd
 		ret
 	}
 }

--- a/src/core/kernel/support/EmuFS.cpp
+++ b/src/core/kernel/support/EmuFS.cpp
@@ -365,7 +365,6 @@ __declspec(naked) void EmuFS_MovzxEaxBytePtrFs24()
 		call UnlockFS
 		ret
 	}
-	UnlockFS();
 }
 
 __declspec(naked) void EmuFS_MovFs00Eax()


### PR DESCRIPTION
Rehash of #1677 (Which did not preserve the flags registers correctly, causing hanging in some games)

We patch instructions like `mov fs esp`
But `esp` is modified by calling the patch and pushing registers

This PR reverses `esp` changes before storing it in the emulated `fs`

It also removes an extra `UnlockFS` call

Haven't observed any improvements or regressions