### PR TITLE
Fix IP network traffic

### DIFF
--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -235,7 +235,10 @@ XBSYSAPI EXPORTNUM(264) xboxkrnl::VOID NTAPI xboxkrnl::RtlAssert
 		LOG_FUNC_ARG(Message)
 		LOG_FUNC_END;
 
-	CxbxPopupMessage(LOG_LEVEL::WARNING, CxbxMsgDlgIcon_Warn, "RtlAssert() raised by emulated program - consult Debug log");
+   //printf("Assertion Failed: %s %s:%d %s\n", FailedAssertion, FileName, LineNumber, Message);
+
+
+	//CxbxPopupMessage(LOG_LEVEL::WARNING, CxbxMsgDlgIcon_Warn, "RtlAssert() raised by emulated program - consult Debug log");
 }
 
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -235,10 +235,15 @@ XBSYSAPI EXPORTNUM(264) xboxkrnl::VOID NTAPI xboxkrnl::RtlAssert
 		LOG_FUNC_ARG(Message)
 		LOG_FUNC_END;
 
-   //printf("Assertion Failed: %s %s:%d %s\n", FailedAssertion, FileName, LineNumber, Message);
+	std::stringstream ss;
+	ss << "RtlAssert() raised by emulated program\n" << FileName << ":" << LineNumber << ":" << FailedAssertion ;
+	if (Message) {
+		ss << " " << Message;
+	}
 
+	ss << ")";
 
-	//CxbxPopupMessage(LOG_LEVEL::WARNING, CxbxMsgDlgIcon_Warn, "RtlAssert() raised by emulated program - consult Debug log");
+	CxbxPopupMessage(LOG_LEVEL::WARNING, CxbxMsgDlgIcon_Warn, ss.str().c_str());
 }
 
 // ******************************************************************

--- a/src/core/kernel/support/EmuNtDll.cpp
+++ b/src/core/kernel/support/EmuNtDll.cpp
@@ -86,6 +86,7 @@ IMPORT(NtReadFile);
 IMPORT(NtReleaseMutant);
 IMPORT(NtReleaseSemaphore);
 IMPORT(NtResumeThread);
+IMPORT(NtResetEvent);
 IMPORT(NtSetEvent);
 IMPORT(NtSetInformationFile);
 IMPORT(NtSetLdtEntries);

--- a/src/core/kernel/support/EmuNtDll.h
+++ b/src/core/kernel/support/EmuNtDll.h
@@ -1475,6 +1475,15 @@ typedef NTSTATUS(NTAPI *FPTR_NtPulseEvent)
 );
 
 // ******************************************************************
+// * NtResetEvent
+// ******************************************************************
+typedef NTSTATUS(NTAPI *FPTR_NtResetEvent)
+(
+    IN HANDLE	EventHandle,
+    OUT PLONG	PreviousState OPTIONAL
+);
+
+// ******************************************************************
 // * NtCreateMutant
 // ******************************************************************
 typedef NTSTATUS (NTAPI *FPTR_NtCreateMutant)
@@ -1946,6 +1955,7 @@ EXTERN(NtQueueApcThread);
 EXTERN(NtReadFile);
 EXTERN(NtReleaseMutant);
 EXTERN(NtReleaseSemaphore);
+EXTERN(NtResetEvent);
 EXTERN(NtResumeThread);
 EXTERN(NtSetEvent);
 EXTERN(NtSetInformationFile);

--- a/src/devices/EmuNVNet.cpp
+++ b/src/devices/EmuNVNet.cpp
@@ -688,11 +688,13 @@ bool NVNetDevice::PCAPSend(void* packet, size_t length)
 
 	// TODO: Optional
 	// PrintPacket(packet, length);
-	
+
+	// Forward broadcast packets direct to the host PC, as well as over the network
 	if (memcmp(header->dst.bytes, m_BroadcastMacAddress.bytes, 6) == 0) {
 		static char pack[65536];
 		memcpy(pack, packet, length);
-		header->dst = m_HostMacAddress;
+		ethernet_header* _header = (ethernet_header*)pack;
+		_header->dst = m_HostMacAddress;
 		pcap_sendpacket((pcap_t*)m_AdapterHandle, (uint8_t*)pack, length);
 	}
 

--- a/src/devices/EmuNVNet.h
+++ b/src/devices/EmuNVNet.h
@@ -215,8 +215,6 @@ public:
 	uint32_t MMIORead(int barIndex, uint32_t addr, unsigned size);
 	void MMIOWrite(int barIndex, uint32_t addr, uint32_t value, unsigned size);
 
-	void SetGuestMacAddress(mac_address* mac);
-
 	__declspec(noinline) bool PCAPSend(void* packet, size_t length);
 	size_t PCAPReceive(void* packet, size_t max_length);
 private:
@@ -229,4 +227,5 @@ private:
 	std::string m_HostAdapterName;
 	mac_address m_HostMacAddress;
 	mac_address m_GuestMacAddress = { 0x00, 0x50, 0xF2, 0x00, 0x00, 0x34 };
+	mac_address m_BroadcastMacAddress = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 };

--- a/src/devices/EmuNVNet.h
+++ b/src/devices/EmuNVNet.h
@@ -229,5 +229,4 @@ private:
 	std::string m_HostAdapterName;
 	mac_address m_HostMacAddress;
 	mac_address m_GuestMacAddress = { 0x00, 0x50, 0xF2, 0x00, 0x00, 0x34 };
-	mac_address m_BroadcastMacAddress = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/740003/68536201-00d8f000-0347-11ea-8027-160921c02b19.png)

DNS queries and other IP network traffic is now working within Cxbx-R.

This was achieved by means of a hack to allow handles created with the Nt Event APIs to function properly when passed to Ke APIs.

The Xbox network drivers depend on this functionality.

This also has potential to solve crash/hang issues in other games too.