### PR TITLE
Add support for Xbox Controller S

### DIFF
--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -478,11 +478,19 @@ bool Settings::LoadConfig()
 
 	// ==== Input Profile Begin ====
 	std::array<std::vector<std::string>, to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)> control_names;
-	for (int i = 0; i < dev_num_buttons[0]; i++) {
-		char control_name[30];
-		std::sprintf(control_name, sect_input_profiles.control, button_xbox_ctrl_names[i][0]);
-		control_names[0].push_back(control_name);
+
+	for (int device = 0; device < to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX); device++) {
+		if (dev_num_buttons[device] == 0) {
+			continue;
+		}
+
+		for (int i = 0; i < dev_num_buttons[device]; i++) {
+			char control_name[30];
+			std::sprintf(control_name, sect_input_profiles.control, button_xbox_ctrl_names[i][0]);
+			control_names[device].push_back(control_name);
+		}
 	}
+
 	// TODO: add the control names of the other devices
 
 	index = 0;
@@ -609,11 +617,18 @@ bool Settings::Save(std::string file_path)
 	// ==== Input Profile Begin ====
 
 	std::array<std::vector<std::string>, to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)> control_names;
-	for (int i = 0; i < dev_num_buttons[0]; i++) {
-		char control_name[30];
-		std::sprintf(control_name, sect_input_profiles.control, button_xbox_ctrl_names[i][0]);
-		control_names[0].push_back(control_name);
+	for (int device = 0; device < to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX); device++) {
+		if (dev_num_buttons[device] == 0) {
+			continue;
+		}
+
+		for (int i = 0; i < dev_num_buttons[device]; i++) {
+			char control_name[30];
+			std::sprintf(control_name, sect_input_profiles.control, button_xbox_ctrl_names[i][0]);
+			control_names[device].push_back(control_name);
+		}
 	}
+
 	// TODO: add the control names of the other devices
 
 	int profile_num = 0;

