### PR TITLE
AppVeyor: Minor changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,38 +1,43 @@
 # Documentation is here: https://www.appveyor.com/docs/appveyor-yml/
+# You can validate ymls here: https://ci.appveyor.com/tools/validate-yaml
 
 skip_commits:
   files:
+    - doc/*
+    - doc/*/*
+    - .github/*
+    - .github/*/*
     - .azure-pipelines.yml
     - .travis.yml
+    - CONTRIBUTORS
+    - COPYING
+    - README.md
+    - gen-msvc-project.bat
+    - setup.bat
 
 init:
   - ps: Update-AppveyorBuild -Version "$env:appveyor_repo_commit"
 
-image:
-  # If this is modified, please also update the build script
+image: # If this is modified, please also update the build script
   - Visual Studio 2019
 
-configuration:
-  # The builds will be run in this order
+configuration: # The builds will be run in this order
   - Release
-  - Debug
 
 before_build:
-  - cmd: |-
+  - |-
       git submodule update --init --recursive
       mkdir build
       cd build
       cmake .. -G "Visual Studio 16 2019" -A Win32
 
 build_script:
-  - cmd: cmake --build . --config %configuration%
+  - cmake --build . --config %configuration%
 
 on_success:
   - ps: |-
-      If ($env:configuration -eq 'Release') {
-        cd "bin\${env:configuration}"
-        7z u "${env:configuration}.zip" ..\..\..\COPYING ..\..\..\README.md
-        7z u "${env:configuration}.zip" Cxbx.exe glew32.dll subhook.dll SDL2.dll
-        7z u "${env:configuration}.zip" cxbxr-debugger.exe capstone.dll cs_x86.dll
-        Get-ChildItem .\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-      }
+      cd bin\$env:configuration
+      7z u "$env:configuration.zip" ..\..\..\COPYING ..\..\..\README.md
+      7z u "$env:configuration.zip" Cxbx.exe glew32.dll subhook.dll SDL2.dll
+      7z u "$env:configuration.zip" cxbxr-debugger.exe capstone.dll cs_x86.dll
+      Get-ChildItem .\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }


### PR DESCRIPTION
Add yml validater to top.
Skip files unrelated to build.
Reformat comments.
Only build Release since Azure Pipelines already builds Debug and is faster.
Remove cmd since it's the default shell, and unneeded characters.