### PR TITLE
Speed up drawing indexed quads

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6949,8 +6949,10 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 			if (StartVertex > 0) {
 				LOG_TEST_CASE("X_D3DPT_QUADLIST StartVertex > 0");
 				// test-case : BLiNX: the time sweeper
+				// test-case : Call of Duty: Finest Hour
 				// test-case : Halo - Combat Evolved
 				// test-case : Worms 3D Special Edition
+				// test-case : Tony Hawk's Pro Skater 2X
 				// test-case : XDK sample Lensflare 
 				DrawContext.dwStartVertex = StartVertex; // Breakpoint location for testing. 
 			}

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6714,7 +6714,7 @@ void CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 
 	VertexBufferConverter.Apply(&DrawContext);
 	if (DrawContext.XboxPrimitiveType == XTL::X_D3DPT_QUADLIST) {
-		// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // X-Marbles and XDK Sample PlayField hits this case
+		// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // test-case : X-Marbles and XDK Sample PlayField
 		// Draw quadlists using a single 'quad-to-triangle mapping' index buffer :
 		INDEX16 *pIndexData = CxbxAssureQuadListIndexBuffer(DrawContext.dwVertexCount);
 		// Convert quad vertex-count to triangle vertex count :
@@ -6945,7 +6945,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawVertices)
 
 		VertexBufferConverter.Apply(&DrawContext);
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_QUADLIST) {
-			// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // ?X-Marbles and XDK Sample (Cartoon, ?maybe PlayField?) hits this case
+			// LOG_TEST_CASE("X_D3DPT_QUADLIST"); // test-case : ?X-Marbles and XDK Sample (Cartoon, ?maybe PlayField?)
 			if (StartVertex > 0) {
 				LOG_TEST_CASE("X_D3DPT_QUADLIST StartVertex > 0");
 				// test-case : BLiNX: the time sweeper

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6668,10 +6668,9 @@ void CxbxDrawIndexed(CxbxDrawContext &DrawContext)
 	INDEX16 LowIndex, HighIndex;
 	WalkIndexBuffer(LowIndex, HighIndex, &(DrawContext.pIndexData[/*DrawContext.dwStartVertex=*/0]), DrawContext.dwVertexCount);
 
-	D3DPRIMITIVETYPE PrimitiveType = bQuadListAsTriangleList ? D3DPT_TRIANGLELIST : EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType);
 	UINT primCount = (bQuadListAsTriangleList ? TRIANGLES_PER_QUAD : 1) * DrawContext.dwHostPrimitiveCount;
 	HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitive(
-		PrimitiveType,
+		/* PrimitiveType = */EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 		/* BaseVertexIndex = */DrawContext.dwIndexBase,
 		/* MinVertexIndex = */LowIndex,
 		/* NumVertices = */(HighIndex - LowIndex) + 1,//using index vertex span here.  // TODO : g_EmuD3DActiveStreamSizes[0], // Note : ATI drivers are especially picky about this -
@@ -7166,10 +7165,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 			pHostIndexData = (INDEX16 *)pIndexData;
 		}
 
-		D3DPRIMITIVETYPE PrimitiveType = bQuadListAsTriangleList ? D3DPT_TRIANGLELIST : EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType);
 		UINT PrimitiveCount = (bQuadListAsTriangleList ? TRIANGLES_PER_QUAD : 1) * DrawContext.dwHostPrimitiveCount;
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
-			PrimitiveType,
+			/*PrimitiveType=*/EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 			/*MinVertexIndex=*/LowIndex,
 			/*NumVertexIndices=*/(HighIndex - LowIndex) + 1, //this shall be Vertex Spans DrawContext.dwVertexCount,
 			PrimitiveCount,
@@ -7184,7 +7182,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 			CxbxReleaseQuadListIndexBuffer(pHostIndexData);
 		}
 