--- a/src/common/input/EmuDevice.cpp
+++ b/src/common/input/EmuDevice.cpp
@@ -35,7 +35,8 @@ EmuDevice::EmuDevice(int type, HWND hwnd)
 {
 	switch (type)
 	{
-	case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE): {
+	case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE):
+	case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_S): {
 		m_hwnd = hwnd;
 		for (int i = 0; i < ARRAY_SIZE(button_xbox_ctrl_id); i++) {
 			m_buttons.push_back(new Button(button_xbox_ctrl_id[i], i, hwnd));

--- a/src/common/input/InputManager.cpp
+++ b/src/common/input/InputManager.cpp
@@ -62,8 +62,8 @@ int Gui2XboxPortArray[4] = {
 };
 
 int dev_num_buttons[to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)] = {
-	XBOX_CTRL_NUM_BUTTONS,
-	0,
+	XBOX_CTRL_NUM_BUTTONS, // MS_CONTROLLER_DUKE
+	XBOX_CTRL_NUM_BUTTONS, // MS_CONTROLLER_S
 	0,
 	0,
 	0,
@@ -349,12 +349,12 @@ bool InputDeviceManager::UpdateXboxPortInput(int usb_port, void* Buffer, int Dir
 			if (dev_ptr->GetPort(usb_port)) {
 				switch (xid_type)
 				{
-				case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE): {
+				case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE):
+                case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_S): {
 					has_changed = UpdateInputXpad(dev_ptr, Buffer, Direction);
 				}
 				break;
 
-				case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_S):
 				case to_underlying(XBOX_INPUT_DEVICE::LIGHT_GUN):
 				case to_underlying(XBOX_INPUT_DEVICE::STEERING_WHEEL):
 				case to_underlying(XBOX_INPUT_DEVICE::MEMORY_UNIT):

--- a/src/core/hle/XAPI/Xapi.cpp
+++ b/src/core/hle/XAPI/Xapi.cpp
@@ -83,14 +83,14 @@ bool operator==(XTL::PXPP_DEVICE_TYPE XppType, XBOX_INPUT_DEVICE XidType)
 {
 	switch (XidType)
 	{
-	case XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE: {
+	case XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE:
+    case XBOX_INPUT_DEVICE::MS_CONTROLLER_S: {
 		if (XppType == g_DeviceType_Gamepad) {
 			return true;
 		}
 	}
 	break;
 
-	case XBOX_INPUT_DEVICE::MS_CONTROLLER_S:
 	case XBOX_INPUT_DEVICE::LIGHT_GUN:
 	case XBOX_INPUT_DEVICE::STEERING_WHEEL:
 	case XBOX_INPUT_DEVICE::MEMORY_UNIT:
@@ -129,13 +129,25 @@ bool ConstructHleInputDevice(int Type, int Port)
 		g_XboxControllerHostBridge[Port].XboxDeviceInfo.dwPacketNumber = 0;
 	}
 	break;
-
+    case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_S): {
+        g_XboxControllerHostBridge[Port].XboxPort = Port;
+        g_XboxControllerHostBridge[Port].XboxType = XBOX_INPUT_DEVICE::MS_CONTROLLER_S;
+        g_XboxControllerHostBridge[Port].InState = new XpadInput();
+        g_XboxControllerHostBridge[Port].bPendingRemoval = false;
+        g_XboxControllerHostBridge[Port].bSignaled = false;
+        g_XboxControllerHostBridge[Port].bIoInProgress = false;
+        g_XboxControllerHostBridge[Port].XboxDeviceInfo.ucType = XINPUT_DEVTYPE_GAMEPAD;
+        g_XboxControllerHostBridge[Port].XboxDeviceInfo.ucSubType = XINPUT_DEVSUBTYPE_GC_GAMEPAD_ALT;
+        g_XboxControllerHostBridge[Port].XboxDeviceInfo.ucInputStateSize = sizeof(XpadInput);
+        g_XboxControllerHostBridge[Port].XboxDeviceInfo.ucFeedbackSize = sizeof(XpadOutput);
+        g_XboxControllerHostBridge[Port].XboxDeviceInfo.dwPacketNumber = 0;
+    }
+	break;
 	case to_underlying(XBOX_INPUT_DEVICE::STEEL_BATTALION_CONTROLLER): {
 		// TODO
 	}
 	break;
 
-	case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_S):
 	case to_underlying(XBOX_INPUT_DEVICE::LIGHT_GUN):
 	case to_underlying(XBOX_INPUT_DEVICE::STEERING_WHEEL):
 	case to_underlying(XBOX_INPUT_DEVICE::MEMORY_UNIT):

--- a/src/gui/DlgInputConfig.cpp
+++ b/src/gui/DlgInputConfig.cpp
@@ -97,7 +97,7 @@ INT_PTR CALLBACK DlgInputConfigProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPAR
 
 		for (int i = 0, j = 0; i != 4; i++) {
 			hHandle = GetDlgItem(hWndDlg, IDC_DEVICE_PORT1 + i);
-			for (auto str : { "None", "MS Controller Duke" }) {
+			for (auto str : { "None", "MS Controller Duke", "MS Controller S" }) {
 				LRESULT index = SendMessage(hHandle, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(str));
 				SendMessage(hHandle, CB_SETITEMDATA, index,
 					to_underlying(XBOX_INPUT_DEVICE::DEVICE_INVALID) + j);
@@ -142,7 +142,8 @@ INT_PTR CALLBACK DlgInputConfigProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPAR
 				int DeviceType = SendMessage(hHandle, CB_GETITEMDATA, SendMessage(hHandle, CB_GETCURSEL, 0, 0), 0);
 				switch (DeviceType)
 				{
-				case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE): {
+				case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE): 
+				case to_underlying(XBOX_INPUT_DEVICE::MS_CONTROLLER_S): {
 					DialogBoxParam(GetModuleHandle(NULL), MAKEINTRESOURCE(IDD_XID_DUKE_CFG), hWndDlg, DlgXidControllerConfigProc,
 						(DeviceType << 8) | port);
 				}


### PR DESCRIPTION
This PR adds support for 'Xbox Controller S' to the input system.

The Xbox Controller S is functionally identical to the standard controller, it has all the same inputs, but the physical layout of the buttons is different: You can see the layouts represented in the XDK Controller Test sample screenshots below.

Device Selection Dialog:
![image](https://user-images.githubusercontent.com/740003/65818327-7742e800-e208-11e9-8f14-1e9b13dbb3b1.png)

XDK Controller Test (Controller S Connected):
![image](https://user-images.githubusercontent.com/740003/65818337-9b9ec480-e208-11e9-9824-59a0ad8446d6.png)

XDK Controller Test (Controller 'Duke' Connected):
![image](https://user-images.githubusercontent.com/740003/65818345-b07b5800-e208-11e9-8784-aa441dc1880a.png)
