### PR TITLE
Fix CopyRects when upscaling is used

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4812,8 +4812,13 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_CopyRects)
             DestRect.right = DestRect.left + (SourceRect.right - SourceRect.left);
             DestRect.top = pDestPointsArray[i].y;
             DestRect.bottom = DestRect.top + (SourceRect.bottom - SourceRect.top);
-        } else {
+        } else if (pSourceRectsArray) {
             DestRect = SourceRect;
+        } else {
+            DestRect.left = 0;
+            DestRect.right = DestinationDesc.Width;
+            DestRect.top = 0;
+            DestRect.bottom = DestinationDesc.Height;
         }
 
         HRESULT hRet = g_pD3DDevice->StretchRect(pHostSourceSurface, &SourceRect, pHostDestSurface, &DestRect, D3DTEXF_NONE);


### PR DESCRIPTION
This is a hotfix to #1715 in which CopyRects would still fail if upscaling was being used.