### PR TITLE
Speed up paletized texture

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3640,9 +3640,9 @@ void ValidateRenderTargetDimensions(DWORD HostRenderTarget_Width, DWORD HostRend
     // Because of this, we need to validate that the associated host resource still matches the dimensions of the Xbox Render Target
     // If not, we must force them to be re-created
     // TEST CASE: Chihiro Factory Test Program
-    DWORD HostRenderTarget_Width_Unscaled = HostRenderTarget_Width / g_RenderScaleFactor;
-    DWORD HostRenderTarget_Height_Unscaled = HostRenderTarget_Height / g_RenderScaleFactor;
-    if (HostRenderTarget_Width_Unscaled != XboxRenderTarget_Width || HostRenderTarget_Height_Unscaled != XboxRenderTarget_Height) {
+    DWORD XboxRenderTarget_Width_Scaled = XboxRenderTarget_Width * g_RenderScaleFactor;
+    DWORD XboxRenderTarget_Height_Scaled = XboxRenderTarget_Height * g_RenderScaleFactor;
+    if (HostRenderTarget_Width != XboxRenderTarget_Width_Scaled || HostRenderTarget_Height != XboxRenderTarget_Height_Scaled) {
         LOG_TEST_CASE("Existing RenderTarget width/height changed");
 
         if (g_pXbox_RenderTarget == g_pXbox_BackBufferSurface) {

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -137,7 +137,7 @@ typedef struct {
 } s_Xbox_Callback;
 
 static std::queue<s_Xbox_Callback>  g_Xbox_CallbackQueue;
-static bool                         g_bHack_DisableHostGPUQueries = true; // TODO : Make configurable
+static bool                         g_bHack_DisableHostGPUQueries = false; // TODO : Make configurable
 static IDirect3DQuery              *g_pHostQueryWaitForIdle = nullptr;
 static IDirect3DQuery              *g_pHostQueryCallbackEvent = nullptr;
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -196,7 +196,7 @@ static void							UpdateCurrentMSpFAndFPS(); // Used for benchmarking/fps count
 
 extern void UpdateFPSCounter();
 
-#define CXBX_D3DCOMMON_IDENTIFYING_MASK (X_D3DCOMMON_TYPE_MASK | X_D3DCOMMON_VIDEOMEMORY | X_D3DCOMMON_D3DCREATED)
+#define CXBX_D3DCOMMON_IDENTIFYING_MASK (X_D3DCOMMON_TYPE_MASK | X_D3DCOMMON_D3DCREATED)
 
 typedef struct resource_key_hash {
 	// All Xbox X_D3DResource structs have these fields :

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -2322,7 +2322,7 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 					0, // RenderTargetIndex
 					&pCurrentHostRenderTarget);
 				DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetRenderTarget");
-				// TODO : SetHostResource(BackBuffer[0], pCurrentHostRenderTarget);
+				// TODO : SetHostSurface(BackBuffer[0], pCurrentHostRenderTarget);
 */
 
 				// update z-stencil surface cache
@@ -2407,9 +2407,6 @@ static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD D
 	// Skip resources without data
 	if (pResource->Data == xbnull)
 		return;
-
-	// Before we start, make sure the cache stays limited in size
-	PruneResourceCache();
 
 	auto key = GetHostResourceKey(pResource);
 	auto it = g_Xbox_Direct3DResources.find(key);
@@ -6923,6 +6920,9 @@ void EmuUpdateActiveTextureStages()
 
 void CxbxUpdateNativeD3DResources()
 {
+	// Before we start, make sure our resource cache stays limited in size
+	PruneResourceCache(); // TODO : Could we move this to Swap instead?
+
     EmuUpdateActiveTextureStages();
 
 	// Some titles set Vertex Shader constants directly via pushbuffers rather than through D3D

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -643,7 +643,7 @@ XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::DWORD XboxPixelContainer
 	return d3d_format;
 }
 
-XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::X_D3DPixelContainer* pXboxPixelContainer)
+XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::X_D3DPixelContainer *pXboxPixelContainer)
 {
 	// Don't pass in unassigned Xbox pixel container
 	assert(pXboxPixelContainer != xbnullptr);
@@ -898,7 +898,7 @@ void ForceResourceRehash(XTL::X_D3DResource* pXboxResource)
 	}
 }
 
-IDirect3DResource *GetHostResource(XTL::X_D3DResource *pXboxResource, DWORD D3DUsage = 0, int iTextureStage = 0)
+IDirect3DResource *GetHostResource(XTL::X_D3DResource *pXboxResource, DWORD D3DUsage = 0, int iTextureStage = -1)
 {
 	if (pXboxResource == xbnullptr || pXboxResource->Data == xbnull)
 		return nullptr;
@@ -1045,8 +1045,9 @@ IDirect3DBaseTexture *GetHostBaseTexture(XTL::X_D3DResource *pXboxResource, DWOR
 	if (pXboxResource == xbnullptr)
 		return nullptr;
 
-	if (GetXboxCommonResourceType(pXboxResource) != X_D3DCOMMON_TYPE_TEXTURE) // Allows breakpoint below
+	if (GetXboxCommonResourceType(pXboxResource) != X_D3DCOMMON_TYPE_TEXTURE) { // Allows breakpoint below
 		assert(GetXboxCommonResourceType(pXboxResource) == X_D3DCOMMON_TYPE_TEXTURE);
+	}
 
 	return (IDirect3DBaseTexture*)GetHostResource(pXboxResource, D3DUsage, iTextureStage);
 }
@@ -2487,7 +2488,7 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 
 // check if a resource has been registered yet (if not, register it)
 void CreateHostResource(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iTextureStage, DWORD dwSize); // Forward declartion to prevent restructure of code
-static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD D3DUsage = 0, int iTextureStage = 0, DWORD dwSize = 0)
+static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD D3DUsage, int iTextureStage, DWORD dwSize)
 {
 	// Skip resources without data
 	if (pResource->Data == xbnull)
@@ -2572,6 +2573,9 @@ static void EmuVerifyResourceIsRegistered(XTL::X_D3DResource *pResource, DWORD D
 		}
 
 		FreeHostResource(key);
+	} else {
+		resource_info_t newResource;
+		ResourceCache[key] = newResource;
 	}
 
 	CreateHostResource(pResource, D3DUsage, iTextureStage, dwSize);

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6992,7 +6992,7 @@ void EmuUpdateActiveTextureStages()
 			DWORD Type = GetXboxCommonResourceType(pBaseTexture);
 			switch (Type) {
 			case X_D3DCOMMON_TYPE_TEXTURE:
-				pHostBaseTexture = GetHostBaseTexture(pBaseTexture, i);
+				pHostBaseTexture = GetHostBaseTexture(pBaseTexture, /*D3DUsage=*/0, i);
 				break;
 			case X_D3DCOMMON_TYPE_SURFACE:
 				// Surfaces can be set in the texture stages, instead of textures

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp.unused-patches
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp.unused-patches
@@ -3867,3 +3867,57 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_GetLight)
     HRESULT hRet = g_pD3DDevice->GetLight(Index, pLight);
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetLight");
 }
