### PR TITLE
Fix an issue with reading FOGCOLOR in a pixel shader

### DIFF
--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -6074,7 +6074,10 @@ VOID DxbxUpdateActivePixelShader() // NOPATCH
             // Note : FOG.RGB is correct like this, but FOG.a should be coming
             // from the vertex shader (oFog) - however, D3D8 does not forward this...
 			g_pD3DDevice->GetRenderState(D3DRS_FOGCOLOR, &dwColor);
-            fColor = dwColor;
+			fColor.a = ((dwColor >> 24) & 0xFF) / 255.0f;
+			fColor.r = ((dwColor >> 16) & 0xFF) / 255.0f;
+			fColor.g = ((dwColor >> 8) & 0xFF) / 255.0f;
+			fColor.b = (dwColor & 0xFF) / 255.0f;
 			break;
 		  case PSH_XBOX_CONSTANT_FC0:
             //dwColor = *EmuMappedD3DRenderState[XTL::X_D3DRS_PSFINALCOMBINERCONSTANT0];


### PR DESCRIPTION
I'm not aware of a specific case what this improves, but I came across this bug when reviewing the code to investigate a different issue.

Direct3D defined the D3DRS_FOGCOLOR render state as a DWORD value, in the format AARRGGBB, however, pixel shaders expect an array of 4 floats (ARGB).

Previously, we were simply copying the value, leading to the a,r,g,b fog components having invalid values.

With this fix, we now convert from D3DCOLOR to ARGB floats properly.

Testers: Please let me know if you notice any improvements from this.