### PR TITLE
kernel: Define and init IdexChannelObject

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/xbox.h
+++ b/import/OpenXDK/include/xboxkrnl/xbox.h
@@ -483,7 +483,7 @@ XBSYSAPI EXPORTNUM(355) UCHAR XePublicKeyDataChihiroBoot[284];
 // ******************************************************************
 // * 0x0165 - IdexChannelObject
 // ******************************************************************
-XBSYSAPI EXPORTNUM(357) BYTE IdexChannelObject[0x100];
+XBSYSAPI EXPORTNUM(357) IDE_CHANNEL_OBJECT IdexChannelObject;
 
 // ******************************************************************
 // * 0x0169 - RtlSnprintf()

--- a/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
+++ b/import/OpenXDK/include/xboxkrnl/xboxkrnl.h
@@ -2617,6 +2617,45 @@ typedef struct _IO_COMPLETION_BASIC_INFORMATION {
 	LONG Depth;
 } IO_COMPLETION_BASIC_INFORMATION, *PIO_COMPLETION_BASIC_INFORMATION;
 
+typedef VOID(*PIDE_INTERRUPT_ROUTINE) (void);
+
+typedef VOID(*PIDE_FINISHIO_ROUTINE) (void);
+
+typedef BOOLEAN(*PIDE_POLL_RESET_COMPLETE_ROUTINE) (void);
+
+typedef VOID(*PIDE_TIMEOUT_EXPIRED_ROUTINE) (void);
+
+typedef VOID(*PIDE_START_PACKET_ROUTINE) (
+    IN PDEVICE_OBJECT DeviceObject,
+    IN PIRP Irp
+);
+
+typedef VOID(*PIDE_START_NEXT_PACKET_ROUTINE) (void);
+
+typedef struct _IDE_CHANNEL_OBJECT
+{
+    PIDE_INTERRUPT_ROUTINE InterruptRoutine;
+    PIDE_FINISHIO_ROUTINE FinishIoRoutine;
+    PIDE_POLL_RESET_COMPLETE_ROUTINE PollResetCompleteRoutine;
+    PIDE_TIMEOUT_EXPIRED_ROUTINE TimeoutExpiredRoutine;
+    PIDE_START_PACKET_ROUTINE StartPacketRoutine;
+    PIDE_START_NEXT_PACKET_ROUTINE StartNextPacketRoutine;
+    KIRQL InterruptIrql;
+    BOOLEAN ExpectingBusMasterInterrupt;
+    BOOLEAN StartPacketBusy;
+    BOOLEAN StartPacketRequested;
+    UCHAR Timeout;
+    UCHAR IoRetries;
+    UCHAR MaximumIoRetries;
+    PIRP CurrentIrp;
+    KDEVICE_QUEUE DeviceQueue;
+    ULONG PhysicalRegionDescriptorTablePhysical;
+    KDPC TimerDpc;
+    KDPC FinishDpc;
+    KTIMER Timer;
+    KINTERRUPT InterruptObject;
+} IDE_CHANNEL_OBJECT, *PIDE_CHANNEL_OBJECT;
+
 // ******************************************************************
 // * Debug
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnl.cpp
+++ b/src/core/kernel/exports/EmuKrnl.cpp
@@ -463,8 +463,7 @@ XBSYSAPI EXPORTNUM(163) xboxkrnl::VOID FASTCALL xboxkrnl::KiUnlockDispatcherData
 // ******************************************************************
 // * 0x0165 - IdexChannelObject
 // ******************************************************************
-// TODO : Determine size, structure & filling behind IdexChannelObject
-XBSYSAPI EXPORTNUM(357) xboxkrnl::BYTE xboxkrnl::IdexChannelObject[0x100] = { };
+XBSYSAPI EXPORTNUM(357) xboxkrnl::IDE_CHANNEL_OBJECT xboxkrnl::IdexChannelObject = { };
 
 // ******************************************************************
 // * 0x0169 - RtlSnprintf()

--- a/src/core/kernel/exports/EmuKrnlKi.cpp
+++ b/src/core/kernel/exports/EmuKrnlKi.cpp
@@ -112,6 +112,8 @@ xboxkrnl::VOID xboxkrnl::KiInitSystem()
 		KiTimerTableListHead[i].Time.u.HighPart = 0xFFFFFFFF;
 		KiTimerTableListHead[i].Time.u.LowPart = 0;
 	}
+
+	InitializeListHead(&IdexChannelObject.DeviceQueue.DeviceListHead);
 }
 
 xboxkrnl::VOID xboxkrnl::KiTimerLock()


### PR DESCRIPTION
Sources: xboxdev nxdk, haxar's xexec

Fixes Mechassult hang, which was caused by an invalid List object.
![image](https://user-images.githubusercontent.com/740003/70946180-a79f6300-204e-11ea-8b8a-1977d2591947.png)
