### PR TITLE
Remove Any Experimental filesystem Linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ file (GLOB CXBXR_HEADER_COMMON
  "${CXBXR_ROOT_DIR}/src/common/util/CPUID.h"
  "${CXBXR_ROOT_DIR}/src/common/util/crc32c.h"
  "${CXBXR_ROOT_DIR}/src/common/util/CxbxUtil.h"
+ "${CXBXR_ROOT_DIR}/src/common/util/strConverter.hpp"
  "${CXBXR_ROOT_DIR}/src/common/win32/AlignPosfix1.h"
  "${CXBXR_ROOT_DIR}/src/common/win32/AlignPrefix1.h"
  "${CXBXR_ROOT_DIR}/src/common/win32/EmuShared.h"

--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -95,7 +95,6 @@ extern volatile bool g_bPrintfOn;
 #define CxbxSetThreadName(Name)
 #endif
 
-// NOTE: #include <filesystem> didn't work plus C++ 17 is still using experimental filesystem.
-#include <experimental/filesystem>
+#include <filesystem>
 
 #endif

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -30,7 +30,7 @@
 #include "Settings.hpp"
 #include "core\kernel\support\Emu.h"
 #include "EmuShared.h"
-#include <experimental/filesystem>
+#include <filesystem>
 #include "common\input\EmuDevice.h"
 
 // TODO: Implement Qt support when real CPU emulation is available.
@@ -146,7 +146,7 @@ std::string GenerateExecDirectoryStr()
 	return g_exec_filepath.substr(0, g_exec_filepath.find_last_of("\\/"));
 }
 
-// NOTE: This function will be only have Qt support, std::experimental::filesystem doesn't have generic support.
+// NOTE: This function will be only have Qt support, std::filesystem doesn't have generic support.
 // Plus appending support for each OSes are not worthy to work on.
 std::string GenerateUserProfileDirectoryStr()
 {
@@ -222,10 +222,10 @@ bool Settings::Init()
 			}
 
 			// Check if data directory exists.
