### PR TITLE
Use a file to store persistent memory across quick reboots

### DIFF
--- a/src/common/IPCHybrid.hpp
+++ b/src/common/IPCHybrid.hpp
@@ -38,7 +38,6 @@ typedef enum class _IPC_UPDATE_GUI {
 	, XBOX_LED_COLOUR
 	, LOG_ENABLED
 	, KRNL_IS_READY
-	, VM_PERSIST_MEM
 } IPC_UPDATE_GUI;
 
 void ipc_send_gui_update(IPC_UPDATE_GUI command, const unsigned int value);

--- a/src/common/win32/IPCWindows.cpp
+++ b/src/common/win32/IPCWindows.cpp
@@ -65,10 +65,6 @@ void ipc_send_gui_update(IPC_UPDATE_GUI command, const unsigned int value)
 			cmdParam = ID_GUI_STATUS_KRNL_IS_READY;
 			break;
 
-		case IPC_UPDATE_GUI::VM_PERSIST_MEM:
-			cmdParam = ID_GUI_VM_PERSIST_MEM;
-			break;
-
 		default:
 			cmdParam = 0;
 			break;

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1748,6 +1748,9 @@ void CxbxKrnlShutDown()
 	// Shutdown the input device manager
 	g_InputDeviceManager.Shutdown();
 
+	// Shutdown the memory manager
+	g_VMManager.Shutdown();
+
 	CxbxUnlockFilePath();
 
 	if (CxbxKrnl_hEmuParent != NULL) {

--- a/src/core/kernel/memory-manager/VMManager.cpp
+++ b/src/core/kernel/memory-manager/VMManager.cpp
@@ -416,6 +416,7 @@ void VMManager::SavePersistentMemory()
 	std::vector<PMMPTE> cached_persisted_ptes;
 	PMMPTE PointerPte;
 	PMMPTE EndingPte;
+	size_t size;
 	int i;
 
 	Lock();
@@ -444,7 +445,8 @@ void VMManager::SavePersistentMemory()
 		CxbxKrnlCleanup("Couldn't persist memory!");
 	}
 
-	persisted_mem = (PersistedMemory*)new uint8_t[num_persisted_ptes * PAGE_SIZE + num_persisted_ptes * 4 * 2 + sizeof(PersistedMemory)]();
+	size = num_persisted_ptes * PAGE_SIZE + num_persisted_ptes * 4 * 2 + sizeof(PersistedMemory);
+	persisted_mem = (PersistedMemory*)new uint8_t[size]();
 	persisted_mem->NumOfPtes = num_persisted_ptes;
 
 	if (xboxkrnl::LaunchDataPage != xbnullptr) {
@@ -468,7 +470,7 @@ void VMManager::SavePersistentMemory()
 
 	assert(i == num_persisted_ptes);
 
-	ofs.write((const char*)persisted_mem, (std::streamsize)num_persisted_ptes * PAGE_SIZE + (std::streamsize)num_persisted_ptes * 4 * 2 + sizeof(PersistedMemory));
+	ofs.write((const char*)persisted_mem, (std::streamsize)size);
 	if (!ofs.good()) {
 		ofs.clear();
 		ofs.close();

--- a/src/core/kernel/memory-manager/VMManager.h
+++ b/src/core/kernel/memory-manager/VMManager.h
@@ -84,6 +84,7 @@ typedef enum _MemoryRegionType
 	COUNTRegion,
 }MemoryRegionType;
 
+
 /* struct used to save the persistent memory between reboots */
 typedef struct _PersistedMemory
 {
@@ -100,13 +101,13 @@ class VMManager : public PhysicalMemory
 	public:
 		// constructor
 		VMManager() {};
-		// destructor
-		~VMManager()
+		// shutdown routine
+		void Shutdown()
 		{
-			// DestroyMemoryRegions is not called when emulation ends, but only when the GUI process ends. This is probably because the emu
-			// process is killed with TerminateProcess and so it doesn't have a chance to perform a cleanup...
+			// Can't enable this yet. After the memory is deleted, other parts of cxbxr still run before process termination, and attempt to
+			// access the now deleted memory, causing a crash at shutdown
 			//DestroyMemoryRegions();
-			DeleteCriticalSection(&m_CriticalSection);
+			//DeleteCriticalSection(&m_CriticalSection);
 		}
 		// initializes the memory manager to the default configuration
 		void Initialize(int SystemType, int BootFlags, uint32_t blocks_reserved[384]);

--- a/src/gui/resource/ResCxbx.h
+++ b/src/gui/resource/ResCxbx.h
@@ -189,7 +189,6 @@
 #define ID_GUI_STATUS_LLE_FLAGS         1097
 #define ID_GUI_STATUS_XBOX_LED_COLOUR   1098
 #define ID_GUI_STATUS_LOG_ENABLED       1099
-#define ID_GUI_VM_PERSIST_MEM           1100
 #define IDC_AC_MUTE_ON_UNFOCUS_DISABLE  1101
 #define IDC_XBOX_PORT_0                 1158
 #define IDC_XBOX_PORT_1                 1166


### PR DESCRIPTION
Currently, the loader uses shared memory to persist the pages across a quick reboot. @RadWolfie  has brought to my attention that this approach will not work when using a third-party GUI (so only when the cxbxr process is running). This fixes this problem by saving the pages on a disk `memory.bin` file.
@RadWolfie I also included your commit `20b301954378c9aeb1c020fd1172b7eaa5237253` because, without it, it triggers the error "Data path directory is currently in used. Use different data path directory or stop emulation from another process.", which is a bug introduced in https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/1741 and your commit fixes it.