### PR TITLE
Fix Xapi controller capabilities structure

### DIFF
--- a/src/core/hle/XAPI/Xapi.h
+++ b/src/core/hle/XAPI/Xapi.h
@@ -320,6 +320,7 @@ X_XINPUT_RUMBLE, *PX_XINPUT_RUMBLE;
 // ******************************************************************
 // * XINPUT_CAPABILITIES
 // ******************************************************************
+#include "AlignPrefix1.h"
 typedef struct _X_XINPUT_CAPABILITIES
 {
     BYTE SubType;
@@ -337,6 +338,7 @@ typedef struct _X_XINPUT_CAPABILITIES
     }
     Out;
 }
+#include "AlignPosfix1.h"
 X_XINPUT_CAPABILITIES, *PX_XINPUT_CAPABILITIES;
 
 // ******************************************************************


### PR DESCRIPTION
There's a bug with the Xapi controller capabilities structure which places it in the wrong memory address. This fixes it. 

Resolves controller input issues in: https://github.com/Cxbx-Reloaded/game-compatibility/issues/666