### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@
 
 skip_commits:
   files:
+    - .azure-pipelines.yml
     - .travis.yml
 
 init:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,52 @@
+trigger:
+  branches:
+    include:
+    - '*'
+  paths:
+    exclude:
+    - .appveyor.yml
+    - .travis.yml
+
+pr:
+  branches:
+    include:
+    - '*'
+  paths:
+    exclude:
+    - .appveyor.yml
+    - .travis.yml
+
+jobs:
+- job:
+  pool:
+    vmImage: windows-latest
+  strategy:
+    matrix:
+      Release:
+        configuration: Release
+      Debug:
+        configuration: Debug
+
+  steps:
+  - script: |
+      git submodule update --init --recursive
+      mkdir build
+      cd build
+      cmake .. -G "Visual Studio 16 2019" -A Win32
+    displayName: 'Before build'
+
+  - script: |
+      cd build
+      cmake --build . --config %configuration%
+    displayName: 'Build'
+
+  - script: |
+      cd "build\bin\%configuration%"
+      7z a "..\..\..\%configuration%.zip" ..\..\..\COPYING ..\..\..\README.md Cxbx.exe glew32.dll subhook.dll CxbxVSBC.dll cxbxr-debugger.exe capstone.dll cs_x86.dll
+    condition: and(succeeded(), eq(variables['Agent.JobName'], 'Release'))
+    displayName: 'After build'
+
+  - publish: $(configuration).zip
+    artifact: $(configuration)
+    condition: and(succeeded(), eq(variables['Agent.JobName'], 'Release'))
+    displayName: Publish artifact(s)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cxbx-Reloaded - Original Xbox Emulator 
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://img.shields.io/badge/License-GPL%20v2-blue.svg)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/iao43irxl3umbp33?svg=true)](https://ci.appveyor.com/project/SoullessSentinel/cxbx-reloaded)
+[![Azure](https://Cxbx-Reloaded.visualstudio.com/Cxbx-Reloaded/_apis/build/status/Cxbx-Reloaded.Cxbx-Reloaded?branchName=develop)](https://Cxbx-Reloaded.visualstudio.com/Cxbx-Reloaded/_build/latest?definitionId=7&branchName=develop)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-7289da.svg?logo=discord)](https://discord.gg/26Xjx23)
 
 Cxbx-Reloaded is an emulator for running Microsoft Xbox (and eventually, Chihiro) games on Microsoft Windows.


### PR DESCRIPTION
This will only create artifacts for Release just like AppVeyor.

Reasons to add Azure:
* Faster than AppVeyor.
* Can build multiple configurations at the same time.

However, merging this PR alone isn't enough to add it. You must register for [Azure DevOps](https://azure.microsoft.com/en-in/services/devops) then set up a build pipeline using the .azure-pipelines.yml from this PR.
The build status badge may not work as-is so it may need to be fixed. (it's broken currently since no such Azure repo exists.)

Here's what my Azure build looks like:
https://margen67.visualstudio.com/Cxbx-Reloaded/_build/results?buildId=215&view=results