### PR TITLE
Implement BeginVisibilityTest, EndVisibilityTest and GetVisibilityTestResult

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3239,7 +3239,11 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_BeginVisibilityTest)()
 {
 	LOG_FUNC();
 
-	g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &g_pVisibilityQuery);
+	HRESULT hRes = g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &g_pVisibilityQuery);
+	if (hRes != D3D_OK) {
+		LOG_TEST_CASE("BeginVisibilityTest: CreateQuery failed");
+		RETURN(hRes);
+	}
 
 	g_pVisibilityQuery->Issue(D3DISSUE_BEGIN);
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3322,7 +3322,14 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult)
 		LOG_FUNC_ARG(pTimeStamp)
 		LOG_FUNC_END;
 
-	while(S_FALSE == g_pVisibilityQuery->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
+	if (g_pVisibilityQuery != nullptr)
+	{
+		while (S_FALSE == g_pVisibilityQuery->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
+	}
+	else
+	{
+		LOG_TEST_CASE("GetVisibilityTestResult: g_pVisibilityQuery = nullptr");
+	}
 
     return D3D_OK;
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -113,6 +113,7 @@ static IDirect3DVertexBuffer       *g_pDummyBuffer = nullptr;  // Dummy buffer, 
 static IDirect3DIndexBuffer        *g_pClosingLineLoopHostIndexBuffer = nullptr;
 static IDirect3DIndexBuffer        *g_pQuadToTriangleHostIndexBuffer = nullptr;
 static IDirect3DSurface            *g_pDefaultHostDepthBufferSurface = nullptr;
+static IDirect3DQuery              *g_pVisibilityQuery = nullptr;
 
 // cached Direct3D state variable(s)
 static size_t                       g_QuadToTriangleHostIndexBuffer_Size = 0; // = NrOfQuadIndices
@@ -3231,8 +3232,6 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_EndPush)(DWORD *pPush)
 	}
 }
 
-IDirect3DQuery9* VisibilityQuery;
-
 // ******************************************************************
 // * patch: D3DDevice_BeginVisibilityTest
 // ******************************************************************
@@ -3240,9 +3239,9 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_BeginVisibilityTest)()
 {
 	LOG_FUNC();
 
-	g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &VisibilityQuery);
+	g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &g_pVisibilityQuery);
 
-	VisibilityQuery->Issue(D3DISSUE_BEGIN);
+	g_pVisibilityQuery->Issue(D3DISSUE_BEGIN);
 
 	return D3D_OK;
 }
@@ -3273,7 +3272,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndVisibilityTest)
 {
 	LOG_FUNC_ONE_ARG(Index);
 
-	VisibilityQuery->Issue(D3DISSUE_END);
+	g_pVisibilityQuery->Issue(D3DISSUE_END);
 
     return D3D_OK;
 }
@@ -3307,7 +3306,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult)
 		LOG_FUNC_ARG(pTimeStamp)
 		LOG_FUNC_END;
 
-	while(S_FALSE == VisibilityQuery->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
+	while(S_FALSE == g_pVisibilityQuery->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
 
     return D3D_OK;
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3324,6 +3324,11 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult)
 
 	if (g_pVisibilityQuery != nullptr)
 	{
+		// In order to prevent an endless loop if the D3D device becomes lost, we pass
+		// the D3DGETDATA_FLUSH flag. This tells GetData to return D3DERR_DEVICELOST if
+		// such a situation occurs, and break out of the loop as a result.
+		// Note: By Cxbx's design, we cannot do drawing within this while loop in order
+		// to further prevent any other endless loop situations.
 		while (S_FALSE == g_pVisibilityQuery->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
 	}
 	else

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3276,7 +3276,19 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndVisibilityTest)
 {
 	LOG_FUNC_ONE_ARG(Index);
 
-	g_pVisibilityQuery->Issue(D3DISSUE_END);
+	if (g_pVisibilityQuery != nullptr)
+	{
+		HRESULT hRes = g_pVisibilityQuery->Issue(D3DISSUE_END);
+		if (hRes != D3D_OK)
+		{
+			LOG_TEST_CASE("EndVisibilityTest: Failed to issue query");
+			RETURN(hRes);
+		}
+	}
+	else
+	{
+		LOG_TEST_CASE("EndVisibilityTest: g_pVisibilityQuery = nullptr");
+	}
 
     return D3D_OK;
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -28,6 +28,7 @@
 
 #include "common\util\hasher.h"
 #include <condition_variable>
+#include <stack>
 
 // prevent name collisions
 namespace xboxkrnl
@@ -113,7 +114,10 @@ static IDirect3DVertexBuffer       *g_pDummyBuffer = nullptr;  // Dummy buffer, 
 static IDirect3DIndexBuffer        *g_pClosingLineLoopHostIndexBuffer = nullptr;
 static IDirect3DIndexBuffer        *g_pQuadToTriangleHostIndexBuffer = nullptr;
 static IDirect3DSurface            *g_pDefaultHostDepthBufferSurface = nullptr;
-static IDirect3DQuery              *g_pVisibilityQuery = nullptr;
+
+static bool                         g_bEnableHostQueryVisibilityTest = true;
+static std::stack<IDirect3DQuery*>  g_HostQueryVisibilityTests;
+static std::map<int, IDirect3DQuery*> g_HostVisibilityTestMap;
 
 // cached Direct3D state variable(s)
 static size_t                       g_QuadToTriangleHostIndexBuffer_Size = 0; // = NrOfQuadIndices
@@ -2449,7 +2453,20 @@ static DWORD WINAPI EmuCreateDeviceProxy(LPVOID)
 						DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateQuery (callback event)");
 					}
 				} else {
-					LOG_TEST_CASE("Can't CreateQuery on host!");
+					LOG_TEST_CASE("Can't CreateQuery(D3DQUERYTYPE_EVENT) on host!");
+				}
+
+				// Can host driver create occlusion queries?
+				g_bEnableHostQueryVisibilityTest = false;
+				if (SUCCEEDED(g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, nullptr))) {
+					// Is host GPU query creation enabled?
+					if (!g_bHack_DisableHostGPUQueries) {
+						g_bEnableHostQueryVisibilityTest = true;
+					} else {
+						LOG_TEST_CASE("Disabled D3DQUERYTYPE_OCCLUSION on host!");
+					}
+				} else {
+					LOG_TEST_CASE("Can't CreateQuery(D3DQUERYTYPE_OCCLUSION) on host!");
 				}
 
 				hRet = g_pD3DDevice->CreateVertexBuffer
