### PR TITLE
Introduce two CxbxImpl_*'s for as-yet unimplemented functions.

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3630,8 +3630,8 @@ void UpdateViewPortOffsetAndScaleConstants()
 		float vScale[] = { (2.0f / ViewPort.Width) * g_RenderScaleFactor, (-2.0f / ViewPort.Height) * g_RenderScaleFactor, 0.0f, 0.0f };
 		static float vOffset[] = { -1.0f, 1.0f, 0.0f, 1.0f };
 
-		g_pD3DDevice->SetVertexShaderConstantF(58, vScale, 1);
-		g_pD3DDevice->SetVertexShaderConstantF(59, vOffset, 1);
+		g_pD3DDevice->SetVertexShaderConstantF(X_D3DVS_RESERVED_CONSTANT1_CORRECTED, vScale, 1);
+		g_pD3DDevice->SetVertexShaderConstantF(X_D3DVS_RESERVED_CONSTANT2_CORRECTED, vOffset, 1);
 	}
 }
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -188,6 +188,10 @@ static DWORD WINAPI                 EmuUpdateTickCount(LPVOID);
 static inline void                  EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iTextureStage, DWORD dwSize);
 static void							UpdateCurrentMSpFAndFPS(); // Used for benchmarking/fps count
 
+// Declared in XbVertexShader.cpp
+extern void CxbxImpl_SetVertexShaderInput(DWORD Handle, UINT StreamCount, XTL::X_STREAMINPUT* pStreamInputs);
+extern void CxbxImpl_SelectVertexShaderDirect(XTL::X_VERTEXATTRIBUTEFORMAT* pVAF, DWORD Address);
+
 extern void UpdateFPSCounter();
 
 typedef uint64_t resource_key_t;
@@ -7808,7 +7812,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SelectVertexShaderDirect)
 		LOG_FUNC_ARG(Address)
 		LOG_FUNC_END;
 
-    LOG_UNIMPLEMENTED(); 
+	CxbxImpl_SelectVertexShaderDirect(pVAF, Address);
 }
 
 // ******************************************************************
@@ -7933,15 +7937,8 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_SetVertexShaderInput)
 		LOG_FUNC_ARG(pStreamInputs)
 		LOG_FUNC_END;
 
-	// If Handle is NULL, all VertexShader input state is cleared.
-	// Otherwise, Handle is the address of an Xbox VertexShader struct, or-ed with 1 (X_D3DFVF_RESERVED0)
-
-
-    LOG_UNIMPLEMENTED(); 
-
-	return;
+	CxbxImpl_SetVertexShaderInput(Handle, StreamCount, pStreamInputs);
 }
-
 
 // ******************************************************************
 // * patch: D3DDevice_RunVertexStateShader

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -55,8 +55,10 @@ FLOAT *g_InlineVertexBuffer_pData = nullptr;
 UINT   g_InlineVertexBuffer_DataSize = 0;
 
 extern DWORD				g_dwPrimPerFrame = 0;
-extern XTL::X_D3DVertexBuffer*g_D3DStreams[X_VSH_MAX_STREAMS];
-extern UINT g_D3DStreamStrides[X_VSH_MAX_STREAMS];
+
+// Copy of active Xbox D3D Vertex Streams (and strides), set by [D3DDevice|CxbxImpl]_SetStreamSource*
+XTL::X_STREAMINPUT g_SetStreamSources[X_VSH_MAX_STREAMS] = { 0 }; // Note : .Offset member is never set (so always 0)
+
 extern XTL::X_D3DSurface* g_pXbox_RenderTarget;
 extern XTL::X_D3DSurface* g_pXbox_BackBufferSurface;
 void *GetDataFromXboxResource(XTL::X_D3DResource *pXboxResource);