+
+// ******************************************************************
+// * patch: IDirect3DPalette8_Lock
+// ******************************************************************
+VOID WINAPI XTL::EMUPATCH(D3DPalette_Lock)
+(
+	X_D3DPalette   *pThis,
+	D3DCOLOR      **ppColors,
+	DWORD           Flags
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(pThis)
+		LOG_FUNC_ARG_OUT(ppColors)
+		LOG_FUNC_ARG(Flags)
+		LOG_FUNC_END;
+
+	XB_trampoline(VOID, WINAPI, D3DPalette_Lock, (X_D3DPalette*, D3DCOLOR**, DWORD));
+	XB_D3DPalette_Lock(pThis, ppColors, Flags);
+
+	// Check if this palette is in use by a texture stage, and force it to be re-converted if yes
+	for (int i = 0; i < XTL::X_D3DTS_STAGECOUNT; i++) {
+		if (g_pXbox_Texture[i] != nullptr && g_pXbox_Palette[i] == GetDataFromXboxResource(pThis)) {
+			FreeHostResource(GetHostResourceKey(g_pXbox_Texture[i]));
+		}
+	}
+}
+
+// ******************************************************************
+// * patch: IDirect3DPalette8_Lock2
+// ******************************************************************
+D3DCOLOR * WINAPI XTL::EMUPATCH(D3DPalette_Lock2)
+(
+	X_D3DPalette   *pThis,
+	DWORD           Flags
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(pThis)
+		LOG_FUNC_ARG(Flags)
+		LOG_FUNC_END;
+
+	XB_trampoline(D3DCOLOR*, WINAPI, D3DPalette_Lock2, (X_D3DPalette*, DWORD));
+	D3DCOLOR* pData = XB_D3DPalette_Lock2(pThis, Flags);
+
+	// Check if this palette is in use by a texture stage, and force it to be re-converted if yes
+	for (int i = 0; i < XTL::X_D3DTS_STAGECOUNT; i++) {
+		if (g_pXbox_Texture[i] != nullptr && g_pXbox_Palette[i] == GetDataFromXboxResource(pThis)) {
+			FreeHostResource(GetHostResourceKey(g_pXbox_Texture[i]));
+		}
+	}
+
+	RETURN(pData);
+}

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -67,8 +67,7 @@ extern DWORD g_Xbox_VertexShader_Handle;
 
 extern XTL::X_PixelShader *g_pXbox_PixelShader;
 