@@ -3239,13 +3256,24 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_BeginVisibilityTest)()
 {
 	LOG_FUNC();
 
-	HRESULT hRes = g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &g_pVisibilityQuery);
-	if (hRes != D3D_OK) {
-		LOG_TEST_CASE("BeginVisibilityTest: CreateQuery failed");
-		RETURN(hRes);
-	}
+	if (g_bEnableHostQueryVisibilityTest) {
+		// Create a D3D occlusion query to handle "visibility test" with
+		IDirect3DQuery* pHostQueryVisibilityTest = nullptr;
+		HRESULT hRet = g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &pHostQueryVisibilityTest);
+		DEBUG_D3DRESULT(hRet, "g_pD3DDevice->CreateQuery (visibility test)");
+		if (pHostQueryVisibilityTest != nullptr) {
+			hRet = pHostQueryVisibilityTest->Issue(D3DISSUE_BEGIN);
+			DEBUG_D3DRESULT(hRet, "g_pHostQueryVisibilityTest->Issue(D3DISSUE_BEGIN)");
+			if (SUCCEEDED(hRet)) {
+				g_HostQueryVisibilityTests.push(pHostQueryVisibilityTest);
+			} else {
+				LOG_TEST_CASE("Failed to issue query");
+				pHostQueryVisibilityTest->Release();
+			}
 
-	g_pVisibilityQuery->Issue(D3DISSUE_BEGIN);
+			pHostQueryVisibilityTest = nullptr;
+		}
+	}
 
 	return D3D_OK;
 }