-			bRet = std::experimental::filesystem::exists(saveFile);
+			bRet = std::filesystem::exists(saveFile);
 			if (!bRet) {
 				// Then try create data directory.
-				bRet = std::experimental::filesystem::create_directory(saveFile);
+				bRet = std::filesystem::create_directory(saveFile);
 				if (!bRet) {
 					// Unable to create a data directory
 					return false;
@@ -258,7 +258,7 @@ bool Settings::LoadUserConfig()
 	fileSearch.append(szSettings_settings_file);
 
 	// Check and see if file exists from portable, current, directory.
-	if (std::experimental::filesystem::exists(fileSearch) == false) {
+	if (std::filesystem::exists(fileSearch) == false) {
 
 		fileSearch = GenerateUserProfileDirectoryStr();
 		if (fileSearch.size() == 0) {
@@ -267,7 +267,7 @@ bool Settings::LoadUserConfig()
 		fileSearch.append(szSettings_settings_file);
 
 		// Check if the user profile directory settings file exists.
-		if (std::experimental::filesystem::exists(fileSearch) == false) {
+		if (std::filesystem::exists(fileSearch) == false) {
 			return false;
 		}
 	}
@@ -675,7 +675,7 @@ bool Settings::Save(std::string file_path)
 
 void Settings::Delete()
 {
-    std::experimental::filesystem::remove(m_file_path);
+    std::filesystem::remove(m_file_path);
 }
 
 // Universal update to EmuShared from both standalone kernel, and GUI process.
@@ -744,7 +744,7 @@ void verifyDebugFilePath(DebugMode& debug_mode, std::string& file_path)
 			else {
 				szDebugPath = file_path.substr(0, file_path.size() - szDebugName.size());
 
-				if(std::experimental::filesystem::exists(szDebugPath) == false) {
+				if(std::filesystem::exists(szDebugPath) == false) {
 					file_path = "";
 					debug_mode = DM_NONE;
 				}

--- a/src/common/util/strConverter.hpp
+++ b/src/common/util/strConverter.hpp
@@ -1,0 +1,61 @@
+// ******************************************************************
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// *
+// *  (c) 2019      RadWolfie
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+#pragma once
+
+#include <string>
+#include <SDL_stdinc.h>
+
+// Depending on what type of UTF-8 string is input, otherwise will use native by default.
+static std::wstring utf8_to_utf16(const char* utf8_string)
+{
+	wchar_t* tempUTF16 = reinterpret_cast<wchar_t*>(SDL_iconv_string(/*to:*/"UTF-16", /*from:*/"UTF-8", utf8_string, strlen(utf8_string) + 1));
+	std::wstring strUTF16 = tempUTF16;
+	// Don't forget to free allocated string from SDL library.
+	SDL_free(tempUTF16);
+
+	return strUTF16;
+};
+
+// Depending on what type of UTF-16 string is input, otherwise will use native by default.
+static std::string utf16_to_ascii(const wchar_t* utf16_string)
+{
+	char* tempASCII = SDL_iconv_string(/*to:*/"ASCII", /*from:*/"UTF-16", reinterpret_cast<const char*>(utf16_string), wcslen(utf16_string)*2 + 1);
+	const std::string strASCII = tempASCII;
+	// Don't forget to free allocated string from SDL library.
+	SDL_free(tempASCII);
+
+	return strASCII;
+}
+
+// Enforce to expect little endian UTF-16 string is input.
+static std::string utf16le_to_ascii(const wchar_t* utf16le_string)
+{
+	char* tempASCII = SDL_iconv_string(/*to:*/"ASCII", /*from:*/"UTF-16LE", reinterpret_cast<const char*>(utf16le_string), wcslen(utf16le_string)*2 + 1);
+	const std::string strASCII = tempASCII;
+	// Don't forget to free allocated string from SDL library.
+	SDL_free(tempASCII);
+
+	return strASCII;
+}

--- a/src/common/xbe/Xbe.cpp
+++ b/src/common/xbe/Xbe.cpp
@@ -33,7 +33,7 @@ namespace xboxkrnl
 
 #include "common\xbe\Xbe.h"
 #include "common\util\CxbxUtil.h" // For RoundUp
-#include <experimental/filesystem> // filesystem related functions available on C++ 17
+#include <filesystem> // filesystem related functions available on C++ 17
 #include <locale> // For ctime
 #include <array>
 #include "devices\LED.h" // For LED::Sequence
@@ -43,7 +43,7 @@ namespace xboxkrnl
 #include "core\hle\XAPI\Xapi.h" // For LDT_FROM_DASHBOARD
 #include "core\hle\D3D8\Direct3D9\Direct3D9.h" // For CxbxInitWindow
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 
 

--- a/src/common/xbe/XbePrinter.cpp
+++ b/src/common/xbe/XbePrinter.cpp
@@ -29,9 +29,9 @@
 #include "CxbxVersion.h" // For _CXBX_VERSION
 
 #include <locale> // For ctime
-#include <codecvt> // For std::codecvt_utf8<>
 #include <sstream> // For std::stringstream
 #include <iomanip> // For std::setfill, std::uppercase, std::hex
+#include "common/util/strConverter.hpp" // for utf16le_to_ascii
 
 extern std::string FormatTitleId(uint32_t title_id); // Exposed in Emu.cpp
 
@@ -92,14 +92,6 @@ std::string XbePrinter::GenHexRow(
         text << std::setw(2) << static_cast<unsigned>(signature[offset + x]);
     }
     return text.str();
-}
-
-// https://stackoverflow.com/questions/4786292/converting-unicode-strings-and-vice-versa
-std::string XbePrinter::utf8_to_ascii(const wchar_t* utf8_string)
-{
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_to_ascii;
-    const std::wstring utf8_filename(utf8_string);
-    return utf8_to_ascii.to_bytes(utf8_filename);
 }
 
 std::string XbePrinter::AllowedMediaToString()
@@ -253,7 +245,7 @@ std::string XbePrinter::GenGeneralHeaderInfo2()
     const uint32_t debug_entry_point = Xbe_header->dwEntryAddr ^ XOR_EP_DEBUG;
     const uint32_t retail_thunk_addr = Xbe_header->dwKernelImageThunkAddr ^ XOR_KT_RETAIL;
     const uint32_t debug_thunk_addr = Xbe_header->dwKernelImageThunkAddr ^ XOR_KT_DEBUG;
-    const std::string AsciiFilename = utf8_to_ascii(Xbe_to_print->GetUnicodeFilenameAddr());
+    const std::string AsciiFilename = utf16le_to_ascii(Xbe_to_print->GetUnicodeFilenameAddr());
     std::stringstream text;
     SSTREAM_SET_HEX(text);
     text << "Entry Point                      : 0x" << std::setw(8) << Xbe_header->dwEntryAddr << " (Retail: 0x" << std::setw(8) << retail_entry_point << ", Debug: 0x" <<  std::setw(8) << debug_entry_point << ")\n";

--- a/src/common/xbe/XbePrinter.h
+++ b/src/common/xbe/XbePrinter.h
@@ -44,7 +44,6 @@ class XbePrinter
         Xbe::Certificate *Xbe_certificate;
 
         std::string GenHexRow(uint8_t*, const uint8_t, const uint8_t);
-        std::string utf8_to_ascii(const wchar_t*);
         std::string AllowedMediaToString();
         std::string GameRatingToString();
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -59,6 +59,7 @@ namespace xboxkrnl
 #include "WalkIndexBuffer.h"
 #include "core\kernel\common\strings.hpp" // For uem_str
 #include "common\input\SdlJoystick.h"
+#include "common/util/strConverter.hpp" // for utf8_to_utf16
 
 #include <assert.h>
 #include <process.h>
@@ -549,8 +550,7 @@ void DrawUEM(HWND hWnd)
 
 	SetTextColor(hMemDC, RGB(0, 204, 0));
 
-	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> UTF8toUTF16;
-	std::wstring utf16str = UTF8toUTF16.from_bytes(uem_str);
+	std::wstring utf16str = utf8_to_utf16(uem_str.c_str());
 
 	// Unfortunately, DrawTextW doesn't support vertical alignemnt, so we have to do the calculation
 	// ourselves. See here: https://social.msdn.microsoft.com/Forums/vstudio/en-US/abd89aae-16a0-41c6-8db6-b119ea90b42a/win32-drawtext-how-center-in-vertical-with-new-lines-and-tabs?forum=vclanguage

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -396,7 +396,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 
 	// Make sure the Symbol Cache directory exists
 	std::string cachePath = std::string(szFolder_CxbxReloadedData) + "\\SymbolCache\\";
-	if (!std::experimental::filesystem::exists(cachePath) && !std::experimental::filesystem::create_directory(cachePath)) {
+	if (!std::filesystem::exists(cachePath) && !std::filesystem::create_directory(cachePath)) {
 		CxbxKrnlCleanup("Couldn't create Cxbx-Reloaded SymbolCache folder!");
 	}
 
@@ -416,7 +416,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 
 	CSimpleIniA symbolCacheData;
 
-	if (std::experimental::filesystem::exists(filename.c_str())) {
+	if (std::filesystem::exists(filename.c_str())) {
 		std::printf("Found Symbol Cache File: %08llX.ini\n", uiHash);
 
 		symbolCacheData.LoadFile(filename.c_str());

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -47,6 +47,7 @@ namespace xboxkrnl
 #include "common\EmuEEPROM.h" // For EEPROM
 #include "devices\Xbox.h" // For g_SMBus, SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER
 #include "devices\SMCDevice.h" // For SMC_COMMAND_SCRATCH
+#include "common/util/strConverter.hpp" // for utf16_to_ascii
 
 #include <algorithm> // for std::replace
 #include <locale>
@@ -536,7 +537,7 @@ XBSYSAPI EXPORTNUM(49) xboxkrnl::VOID DECLSPEC_NORETURN NTAPI xboxkrnl::HalRetur
 				CxbxConvertFilePath(TitlePath, wXbePath, &rootDirectoryHandle, "NtCreateFile");
 
 				// Convert Wide String as returned by above to a string, for XbePath
-				XbePath = std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(wXbePath);
+				XbePath = utf16_to_ascii(wXbePath.c_str());
 
 				// If the rootDirectoryHandle is not null, we have a relative path
 				// We need to prepend the path of the root directory to get a full DOS path

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1176,7 +1176,7 @@ void CxbxKrnlMain(int argc, char* argv[])
 		// TODO: How to we detect who launched us, to prevent a reboot-loop
 		if (g_bIsChihiro) {
 			std::string chihiroMediaBoardRom = std::string(szFolder_CxbxReloadedData) + std::string("/EmuDisk/") + MediaBoardRomFile;
-			if (!std::experimental::filesystem::exists(chihiroMediaBoardRom)) {
+			if (!std::filesystem::exists(chihiroMediaBoardRom)) {
 				CxbxKrnlCleanup("Chihiro Media Board ROM (fpr21042_m29w160et.bin) could not be found");
 			}
 
@@ -1614,15 +1614,15 @@ void CxbxInitFilePaths()
 	g_EmuShared->GetStorageLocation(szFolder_CxbxReloadedData);
 
 	// Make sure our data folder exists :
-	bool result = std::experimental::filesystem::exists(szFolder_CxbxReloadedData);
-	if (!result && !std::experimental::filesystem::create_directory(szFolder_CxbxReloadedData)) {
+	bool result = std::filesystem::exists(szFolder_CxbxReloadedData);
+	if (!result && !std::filesystem::create_directory(szFolder_CxbxReloadedData)) {
 		CxbxKrnlCleanup("%s : Couldn't create Cxbx-Reloaded's data folder!", __func__);
 	}
 
 	// Make sure the EmuDisk folder exists
 	std::string emuDisk = std::string(szFolder_CxbxReloadedData) + std::string("\\EmuDisk");
-	result = std::experimental::filesystem::exists(emuDisk);
-	if (!result && !std::experimental::filesystem::create_directory(emuDisk)) {
+	result = std::filesystem::exists(emuDisk);
+	if (!result && !std::filesystem::create_directory(emuDisk)) {
 		CxbxKrnlCleanup("%s : Couldn't create Cxbx-Reloaded EmuDisk folder!", __func__);
 	}
 

--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -41,7 +41,7 @@
 #include "core\kernel\memory-manager\VMManager.h"
 #include "Logging.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 
 // Default Xbox Partition Table
 #define PE_PARTFLAGS_IN_USE	0x80000000
@@ -178,13 +178,13 @@ void CxbxFormatPartitionByHandle(HANDLE hFile)
 	// Previously, we deleted and re-created the folder, but that caused permission issues for some users
 	try
 	{
-		for (auto& directoryEntry : std::experimental::filesystem::recursive_directory_iterator(partitionPath)) {
-			std::experimental::filesystem::remove_all(directoryEntry);
+		for (auto& directoryEntry : std::filesystem::recursive_directory_iterator(partitionPath)) {
+			std::filesystem::remove_all(directoryEntry);
 		}
 	}
-	catch (std::experimental::filesystem::filesystem_error fsException)
+	catch (std::filesystem::filesystem_error fsException)
 	{
-		printf("std::experimental::filesystem failed with message: %s\n", fsException.what());
+		printf("std::filesystem failed with message: %s\n", fsException.what());
 	}
 
 

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -82,7 +82,7 @@ void ClearSymbolCache(const char sStorageLocation[MAX_PATH])
 			if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
 				fullpath = cacheDir + data.cFileName;
 
-				if (!std::experimental::filesystem::remove(fullpath)) {
+				if (!std::filesystem::remove(fullpath)) {
 					break;
 				}
 			}
@@ -1078,7 +1078,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				sstream << cacheDir << szTitleName << "-" << std::hex << uiHash << ".ini";
 				std::string fullpath = sstream.str();
 
-				if (std::experimental::filesystem::remove(fullpath)) {
+				if (std::filesystem::remove(fullpath)) {
 					MessageBox(m_hwnd, "This title's Symbol Cache entry has been cleared.", "Cxbx-Reloaded", MB_OK);
 				}
 			}


### PR DESCRIPTION
Since AppVeyor CI's Visual Studio start making errors about experimental filesystem. Let's move on to use std filesystem than experimental version. After all, C++17 does have std filesystem implemented.

**EDIT:** And to replace `std::wstring_convert` to SDL's iconv library.