### PR TITLE
RenderTarget and CopyRect fixes

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5569,8 +5569,8 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 				}
 			}
 
-            // Now create our intermediate texture for UpdateTexture, but not for render targets
-            if (hRet == D3D_OK && (D3DUsage & D3DUSAGE_RENDERTARGET) == 0) {
+            // Now create our intermediate texture for UpdateTexture, but not for render targets or depth stencils
+            if (hRet == D3D_OK && (D3DUsage & D3DUSAGE_RENDERTARGET) == 0 && (D3DUsage & D3DUSAGE_DEPTHSTENCIL) == 0) {
                 hRet = g_pD3DDevice->CreateTexture(dwWidth, dwHeight, dwMipMapLevels,
                     0, PCFormat, XTL::D3DPOOL_SYSTEMMEM, &pIntermediateHostTexture,
                     nullptr
@@ -5607,8 +5607,8 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 			);
 			DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateVolumeTexture");
 
-            // Now create our intermediate texture for UpdateTexture, but not for render targets
-            if (hRet == D3D_OK && (D3DUsage & D3DUSAGE_RENDERTARGET) == 0) {
+            // Now create our intermediate texture for UpdateTexture, but not for render targets or depth stencils
+            if (hRet == D3D_OK && (D3DUsage & D3DUSAGE_RENDERTARGET) == 0 && (D3DUsage & D3DUSAGE_DEPTHSTENCIL) == 0) {
                 hRet = g_pD3DDevice->CreateVolumeTexture(dwWidth, dwHeight, dwDepth,
                     dwMipMapLevels, 0, PCFormat, XTL::D3DPOOL_SYSTEMMEM, &pIntermediateHostVolumeTexture,
                     nullptr
@@ -5636,8 +5636,8 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 			);
 			DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateCubeTexture");
 
-            // Now create our intermediate texture for UpdateTexture, but not for render targets
-            if (hRet == D3D_OK && (D3DUsage & D3DUSAGE_RENDERTARGET) == 0) {
+            // Now create our intermediate texture for UpdateTexture, but not for render targets or depth stencils
+            if (hRet == D3D_OK && (D3DUsage & D3DUSAGE_RENDERTARGET) == 0 && (D3DUsage & D3DUSAGE_DEPTHSTENCIL) == 0) {
                 hRet = g_pD3DDevice->CreateCubeTexture(dwWidth, dwMipMapLevels, 0,
                     PCFormat, XTL::D3DPOOL_SYSTEMMEM, &pIntermediateHostCubeTexture,
                     nullptr
@@ -5660,6 +5660,12 @@ void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iText
 			break;
 		}
 		} // switch XboxResourceType
+
+        // If this resource is a render target or depth stencil, don't attempt to lock/copy it as it won't work anyway
+        // In this case, we simply return
+        if (D3DUsage & D3DUSAGE_RENDERTARGET || D3DUsage & D3DUSAGE_DEPTHSTENCIL) {
+            return;
+        }
 
 		DWORD D3DLockFlags = D3DLOCK_NOSYSLOCK;
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4783,7 +4783,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_CopyRects)
     pHostDestSurface->GetDesc(&DestinationDesc);
 
     // If no rectangles were given, default to 1 (entire surface)
-    if (cRects = 0) {
+    if (cRects == 0) {
         cRects = 1;
     }
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -2439,7 +2439,6 @@ static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD D
                             // Re-create the texture with D3DUSAGE_RENDERTARGET, this will automatically create any child-surfaces
                             FreeHostResource(GetHostResourceKey(pParentXboxTexture));
                             CreateHostResource(pParentXboxTexture, D3DUsage, iTextureStage, dwSize);
-                            return;
                         }
 
                         // Re-create the surface with D3DUSAGE_RENDERTARGET


### PR DESCRIPTION
This PR fixes the following issues:

1. Fix a stupid bug that preventing the CopyRects patch from ever working to begin with
2. Fix an issue where attempting to copy a backbuffer to a texture would fail, due to mismatching pool types (StrechRects only works with D3DPOOL_DEFAULT)
3. Fix an issue where converting a RenderTarget to a Texture would not assign the child surface

Two Notable Improvements:

**Crash Bandicoot: The Wrath of Cortex (Fixed Pause screenshot)**
_Before:_
Pause screen has corrupted graphics
![image](https://user-images.githubusercontent.com/740003/64267253-fd338200-cf2d-11e9-98c4-3c4d122a3f1d.png)

_After:_
Pause screen renders as expected
![image](https://user-images.githubusercontent.com/740003/64267300-10dee880-cf2e-11e9-8b9b-335cd55b8bfc.png)

**Jet Set Radio Future (Fixed Graffiti Editor)**

_Before:_ 
Graffiti Editor partially works, some sizes don't update the view
![image](https://user-images.githubusercontent.com/740003/64267087-acbc2480-cf2d-11e9-862e-c9fc8e26380c.png)

_After:_
Graffiti Editor works as expected
![image](https://user-images.githubusercontent.com/740003/64267119-bb0a4080-cf2d-11e9-9a2d-2f010f97a337.png)