@@ -3276,18 +3304,29 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndVisibilityTest)
 {
 	LOG_FUNC_ONE_ARG(Index);
 
-	if (g_pVisibilityQuery != nullptr)
-	{
-		HRESULT hRes = g_pVisibilityQuery->Issue(D3DISSUE_END);
-		if (hRes != D3D_OK)
-		{
-			LOG_TEST_CASE("EndVisibilityTest: Failed to issue query");
-			RETURN(hRes);
+	if (g_bEnableHostQueryVisibilityTest) {
+		// Check that the dedicated storage for the given Index isn't in use
+		if (g_HostVisibilityTestMap[Index] != nullptr) {
+			return E_OUTOFMEMORY;
 		}
-	}
-	else
-	{
-		LOG_TEST_CASE("EndVisibilityTest: g_pVisibilityQuery = nullptr");
+
+		if (g_HostQueryVisibilityTests.empty()) {
+			return 2088; // visibility test incomplete (a prior BeginVisibilityTest call is needed)
+		}
+
+		IDirect3DQuery* pHostQueryVisibilityTest = g_HostQueryVisibilityTests.top();
+		g_HostQueryVisibilityTests.pop();
+		assert(pHostQueryVisibilityTest != nullptr);
+
+		HRESULT hRet = pHostQueryVisibilityTest->Issue(D3DISSUE_END);
+		DEBUG_D3DRESULT(hRet, "g_pHostQueryVisibilityTest->Issue(D3DISSUE_END)");
+		if (hRet == D3D_OK) {
+			// Associate the result of this call with the given Index
+			g_HostVisibilityTestMap[Index] = pHostQueryVisibilityTest;
+		} else {
+			LOG_TEST_CASE("Failed to issue query");
+			pHostQueryVisibilityTest->Release();
+		}
 	}
 
     return D3D_OK;
@@ -3322,18 +3361,31 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult)
 		LOG_FUNC_ARG(pTimeStamp)
 		LOG_FUNC_END;
 
-	if (g_pVisibilityQuery != nullptr)
-	{
+	if (g_bEnableHostQueryVisibilityTest) {
+		IDirect3DQuery* pHostQueryVisibilityTest = g_HostVisibilityTestMap[Index];
+		if (pHostQueryVisibilityTest == nullptr) {
+			return E_OUTOFMEMORY;
+		}
+
 		// In order to prevent an endless loop if the D3D device becomes lost, we pass
 		// the D3DGETDATA_FLUSH flag. This tells GetData to return D3DERR_DEVICELOST if
 		// such a situation occurs, and break out of the loop as a result.
 		// Note: By Cxbx's design, we cannot do drawing within this while loop in order
 		// to further prevent any other endless loop situations.
-		while (S_FALSE == g_pVisibilityQuery->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
+		while (S_FALSE == pHostQueryVisibilityTest->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
+
+		g_HostVisibilityTestMap[Index] = nullptr;
+		pHostQueryVisibilityTest->Release();
+	} else {
+		// Fallback to old faked result when there's no host occlusion query :
+		if (pResult != xbnullptr) {
+			*pResult = 640 * 480; // TODO : Use actual backbuffer dimensions
+		}
 	}
-	else
-	{
-		LOG_TEST_CASE("GetVisibilityTestResult: g_pVisibilityQuery = nullptr");
+
+	if (pTimeStamp != xbnullptr) {
+		LOG_TEST_CASE("pTimeStamp = nullptr");
+		*pTimeStamp = sizeof(DWORD); // TODO : This should be an incrementing GPU-memory based DWORD-aligned memory address
 	}
 
     return D3D_OK;

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3231,14 +3231,20 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_EndPush)(DWORD *pPush)
 	}
 }
 
+IDirect3DQuery9* VisibilityQuery;
+
 // ******************************************************************
 // * patch: D3DDevice_BeginVisibilityTest
 // ******************************************************************
-VOID WINAPI XTL::EMUPATCH(D3DDevice_BeginVisibilityTest)()
+HRESULT WINAPI XTL::EMUPATCH(D3DDevice_BeginVisibilityTest)()
 {
 	LOG_FUNC();
 
-	LOG_UNIMPLEMENTED();
+	g_pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &VisibilityQuery);
+
+	VisibilityQuery->Issue(D3DISSUE_BEGIN);
+
+	return D3D_OK;
 }
 
 // LTCG specific D3DDevice_EndVisibilityTest function...
@@ -3267,7 +3273,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_EndVisibilityTest)
 {
 	LOG_FUNC_ONE_ARG(Index);
 
-	LOG_UNIMPLEMENTED();
+	VisibilityQuery->Issue(D3DISSUE_END);
 
     return D3D_OK;
 }
@@ -3301,13 +3307,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult)
 		LOG_FUNC_ARG(pTimeStamp)
 		LOG_FUNC_END;
 
-    // TODO: actually emulate this!?
-
-    if(pResult != 0)
-        *pResult = 640*480;
-
-    if(pTimeStamp != 0)
-        *pTimeStamp = 0;
+	while(S_FALSE == VisibilityQuery->GetData(pResult, sizeof(DWORD), D3DGETDATA_FLUSH));
 
     return D3D_OK;
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3384,7 +3384,7 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVisibilityTestResult)
 	}
 
 	if (pTimeStamp != xbnullptr) {
-		LOG_TEST_CASE("pTimeStamp = nullptr");
+		LOG_TEST_CASE("requested value for pTimeStamp");
 		*pTimeStamp = sizeof(DWORD); // TODO : This should be an incrementing GPU-memory based DWORD-aligned memory address
 	}
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -161,7 +161,7 @@ VOID WINAPI EMUPATCH(D3DDevice_EndPush)(DWORD *pPush);
 // ******************************************************************
 // * patch: D3DDevice_BeginVisibilityTest
 // ******************************************************************
-VOID WINAPI EMUPATCH(D3DDevice_BeginVisibilityTest)();
+HRESULT WINAPI EMUPATCH(D3DDevice_BeginVisibilityTest)();
 
 // ******************************************************************
 // * patch: D3DDevice_EndVisibilityTest


### PR DESCRIPTION
(Note : An initial PR for this was submitted by @Voxel9, I merely finished it.)

The following implementations fix the VisibilityTest XDK sample, and also slightly improves the LensFlare sample. Very likely won't affect much else in the way of games or other samples.

Before:
=====
![image](https://user-images.githubusercontent.com/16278868/71326719-f89fd300-24f6-11ea-9063-f5eb9119a18c.png)

After:
=====
![image](https://user-images.githubusercontent.com/16278868/71326711-dc9c3180-24f6-11ea-920f-9b288719d4d1.png)
![image](https://user-images.githubusercontent.com/16278868/71326714-e9208a00-24f6-11ea-9094-c39bde44e9ac.png)
