### PR TITLE
Initialize pCurrentvertexShaderStreamInfo to nullptr

### DIFF
--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -1738,7 +1738,7 @@ class XboxVertexDeclarationConverter
 protected:
 	// Internal variables
 	XTL::CxbxVertexShaderInfo* pVertexShaderInfoToSet;
-	XTL::CxbxVertexShaderStreamInfo* pCurrentVertexShaderStreamInfo;
+	XTL::CxbxVertexShaderStreamInfo* pCurrentVertexShaderStreamInfo = nullptr;
 	DWORD temporaryCount;
 	bool IsFixedFunction;
 	XTL::D3DVERTEXELEMENT* pRecompiled;


### PR DESCRIPTION
There's a branch that checks if this is `nullptr`, but it might not be unless we initialize it
Fixes Lego Star Wars II