### PR TITLE
Fix New GUI Input Breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,13 +73,11 @@ file (GLOB CXBXR_HEADER_COMMON
  "${CXBXR_ROOT_DIR}/src/common/CxbxDebugger.h"
  "${CXBXR_ROOT_DIR}/src/common/EmuEEPROM.h"
  "${CXBXR_ROOT_DIR}/src/common/Error.h"
- "${CXBXR_ROOT_DIR}/src/common/input/Button.h"
  "${CXBXR_ROOT_DIR}/src/common/input/DInputKeyboardCodes.h"
  "${CXBXR_ROOT_DIR}/src/common/input/DInputKeyboardMouse.h"
- "${CXBXR_ROOT_DIR}/src/common/input/EmuDevice.h"
+ "${CXBXR_ROOT_DIR}/src/common/input/layout_xbox_controller.h"
  "${CXBXR_ROOT_DIR}/src/common/input/InputDevice.h"
  "${CXBXR_ROOT_DIR}/src/common/input/InputManager.h"
- "${CXBXR_ROOT_DIR}/src/common/input/InputWindow.h"
  "${CXBXR_ROOT_DIR}/src/common/input/SdlJoystick.h"
  "${CXBXR_ROOT_DIR}/src/common/input/XInputPad.h"
  "${CXBXR_ROOT_DIR}/src/common/IPCHybrid.hpp"
@@ -108,6 +106,9 @@ file (GLOB CXBXR_HEADER_COMMON
 
 # GUI v1
 file (GLOB CXBXR_HEADER_GUIv1
+ "${CXBXR_ROOT_DIR}/src/common/input/Button.h"
+ "${CXBXR_ROOT_DIR}/src/common/input/EmuDevice.h"
+ "${CXBXR_ROOT_DIR}/src/common/input/InputWindow.h"
  "${CXBXR_ROOT_DIR}/src/gui/DbgConsole.h"
  "${CXBXR_ROOT_DIR}/src/gui/DlgAbout.h"
  "${CXBXR_ROOT_DIR}/src/gui/DlgAudioConfig.h"
@@ -203,12 +204,9 @@ file (GLOB CXBXR_SOURCE_COMMON
  "${CXBXR_ROOT_DIR}/src/common/CxbxDebugger.cpp"
  "${CXBXR_ROOT_DIR}/src/common/EmuEEPROM.cpp"
  "${CXBXR_ROOT_DIR}/src/common/Error.cpp"
- "${CXBXR_ROOT_DIR}/src/common/input/Button.cpp"
  "${CXBXR_ROOT_DIR}/src/common/input/DInputKeyboardMouse.cpp"
- "${CXBXR_ROOT_DIR}/src/common/input/EmuDevice.cpp"
  "${CXBXR_ROOT_DIR}/src/common/input/InputDevice.cpp"
  "${CXBXR_ROOT_DIR}/src/common/input/InputManager.cpp"
- "${CXBXR_ROOT_DIR}/src/common/input/InputWindow.cpp"
  "${CXBXR_ROOT_DIR}/src/common/input/SdlJoystick.cpp"
  "${CXBXR_ROOT_DIR}/src/common/input/XInputPad.cpp"
  "${CXBXR_ROOT_DIR}/src/common/Logging.cpp"
@@ -233,6 +231,9 @@ file (GLOB CXBXR_SOURCE_COMMON
 
 # GUI v1
 file (GLOB CXBXR_SOURCE_GUIv1
+ "${CXBXR_ROOT_DIR}/src/common/input/Button.cpp"
+ "${CXBXR_ROOT_DIR}/src/common/input/EmuDevice.cpp"
+ "${CXBXR_ROOT_DIR}/src/common/input/InputWindow.cpp"
  "${CXBXR_ROOT_DIR}/src/gui/DlgAbout.cpp"
  "${CXBXR_ROOT_DIR}/src/gui/DlgAudioConfig.cpp"
  "${CXBXR_ROOT_DIR}/src/gui/DlgInputConfig.cpp"

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -176,13 +176,13 @@ set(WINS_LIB
  XINPUT9_1_0
  Iphlpapi
  wpcap
- SDL2
 )
 
 target_link_libraries(cxbx
  PUBLIC XbSymbolDatabase
  subhook
  libtomcrypt
+ SDL2
 
  ${WINS_LIB}
 )

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -31,7 +31,8 @@
 #include "core\kernel\support\Emu.h"
 #include "EmuShared.h"
 #include <filesystem>
-#include "common\input\EmuDevice.h"
+#include "common\input\InputManager.h"
+#include "common\input\layout_xbox_controller.h"
 
 // TODO: Implement Qt support when real CPU emulation is available.
 #ifndef QT_VERSION // NOTE: Non-Qt will be using current directory for data

--- a/src/common/input/Button.cpp
+++ b/src/common/input/Button.cpp
@@ -27,6 +27,7 @@
 
 #include "Button.h"
 #include "InputWindow.h"
+#include "layout_xbox_controller.h" // TODO: Needs a better fix for custom input device support.
 #include "..\..\gui\ResCxbx.h"
 
 

--- a/src/common/input/EmuDevice.cpp
+++ b/src/common/input/EmuDevice.cpp
@@ -27,63 +27,8 @@
 
 #include"Button.h"
 #include "InputManager.h"
+#include "layout_xbox_controller.h"
 #include "..\..\gui\ResCxbx.h"
-
-static int button_xbox_ctrl_id[XBOX_CTRL_NUM_BUTTONS] = {
-	IDC_SET_DPAD_UP,
-	IDC_SET_DPAD_DOWN,
-	IDC_SET_DPAD_LEFT,
-	IDC_SET_DPAD_RIGHT,
-	IDC_SET_START,
-	IDC_SET_BACK,
-	IDC_SET_LTHUMB,
-	IDC_SET_RTHUMB,
-	IDC_SET_A,
-	IDC_SET_B,
-	IDC_SET_X,
-	IDC_SET_Y,
-	IDC_SET_BLACK,
-	IDC_SET_WHITE,
-	IDC_SET_LTRIGGER,
-	IDC_SET_RTRIGGER,
-	IDC_SET_LEFT_POSX,
-	IDC_SET_LEFT_NEGX,
-	IDC_SET_LEFT_POSY,
-	IDC_SET_LEFT_NEGY,
-	IDC_SET_RIGHT_POSX,
-	IDC_SET_RIGHT_NEGX,
-	IDC_SET_RIGHT_POSY,
-	IDC_SET_RIGHT_NEGY,
-	IDC_SET_MOTOR,
-};
-
-const char* button_xbox_ctrl_names[XBOX_CTRL_NUM_BUTTONS][3] = {
-	"D Pad Up",      "Pad N",      "UP",
-	"D Pad Down",    "Pad S",      "DOWN",
-	"D Pad Left",    "Pad W",      "LEFT",
-	"D Pad Right",   "Pad E",      "RIGHT",
-	"Start",         "Start",      "RETURN",
-	"Back",          "Back",       "SPACE",
-	"L Thumb",       "Thumb L",    "B",
-	"R Thumb",       "Thumb R",    "M",
-	"A",             "Button A",   "S",
-	"B",             "Button B",   "D",
-	"X",             "Button X",   "W",
-	"Y",             "Button Y",   "E",
-	"Black",         "Shoulder R", "C",
-	"White",         "Shoulder L", "X",
-	"L Trigger",     "Trigger L",  "Q",
-	"R Trigger",     "Trigger R",  "R",
-	"Left Axis X+",  "Left X+",    "H",
-	"Left Axis X-",  "Left X-",    "F",
-	"Left Axis Y+",  "Left Y+",    "T",
-	"Left Axis Y-",  "Left Y-",    "G",
-	"Right Axis X+", "Right X+",   "L",
-	"Right Axis X-", "Right X-",   "J",
-	"Right Axis Y+", "Right Y+",   "I",
-	"Right Axis Y-", "Right Y-",   "K",
-	"Motor",         "LeftRight",  "",
-};
 
 
 EmuDevice::EmuDevice(int type, HWND hwnd)

--- a/src/common/input/EmuDevice.h
+++ b/src/common/input/EmuDevice.h
@@ -30,9 +30,6 @@
 #include "Button.h"
 #include "common\util\CxbxUtil.h"
 
-extern const char* button_xbox_ctrl_names[XBOX_CTRL_NUM_BUTTONS][3];
-extern int dev_num_buttons[to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)];
-
 
 /* Represents the guest device currently being configured in the gui */
 class EmuDevice

--- a/src/common/input/InputManager.cpp
+++ b/src/common/input/InputManager.cpp
@@ -54,6 +54,23 @@ namespace xboxkrnl
 #include "core\hle\XAPI\Xapi.h"
 #include "core\hle\XAPI\XapiCxbxr.h"
 
+int Gui2XboxPortArray[4] = {
+	3,
+	4,
+	1,
+	2
+};
+
+int dev_num_buttons[to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)] = {
+	XBOX_CTRL_NUM_BUTTONS,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+};
+
 extern CXBX_CONTROLLER_HOST_BRIDGE g_XboxControllerHostBridge[4]; // hle xinput
 
 

--- a/src/common/input/InputManager.h
+++ b/src/common/input/InputManager.h
@@ -36,6 +36,8 @@
 #undef SetPort
 #endif
 
+extern int dev_num_buttons[to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)];
+
 #pragma pack(1)
 
 // xpad in/out buffers stripped of the first two bytes

--- a/src/common/input/InputWindow.cpp
+++ b/src/common/input/InputWindow.cpp
@@ -37,15 +37,6 @@
 
 constexpr ControlState INPUT_DETECT_THRESHOLD = 0.55; // arbitrary number, using what Dolphin uses
 InputWindow* g_InputWindow = nullptr;
-int dev_num_buttons[to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)] = {
-	XBOX_CTRL_NUM_BUTTONS,
-	0,
-	0,
-	0,
-	0,
-	0,
-	0,
-};
 
 
 void InputWindow::Initialize(HWND hwnd, int port_num, int dev_type)

--- a/src/common/input/layout_xbox_controller.h
+++ b/src/common/input/layout_xbox_controller.h
@@ -1,0 +1,88 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+// ******************************************************************
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2019 ergo720
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+#pragma once
+
+#ifndef CXBXR_EMU_EXPORTS
+#include "gui/ResCxbx.h"
+
+static int button_xbox_ctrl_id[XBOX_CTRL_NUM_BUTTONS] = {
+	IDC_SET_DPAD_UP,
+	IDC_SET_DPAD_DOWN,
+	IDC_SET_DPAD_LEFT,
+	IDC_SET_DPAD_RIGHT,
+	IDC_SET_START,
+	IDC_SET_BACK,
+	IDC_SET_LTHUMB,
+	IDC_SET_RTHUMB,
+	IDC_SET_A,
+	IDC_SET_B,
+	IDC_SET_X,
+	IDC_SET_Y,
+	IDC_SET_BLACK,
+	IDC_SET_WHITE,
+	IDC_SET_LTRIGGER,
+	IDC_SET_RTRIGGER,
+	IDC_SET_LEFT_POSX,
+	IDC_SET_LEFT_NEGX,
+	IDC_SET_LEFT_POSY,
+	IDC_SET_LEFT_NEGY,
+	IDC_SET_RIGHT_POSX,
+	IDC_SET_RIGHT_NEGX,
+	IDC_SET_RIGHT_POSY,
+	IDC_SET_RIGHT_NEGY,
+	IDC_SET_MOTOR,
+};
+#endif
+
+static const char* button_xbox_ctrl_names[XBOX_CTRL_NUM_BUTTONS][3] = {
+	"D Pad Up",      "Pad N",      "UP",
+	"D Pad Down",    "Pad S",      "DOWN",
+	"D Pad Left",    "Pad W",      "LEFT",
+	"D Pad Right",   "Pad E",      "RIGHT",
+	"Start",         "Start",      "RETURN",
+	"Back",          "Back",       "SPACE",
+	"L Thumb",       "Thumb L",    "B",
+	"R Thumb",       "Thumb R",    "M",
+	"A",             "Button A",   "S",
+	"B",             "Button B",   "D",
+	"X",             "Button X",   "W",
+	"Y",             "Button Y",   "E",
+	"Black",         "Shoulder R", "C",
+	"White",         "Shoulder L", "X",
+	"L Trigger",     "Trigger L",  "Q",
+	"R Trigger",     "Trigger R",  "R",
+	"Left Axis X+",  "Left X+",    "H",
+	"Left Axis X-",  "Left X-",    "F",
+	"Left Axis Y+",  "Left Y+",    "T",
+	"Left Axis Y-",  "Left Y-",    "G",
+	"Right Axis X+", "Right X+",   "L",
+	"Right Axis X-", "Right X-",   "J",
+	"Right Axis Y+", "Right Y+",   "I",
+	"Right Axis Y-", "Right Y-",   "K",
+	"Motor",         "LeftRight",  "",
+};

--- a/src/gui/DlgInputConfig.cpp
+++ b/src/gui/DlgInputConfig.cpp
@@ -39,13 +39,6 @@
 static INT_PTR CALLBACK DlgInputConfigProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 HWND g_ChildWnd = NULL;
 
-int Gui2XboxPortArray[4] = {
-	 3,
-	 4,
-	 1,
-	 2
-};
-
 
 void SyncInputSettings(int port_num, int dev_type)
 {


### PR DESCRIPTION
The changes are to fix #1713 pull request to able allow loader's emulator project to compile. Since some includes were not meant for emulation usage. And moved emulation codes into proper common files.

Plus move SDL2 linkage directly into target_link_libraries, CMake, call since SDL2 is not Windows only platform. 😉