### PR TITLE
Fix sdl controller input bindings

### DIFF
--- a/src/common/input/InputWindow.h
+++ b/src/common/input/InputWindow.h
@@ -64,7 +64,7 @@ public:
 
 private:
 	typedef std::vector<Settings::s_input_profiles>::iterator ProfileIt;
-	InputDevice::Input* DetectInput(InputDevice* const Device, Button* const xbox_button, int ms);
+	InputDevice::Input* DetectInput(InputDevice* const Device, int ms);
 	void DetectOutput(int ms);
 	ProfileIt FindProfile(std::string& name);
 	void LoadProfile(std::string& name);


### PR DESCRIPTION
Some users reported that the sdl controller axes are bound erroneously in the input gui. I managed to trace back the original broken commit to PR #1721. This fixes the problem by reverting most of those changes and using an alternative implementation to fix the SPACE/ENTER problem mentioned in that PR.