### PR TITLE
Avoid memory leak in point-sprite texture swaps

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
@@ -260,6 +260,10 @@ void XboxTextureStateConverter::Apply()
         g_pD3DDevice->GetTexture(3, &pTexture);
         g_pD3DDevice->SetTexture(0, pTexture);
 
+        // Avoid a dangling reference that would lead to a memory leak
+        if (pTexture != nullptr)
+            pTexture->Release();
+
         // disable all other stages
         g_pD3DDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
         g_pD3DDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);


### PR DESCRIPTION
On Xbox, point-sprites must use texture channel 3 (three).
On Windows Direct3D, point-sprites must use texture channel 0 (zero).

To make point-sprites visible, we already copy the texture reference from channel 3 over to channel 0.
So point-sprites already work.

However, all resources retrieved from Direct3D internal state, including textures, must always be `Release()`'ed once the variable goes out of scope. Failing to do so, would introduce a dangling reference, leading to a memory leak.

This PR fixes an oversight on this, related to the point-sprite scenario described above.

Other than preventing this leak, there should be no other discernible effect from this change.
