### PR TITLE
Disable LLE GPU option in the gui

### DIFF
--- a/resource/Cxbx.rc
+++ b/resource/Cxbx.rc
@@ -628,7 +628,7 @@ BEGIN
         MENUITEM MFT_SEPARATOR
         POPUP "&LLE (Experimental)",            65535,MFT_STRING,MFS_ENABLED
         BEGIN
-            MENUITEM "LLE &GPU",                    ID_EMULATION_LLE_GPU,MFT_STRING,MFS_ENABLED
+            MENUITEM "LLE &GPU",                    ID_EMULATION_LLE_GPU,MFT_STRING,MFS_DISABLED
         END
         POPUP "Hacks",                          65535,MFT_STRING,MFS_ENABLED
         BEGIN


### PR DESCRIPTION
Disables the LLE GPU option in the GUI, so that end users cannot enable it any longer (it's too slow to play games at acceptable speeds any way). It can still be enabled in the settings file, by writing 0x2 to the variable "FlagsLLE", in the case developers and/or power users need it for testing purposes.