### PR TITLE
Fix Audio Stream Flush(Ex) Functions

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.hpp
@@ -38,3 +38,5 @@ extern void DSStream_Packet_Clear(
     XTL::X_CDirectSoundStream*  pThis);
 
 extern bool DSStream_Packet_Process(XTL::X_CDirectSoundStream* pThis);
+
+extern bool DSStream_Packet_Flush(XTL::X_CDirectSoundStream* pThis);

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -395,7 +395,7 @@ static void dsound_thread_worker(LPVOID nullPtr)
                 if ((*ppDSStream)->Host_BufferPacketArray.size() == 0) {
                     continue;
                 }
-                if (((*ppDSStream)->EmuFlags & DSE_FLAG_FLUSH_ASYNC) > 0 && (*ppDSStream)->Xb_rtFlushEx == 0) {
+                if (((*ppDSStream)->EmuFlags & DSE_FLAG_FLUSH_ASYNC) > 0 && (*ppDSStream)->Xb_rtFlushEx == 0LL) {
                     DSStream_Packet_Process((*ppDSStream));
                 }
             }


### PR DESCRIPTION
After re-review disassembly of CDirectSoundStream_Flush(Ex) and CDirectSoundStream_Discontinuity, along with later callers. There was some mistakes were made.
- FlushEx with rtTimeStamp given with zero were not properly checked since it is asking for immediate trigger to flush. It was originally check within `X_DSSFLUSHEX_ENVELOPE` flag conditional process.
- When Flush is called, it does halt the buffer play-state. Once audio is stopped, then flush all of packets.
- Discontinuity is only used after final active packet in case of need more input packets. In a way, it free up inactive pending packets in order to accept new packets.

Titles been tested and has improve:
- Hunter The Reckoning
- WWE RAW 2