-		g_dwPrimPerFrame += DrawContext.dwHostPrimitiveCount;
+		g_dwPrimPerFrame += PrimitiveCount;
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_LINELOOP) {
 			// Close line-loops using a final single line, drawn from the end to the start vertex
 			LOG_TEST_CASE("X_D3DPT_LINELOOP"); // TODO : Which titles reach this case?

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -933,7 +933,7 @@ IDirect3DBaseTexture *GetHostBaseTexture(XTL::X_D3DResource *pXboxResource, DWOR
 		return nullptr;
 
 	if (GetXboxCommonResourceType(pXboxResource) != X_D3DCOMMON_TYPE_TEXTURE) { // Allows breakpoint below
-        // Burnout and Outrun 2006 hit this case (retrieving a surface instead of a texture)
+        // test-case : Burnout and Outrun 2006 hit this case (retrieving a surface instead of a texture)
         // TODO : Surfaces can be set in the texture stages, instead of textures
         // We'll need to wrap the surface somehow before using it as a texture
         LOG_TEST_CASE("GetHostBaseTexture called on a non-texture object");
@@ -6818,7 +6818,7 @@ void CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 
 		g_dwPrimPerFrame += DrawContext.dwHostPrimitiveCount;
 		if (DrawContext.XboxPrimitiveType == XTL::X_D3DPT_LINELOOP) {
-			// Note : XDK samples reaching this case : DebugKeyboard, Gamepad, Tiling, ShadowBuffer
+			// test-case : XDK samples reaching this case : DebugKeyboard, Gamepad, Tiling, ShadowBuffer
 			// Close line-loops using a final single line, drawn from the end to the start vertex :
 			CxbxDrawIndexedClosingLineUP(
 				(INDEX16)0, // LowIndex
@@ -7264,7 +7264,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 		g_dwPrimPerFrame += PrimitiveCount;
 		if (DrawContext.XboxPrimitiveType == X_D3DPT_LINELOOP) {
 			// Close line-loops using a final single line, drawn from the end to the start vertex
-			LOG_TEST_CASE("X_D3DPT_LINELOOP"); // TODO : Which titles reach this case?
+			LOG_TEST_CASE("X_D3DPT_LINELOOP"); // TODO : Which titles reach this test-case?
 			// Read the end and start index from the supplied index data
 			INDEX16 LowIndex = pXboxIndexData[0];
 			INDEX16 HighIndex = pXboxIndexData[DrawContext.dwHostPrimitiveCount];

--- a/src/core/hle/D3D8/XbConvert.cpp
+++ b/src/core/hle/D3D8/XbConvert.cpp
@@ -1181,27 +1181,27 @@ D3DMULTISAMPLE_TYPE EmuXB2PC_D3DMultiSampleFormat(DWORD Type)
 }
 
 // lookup table for converting vertex count to primitive count
-UINT EmuD3DVertexToPrimitive[11][2] =
+const unsigned g_XboxPrimitiveTypeInfo[11][2] =
 {
-	// First number the number of vertices per primitive
-	// Second number is the starting number of vertices the draw requires
+	// First number is the starting number of vertices the draw requires
+	// Second number the number of vertices per primitive
 	// Example : Triangle list, has no starting vertices, and uses 3 vertices for each triangle
 	// Example : Triangle strip, starts with 2 vertices, and adds 1 for each triangle
     {0, 0}, // NULL
-    {1, 0}, // X_D3DPT_POINTLIST
-    {2, 0}, // X_D3DPT_LINELIST
-    {1, 1}, // X_D3DPT_LINELOOP
-    {1, 1}, // X_D3DPT_LINESTRIP
-    {3, 0}, // X_D3DPT_TRIANGLELIST
-    {1, 2}, // X_D3DPT_TRIANGLESTRIP
-    {1, 2}, // X_D3DPT_TRIANGLEFAN
-    {4, 0}, // X_D3DPT_QUADLIST
-    {2, 2}, // X_D3DPT_QUADSTRIP
-    {1, 0}, // X_D3DPT_POLYGON
+	{0, 1}, // X_D3DPT_POINTLIST
+	{0, 2}, // X_D3DPT_LINELIST
+	{1, 1}, // X_D3DPT_LINELOOP
+	{1, 1}, // X_D3DPT_LINESTRIP
+	{0, 3}, // X_D3DPT_TRIANGLELIST
+	{2, 1}, // X_D3DPT_TRIANGLESTRIP
+	{2, 1}, // X_D3DPT_TRIANGLEFAN
+	{0, 4}, // X_D3DPT_QUADLIST
+	{2, 2}, // X_D3DPT_QUADSTRIP
+	{0, 1}, // X_D3DPT_POLYGON
 };
 
 // conversion table for xbox->pc primitive types
-D3DPRIMITIVETYPE EmuPrimitiveTypeLookup[] =
+const D3DPRIMITIVETYPE g_XboxPrimitiveTypeToHost[] =
 {
     /* NULL                   = 0         */ (D3DPRIMITIVETYPE)0,
     /* X_D3DPT_POINTLIST      = 1,        */ D3DPT_POINTLIST,

--- a/src/core/hle/D3D8/XbConvert.cpp
+++ b/src/core/hle/D3D8/XbConvert.cpp
@@ -1183,6 +1183,10 @@ D3DMULTISAMPLE_TYPE EmuXB2PC_D3DMultiSampleFormat(DWORD Type)
 // lookup table for converting vertex count to primitive count
 UINT EmuD3DVertexToPrimitive[11][2] =
 {
+	// First number the number of vertices per primitive
+	// Second number is the starting number of vertices the draw requires
+	// Example : Triangle list, has no starting vertices, and uses 3 vertices for each triangle
+	// Example : Triangle strip, starts with 2 vertices, and adds 1 for each triangle
     {0, 0}, // NULL
     {1, 0}, // X_D3DPT_POINTLIST
     {2, 0}, // X_D3DPT_LINELIST

--- a/src/core/hle/D3D8/XbConvert.cpp
+++ b/src/core/hle/D3D8/XbConvert.cpp
@@ -1203,18 +1203,18 @@ UINT EmuD3DVertexToPrimitive[11][2] =
 // conversion table for xbox->pc primitive types
 D3DPRIMITIVETYPE EmuPrimitiveTypeLookup[] =
 {
-    /* NULL                 = 0         */ (D3DPRIMITIVETYPE)0,
-    /* D3DPT_POINTLIST      = 1,        */ D3DPT_POINTLIST,
-    /* D3DPT_LINELIST       = 2,        */ D3DPT_LINELIST,
-    /* D3DPT_LINELOOP       = 3,  Xbox  */ D3DPT_LINESTRIP,
-    /* D3DPT_LINESTRIP      = 4,        */ D3DPT_LINESTRIP,
-    /* D3DPT_TRIANGLELIST   = 5,        */ D3DPT_TRIANGLELIST,
-    /* D3DPT_TRIANGLESTRIP  = 6,        */ D3DPT_TRIANGLESTRIP,
-    /* D3DPT_TRIANGLEFAN    = 7,        */ D3DPT_TRIANGLEFAN,
-    /* D3DPT_QUADLIST       = 8,  Xbox  */ D3DPT_TRIANGLELIST,
-    /* D3DPT_QUADSTRIP      = 9,  Xbox  */ D3DPT_TRIANGLESTRIP,
-    /* D3DPT_POLYGON        = 10, Xbox  */ D3DPT_TRIANGLEFAN,
-    /* D3DPT_MAX            = 11,       */ (D3DPRIMITIVETYPE)11
+    /* NULL                   = 0         */ (D3DPRIMITIVETYPE)0,
+    /* X_D3DPT_POINTLIST      = 1,        */ D3DPT_POINTLIST,
+    /* X_D3DPT_LINELIST       = 2,        */ D3DPT_LINELIST,
+    /* X_D3DPT_LINELOOP       = 3,  Xbox  */ D3DPT_LINESTRIP,
+    /* X_D3DPT_LINESTRIP      = 4,        */ D3DPT_LINESTRIP,
+    /* X_D3DPT_TRIANGLELIST   = 5,        */ D3DPT_TRIANGLELIST,
+    /* X_D3DPT_TRIANGLESTRIP  = 6,        */ D3DPT_TRIANGLESTRIP,
+    /* X_D3DPT_TRIANGLEFAN    = 7,        */ D3DPT_TRIANGLEFAN,
+    /* X_D3DPT_QUADLIST       = 8,  Xbox  */ D3DPT_TRIANGLELIST,
+    /* X_D3DPT_QUADSTRIP      = 9,  Xbox  */ D3DPT_TRIANGLESTRIP,
+    /* X_D3DPT_POLYGON        = 10, Xbox  */ D3DPT_TRIANGLEFAN,
+    /* X_D3DPT_MAX            = 11,       */ (D3DPRIMITIVETYPE)11
 };
 
 void EmuUnswizzleBox

--- a/src/core/hle/D3D8/XbConvert.h
+++ b/src/core/hle/D3D8/XbConvert.h
@@ -29,6 +29,8 @@
 
 #include "core\hle\D3D8\XbD3D8Types.h"
 
+#define VERTICES_PER_DOT 1
+#define VERTICES_PER_LINE 2
 #define VERTICES_PER_TRIANGLE 3
 #define VERTICES_PER_QUAD 4
 #define TRIANGLES_PER_QUAD 2

--- a/src/core/hle/D3D8/XbConvert.h
+++ b/src/core/hle/D3D8/XbConvert.h
@@ -233,33 +233,31 @@ inline D3DSTENCILOP EmuXB2PC_D3DSTENCILOP(XTL::X_D3DSTENCILOP Value)
 }
 
 // table used for vertex->primitive count conversion
-extern UINT EmuD3DVertexToPrimitive[XTL::X_D3DPT_POLYGON + 1][2];
+extern const UINT g_XboxPrimitiveTypeInfo[XTL::X_D3DPT_POLYGON + 1][2];
 
-inline bool EmuD3DValidVertexCount(XTL::X_D3DPRIMITIVETYPE XboxPrimitiveType, UINT VertexCount)
+inline bool IsValidXboxVertexCount(XTL::X_D3DPRIMITIVETYPE XboxPrimitiveType, UINT VertexCount)
 {
+	assert(XboxPrimitiveType < XTL::X_D3DPT_MAX);
+
 	// Are there more vertices than required for setup?
-	if (VertexCount > EmuD3DVertexToPrimitive[XboxPrimitiveType][1])
+	if (VertexCount > g_XboxPrimitiveTypeInfo[XboxPrimitiveType][0])
 		// Are the additional vertices exact multiples of the required additional vertices per primitive?
-		if (0 == ((VertexCount - EmuD3DVertexToPrimitive[XboxPrimitiveType][1]) % EmuD3DVertexToPrimitive[XboxPrimitiveType][0]))
+		if (0 == ((VertexCount - g_XboxPrimitiveTypeInfo[XboxPrimitiveType][0]) % g_XboxPrimitiveTypeInfo[XboxPrimitiveType][1]))
 			return true;
 
 	return false;
 }
 
 // convert from vertex count to primitive count (Xbox)
-inline int EmuD3DVertex2PrimitiveCount(XTL::X_D3DPRIMITIVETYPE PrimitiveType, int VertexCount)
+inline unsigned ConvertXboxVertexCountToPrimitiveCount(XTL::X_D3DPRIMITIVETYPE XboxPrimitiveType, unsigned VertexCount)
 {
-    return (VertexCount - EmuD3DVertexToPrimitive[PrimitiveType][1]) / EmuD3DVertexToPrimitive[PrimitiveType][0];
-}
+	assert(XboxPrimitiveType < XTL::X_D3DPT_MAX);
 
-// convert from primitive count to vertex count (Xbox)
-inline int EmuD3DPrimitive2VertexCount(XTL::X_D3DPRIMITIVETYPE PrimitiveType, int PrimitiveCount)
-{
-    return (PrimitiveCount * EmuD3DVertexToPrimitive[PrimitiveType][0]) + EmuD3DVertexToPrimitive[PrimitiveType][1];
+	return (VertexCount - g_XboxPrimitiveTypeInfo[XboxPrimitiveType][0]) / g_XboxPrimitiveTypeInfo[XboxPrimitiveType][1];
 }
 
 // conversion table for xbox->pc primitive types
-extern D3DPRIMITIVETYPE EmuPrimitiveTypeLookup[];
+extern const D3DPRIMITIVETYPE g_XboxPrimitiveTypeToHost[];
 
 // convert xbox->pc primitive type
 inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(XTL::X_D3DPRIMITIVETYPE XboxPrimitiveType)
@@ -269,12 +267,7 @@ inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(XTL::X_D3DPRIMITIVETYPE XboxPr
 		return D3DPT_FORCE_DWORD;
 	}
 
-    return EmuPrimitiveTypeLookup[XboxPrimitiveType];
-}
-
-inline int EmuD3DIndexCountToVertexCount(XTL::X_D3DPRIMITIVETYPE XboxPrimitiveType, int IndexCount)
-{
-	return IndexCount;
+    return g_XboxPrimitiveTypeToHost[XboxPrimitiveType];
 }
 
 extern void EmuUnswizzleBox

--- a/src/core/hle/D3D8/XbConvert.h
+++ b/src/core/hle/D3D8/XbConvert.h
@@ -262,12 +262,14 @@ inline int EmuD3DPrimitive2VertexCount(XTL::X_D3DPRIMITIVETYPE PrimitiveType, in
 extern D3DPRIMITIVETYPE EmuPrimitiveTypeLookup[];
 
 // convert xbox->pc primitive type
-inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(XTL::X_D3DPRIMITIVETYPE PrimitiveType)
+inline D3DPRIMITIVETYPE EmuXB2PC_D3DPrimitiveType(XTL::X_D3DPRIMITIVETYPE XboxPrimitiveType)
 {
-    if((DWORD)PrimitiveType == 0x7FFFFFFF)
-        return D3DPT_FORCE_DWORD;
+	if (XboxPrimitiveType >= XTL::X_D3DPT_MAX) {
+		LOG_TEST_CASE("XboxPrimitiveType too large");
+		return D3DPT_FORCE_DWORD;
+	}
 
-    return EmuPrimitiveTypeLookup[PrimitiveType];
+    return EmuPrimitiveTypeLookup[XboxPrimitiveType];
 }
 
 inline int EmuD3DIndexCountToVertexCount(XTL::X_D3DPRIMITIVETYPE XboxPrimitiveType, int IndexCount)

--- a/src/core/hle/D3D8/XbPushBuffer.cpp
+++ b/src/core/hle/D3D8/XbPushBuffer.cpp
@@ -258,7 +258,7 @@ void HLE_draw_inline_elements(NV2AState *d)
 		CxbxDrawContext DrawContext = {};
 
 		DrawContext.XboxPrimitiveType = (XTL::X_D3DPRIMITIVETYPE)pg->primitive_mode;
-		DrawContext.dwVertexCount = EmuD3DIndexCountToVertexCount(DrawContext.XboxPrimitiveType, uiIndexCount);
+		DrawContext.dwVertexCount = uiIndexCount;
 		DrawContext.pXboxIndexData = d->pgraph.inline_elements;
 
 		CxbxDrawIndexed(DrawContext);

--- a/src/core/hle/D3D8/XbPushBuffer.cpp
+++ b/src/core/hle/D3D8/XbPushBuffer.cpp
@@ -259,7 +259,7 @@ void HLE_draw_inline_elements(NV2AState *d)
 
 		DrawContext.XboxPrimitiveType = (XTL::X_D3DPRIMITIVETYPE)pg->primitive_mode;
 		DrawContext.dwVertexCount = EmuD3DIndexCountToVertexCount(DrawContext.XboxPrimitiveType, uiIndexCount);
-		DrawContext.pIndexData = d->pgraph.inline_elements; // Used by GetVerticesInBuffer
+		DrawContext.pXboxIndexData = d->pgraph.inline_elements; // Used by GetVerticesInBuffer
 
 		CxbxDrawIndexed(DrawContext);
 	}

--- a/src/core/hle/D3D8/XbPushBuffer.cpp
+++ b/src/core/hle/D3D8/XbPushBuffer.cpp
@@ -259,7 +259,7 @@ void HLE_draw_inline_elements(NV2AState *d)
 
 		DrawContext.XboxPrimitiveType = (XTL::X_D3DPRIMITIVETYPE)pg->primitive_mode;
 		DrawContext.dwVertexCount = EmuD3DIndexCountToVertexCount(DrawContext.XboxPrimitiveType, uiIndexCount);
-		DrawContext.pXboxIndexData = d->pgraph.inline_elements; // Used by GetVerticesInBuffer
+		DrawContext.pXboxIndexData = d->pgraph.inline_elements;
 
 		CxbxDrawIndexed(DrawContext);
 	}

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -84,7 +84,7 @@ void CxbxPatchedStream::Activate(CxbxDrawContext *pDrawContext, UINT uiStream) c
 		//DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetStreamSource");
 		if (FAILED(hRet)) {
 			CxbxKrnlCleanup("Failed to set the type patched buffer as the new stream source!\n");
-			// TODO : Cartoon hits the above case when the vertex cache size is 0.
+			// TODO : test-case : XDK Cartoon hits the above case when the vertex cache size is 0.
 		}
 	}
 }
@@ -632,6 +632,7 @@ void CxbxVertexBufferConverter::ConvertStream
 				}
 				case XTL::X_D3DVSDT_NONE: { // 0x02:
 					// Test-case : WWE RAW2
+					// Test-case : PetitCopter 
 					LOG_TEST_CASE("X_D3DVSDT_NONE");
 					// No host element data (but Xbox size can be above zero, when used for X_D3DVSD_MASK_SKIP*
 					break;

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -126,6 +126,7 @@ size_t GetVerticesInBuffer(DWORD dwOffset, DWORD dwVertexCount, PWORD pIndexData
 
 	// We are an indexed draw, so we have to parse the index buffer
 	// The highest index we see can be used to determine the vertex buffer size
+	// TODO : Should we use WalkIndexBuffer() instead?
 	DWORD highestVertexIndex = 0;
 	for (DWORD i = 0; i < dwVertexCount; i++) {
 		if (highestVertexIndex < pIndexData[i]) {

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -767,8 +767,9 @@ void CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext)
 	// If we are drawing from an offset, we know that the vertex count must have
 	// 'offset' vertices before the first drawn vertices
 	pDrawContext->VerticesInBuffer = pDrawContext->dwStartVertex + pDrawContext->dwVertexCount;
-	// Whhen this is an indexed draw, take the index buffer into account
+	// When this is an indexed draw, take the index buffer into account
 	if (pDrawContext->pXboxIndexData) {
+		// Is the highest index in this buffer not set yet?
 		if (pDrawContext->HighIndex == 0) {
 			// TODO : Instead of calling WalkIndexBuffer here, set LowIndex and HighIndex
 			// in all callers that end up here (since they might be able to avoid the call)

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -805,9 +805,9 @@ void CxbxVertexBufferConverter::Apply(CxbxDrawContext *pDrawContext)
 		// handled by d3d :
 		// Test-case : XDK Samples (FocusBlur, MotionBlur, Trees, PaintEffect, PlayField)
 		// No need to set : pDrawContext->XboxPrimitiveType = X_D3DPT_TRIANGLESTRIP;
-		pDrawContext->dwHostPrimitiveCount = EmuD3DVertex2PrimitiveCount(XTL::X_D3DPT_TRIANGLESTRIP, pDrawContext->dwVertexCount);
+		pDrawContext->dwHostPrimitiveCount = ConvertXboxVertexCountToPrimitiveCount(XTL::X_D3DPT_TRIANGLESTRIP, pDrawContext->dwVertexCount);
 	} else {
-		pDrawContext->dwHostPrimitiveCount = EmuD3DVertex2PrimitiveCount(pDrawContext->XboxPrimitiveType, pDrawContext->dwVertexCount);
+		pDrawContext->dwHostPrimitiveCount = ConvertXboxVertexCountToPrimitiveCount(pDrawContext->XboxPrimitiveType, pDrawContext->dwVertexCount);
 	}
 
 	if (pDrawContext->XboxPrimitiveType == XTL::X_D3DPT_POLYGON) {

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -36,8 +36,8 @@ typedef struct _CxbxDrawContext
     IN     XTL::X_D3DPRIMITIVETYPE    XboxPrimitiveType;
     IN     DWORD                 dwVertexCount;
     IN     DWORD                 dwStartVertex; // Only D3DDevice_DrawVertices sets this (potentially higher than default 0)
-	IN	   PWORD				 pIndexData;
-	IN	   DWORD				 dwIndexBase;
+	IN	   PWORD				 pXboxIndexData;
+	IN	   DWORD				 dwBaseVertexIndex;
 	IN	   size_t				 VerticesInBuffer;
     // Data if Draw...UP call
     IN PVOID                     pXboxVertexStreamZeroData;

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -38,7 +38,8 @@ typedef struct _CxbxDrawContext
     IN     DWORD                 dwStartVertex; // Only D3DDevice_DrawVertices sets this (potentially higher than default 0)
 	IN	   PWORD				 pXboxIndexData;
 	IN	   DWORD				 dwBaseVertexIndex;
-	IN	   size_t				 VerticesInBuffer;
+	IN	   INDEX16				 LowIndex, HighIndex; // Set when pXboxIndexData is set
+	IN	   size_t				 VerticesInBuffer; // Set by CxbxVertexBufferConverter::Apply
     // Data if Draw...UP call
     IN PVOID                     pXboxVertexStreamZeroData;
     IN UINT                      uiXboxVertexStreamZeroStride;

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -36,7 +36,7 @@ typedef struct _CxbxDrawContext
     IN     XTL::X_D3DPRIMITIVETYPE    XboxPrimitiveType;
     IN     DWORD                 dwVertexCount;
     IN     DWORD                 dwStartVertex; // Only D3DDevice_DrawVertices sets this (potentially higher than default 0)
-	IN	   PWORD				 pXboxIndexData;
+	IN	   PWORD				 pXboxIndexData; // Set by D3DDevice_DrawIndexedVertices, D3DDevice_DrawIndexedVerticesUP and HLE_draw_inline_elements
 	IN	   DWORD				 dwBaseVertexIndex;
 	IN	   INDEX16				 LowIndex, HighIndex; // Set when pXboxIndexData is set
 	IN	   size_t				 VerticesInBuffer; // Set by CxbxVertexBufferConverter::Apply

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -37,7 +37,7 @@ typedef struct _CxbxDrawContext
     IN     DWORD                 dwVertexCount;
     IN     DWORD                 dwStartVertex; // Only D3DDevice_DrawVertices sets this (potentially higher than default 0)
 	IN	   PWORD				 pXboxIndexData; // Set by D3DDevice_DrawIndexedVertices, D3DDevice_DrawIndexedVerticesUP and HLE_draw_inline_elements
-	IN	   DWORD				 dwBaseVertexIndex;
+	IN	   DWORD				 dwBaseVertexIndex; // Set to g_XboxBaseVertexIndex in D3DDevice_DrawIndexedVertices
 	IN	   INDEX16				 LowIndex, HighIndex; // Set when pXboxIndexData is set
 	IN	   size_t				 VerticesInBuffer; // Set by CxbxVertexBufferConverter::Apply
     // Data if Draw...UP call
@@ -46,7 +46,7 @@ typedef struct _CxbxDrawContext
 	// Values to be used on host
 	OUT PVOID                    pHostVertexStreamZeroData;
 	OUT UINT                     uiHostVertexStreamZeroStride;
-    OUT DWORD                    dwHostPrimitiveCount;
+    OUT DWORD                    dwHostPrimitiveCount; // Set by CxbxVertexBufferConverter::Apply
 }
 CxbxDrawContext;
 

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -911,6 +911,11 @@ static void VshWriteShader(VSH_XBOX_SHADER *pShader,
 					// We count down from the highest available on the host because Xbox titles don't use values that high, and we read from c192 (one above maximum Xbox c191 constant) and up
 					static int temporaryRegisterBase = g_D3DCaps.VS20Caps.NumTemps - 13;
 					moveConstantsToTemporaries << "mov r" << (temporaryRegisterBase + i) << ", c" << (CXBX_D3DVS_CONSTREG_VERTEXDATA4F_BASE + i) << "\n";
+					// test-case : Blade II (before menu's)
+					// test-case : Namco Museum 50th Anniversary (at boot)
+					// test-case : Pac-Man World 2 (at boot)
+					// test-case : The Simpsons Road Rage (leaving menu's, before entering in-game)
+					// test-case : The SpongeBob SquarePants Movie (before menu's)
 					LOG_TEST_CASE("Shader uses undeclared Vertex Input Registers");
 					i++;
 					continue;
@@ -1824,7 +1829,7 @@ private:
 	{
 		DWORD regNum = (XboxToken & X_D3DVSD_VERTEXREGINMASK) >> X_D3DVSD_VERTEXREGINSHIFT;
 		if (regNum >= hostTemporaryRegisterCount /*12 for D3D8, D3D9 value depends on host GPU */) {
-			// Lego Star Wars hits this
+			// test-case : Lego Star Wars
 			LOG_TEST_CASE("RegNum > NumTemps");
 		}
 		return regNum;

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -1813,7 +1813,8 @@ private:
 	{
 		DWORD regNum = (XboxToken & X_D3DVSD_VERTEXREGMASK) >> X_D3DVSD_VERTEXREGSHIFT;
 		if (regNum >= hostTemporaryRegisterCount /*12 for D3D8, D3D9 value depends on host GPU */) {
-			// Lego Star Wars hits this
+			// test-case : BLiNX: the time sweeper
+			// test-case : Lego Star Wars
 			LOG_TEST_CASE("RegNum > NumTemps");
 		}
 		return regNum;

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -149,7 +149,7 @@ bool VerifySymbolAddressAgainstXRef(char *SymbolName, xbaddr Address, int XRef)
 
     CxbxPopupMessage(LOG_LEVEL::WARNING, CxbxMsgDlgIcon_Warn,
 		"Verification of %s failed : XREF was 0x%.8X while lookup gave 0x%.8X", SymbolName, XRefAddr, Address);
-    // this case : Kabuki Warriors (for XREF_D3DTSS_TEXCOORDINDEX)
+    // test case : Kabuki Warriors (for XREF_D3DTSS_TEXCOORDINDEX)
     return false;
 }*/
 

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -147,10 +147,9 @@ bool VerifySymbolAddressAgainstXRef(char *SymbolName, xbaddr Address, int XRef)
         return true;
     }
 
-    // For XREF_D3DTSS_TEXCOORDINDEX, Kabuki Warriors hits this case
     CxbxPopupMessage(LOG_LEVEL::WARNING, CxbxMsgDlgIcon_Warn,
 		"Verification of %s failed : XREF was 0x%.8X while lookup gave 0x%.8X", SymbolName, XRefAddr, Address);
-    // For XREF_D3DTSS_TEXCOORDINDEX, Kabuki Warriors hits this case
+    // this case : Kabuki Warriors (for XREF_D3DTSS_TEXCOORDINDEX)
     return false;
 }*/
 

--- a/src/devices/x86/EmuX86.cpp
+++ b/src/devices/x86/EmuX86.cpp
@@ -3282,7 +3282,7 @@ bool EmuX86_DecodeException(LPEXCEPTION_POINTERS e)
 				// We do not emulate processor specific registers just yet
 				// Some titles attempt to manually set the TSC via this instruction
 				// This needs fixing eventually, but should be acceptible to ignore for now!
-				// Chase: Hollywood Stunt Driver hits this
+				// test-case : Chase: Hollywood Stunt Driver
 				EmuLog(LOG_LEVEL::WARNING, "WRMSR instruction ignored");
 				break;
 			case I_XOR:


### PR DESCRIPTION
Speed up drawing indexed quads by converting the indices (from ABCD quads to ABC+CDA triangles), and doing one call with those indices (instead of drawing each quad separately)

Fixes issue #1749

Test at least with a few titles that are known to draw indexed quads: Buffy: The Vampire Slayer, FastLoad XDK Sample (more reports on this "X_D3DPT_QUADLIST" test-case are welcome).

EDIT : READY FOR REVIEW AND MERGE (all reported regression, like in Indiana Jones, are resolved)