-// EmuD3DActiveTexture
-extern XTL::X_D3DBaseTexture *EmuD3DActiveTexture[XTL::X_D3DTS_STAGECOUNT];
+extern XTL::X_D3DBaseTexture *g_pXbox_SetTexture[XTL::X_D3DTS_STAGECOUNT];
 
 namespace XTL {
 

--- a/src/core/hle/D3D8/XbD3D8Types.h
+++ b/src/core/hle/D3D8/XbD3D8Types.h
@@ -444,7 +444,7 @@ struct X_D3DResource
 #define X_D3DCOMMON_INTREFCOUNT_MASK   0x00780000
 #define X_D3DCOMMON_INTREFCOUNT_SHIFT  19
 #define X_D3DCOMMON_INTREFCOUNT_1      (1 << X_D3DCOMMON_INTREFCOUNT_SHIFT) // Dxbx addition
-#define X_D3DCOMMON_VIDEOMEMORY        0x00800000 // Not used.
+#define X_D3DCOMMON_VIDEOMEMORY        0x00000000 // Was 0x00800000, but Xbox doesn't have this flag!
 #define X_D3DCOMMON_D3DCREATED         0x01000000
 #define X_D3DCOMMON_ISLOCKED           0x02000010 // Surface is currently locked (potential unswizzle candidate)
 #define X_D3DCOMMON_UNUSED_MASK        0xFE000000

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -2922,7 +2922,7 @@ bool PSH_XBOX_SHADER::InsertTextureModeInstruction(XTL::X_D3DPIXELSHADERDEF *pPS
             // and include the texture formats in the shader hash, somehow.
             bool bias = false;
 			auto biasModifier = (1 << ARGMOD_SCALE_BX2);
-			auto pXboxTexture = EmuD3DActiveTexture[inputStage];
+			auto pXboxTexture = g_pXbox_SetTexture[inputStage];
 			if (pXboxTexture != nullptr) {
 				extern XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::X_D3DPixelContainer *pXboxPixelContainer); // TODO : Move to XTL-independent header file
 

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -240,7 +240,7 @@ void CxbxVertexBufferConverter::ConvertStream
 			if (i + 1 <= dwTexN) {
 				pActivePixelContainer[i].NrTexCoords = DxbxFVF_GetNumberOfTextureCoordinates(XboxFVF, i);
 				// TODO : Use GetXboxBaseTexture()
-				XTL::X_D3DBaseTexture *pXboxBaseTexture = EmuD3DActiveTexture[i];
+				XTL::X_D3DBaseTexture *pXboxBaseTexture = g_pXbox_SetTexture[i];
 				if (pXboxBaseTexture != xbnullptr) {
 					extern XTL::X_D3DFORMAT GetXboxPixelContainerFormat(const XTL::X_D3DPixelContainer *pXboxPixelContainer); // TODO : Move to XTL-independent header file
 

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -175,8 +175,6 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_Swap_0", XTL::EMUPATCH(D3DDevice_Swap_0), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SwitchTexture", XTL::EMUPATCH(D3DDevice_SwitchTexture), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_UpdateOverlay", XTL::EMUPATCH(D3DDevice_UpdateOverlay), PATCH_HLE_D3D),
-	PATCH_ENTRY("D3DPalette_Lock", XTL::EMUPATCH(D3DPalette_Lock), PATCH_HLE_D3D),
-	PATCH_ENTRY("D3DPalette_Lock2", XTL::EMUPATCH(D3DPalette_Lock2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DResource_BlockUntilNotBusy", XTL::EMUPATCH(D3DResource_BlockUntilNotBusy), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3D_BlockOnTime", XTL::EMUPATCH(D3D_BlockOnTime), PATCH_HLE_D3D),
     PATCH_ENTRY("D3D_DestroyResource", XTL::EMUPATCH(D3D_DestroyResource), PATCH_HLE_D3D),


### PR DESCRIPTION
Include a palette hash in the texture lookup key, instead of patching  Palette_Lock functions and freeing textures when setting palette's.

To avoid overflowing the resource cache, PruneResourceCache now applies cache eviction as well.
Thanks to that change, two `Palette_Lock` patches could be removed as well.

This speeds up titles that use paletized textures a lot, here `Yu-Gi-Oh! The Dawn Of Destiny` (YuGiOh DOD) running in-game at 30fps :
![image](https://user-images.githubusercontent.com/461930/69357262-16bead00-0c85-11ea-8912-65182c4ecc2f.png)
