### PR TITLE
Restore fog hack: Fixes Silent Hill 2

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
@@ -311,6 +311,15 @@ void XboxRenderStateConverter::ApplyDeferredRenderState(uint32_t State, uint32_t
             }
         } break;
         case XTL::X_D3DRS_FOGENABLE:
+            if (g_LibVersion_D3D8 == 3925) {
+                // HACK: Many 3925 games only show a black screen if fog is enabled
+                // Initially, this was thought to be bad offsets, but it has been verified to be correct
+                // Unitl we find out the true underlying cause, disable fog and carry on
+                // Test Cases: Halo, Silent Hill 2.
+                LOG_TEST_CASE("Applying 3925 fog disable hack");
+                Value = false;
+            }
+            break;
         case XTL::X_D3DRS_FOGTABLEMODE:
         case XTL::X_D3DRS_FOGDENSITY:
         case XTL::X_D3DRS_RANGEFOGENABLE:

--- a/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
@@ -314,7 +314,7 @@ void XboxRenderStateConverter::ApplyDeferredRenderState(uint32_t State, uint32_t
             if (g_LibVersion_D3D8 == 3925) {
                 // HACK: Many 3925 games only show a black screen if fog is enabled
                 // Initially, this was thought to be bad offsets, but it has been verified to be correct
-                // Unitl we find out the true underlying cause, disable fog and carry on
+                // Until we find out the true underlying cause, disable fog and carry on
                 // Test Cases: Halo, Silent Hill 2.
                 LOG_TEST_CASE("Applying 3925 fog disable hack");
                 Value = false;


### PR DESCRIPTION
This restores a hack that was accidentally removed during the work on #1742.

