### PR TITLE
Create GitHub Actions for some CI tasks

### DIFF
--- a/.github/workflows/master_artifact_publish.yml
+++ b/.github/workflows/master_artifact_publish.yml
@@ -1,0 +1,34 @@
+name: Release Artifacts
+
+on:
+  push:
+    branches: develop
+
+jobs:
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        configuration: [Release]
+    steps:
+      - uses: actions/checkout@master
+      - name: Generate cmake files
+        run: |
+          git submodule update --init --recursive --force
+          mkdir build && cd build
+          cmake .. -G "Visual Studio 16 2019" -A Win32
+      - name: Build
+        run: cmake --build build/ --config ${{ matrix.configuration }}
+      - name: Organize artifact files
+        shell: bash
+        run: |
+          mkdir dist
+          cp {COPYING,README.md} dist/
+          cd build/bin/${{ matrix.configuration }}
+          [ "${{ matrix.configuration }}" = "Debug" ] && sdl="SDL2d.dll" || sdl=SDL2.dll; cp {Cxbx.exe,glew32.dll,subhook.dll,$sdl} ../../../dist/
+          cp {cxbxr-debugger.exe,capstone.dll,cs_x86.dll} ../../../dist/
+      - uses: actions/upload-artifact@master
+        with:
+          name: CXBX-R-${{ matrix.configuration }}-${{ github.sha }}
+          path: dist/

--- a/.github/workflows/pr_verify_build.yml
+++ b/.github/workflows/pr_verify_build.yml
@@ -1,0 +1,21 @@
+name: Verify PR Builds
+
+on: pull_request
+
+jobs:
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+    steps:
+      - uses: actions/checkout@master
+      - name: Generate cmake files
+        run: |
+          git submodule update --init --recursive --force
+          mkdir build && cd build
+          cmake .. -G "Visual Studio 16 2019" -A Win32
+      - name: Build
+        run: cmake --build build/ --config ${{ matrix.configuration }}
+


### PR DESCRIPTION
These commits will add 2 different actions to CXBX-R. One will run only on pull requests and will verify that the build passes with both `Release` & `Debug` configurations, the second will run on a push event to `develop` and publish an artifact for it.

Currently GitHub has little to no information published about artifacts but I'm assuming they'll be similar to GitHub Releases and will be indefinite, there's also seems to be no way to directly link to 'latest build' so users will have to manually find them (Actions > Release Artifacts > develop > Artifacts).

The end goal here is to remove all 3rd party requirements such as AppVeyor, Travis-CI, and Azure.

Because this feature is still in "invite only" beta I'm leaving this as a draft PR, however those with access can fork and verify functionality.

Suggestions welcomed.