### PR TITLE
Loader: Fix Standalone Persisted Memory

### DIFF
--- a/src/common/IPCHybrid.hpp
+++ b/src/common/IPCHybrid.hpp
@@ -38,7 +38,6 @@ typedef enum class _IPC_UPDATE_GUI {
 	, XBOX_LED_COLOUR
 	, LOG_ENABLED
 	, KRNL_IS_READY
-	, VM_PERSIST_MEM
 } IPC_UPDATE_GUI;
 
 void ipc_send_gui_update(IPC_UPDATE_GUI command, const unsigned int value);

--- a/src/common/win32/IPCWindows.cpp
+++ b/src/common/win32/IPCWindows.cpp
@@ -65,10 +65,6 @@ void ipc_send_gui_update(IPC_UPDATE_GUI command, const unsigned int value)
 			cmdParam = ID_GUI_STATUS_KRNL_IS_READY;
 			break;
 
-		case IPC_UPDATE_GUI::VM_PERSIST_MEM:
-			cmdParam = ID_GUI_VM_PERSIST_MEM;
-			break;
-
 		default:
 			cmdParam = 0;
 			break;

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -784,6 +784,11 @@ void CxbxKrnlEmulate(uint32_t blocks_reserved[384])
 	// Set up the logging variables for the kernel process during initialization.
 	log_sync_config();
 
+	// When a reboot occur, we need to keep persistent memory buffer open before emulation process shutdown.
+	if ((BootFlags & BOOT_QUICK_REBOOT) != 0) {
+		g_VMManager.GetPersistentMemory();
+	}
+
 	if (CxbxKrnl_hEmuParent != NULL) {
 		ipc_send_gui_update(IPC_UPDATE_GUI::KRNL_IS_READY, static_cast<UINT>(GetCurrentProcessId()));
 
@@ -1748,6 +1753,9 @@ void CxbxKrnlShutDown()
 
 	// Shutdown the input device manager
 	g_InputDeviceManager.Shutdown();
+
+	// Shutdown the memory manager
+	g_VMManager.Shutdown();
 
 	CxbxUnlockFilePath();
 

--- a/src/core/kernel/memory-manager/VMManager.h
+++ b/src/core/kernel/memory-manager/VMManager.h
@@ -100,14 +100,8 @@ class VMManager : public PhysicalMemory
 	public:
 		// constructor
 		VMManager() {};
-		// destructor
-		~VMManager()
-		{
-			// DestroyMemoryRegions is not called when emulation ends, but only when the GUI process ends. This is probably because the emu
-			// process is killed with TerminateProcess and so it doesn't have a chance to perform a cleanup...
-			//DestroyMemoryRegions();
-			DeleteCriticalSection(&m_CriticalSection);
-		}
+		// shutdown routine
+		void Shutdown();
 		// initializes the memory manager to the default configuration
 		void Initialize(int SystemType, int BootFlags, uint32_t blocks_reserved[384]);
 		// retrieves memory statistics
@@ -158,6 +152,8 @@ class VMManager : public PhysicalMemory
 		xboxkrnl::NTSTATUS XbVirtualProtect(VAddr* addr, size_t* Size, DWORD* Protect);
 		// xbox implementation of NtQueryVirtualMemory
 		xboxkrnl::NTSTATUS XbVirtualMemoryStatistics(VAddr addr, xboxkrnl::PMEMORY_BASIC_INFORMATION memory_statistics);
+		// get persistent memory from previous process until RestorePersistentMemory is called
+		void GetPersistentMemory();
 		// saves all persisted memory just before a quick reboot
 		void SavePersistentMemory();
 
@@ -171,6 +167,8 @@ class VMManager : public PhysicalMemory
 		DWORD m_AllocationGranularity = 0;
 		// number of bytes reserved with XBOX_MEM_RESERVE by XbAllocateVirtualMemory
 		size_t m_VirtualMemoryBytesReserved = 0;
+		// handle "shared" persistent memory open for reboot process
+		void* m_PersistentMemoryHandle = nullptr;
 
 		// same as AllocateContiguousMemory, but it allows to allocate beyond m_MaxContiguousPfn
 		VAddr AllocateContiguousMemoryInternal(PFN_COUNT NumberOfPages, PFN LowestPfn, PFN HighestPfn, PFN PfnAlignment, DWORD Perms);

--- a/src/gui/resource/ResCxbx.h
+++ b/src/gui/resource/ResCxbx.h
@@ -189,7 +189,6 @@
 #define ID_GUI_STATUS_LLE_FLAGS         1097
 #define ID_GUI_STATUS_XBOX_LED_COLOUR   1098
 #define ID_GUI_STATUS_LOG_ENABLED       1099
-#define ID_GUI_VM_PERSIST_MEM           1100
 #define IDC_AC_MUTE_ON_UNFOCUS_DISABLE  1101
 #define IDC_XBOX_PORT_0                 1158
 #define IDC_XBOX_PORT_1                 1166


### PR DESCRIPTION
Since pr #1759 has been merged, it is safe allow standalone emulation to pass persisted memory to rebooted emulation process at ease.

I had made an recent update to comply @ergo720's request from original change I had made in the past.