@@ -118,7 +120,7 @@ int CountActiveD3DStreams()
 {
 	int lastStreamIndex = 0;
 	for (int i = 0; i < X_VSH_MAX_STREAMS; i++) {
-		if (g_D3DStreams[i] != xbnullptr) {
+		if (g_SetStreamSources[i].VertexBuffer != xbnullptr) {
 			lastStreamIndex = i + 1;
 		}
 	}
@@ -292,7 +294,7 @@ void CxbxVertexBufferConverter::ConvertStream
 		uiHostVertexStride = (bNeedVertexPatching) ? pVertexShaderStreamInfo->HostVertexStride : uiXboxVertexStride;
 		dwHostVertexDataSize = uiVertexCount * uiHostVertexStride;
 	} else {
-		XTL::X_D3DVertexBuffer *pXboxVertexBuffer = g_D3DStreams[uiStream];
+		XTL::X_D3DVertexBuffer *pXboxVertexBuffer = g_SetStreamSources[uiStream].VertexBuffer;
         pXboxVertexData = (uint8_t*)GetDataFromXboxResource(pXboxVertexBuffer);
 		if (pXboxVertexData == xbnullptr) {
 			HRESULT hRet = g_pD3DDevice->SetStreamSource(
@@ -308,7 +310,7 @@ void CxbxVertexBufferConverter::ConvertStream
 			return;
 		}
 
-		uiXboxVertexStride = g_D3DStreamStrides[uiStream];
+		uiXboxVertexStride = g_SetStreamSources[uiStream].Stride;
         // Set a new (exact) vertex count
 		uiVertexCount = pDrawContext->VerticesInBuffer;
 		// Dxbx note : Don't overwrite pDrawContext.dwVertexCount with uiVertexCount, because an indexed draw
@@ -986,4 +988,16 @@ VOID EmuFlushIVB()
 		//DEBUG_D3DRESULT(hRet, "g_pD3DDevice->SetVertexShader");
 	}
     g_InlineVertexBuffer_TableOffset = 0; // Might not be needed (also cleared in D3DDevice_Begin)
+}
+
+void CxbxImpl_SetStreamSource(UINT StreamNumber, XTL::X_D3DVertexBuffer* pStreamData, UINT Stride)
+{
+	if (pStreamData != xbnullptr && Stride == 0) {
+		LOG_TEST_CASE("CxbxImpl_SetStreamSource : Stream assigned, and stride set to 0 (might be okay)");
+	}
+
+	assert(StreamNumber < X_VSH_MAX_STREAMS);
+
+	g_SetStreamSources[StreamNumber].VertexBuffer = pStreamData;
+	g_SetStreamSources[StreamNumber].Stride = Stride;
 }

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -57,7 +57,7 @@ UINT   g_InlineVertexBuffer_DataSize = 0;
 extern DWORD				g_dwPrimPerFrame = 0;
 
 // Copy of active Xbox D3D Vertex Streams (and strides), set by [D3DDevice|CxbxImpl]_SetStreamSource*
-XTL::X_STREAMINPUT g_SetStreamSources[X_VSH_MAX_STREAMS] = { 0 }; // Note : .Offset member is never set (so always 0)
+XTL::X_STREAMINPUT g_Xbox_SetStreamSource[X_VSH_MAX_STREAMS] = { 0 }; // Note : .Offset member is never set (so always 0)
 
 extern XTL::X_D3DSurface* g_pXbox_RenderTarget;
 extern XTL::X_D3DSurface* g_pXbox_BackBufferSurface;
@@ -120,7 +120,7 @@ int CountActiveD3DStreams()
 {
 	int lastStreamIndex = 0;
 	for (int i = 0; i < X_VSH_MAX_STREAMS; i++) {
-		if (g_SetStreamSources[i].VertexBuffer != xbnullptr) {
+		if (g_Xbox_SetStreamSource[i].VertexBuffer != xbnullptr) {
 			lastStreamIndex = i + 1;
 		}
 	}
@@ -294,7 +294,7 @@ void CxbxVertexBufferConverter::ConvertStream
 		uiHostVertexStride = (bNeedVertexPatching) ? pVertexShaderStreamInfo->HostVertexStride : uiXboxVertexStride;
 		dwHostVertexDataSize = uiVertexCount * uiHostVertexStride;
 	} else {
-		XTL::X_D3DVertexBuffer *pXboxVertexBuffer = g_SetStreamSources[uiStream].VertexBuffer;
+		XTL::X_D3DVertexBuffer *pXboxVertexBuffer = g_Xbox_SetStreamSource[uiStream].VertexBuffer;
         pXboxVertexData = (uint8_t*)GetDataFromXboxResource(pXboxVertexBuffer);
 		if (pXboxVertexData == xbnullptr) {
 			HRESULT hRet = g_pD3DDevice->SetStreamSource(
@@ -310,7 +310,7 @@ void CxbxVertexBufferConverter::ConvertStream
 			return;
 		}
 
-		uiXboxVertexStride = g_SetStreamSources[uiStream].Stride;
+		uiXboxVertexStride = g_Xbox_SetStreamSource[uiStream].Stride;
         // Set a new (exact) vertex count
 		uiVertexCount = pDrawContext->VerticesInBuffer;
 		// Dxbx note : Don't overwrite pDrawContext.dwVertexCount with uiVertexCount, because an indexed draw
@@ -998,6 +998,6 @@ void CxbxImpl_SetStreamSource(UINT StreamNumber, XTL::X_D3DVertexBuffer* pStream
 
 	assert(StreamNumber < X_VSH_MAX_STREAMS);
 
-	g_SetStreamSources[StreamNumber].VertexBuffer = pStreamData;
-	g_SetStreamSources[StreamNumber].Stride = Stride;
+	g_Xbox_SetStreamSource[StreamNumber].VertexBuffer = pStreamData;
+	g_Xbox_SetStreamSource[StreamNumber].Stride = Stride;
 }

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -1468,7 +1468,7 @@ static void VshRemoveScreenSpaceInstructions(VSH_XBOX_SHADER *pShader)
                 MulIntermediate.Parameters[1].Active                  = TRUE;
                 MulIntermediate.Parameters[1].IndexesWithA0_X                   = FALSE;
                 MulIntermediate.Parameters[1].Parameter.ParameterType = PARAM_C;
-                MulIntermediate.Parameters[1].Parameter.Address       = ConvertCRegister(58);
+                MulIntermediate.Parameters[1].Parameter.Address       = ConvertCRegister(X_D3DVS_RESERVED_CONSTANT1_CORRECTED);
                 MulIntermediate.Parameters[1].Parameter.Neg           = FALSE;
                 VshSetSwizzle(&MulIntermediate.Parameters[1], SWIZZLE_X, SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_W);
                 MulIntermediate.Parameters[2].Active                  = FALSE;
@@ -1481,7 +1481,7 @@ static void VshRemoveScreenSpaceInstructions(VSH_XBOX_SHADER *pShader)
                 AddIntermediate.Output.Address    = OREG_OPOS;
                 AddIntermediate.Parameters[0].Parameter.ParameterType = PARAM_R;
                 AddIntermediate.Parameters[0].Parameter.Address       = 13;
-                AddIntermediate.Parameters[1].Parameter.Address       = ConvertCRegister(59);
+                AddIntermediate.Parameters[1].Parameter.Address       = ConvertCRegister(X_D3DVS_RESERVED_CONSTANT2_CORRECTED);
                 VshInsertIntermediate(pShader, &AddIntermediate, ++i);
             }
         }

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -2797,3 +2797,33 @@ void SetCxbxVertexShader(DWORD XboxVertexShaderHandle, CxbxVertexShader* shader)
 
 	g_CxbxVertexShaders[XboxVertexShaderHandle] = shader;
 }
+
+void CxbxImpl_SetVertexShaderInput
+(
+	DWORD              Handle,
+	UINT               StreamCount,
+	XTL::X_STREAMINPUT* pStreamInputs
+)
+{
+	LOG_INIT
+
+	// If Handle is NULL, all VertexShader input state is cleared.
+	// Otherwise, Handle is the address of an Xbox VertexShader struct, or-ed with 1 (X_D3DFVF_RESERVED0)
+	// (Thus, a FVF handle is an invalid argument.)
+	//
+
+	LOG_UNIMPLEMENTED();
+}
+
+void CxbxImpl_SelectVertexShaderDirect
+(
+	XTL::X_VERTEXATTRIBUTEFORMAT* pVAF,
+	DWORD Address
+)
+{
+	LOG_INIT;
+
+	// When pVAF is non-null, this vertex attribute format takes precedence over the the one	
+	LOG_UNIMPLEMENTED();
+}
+


### PR DESCRIPTION
This introduces a foundation for later work (which will also allow unpatching a few vertex shader related functions).

Ultimately, all patches could be forwarded to similar `CxbxImpl_`* functions, that can be grouped into separate source flies.