### PR TITLE
Fix Bind Input Detection

### DIFF
--- a/src/common/input/InputWindow.h
+++ b/src/common/input/InputWindow.h
@@ -64,7 +64,7 @@ public:
 
 private:
 	typedef std::vector<Settings::s_input_profiles>::iterator ProfileIt;
-	InputDevice::Input* DetectInput(InputDevice* const Device, int ms);
+	InputDevice::Input* DetectInput(InputDevice* const Device, Button* const xbox_button, int ms);
 	void DetectOutput(int ms);
 	ProfileIt FindProfile(std::string& name);
 	void LoadProfile(std::string& name);
@@ -100,6 +100,8 @@ private:
 	std::string m_rumble;
 	// indicates if the current profile has unsaved changes
 	bool m_bHasChanges;
+	// prevent current input attempt to set the previous input at same time
+	std::atomic<bool> m_bIsBinding;
 };
 
 extern InputWindow* g_InputWindow;


### PR DESCRIPTION
DetectInput function has additional checking if input has been released before provide input than after it was pressed. This fix false positive of space (release) and enter (holding) keys trigger on Windows asking for input again.

Since DetectInput is only checking first pressed and released, the button's text will display "[_____]" while input is still pressed. If the input isn't released after certain time, then original bind will be restore.

Tested with no issues:
- Keyboard & mouse
- Wireless Xbox 360 Controller

Plus only check for changed state instead of repeatedly set unchanged states. This prevent spam in the console while debugging and prevent unnecessary checks.