### PR TITLE
Fix Boot Init Logs Not Always Output

### DIFF
--- a/src/common/Logging.cpp
+++ b/src/common/Logging.cpp
@@ -215,7 +215,7 @@ void log_set_config(int LogLevel, unsigned int* LoggedModules)
 void log_generate_active_filter_output(const CXBXR_MODULE cxbxr_module)
 {
 	LOG_THREAD_INIT;
-	std::string generic_output_str = _logThreadPrefix + g_EnumModules2String[to_underlying(cxbxr_module)];
+	std::string generic_output_str = _logThreadPrefix + log_info + g_EnumModules2String[to_underlying(cxbxr_module)];
 
 	std::cout << generic_output_str << "Current log level: " << g_CurrentLogLevel << std::endl;
 

--- a/src/common/Logging.h
+++ b/src/common/Logging.h
@@ -117,8 +117,9 @@ extern std::atomic_bool g_EnabledModules[to_underlying(CXBXR_MODULE::MAX)];
 extern const char* g_EnumModules2String[to_underlying(CXBXR_MODULE::MAX)];
 extern std::atomic_int g_CurrentLogLevel;
 
-// print out a log message to the kernel debug log file if level is high enough
+// print out a log message to the console or kernel debug log file if level is high enough
 void NTAPI EmuLogEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, const char *szWarningMessage, ...);
+void NTAPI EmuLogInit(LOG_LEVEL level, const char *szWarningMessage, ...);
 
 #define EmuLog(level, fmt, ...) EmuLogEx(LOG_PREFIX, level, fmt, ##__VA_ARGS__)
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -362,20 +362,20 @@ HANDLE CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 		return nullptr;
 	}
 
-	printf("[0x%.4X] INIT: Mapped %d MiB of Xbox contiguous memory at 0x%.8X to 0x%.8X\n",
-		GetCurrentThreadId(), CONTIGUOUS_MEMORY_CHIHIRO_SIZE / ONE_MB, CONTIGUOUS_MEMORY_BASE, CONTIGUOUS_MEMORY_BASE + CONTIGUOUS_MEMORY_CHIHIRO_SIZE - 1);
+	EmuLogInit(LOG_LEVEL::INFO, "Mapped %d MiB of Xbox contiguous memory at 0x%.8X to 0x%.8X",
+		 CONTIGUOUS_MEMORY_CHIHIRO_SIZE / ONE_MB, CONTIGUOUS_MEMORY_BASE, CONTIGUOUS_MEMORY_BASE + CONTIGUOUS_MEMORY_CHIHIRO_SIZE - 1);
 
 	if (NeedsInitialization)
 	{
 		memset(memory, 0, CONTIGUOUS_MEMORY_CHIHIRO_SIZE);
-		printf("[0x%.4X] INIT: Initialized contiguous memory\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Initialized contiguous memory");
 	}
 	else
-		printf("[0x%.4X] INIT: Loaded contiguous memory.bin\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Loaded contiguous memory.bin");
 
 	size_t tiledMemorySize = XBOX_WRITE_COMBINED_SIZE;
 	if (g_bIsWine) {
-		printf("Wine detected: Using 64MB Tiled Memory Size\n");
+		EmuLogInit(LOG_LEVEL::INFO, "Wine detected: Using 64MB Tiled Memory Size");
 		// TODO: Figure out why Wine needs this and Windows doesn't.
 		// Perhaps it's a Wine bug, or perhaps Wine reserves this memory for it's own usage?
 		tiledMemorySize = XBOX_WRITE_COMBINED_SIZE / 2;
@@ -399,8 +399,8 @@ HANDLE CxbxRestoreContiguousMemory(char *szFilePath_memory_bin)
 		return nullptr;
 	}
 
-	printf("[0x%.4X] INIT: Mapped contiguous memory to Xbox tiled memory at 0x%.8X to 0x%.8X\n",
-		GetCurrentThreadId(), XBOX_WRITE_COMBINED_BASE, XBOX_WRITE_COMBINED_BASE + tiledMemorySize - 1);
+	EmuLogInit(LOG_LEVEL::INFO, "Mapped contiguous memory to Xbox tiled memory at 0x%.8X to 0x%.8X",
+		XBOX_WRITE_COMBINED_BASE, XBOX_WRITE_COMBINED_BASE + tiledMemorySize - 1);
 
 
 	return hFileMapping;
@@ -474,16 +474,16 @@ HANDLE CxbxRestorePageTablesMemory(char* szFilePath_page_tables)
 		CxbxKrnlCleanup("%s: Couldn't map PageTables.bin to 0xC0000000!", __func__);
 	}
 
-	printf("[0x%.4X] INIT: Mapped %d MiB of Xbox page tables memory at 0x%.8X to 0x%.8X\n",
-		GetCurrentThreadId(), 4, PAGE_TABLES_BASE, PAGE_TABLES_END);
+	EmuLogInit(LOG_LEVEL::INFO, "Mapped %d MiB of Xbox page tables memory at 0x%.8X to 0x%.8X",
+		4, PAGE_TABLES_BASE, PAGE_TABLES_END);
 
 	if (NeedsInitialization)
 	{
 		memset(memory, 0, 4 * ONE_MB);
-		printf("[0x%.4X] INIT: Initialized page tables memory\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Initialized page tables memory");
 	}
 	else
-		printf("[0x%.4X] INIT: Loaded PageTables.bin\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Loaded PageTables.bin");
 
 	return hFileMapping;
 }
@@ -520,7 +520,7 @@ void CxbxPopupMessageEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, CxbxMsgDlgIc
 	vsprintf(Buffer, message, argp);
 	va_end(argp);
 
-	EmuLogEx(cxbxr_module, level, "Popup : %s\n", Buffer);
+	EmuLogEx(cxbxr_module, level, "Popup : %s", Buffer);
 
 	MessageBox(NULL, Buffer, TEXT("Cxbx-Reloaded"), uType);
 }
@@ -528,7 +528,7 @@ void CxbxPopupMessageEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, CxbxMsgDlgIc
 void PrintCurrentConfigurationLog()
 {
 	if (g_bIsWine) {
-		printf("Running under Wine Version %s \n", wine_get_version());
+		EmuLogInit(LOG_LEVEL::INFO, "Running under Wine Version %s", wine_get_version());
 	}
 
 	// HACK: For API TRace..
@@ -536,11 +536,11 @@ void PrintCurrentConfigurationLog()
 
 	// Print current LLE configuration
 	{
-		printf("---------------------------- LLE CONFIG ----------------------------\n");
-		printf("LLE for APU is %s\n", bLLE_APU ? "enabled" : "disabled");
-		printf("LLE for GPU is %s\n", bLLE_GPU ? "enabled" : "disabled");
-		printf("LLE for USB is %s\n", bLLE_USB ? "enabled" : "disabled");
-		printf("LLE for JIT is %s\n", bLLE_JIT ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "---------------------------- LLE CONFIG ----------------------------");
+		EmuLogInit(LOG_LEVEL::INFO, "LLE for APU is %s", bLLE_APU ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "LLE for GPU is %s", bLLE_GPU ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "LLE for USB is %s", bLLE_USB ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "LLE for JIT is %s", bLLE_JIT ? "enabled" : "disabled");
 	}
 
 	// Print current video configuration (DirectX/HLE)
@@ -548,12 +548,12 @@ void PrintCurrentConfigurationLog()
 		Settings::s_video XBVideoConf;
 		g_EmuShared->GetVideoSettings(&XBVideoConf);
 
-		printf("--------------------------- VIDEO CONFIG ---------------------------\n");
-		printf("Direct3D Device: %s\n", XBVideoConf.direct3DDevice == 0 ? "Direct3D HAL (Hardware Accelerated)" : "Direct3D REF (Software)");
-		printf("Video Resolution: %s\n", XBVideoConf.szVideoResolution);
-		printf("Force VSync is %s\n", XBVideoConf.bVSync ? "enabled" : "disabled");
-		printf("Fullscreen is %s\n", XBVideoConf.bFullScreen ? "enabled" : "disabled");
-		printf("Hardware YUV is %s\n", XBVideoConf.bHardwareYUV ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "--------------------------- VIDEO CONFIG ---------------------------");
+		EmuLogInit(LOG_LEVEL::INFO, "Direct3D Device: %s", XBVideoConf.direct3DDevice == 0 ? "Direct3D HAL (Hardware Accelerated)" : "Direct3D REF (Software)");
+		EmuLogInit(LOG_LEVEL::INFO, "Video Resolution: %s", XBVideoConf.szVideoResolution);
+		EmuLogInit(LOG_LEVEL::INFO, "Force VSync is %s", XBVideoConf.bVSync ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "Fullscreen is %s", XBVideoConf.bFullScreen ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "Hardware YUV is %s", XBVideoConf.bHardwareYUV ? "enabled" : "disabled");
 	}
 
 	// Print current audio configuration
@@ -561,11 +561,11 @@ void PrintCurrentConfigurationLog()
 		Settings::s_audio XBAudioConf;
 		g_EmuShared->GetAudioSettings(&XBAudioConf);
 
-		printf("--------------------------- AUDIO CONFIG ---------------------------\n");
-		printf("Audio Adapter: %s\n", XBAudioConf.adapterGUID.Data1 == 0 ? "Primary Audio Device" : "Secondary Audio Device");
-		printf("PCM is %s\n", XBAudioConf.codec_pcm ? "enabled" : "disabled");
-		printf("XADPCM is %s\n", XBAudioConf.codec_xadpcm ? "enabled" : "disabled");
-		printf("Unknown Codec is %s\n", XBAudioConf.codec_unknown ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "--------------------------- AUDIO CONFIG ---------------------------");
+		EmuLogInit(LOG_LEVEL::INFO, "Audio Adapter: %s", XBAudioConf.adapterGUID.Data1 == 0 ? "Primary Audio Device" : "Secondary Audio Device");
+		EmuLogInit(LOG_LEVEL::INFO, "PCM is %s", XBAudioConf.codec_pcm ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "XADPCM is %s", XBAudioConf.codec_xadpcm ? "enabled" : "disabled");
+		EmuLogInit(LOG_LEVEL::INFO, "Unknown Codec is %s", XBAudioConf.codec_unknown ? "enabled" : "disabled");
 	}
 
 	// Print current network configuration
@@ -573,19 +573,19 @@ void PrintCurrentConfigurationLog()
 		Settings::s_network XBNetworkConf;
 		g_EmuShared->GetNetworkSettings(&XBNetworkConf);
 
-		printf("--------------------------- NETWORK CONFIG -------------------------\n");
-		printf("Network Adapter Name: %s\n", strlen(XBNetworkConf.adapter_name) == 0 ? "Not Configured" : XBNetworkConf.adapter_name);
+		EmuLogInit(LOG_LEVEL::INFO, "--------------------------- NETWORK CONFIG -------------------------");
+		EmuLogInit(LOG_LEVEL::INFO, "Network Adapter Name: %s", strlen(XBNetworkConf.adapter_name) == 0 ? "Not Configured" : XBNetworkConf.adapter_name);
 	}
 
 	// Print Enabled Hacks
 	{
-		printf("--------------------------- HACKS CONFIG ---------------------------\n");
-		printf("Disable Pixel Shaders: %s\n", g_DisablePixelShaders == 1 ? "On" : "Off (Default)");
-		printf("Run Xbox threads on all cores: %s\n", g_UseAllCores == 1 ? "On" : "Off (Default)");
-		printf("Skip RDTSC Patching: %s\n", g_SkipRdtscPatching == 1 ? "On" : "Off (Default)");
+		EmuLogInit(LOG_LEVEL::INFO, "--------------------------- HACKS CONFIG ---------------------------");
+		EmuLogInit(LOG_LEVEL::INFO, "Disable Pixel Shaders: %s", g_DisablePixelShaders == 1 ? "On" : "Off (Default)");
+		EmuLogInit(LOG_LEVEL::INFO, "Run Xbox threads on all cores: %s", g_UseAllCores == 1 ? "On" : "Off (Default)");
+		EmuLogInit(LOG_LEVEL::INFO, "Skip RDTSC Patching: %s", g_SkipRdtscPatching == 1 ? "On" : "Off (Default)");
 	}
 
-	printf("------------------------- END OF CONFIG LOG ------------------------\n");
+	EmuLogInit(LOG_LEVEL::INFO, "------------------------- END OF CONFIG LOG ------------------------");
 	
 }
 
@@ -712,7 +712,7 @@ void PatchRdtsc(xbaddr addr)
 	// When using int 3, attached debuggers trap and rdtsc is used often enough
 	// that it makes Cxbx-Reloaded unusable
 	// A privilaged instruction (like OUT) does not suffer from this
-	printf("INIT: Patching rdtsc opcode at 0x%.8X\n", (DWORD)addr);
+	EmuLogInit(LOG_LEVEL::DEBUG, "Patching rdtsc opcode at 0x%.8X", (DWORD)addr);
 	*(uint16_t*)addr = OPCODE_PATCH_RDTSC;
 	g_RdtscPatches.push_back(addr);
 }
@@ -773,7 +773,7 @@ void PatchRdtscInstructions()
 			continue;
 		}
 
-		printf("INIT: Searching for rdtsc in section %s\n", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
+		EmuLogInit(LOG_LEVEL::INFO, "Searching for rdtsc in section %s", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
 		xbaddr startAddr = CxbxKrnl_Xbe->m_SectionHeader[sectionIndex].dwVirtualAddr;
 		//rdtsc is two bytes instruction, it needs at least one opcode byte after it to finish a function, so the endAddr need to substract 3 bytes.
 		xbaddr endAddr = startAddr + CxbxKrnl_Xbe->m_SectionHeader[sectionIndex].dwSizeofRaw-3;
@@ -792,7 +792,7 @@ void PatchRdtscInstructions()
 						{
 							if (*(uint8_t*)(addr - 2) == 0x88 && *(uint8_t*)(addr - 1) == 0x5C)
 							{
-								printf("Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X\n", next_byte, (DWORD)addr);
+								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
 								continue;
 							}
 
@@ -801,7 +801,7 @@ void PatchRdtscInstructions()
 						{
 							if (*(uint8_t*)(addr - 2) == 0x83 && *(uint8_t*)(addr - 1) == 0xE2)
 							{
-								printf("Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X\n", next_byte, (DWORD)addr);
+								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
 								continue;
 							}
 
@@ -816,13 +816,13 @@ void PatchRdtscInstructions()
 				if (i>= sizeof_rdtsc_pattern)
 				{
 					//no pattern matched, keep record for detections we treat as non-rdtsc for future debugging.
-					printf("Skipped potential rdtsc: Unknown opcode pattern  0x%.2X, @ 0x%.8X\n", next_byte, (DWORD)addr);
+					EmuLogInit(LOG_LEVEL::INFO, "Skipped potential rdtsc: Unknown opcode pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
 				}
 			}
 		}
 	}
 
-	printf("INIT: Done patching rdtsc, total %d rdtsc instructions patched\n", g_RdtscPatches.size());
+	EmuLogInit(LOG_LEVEL::INFO, "Done patching rdtsc, total %d rdtsc instructions patched", g_RdtscPatches.size());
 }
 
 void MapThunkTable(uint32_t* kt, uint32_t* pThunkTable)
@@ -859,6 +859,7 @@ void ImportLibraries(XbeImportEntry *pImportDirectory)
 			MapThunkTable((uint32_t *)pImportDirectory->ThunkAddr, Cxbx_LibXbdmThunkTable);
 		}
 		else {
+			// TODO: replace wprintf to EmuLogInit, how?
 			wprintf(L"LOAD : Skipping unrecognized import library : %s\n", LibName.c_str());
 		}
 
@@ -999,18 +1000,18 @@ void CxbxKrnlMain(int argc, char* argv[])
 
 	// Write a header to the log
 	{
-		printf("[0x%.4X] INIT: Cxbx-Reloaded Version %s\n", GetCurrentThreadId(), CxbxVersionStr);
+		EmuLogInit(LOG_LEVEL::INFO, "Cxbx-Reloaded Version %s", CxbxVersionStr);
 
 		time_t startTime = time(nullptr);
 		struct tm* tm_info = localtime(&startTime);
 		char timeString[26];
 		strftime(timeString, 26, "%F %T", tm_info);
-		printf("[0x%.4X] INIT: Log started at %s\n", GetCurrentThreadId(), timeString);
+		EmuLogInit(LOG_LEVEL::INFO, "Log started at %s", timeString);
 
 #ifdef _DEBUG_TRACE
-		printf("[0x%.4X] INIT: Debug Trace Enabled.\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Debug Trace Enabled.");
 #else
-		printf("[0x%.4X] INIT: Debug Trace Disabled.\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Debug Trace Disabled.");
 #endif
 	}
 
@@ -1136,10 +1137,10 @@ void CxbxKrnlMain(int argc, char* argv[])
 
 		// Check the signature of the xbe
 		if (CxbxKrnl_Xbe->CheckXbeSignature()) {
-			printf("[0x%X] INIT: Valid xbe signature. Xbe is legit\n", GetCurrentThreadId());
+			EmuLogInit(LOG_LEVEL::INFO, "Valid xbe signature. Xbe is legit");
 		}
 		else {
-			printf("[0x%X] INIT: Invalid xbe signature. Homebrew, tampered or pirated xbe?\n", GetCurrentThreadId());
+			EmuLogInit(LOG_LEVEL::WARNING, "Invalid xbe signature. Homebrew, tampered or pirated xbe?");
 		}
 
 		// Check the integrity of the xbe sections
@@ -1152,10 +1153,10 @@ void CxbxKrnlMain(int argc, char* argv[])
 			CalcSHA1Hash(SHADigest, CxbxKrnl_Xbe->m_bzSection[sectionIndex], RawSize);
 
 			if (memcmp(SHADigest, (CxbxKrnl_Xbe->m_SectionHeader)[sectionIndex].bzSectionDigest, A_SHA_DIGEST_LEN) != 0) {
-				printf("[0x%X] INIT: SHA hash of section %s doesn't match, possible section corruption\n", GetCurrentThreadId(), CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
+				EmuLogInit(LOG_LEVEL::WARNING, "SHA hash of section %s doesn't match, possible section corruption", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
 			}
 			else {
-				printf("[0x%X] INIT: SHA hash check of section %s successful\n", GetCurrentThreadId(), CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
+				EmuLogInit(LOG_LEVEL::INFO, "SHA hash check of section %s successful", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
 			}
 		}
 
@@ -1203,7 +1204,7 @@ void CxbxKrnlMain(int argc, char* argv[])
 			if ((sectionHeaders[i].Flags & XBEIMAGE_SECTION_PRELOAD) != 0) {
 				NTSTATUS result = xboxkrnl::XeLoadSection(&sectionHeaders[i]);
 				if (FAILED(result)) {
-					EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::WARNING, "Failed to preload XBE section: %s", CxbxKrnl_Xbe->m_szSectionName[i]);
+					EmuLogInit(LOG_LEVEL::WARNING, "Failed to preload XBE section: %s", CxbxKrnl_Xbe->m_szSectionName[i]);
 				}
 			}
 		}
@@ -1223,12 +1224,12 @@ void CxbxKrnlMain(int argc, char* argv[])
 				continue;
 			}
 
-			EmuLogEx(CXBXR_MODULE::INIT, LOG_LEVEL::INFO, "Searching for XBEH in section %s\n", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
+			EmuLogInit(LOG_LEVEL::INFO, "Searching for XBEH in section %s", CxbxKrnl_Xbe->m_szSectionName[sectionIndex]);
 			xbaddr startAddr = CxbxKrnl_Xbe->m_SectionHeader[sectionIndex].dwVirtualAddr;
 			xbaddr endAddr = startAddr + CxbxKrnl_Xbe->m_SectionHeader[sectionIndex].dwSizeofRaw;
 			for (xbaddr addr = startAddr; addr < endAddr; addr++) {
 				if (*(uint32_t*)addr == 0x48454258) {
-					EmuLogEx(CXBXR_MODULE::INIT, LOG_LEVEL::INFO, "Patching XBEH at %X\n", addr);
+					EmuLogInit(LOG_LEVEL::INFO, "Patching XBEH at 0x%08X", addr);
 					*((uint32_t*)addr) = *(uint32_t*)XBE_IMAGE_BASE;
 				}
 			}
@@ -1349,8 +1350,8 @@ __declspec(noreturn) void CxbxKrnlInit
 	// debug trace
 	{
 #ifdef _DEBUG_TRACE
-		printf("[0x%X] INIT: Debug Trace Enabled.\n", GetCurrentThreadId());
-		printf("[0x%X] INIT: CxbxKrnlInit\n"
+		EmuLogInit(LOG_LEVEL::INFO, "Debug Trace Enabled.");
+		EmuLogInit(LOG_LEVEL::INFO, "CxbxKrnlInit\n"
 			"(\n"
 			"   hwndParent          : 0x%.08p\n"
 			"   pTLSData            : 0x%.08p\n"
@@ -1361,10 +1362,10 @@ __declspec(noreturn) void CxbxKrnlInit
 			"   pXBEHeader          : 0x%.08p\n"
 			"   dwXBEHeaderSize     : 0x%.08X\n"
 			"   Entry               : 0x%.08p\n"
-			");\n",
-			GetCurrentThreadId(), CxbxKrnl_hEmuParent, pTLSData, pTLS, pLibraryVersion, DbgMode, szDebugFilename, pXbeHeader, dwXbeHeaderSize, Entry);
+			");",
+			CxbxKrnl_hEmuParent, pTLSData, pTLS, pLibraryVersion, DbgMode, szDebugFilename, pXbeHeader, dwXbeHeaderSize, Entry);
 #else
-		printf("[0x%X] INIT: Debug Trace Disabled.\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Debug Trace Disabled.");
 #endif
 	}
 
@@ -1385,7 +1386,7 @@ __declspec(noreturn) void CxbxKrnlInit
 		DummyKernel->FileHeader.NumberOfSections = 1;
 		// as long as this doesn't start with "INIT"
 		strncpy_s((PSTR)DummyKernel->SectionHeader.Name, 8, "DONGS", 8);
-		printf("[0x%.4X] INIT: Initialized dummy kernel image header.\n", GetCurrentThreadId());
+		EmuLogInit(LOG_LEVEL::INFO, "Initialized dummy kernel image header.");
 	}
 
 	// Read which components need to be LLE'ed per user request
@@ -1455,7 +1456,7 @@ __declspec(noreturn) void CxbxKrnlInit
 	CxbxRegisterDeviceHostPath(DeviceHarddisk0Partition7, CxbxBasePath + "Partition7");
 
 	// Create default symbolic links :
-	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Creating default symbolic links.\n");
+	EmuLogInit(LOG_LEVEL::DEBUG, "Creating default symbolic links.");
 	{
 		// TODO: DriveD should always point to the Xbe Path
 		// This is the only symbolic link the Xbox Kernel sets, the rest are set by the application, usually via XAPI.
@@ -1484,13 +1485,13 @@ __declspec(noreturn) void CxbxKrnlInit
 		xboxkrnl::XeImageFileName.Buffer = (PCHAR)g_VMManager.Allocate(MAX_PATH);
 		sprintf(xboxkrnl::XeImageFileName.Buffer, "%c:\\%s", CxbxDefaultXbeDriveLetter, fileName.c_str());
 		xboxkrnl::XeImageFileName.Length = (USHORT)strlen(xboxkrnl::XeImageFileName.Buffer);
-		printf("[0x%.4X] INIT: XeImageFileName = %s\n", GetCurrentThreadId(), xboxkrnl::XeImageFileName.Buffer);
+		EmuLogInit(LOG_LEVEL::INFO, "XeImageFileName = %s", xboxkrnl::XeImageFileName.Buffer);
 	}
 
 	// Dump Xbe information
 	{
 		if (CxbxKrnl_Xbe != nullptr) {
-			printf("[0x%.4X] INIT: Title : %s\n", GetCurrentThreadId(), CxbxKrnl_Xbe->m_szAsciiTitle);
+			EmuLogInit(LOG_LEVEL::INFO, "Title : %s", CxbxKrnl_Xbe->m_szAsciiTitle);
 		}
 
 		// Dump Xbe certificate
@@ -1498,18 +1499,18 @@ __declspec(noreturn) void CxbxKrnlInit
 			std::stringstream titleIdHex;
 			titleIdHex << std::hex << g_pCertificate->dwTitleId;
 
-			printf("[0x%.4X] INIT: XBE TitleID : %s\n", GetCurrentThreadId(), FormatTitleId(g_pCertificate->dwTitleId).c_str());
-			printf("[0x%.4X] INIT: XBE TitleID (Hex) : 0x%s\n", GetCurrentThreadId(), titleIdHex.str().c_str());
-			printf("[0x%.4X] INIT: XBE Version : 1.%02d\n", GetCurrentThreadId(), g_pCertificate->dwVersion);
-			printf("[0x%.4X] INIT: XBE TitleName : %ls\n", GetCurrentThreadId(), g_pCertificate->wszTitleName);
-			printf("[0x%.4X] INIT: XBE Region : %s\n", GetCurrentThreadId(), CxbxKrnl_Xbe->GameRegionToString());
+			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID : %s", FormatTitleId(g_pCertificate->dwTitleId).c_str());
+			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID (Hex) : 0x%s", titleIdHex.str().c_str());
+			EmuLogInit(LOG_LEVEL::INFO, "XBE Version : 1.%02d", g_pCertificate->dwVersion);
+			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleName : %ls", g_pCertificate->wszTitleName);
+			EmuLogInit(LOG_LEVEL::INFO, "XBE Region : %s", CxbxKrnl_Xbe->GameRegionToString());
 		}
 
 		// Dump Xbe library build numbers
 		Xbe::LibraryVersion* libVersionInfo = pLibraryVersion;// (LibraryVersion *)(CxbxKrnl_XbeHeader->dwLibraryVersionsAddr);
 		if (libVersionInfo != NULL) {
 			for (uint32_t v = 0; v < CxbxKrnl_XbeHeader->dwLibraryVersions; v++) {
-				printf("[0x%.4X] INIT: XBE Library %u : %.8s (version %d)\n", GetCurrentThreadId(), v, libVersionInfo->szName, libVersionInfo->wBuildVersion);
+				EmuLogInit(LOG_LEVEL::INFO, "XBE Library %u : %.8s (version %d)", v, libVersionInfo->szName, libVersionInfo->wBuildVersion);
 				libVersionInfo++;
 			}
 		}
@@ -1519,7 +1520,7 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	// Make sure the Xbox1 code runs on one core (as the box itself has only 1 CPU,
 	// this will better aproximate the environment with regard to multi-threading) :
-	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Determining CPU affinity.\n");
+	EmuLogInit(LOG_LEVEL::DEBUG, "Determining CPU affinity.");
 	{
 		if (!GetProcessAffinityMask(g_CurrentProcessHandle, &g_CPUXbox, &g_CPUOthers))
 			CxbxKrnlCleanupEx(LOG_PREFIX_INIT, "GetProcessAffinityMask failed.");
@@ -1538,7 +1539,7 @@ __declspec(noreturn) void CxbxKrnlInit
 	}
 
 	// initialize graphics
-	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Initializing render window.\n");
+	EmuLogInit(LOG_LEVEL::DEBUG, "Initializing render window.");
 	CxbxInitWindow(true);
 
 	// Now process the boot flags to see if there are any special conditions to handle
@@ -1574,7 +1575,7 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	if (!bLLE_GPU)
 	{
-		EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Initializing Direct3D.\n");
+		EmuLogInit(LOG_LEVEL::DEBUG, "Initializing Direct3D.");
 		EmuD3DInit();
 	}
 	
@@ -1616,13 +1617,13 @@ __declspec(noreturn) void CxbxKrnlInit
 	TimerObject* KernelClockThr = Timer_Create(CxbxKrnlClockThread, nullptr, "Kernel clock thread", &g_CPUOthers);
 	Timer_Start(KernelClockThr, SCALE_MS_IN_NS);
 
-	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "Calling XBE entry point...\n");
+	EmuLogInit(LOG_LEVEL::DEBUG, "Calling XBE entry point...");
 	CxbxLaunchXbe(Entry);
 
 	// FIXME: Wait for Cxbx to exit or error fatally
 	Sleep(INFINITE);
 
-	EmuLogEx(LOG_PREFIX_INIT, LOG_LEVEL::DEBUG, "XBE entry point returned\n");
+	EmuLogInit(LOG_LEVEL::DEBUG, "XBE entry point returned");
 	fflush(stdout);
 
 	//	EmuShared::Cleanup();   FIXME: commenting this line is a bad workaround for issue #617 (https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/617)
@@ -1683,7 +1684,7 @@ __declspec(noreturn) void CxbxKrnlCleanupEx(CXBXR_MODULE cxbxr_module, const cha
 		CxbxPopupMessageEx(cxbxr_module, LOG_LEVEL::FATAL, CxbxMsgDlgIcon_Error, "Received Fatal Message:\n\n* %s\n", szBuffer2); // Will also EmuLogEx
     }
 
-    printf("[0x%.4X] MAIN: Terminating Process\n", GetCurrentThreadId());
+	EmuLogInit(LOG_LEVEL::INFO, "MAIN: Terminating Process");
     fflush(stdout);
 
     // cleanup debug output


### PR DESCRIPTION
Enforce every CxbxKrnl.cpp's initialize info to console or kernel debug log file with standard EmuLog's format. Since it should be part of log report requirement.

<details>
<summary>Working example with a demo disc:</summary>

```
[0x73D8] INFO : INIT    Cxbx-Reloaded Version a8c57516 (Mar 21 2020)
[0x73D8] INFO : INIT    Log started at 2020-03-21 17:19:20
[0x73D8] INFO : INIT    Debug Trace Disabled.
[0x73D8] INFO : INIT    Current log level: 1
[0x73D8] INFO : INIT    Mapped 128 MiB of Xbox contiguous memory at 0x80000000 to 0x87FFFFFF
[0x73D8] INFO : INIT    Loaded contiguous memory.bin
[0x73D8] INFO : INIT    Mapped contiguous memory to Xbox tiled memory at 0xF0000000 to 0xF7FFFFFF
[0x73D8] INFO : INIT    Mapped 4 MiB of Xbox page tables memory at 0xC0000000 to 0xC03FFFFF
[0x73D8] INFO : INIT    Loaded PageTables.bin
Xbe::Xbe: Opening Xbe file...OK
Xbe::Xbe: Storing Xbe Path...OK
Xbe::Xbe: Reading Image Header...OK
Xbe::Xbe: Reading Image Header Extra Bytes...OK
Xbe::Xbe: Reading Certificate...OK
Xbe::Xbe: Title identified as CDX
Xbe::Xbe: Reading Section Headers...
Xbe::Xbe: Reading Section Header 0x0000...OK
Xbe::Xbe: Reading Section Header 0x0001...OK
Xbe::Xbe: Reading Section Header 0x0002...OK
Xbe::Xbe: Reading Section Header 0x0003...OK
Xbe::Xbe: Reading Section Header 0x0004...OK
Xbe::Xbe: Reading Section Header 0x0005...OK
Xbe::Xbe: Reading Section Header 0x0006...OK
Xbe::Xbe: Reading Section Header 0x0007...OK
Xbe::Xbe: Reading Section Header 0x0008...OK
Xbe::Xbe: Reading Section Header 0x0009...OK
Xbe::Xbe: Reading Section Header 0x000A...OK
Xbe::Xbe: Reading Section Header 0x000B...OK
Xbe::Xbe: Reading Section Header 0x000C...OK
Xbe::Xbe: Reading Section Header 0x000D...OK
Xbe::Xbe: Reading Section Header 0x000E...OK
Xbe::Xbe: Reading Section Header 0x000F...OK
Xbe::Xbe: Reading Section Header 0x0010...OK
Xbe::Xbe: Reading Section Header 0x0011...OK
Xbe::Xbe: Reading Section Header 0x0012...OK
Xbe::Xbe: Reading Section Header 0x0013...OK
Xbe::Xbe: Reading Section Header 0x0014...OK
Xbe::Xbe: Reading Section Header 0x0015...OK
Xbe::Xbe: Reading Section Header 0x0016...OK
Xbe::Xbe: Reading Section Header 0x0017...OK
Xbe::Xbe: Reading Section Header 0x0018...OK
Xbe::Xbe: Reading Section Header 0x0019...OK
Xbe::Xbe: Reading Section Header 0x001A...OK
Xbe::Xbe: Reading Section Header 0x001B...OK
Xbe::Xbe: Reading Section Header 0x001C...OK
Xbe::Xbe: Reading Section Header 0x001D...OK
Xbe::Xbe: Reading Section Names...
Xbe::Xbe: Reading Section Name 0x0000...OK (.text)
Xbe::Xbe: Reading Section Name 0x0001...OK (D3D)
Xbe::Xbe: Reading Section Name 0x0002...OK (XACTENG)
Xbe::Xbe: Reading Section Name 0x0003...OK (DSOUND)
Xbe::Xbe: Reading Section Name 0x0004...OK (WMADEC)
Xbe::Xbe: Reading Section Name 0x0005...OK (XGRPH)
Xbe::Xbe: Reading Section Name 0x0006...OK (D3DX)
Xbe::Xbe: Reading Section Name 0x0007...OK (XMV)
Xbe::Xbe: Reading Section Name 0x0008...OK (BINK)
Xbe::Xbe: Reading Section Name 0x0009...OK (BINK32)
Xbe::Xbe: Reading Section Name 0x000A...OK (BINK32A)
Xbe::Xbe: Reading Section Name 0x000B...OK (BINK16)
Xbe::Xbe: Reading Section Name 0x000C...OK (BINK4444)
Xbe::Xbe: Reading Section Name 0x000D...OK (BINK5551)
Xbe::Xbe: Reading Section Name 0x000E...OK (BINKYUY2)
Xbe::Xbe: Reading Section Name 0x000F...OK (BINKYUY2)
Xbe::Xbe: Reading Section Name 0x0010...OK (BINKYUY2)
Xbe::Xbe: Reading Section Name 0x0011...OK (BINKYUY2)
Xbe::Xbe: Reading Section Name 0x0012...OK (BINK16MX)
Xbe::Xbe: Reading Section Name 0x0013...OK (BINK16X2)
Xbe::Xbe: Reading Section Name 0x0014...OK (BINK16M)
Xbe::Xbe: Reading Section Name 0x0015...OK (BINK32MX)
Xbe::Xbe: Reading Section Name 0x0016...OK (BINK32X2)
Xbe::Xbe: Reading Section Name 0x0017...OK (BINK32M)
Xbe::Xbe: Reading Section Name 0x0018...OK (XPP)
Xbe::Xbe: Reading Section Name 0x0019...OK (.data)
Xbe::Xbe: Reading Section Name 0x001A...OK (DOLBY)
Xbe::Xbe: Reading Section Name 0x001B...OK (BINKDATA)
Xbe::Xbe: Reading Section Name 0x001C...OK (resource)
Xbe::Xbe: Reading Section Name 0x001D...OK (english)
Xbe::Xbe: Reading Library Versions...
Xbe::Xbe: Reading Library Version 0x0000...OK
Xbe::Xbe: Reading Library Version 0x0001...OK
Xbe::Xbe: Reading Library Version 0x0002...OK
Xbe::Xbe: Reading Library Version 0x0003...OK
Xbe::Xbe: Reading Library Version 0x0004...OK
Xbe::Xbe: Reading Library Version 0x0005...OK
Xbe::Xbe: Reading Library Version 0x0006...OK
Xbe::Xbe: Reading Library Version 0x0007...OK
Xbe::Xbe: Reading Library Version 0x0008...OK
Xbe::Xbe: Reading Library Version 0x0009...OK
Xbe::Xbe: Reading Library Version 0x000A...OK
Xbe::Xbe: Reading Library Version 0x000B...OK
Xbe::Xbe: Reading Sections...
Xbe::Xbe: Reading Section 0x0000...OK
Xbe::Xbe: Reading Section 0x0001...OK
Xbe::Xbe: Reading Section 0x0002...OK
Xbe::Xbe: Reading Section 0x0003...OK
Xbe::Xbe: Reading Section 0x0004...OK
Xbe::Xbe: Reading Section 0x0005...OK
Xbe::Xbe: Reading Section 0x0006...OK
Xbe::Xbe: Reading Section 0x0007...OK
Xbe::Xbe: Reading Section 0x0008...OK
Xbe::Xbe: Reading Section 0x0009...OK
Xbe::Xbe: Reading Section 0x000A...OK
Xbe::Xbe: Reading Section 0x000B...OK
Xbe::Xbe: Reading Section 0x000C...OK
Xbe::Xbe: Reading Section 0x000D...OK
Xbe::Xbe: Reading Section 0x000E...OK
Xbe::Xbe: Reading Section 0x000F...OK
Xbe::Xbe: Reading Section 0x0010...OK
Xbe::Xbe: Reading Section 0x0011...OK
Xbe::Xbe: Reading Section 0x0012...OK
Xbe::Xbe: Reading Section 0x0013...OK
Xbe::Xbe: Reading Section 0x0014...OK
Xbe::Xbe: Reading Section 0x0015...OK
Xbe::Xbe: Reading Section 0x0016...OK
Xbe::Xbe: Reading Section 0x0017...OK
Xbe::Xbe: Reading Section 0x0018...OK
Xbe::Xbe: Reading Section 0x0019...OK
Xbe::Xbe: Reading Section 0x001A...OK
Xbe::Xbe: Reading Section 0x001B...OK
Xbe::Xbe: Reading Section 0x001C...OK
Xbe::Xbe: Reading Section 0x001D...OK
Xbe::Xbe: Reading Thread Local Storage...OK
Xbe::Xbe: Reading Signature Header...OK
[0x73D8] INFO : INIT    Valid xbe signature. Xbe is legit
[0x73D8] INFO : INIT    SHA hash check of section .text successful
[0x73D8] INFO : INIT    SHA hash check of section D3D successful
[0x73D8] INFO : INIT    SHA hash check of section XACTENG successful
[0x73D8] INFO : INIT    SHA hash check of section DSOUND successful
[0x73D8] INFO : INIT    SHA hash check of section WMADEC successful
[0x73D8] INFO : INIT    SHA hash check of section XGRPH successful
[0x73D8] INFO : INIT    SHA hash check of section D3DX successful
[0x73D8] INFO : INIT    SHA hash check of section XMV successful
[0x73D8] INFO : INIT    SHA hash check of section BINK successful
[0x73D8] INFO : INIT    SHA hash check of section BINK32 successful
[0x73D8] INFO : INIT    SHA hash check of section BINK32A successful
[0x73D8] INFO : INIT    SHA hash check of section BINK16 successful
[0x73D8] INFO : INIT    SHA hash check of section BINK4444 successful
[0x73D8] INFO : INIT    SHA hash check of section BINK5551 successful
[0x73D8] INFO : INIT    SHA hash check of section BINKYUY2 successful
[0x73D8] INFO : INIT    SHA hash check of section BINKYUY2 successful
[0x73D8] INFO : INIT    SHA hash check of section BINKYUY2 successful
[0x73D8] INFO : INIT    SHA hash check of section BINKYUY2 successful
[0x73D8] INFO : INIT    SHA hash check of section BINK16MX successful
[0x73D8] INFO : INIT    SHA hash check of section BINK16X2 successful
[0x73D8] INFO : INIT    SHA hash check of section BINK16M successful
[0x73D8] INFO : INIT    SHA hash check of section BINK32MX successful
[0x73D8] INFO : INIT    SHA hash check of section BINK32X2 successful
[0x73D8] INFO : INIT    SHA hash check of section BINK32M successful
[0x73D8] INFO : INIT    SHA hash check of section XPP successful
[0x73D8] INFO : INIT    SHA hash check of section .data successful
[0x73D8] INFO : INIT    SHA hash check of section DOLBY successful
[0x73D8] INFO : INIT    SHA hash check of section BINKDATA successful
[0x73D8] INFO : INIT    SHA hash check of section resource successful
[0x73D8] INFO : INIT    SHA hash check of section english successful
Pool manager initialized!
Page table for Retail console initialized!
[0x73D8] INFO : INIT    Debug Trace Disabled.
[0x73D8] INFO : INIT    Initialized dummy kernel image header.
[0x73D8] INFO : INIT    ---------------------------- LLE CONFIG ----------------------------
[0x73D8] INFO : INIT    LLE for APU is disabled
[0x73D8] INFO : INIT    LLE for GPU is disabled
[0x73D8] INFO : INIT    LLE for USB is disabled
[0x73D8] INFO : INIT    LLE for JIT is disabled
[0x73D8] INFO : INIT    --------------------------- VIDEO CONFIG ---------------------------
[0x73D8] INFO : INIT    Direct3D Device: Direct3D HAL (Hardware Accelerated)
[0x73D8] INFO : INIT    Video Resolution: Automatic (Default)
[0x73D8] INFO : INIT    Force VSync is disabled
[0x73D8] INFO : INIT    Fullscreen is disabled
[0x73D8] INFO : INIT    Hardware YUV is disabled
[0x73D8] INFO : INIT    --------------------------- AUDIO CONFIG ---------------------------
[0x73D8] INFO : INIT    Audio Adapter: Primary Audio Device
[0x73D8] INFO : INIT    PCM is enabled
[0x73D8] INFO : INIT    XADPCM is enabled
[0x73D8] INFO : INIT    Unknown Codec is enabled
[0x73D8] INFO : INIT    --------------------------- NETWORK CONFIG -------------------------
[0x73D8] INFO : INIT    Network Adapter Name: Not Configured
[0x73D8] INFO : INIT    --------------------------- HACKS CONFIG ---------------------------
[0x73D8] INFO : INIT    Disable Pixel Shaders: Off (Default)
[0x73D8] INFO : INIT    Run Xbox threads on all cores: Off (Default)
[0x73D8] INFO : INIT    Skip RDTSC Patching: Off (Default)
[0x73D8] INFO : INIT    ------------------------- END OF CONFIG LOG ------------------------
[0x73D8] DEBUG: INIT    Creating default symbolic links.
[0x73D8] INFO : INIT    XeImageFileName = D:\default.xbe
[0x73D8] INFO : INIT    Title : CDX
[0x73D8] INFO : INIT    XBE TitleID : XK-009
[0x73D8] INFO : INIT    XBE TitleID (Hex) : 0x584b0009
[0x73D8] INFO : INIT    XBE Version : 1.02
[0x73D8] INFO : INIT    XBE TitleName : CDX
[0x73D8] INFO : INIT    XBE Region : NTSC
[0x73D8] INFO : INIT    XBE Library 0 : XAPILIB (version 5028)
[0x73D8] INFO : INIT    XBE Library 1 : XSNDTRK (version 5028)
[0x73D8] INFO : INIT    XBE Library 2 : CDX (version 5107)
[0x73D8] INFO : INIT    XBE Library 3 : LIBCMT (version 5028)
[0x73D8] INFO : INIT    XBE Library 4 : XBOXKRNL (version 5028)
[0x73D8] INFO : INIT    XBE Library 5 : D3D8 (version 5028)
[0x73D8] INFO : INIT    XBE Library 6 : XACTENG (version 5028)
[0x73D8] INFO : INIT    XBE Library 7 : DSOUND (version 5028)
[0x73D8] INFO : INIT    XBE Library 8 : XGRAPHC (version 5028)
[0x73D8] INFO : INIT    XBE Library 9 : D3DX8 (version 5028)
[0x73D8] INFO : INIT    XBE Library 10 : XVOICE (version 5028)
[0x73D8] INFO : INIT    XBE Library 11 : XMV (version 5028)
[0x73D8] DEBUG: INIT    Determining CPU affinity.
[0x73D8] DEBUG: INIT    Initializing render window.
CxbxDbg>
*******************************************************************************
* Cxbx-Reloaded High Level Emulation database
*******************************************************************************

Selecting hash algorithm: CRC32C
Found Symbol Cache File: C93DB3F8.ini
Using Symbol Cache
SymbolCache: 0x00062990 -> CDirectSoundBufferSettings_SetBufferData
SymbolCache: 0x00060f63 -> CDirectSoundBuffer_GetCurrentPosition
SymbolCache: 0x00060e8d -> CDirectSoundBuffer_GetStatus
SymbolCache: 0x00060fb8 -> CDirectSoundBuffer_Lock
SymbolCache: 0x00060d94 -> CDirectSoundBuffer_Play
SymbolCache: 0x00062a1c -> CDirectSoundBuffer_SetBufferData
SymbolCache: 0x000621b2 -> CDirectSoundBuffer_SetConeAngles
SymbolCache: 0x00062208 -> CDirectSoundBuffer_SetConeOrientation
SymbolCache: 0x0006226f -> CDirectSoundBuffer_SetConeOutsideVolume
SymbolCache: 0x0006108e -> CDirectSoundBuffer_SetCurrentPosition
SymbolCache: 0x000623bf -> CDirectSoundBuffer_SetDistanceFactor
SymbolCache: 0x00062415 -> CDirectSoundBuffer_SetDopplerFactor
SymbolCache: 0x00061535 -> CDirectSoundBuffer_SetEG
SymbolCache: 0x00061583 -> CDirectSoundBuffer_SetFilter
SymbolCache: 0x000620c8 -> CDirectSoundBuffer_SetFormat
SymbolCache: 0x00062116 -> CDirectSoundBuffer_SetFrequency
SymbolCache: 0x000615d1 -> CDirectSoundBuffer_SetHeadroom
SymbolCache: 0x000614e7 -> CDirectSoundBuffer_SetLFO
SymbolCache: 0x00060ede -> CDirectSoundBuffer_SetLoopRegion
SymbolCache: 0x000622c1 -> CDirectSoundBuffer_SetMaxDistance
SymbolCache: 0x00062317 -> CDirectSoundBuffer_SetMinDistance
SymbolCache: 0x0006166d -> CDirectSoundBuffer_SetMixBinVolumes
SymbolCache: 0x0006161f -> CDirectSoundBuffer_SetMixBins
SymbolCache: 0x0006236d -> CDirectSoundBuffer_SetMode
SymbolCache: 0x00062164 -> CDirectSoundBuffer_SetOutputBuffer
SymbolCache: 0x00061499 -> CDirectSoundBuffer_SetPitch
SymbolCache: 0x00062029 -> CDirectSoundBuffer_SetPlayRegion
SymbolCache: 0x0006246b -> CDirectSoundBuffer_SetRolloffFactor
SymbolCache: 0x0006144b -> CDirectSoundBuffer_SetVolume
SymbolCache: 0x00060de5 -> CDirectSoundBuffer_Stop
SymbolCache: 0x00060e34 -> CDirectSoundBuffer_StopEx
SymbolCache: 0x00061120 -> CDirectSoundStream_AddRef
SymbolCache: 0x00062b03 -> CDirectSoundStream_Constructor
SymbolCache: 0x0006121c -> CDirectSoundStream_Discontinuity
SymbolCache: 0x00061269 -> CDirectSoundStream_Flush
SymbolCache: 0x000613cd -> CDirectSoundStream_FlushEx
SymbolCache: 0x000611b5 -> CDirectSoundStream_GetInfo
SymbolCache: 0x000612b4 -> CDirectSoundStream_GetStatus
SymbolCache: 0x0006137c -> CDirectSoundStream_Pause
SymbolCache: 0x00061305 -> CDirectSoundStream_Process
SymbolCache: 0x00061167 -> CDirectSoundStream_Release
SymbolCache: 0x000617b1 -> CDirectSoundStream_SetEG
SymbolCache: 0x00061803 -> CDirectSoundStream_SetFilter
SymbolCache: 0x000624c1 -> CDirectSoundStream_SetFormat
SymbolCache: 0x00061855 -> CDirectSoundStream_SetHeadroom
SymbolCache: 0x0006175f -> CDirectSoundStream_SetLFO
SymbolCache: 0x00062513 -> CDirectSoundStream_SetOutputBuffer
SymbolCache: 0x000616bb -> CDirectSoundStream_SetPitch
SymbolCache: 0x0006170d -> CDirectSoundStream_SetVolume
SymbolCache: 0x00060a17 -> CDirectSoundVoiceSettings_SetMixBinVolumes
SymbolCache: 0x00060c09 -> CDirectSoundVoice_CommitDeferredSettings
SymbolCache: 0x00061de5 -> CDirectSoundVoice_SetConeAngles
SymbolCache: 0x00061e28 -> CDirectSoundVoice_SetConeOrientation
SymbolCache: 0x00061e7a -> CDirectSoundVoice_SetConeOutsideVolume
SymbolCache: 0x00061f39 -> CDirectSoundVoice_SetDistanceFactor
SymbolCache: 0x00061f6c -> CDirectSoundVoice_SetDopplerFactor
SymbolCache: 0x00060b86 -> CDirectSoundVoice_SetEG
SymbolCache: 0x00060b99 -> CDirectSoundVoice_SetFilter
SymbolCache: 0x00061d29 -> CDirectSoundVoice_SetFormat
SymbolCache: 0x00061d6d -> CDirectSoundVoice_SetFrequency
SymbolCache: 0x00060bac -> CDirectSoundVoice_SetHeadroom
SymbolCache: 0x00060b73 -> CDirectSoundVoice_SetLFO
SymbolCache: 0x00061ead -> CDirectSoundVoice_SetMaxDistance
SymbolCache: 0x00061ee0 -> CDirectSoundVoice_SetMinDistance
SymbolCache: 0x00060bec -> CDirectSoundVoice_SetMixBinVolumes
SymbolCache: 0x00060bcf -> CDirectSoundVoice_SetMixBins
SymbolCache: 0x00061f13 -> CDirectSoundVoice_SetMode
SymbolCache: 0x00061d91 -> CDirectSoundVoice_SetOutputBuffer
SymbolCache: 0x00060b3e -> CDirectSoundVoice_SetPitch
SymbolCache: 0x00061f9f -> CDirectSoundVoice_SetRolloffFactor
SymbolCache: 0x00060b57 -> CDirectSoundVoice_SetVolume
SymbolCache: 0x00061b46 -> CDirectSound_CommitDeferredSettings
SymbolCache: 0x00062e55 -> CDirectSound_CreateSoundBuffer
SymbolCache: 0x00062bf2 -> CDirectSound_CreateSoundStream
SymbolCache: 0x000609e6 -> CDirectSound_DoWork
SymbolCache: 0x00060978 -> CDirectSound_SetMixBinHeadroom
SymbolCache: 0x000609d7 -> CDirectSound_SynchPlayback
SymbolCache: 0x00063d39 -> CMcpxAPU_ServiceDeferredCommandsLow
SymbolCache: 0x00063e05 -> CMcpxAPU_SetMixBinHeadroom
SymbolCache: 0x00063e82 -> CMcpxAPU_SynchPlayback
SymbolCache: 0x00067139 -> CMcpxBuffer_GetCurrentPosition
SymbolCache: 0x000670f7 -> CMcpxBuffer_GetStatus
SymbolCache: 0x00067084 -> CMcpxBuffer_Pause
SymbolCache: 0x00067540 -> CMcpxBuffer_Play
SymbolCache: 0x00067803 -> CMcpxBuffer_SetBufferData
SymbolCache: 0x000676e9 -> CMcpxBuffer_SetCurrentPosition
SymbolCache: 0x00067659 -> CMcpxBuffer_Stop
SymbolCache: 0x000678c2 -> CMcpxBuffer_Stop_Ex
SymbolCache: 0x00064be1 -> CMcpxStream_Discontinuity
SymbolCache: 0x00064cd5 -> CMcpxStream_Flush
SymbolCache: 0x0006465d -> CMcpxStream_GetStatus
SymbolCache: 0x0006512c -> CMcpxStream_Pause
SymbolCache: 0x000645eb -> CMcpxStream_Stop
SymbolCache: 0x00064a9e -> CMcpxStream_Stop_Ex
SymbolCache: 0x000667f9 -> CMcpxVoiceClient_Commit3dSettings
SymbolCache: 0x00065eea -> CMcpxVoiceClient_SetEG
SymbolCache: 0x0006607c -> CMcpxVoiceClient_SetFilter
SymbolCache: 0x00065dbb -> CMcpxVoiceClient_SetLFO
SymbolCache: 0x00066413 -> CMcpxVoiceClient_SetMixBins
SymbolCache: 0x0006656c -> CMcpxVoiceClient_SetPitch
SymbolCache: 0x000664d4 -> CMcpxVoiceClient_SetVolume
SymbolCache: 0x0005072b -> CMiniport_CreateCtxDmaObject
SymbolCache: 0x00050a3d -> CMiniport_InitHardware
SymbolCache: 0x0004f910 -> CMiniport_IsFlipPending
SymbolCache: 0x00020cd9 -> CreateMutex
SymbolCache: 0x0001cba8 -> CreateThread
SymbolCache: 0x00058588 -> D3DDEVICE
SymbolCache: 0x00058460 -> D3DDeferredRenderState
SymbolCache: 0x000580f0 -> D3DDeferredTextureState
SymbolCache: 0x000554c0 -> D3DDevice_Begin
SymbolCache: 0x0004d660 -> D3DDevice_BeginStateBig
SymbolCache: 0x000491d0 -> D3DDevice_BlockUntilVerticalBlank
SymbolCache: 0x0004f520 -> D3DDevice_Clear
SymbolCache: 0x000496d0 -> D3DDevice_CopyRects
SymbolCache: 0x000550e0 -> D3DDevice_CreateTexture2
SymbolCache: 0x000552c0 -> D3DDevice_DrawVerticesUP
SymbolCache: 0x00055500 -> D3DDevice_End
SymbolCache: 0x000495d0 -> D3DDevice_GetBackBuffer2
SymbolCache: 0x000499c0 -> D3DDevice_GetDepthStencilSurface2
SymbolCache: 0x00049d20 -> D3DDevice_GetDisplayFieldStatus
SymbolCache: 0x00049500 -> D3DDevice_GetDisplayMode
SymbolCache: 0x000499a0 -> D3DDevice_GetRenderTarget2
SymbolCache: 0x0004a580 -> D3DDevice_GetViewportOffsetAndScale
SymbolCache: 0x00049cf0 -> D3DDevice_IsBusy
SymbolCache: 0x0004d190 -> D3DDevice_KickOff
SymbolCache: 0x000525f0 -> D3DDevice_LazySetStateUP
SymbolCache: 0x0004c120 -> D3DDevice_LoadVertexShader
SymbolCache: 0x0004d650 -> D3DDevice_MakeSpace
SymbolCache: 0x00049fc0 -> D3DDevice_PersistDisplay
SymbolCache: 0x0004c180 -> D3DDevice_SelectVertexShader
SymbolCache: 0x00049200 -> D3DDevice_SetFlickerFilter
SymbolCache: 0x00049020 -> D3DDevice_SetGammaRamp
SymbolCache: 0x00055610 -> D3DDevice_SetPixelShader
SymbolCache: 0x0004a520 -> D3DDevice_SetRenderStateNotInline
SymbolCache: 0x0004ac30 -> D3DDevice_SetRenderState_BackFillMode
SymbolCache: 0x0004a8c0 -> D3DDevice_SetRenderState_CullMode
SymbolCache: 0x0004bc20 -> D3DDevice_SetRenderState_DoNotCullUncompressed
SymbolCache: 0x0004aa80 -> D3DDevice_SetRenderState_Dxt1NoiseEnable
SymbolCache: 0x0004a7f0 -> D3DDevice_SetRenderState_EdgeAntiAlias
SymbolCache: 0x0004abe0 -> D3DDevice_SetRenderState_FillMode
SymbolCache: 0x0004a870 -> D3DDevice_SetRenderState_FogColor
SymbolCache: 0x0004a930 -> D3DDevice_SetRenderState_FrontFace
SymbolCache: 0x0004aa10 -> D3DDevice_SetRenderState_LineWidth
SymbolCache: 0x0004ab80 -> D3DDevice_SetRenderState_LogicOp
SymbolCache: 0x0004bcc0 -> D3DDevice_SetRenderState_MultiSampleAntiAlias
SymbolCache: 0x0004bd40 -> D3DDevice_SetRenderState_MultiSampleMask
SymbolCache: 0x0004bc40 -> D3DDevice_SetRenderState_MultiSampleMode
SymbolCache: 0x0004bc80 -> D3DDevice_SetRenderState_MultiSampleRenderTargetMode
SymbolCache: 0x0004a970 -> D3DDevice_SetRenderState_NormalizeNormals
SymbolCache: 0x0004bb00 -> D3DDevice_SetRenderState_OcclusionCullEnable
SymbolCache: 0x0004a4c0 -> D3DDevice_SetRenderState_PSTextureModes
SymbolCache: 0x0004bbe0 -> D3DDevice_SetRenderState_RopZCmpAlwaysRead
SymbolCache: 0x0004bc00 -> D3DDevice_SetRenderState_RopZRead
SymbolCache: 0x0004bd90 -> D3DDevice_SetRenderState_SampleAlpha
SymbolCache: 0x0004a830 -> D3DDevice_SetRenderState_ShadowFunc
SymbolCache: 0x0004a4f0 -> D3DDevice_SetRenderState_Simple
SymbolCache: 0x0004bb70 -> D3DDevice_SetRenderState_StencilCullEnable
SymbolCache: 0x0004b9d0 -> D3DDevice_SetRenderState_StencilEnable
SymbolCache: 0x0004ba60 -> D3DDevice_SetRenderState_StencilFail
SymbolCache: 0x0004a9b0 -> D3DDevice_SetRenderState_TextureFactor
SymbolCache: 0x0004ac90 -> D3DDevice_SetRenderState_TwoSidedLighting
SymbolCache: 0x0004ad00 -> D3DDevice_SetRenderState_VertexBlend
SymbolCache: 0x0004bad0 -> D3DDevice_SetRenderState_YuvEnable
SymbolCache: 0x0004ab00 -> D3DDevice_SetRenderState_ZBias
SymbolCache: 0x0004b940 -> D3DDevice_SetRenderState_ZEnable
SymbolCache: 0x00049000 -> D3DDevice_SetRenderTarget
SymbolCache: 0x00049e20 -> D3DDevice_SetScissors
SymbolCache: 0x0004a140 -> D3DDevice_SetScreenSpaceOffset
SymbolCache: 0x0004c200 -> D3DDevice_SetShaderConstantMode
SymbolCache: 0x00049250 -> D3DDevice_SetSoftDisplayFilter
SymbolCache: 0x00049b40 -> D3DDevice_SetTexture
SymbolCache: 0x0004aed0 -> D3DDevice_SetTextureState_BorderColor
SymbolCache: 0x0004ae60 -> D3DDevice_SetTextureState_BumpEnv
SymbolCache: 0x0004af10 -> D3DDevice_SetTextureState_ColorKeyColor
SymbolCache: 0x0004ad50 -> D3DDevice_SetTextureState_TexCoordIndex
SymbolCache: 0x000490b0 -> D3DDevice_SetTransform
SymbolCache: 0x00055420 -> D3DDevice_SetVertexData2f
SymbolCache: 0x00055460 -> D3DDevice_SetVertexData4f
SymbolCache: 0x0004c450 -> D3DDevice_SetVertexShader
SymbolCache: 0x000499e0 -> D3DDevice_SetViewport
SymbolCache: 0x00054f40 -> D3DDevice_Swap
SymbolCache: 0x0000037c -> D3DDevice__m_VertexShader_OFFSET
SymbolCache: 0x0005853c -> D3DRS_CULLMODE
SymbolCache: 0x0004a300 -> D3DResource_AddRef
SymbolCache: 0x0004a390 -> D3DResource_GetType
SymbolCache: 0x0004a420 -> D3DResource_Register
SymbolCache: 0x0004a340 -> D3DResource_Release
SymbolCache: 0x00051110 -> D3DSurface_GetDesc
SymbolCache: 0x00051130 -> D3DSurface_LockRect
SymbolCache: 0x000551b0 -> D3DTexture_GetSurfaceLevel2
SymbolCache: 0x00055200 -> D3DTexture_LockRect
SymbolCache: 0x000555f0 -> D3D_AllocContiguousMemory
SymbolCache: 0x0004d6d0 -> D3D_BlockOnResource
SymbolCache: 0x0004d390 -> D3D_BlockOnTime
SymbolCache: 0x0004f220 -> D3D_CMiniport_GetDisplayCapabilities
SymbolCache: 0x0004b3b0 -> D3D_CommonSetRenderTarget
SymbolCache: 0x0004a1e0 -> D3D_DestroyResource
SymbolCache: 0x0004d6b0 -> D3D_KickOffAndWaitForIdle
SymbolCache: 0x000511f0 -> D3D_LazySetPointParams
SymbolCache: 0x0004d4d0 -> D3D_MakeRequestedSpace_8
SymbolCache: 0x0004d2e0 -> D3D_SetFence
SymbolCache: 0x00049d60 -> D3D_SetTileNoWait
SymbolCache: 0x00063174 -> DSound_CMemoryManager_PoolAlloc
SymbolCache: 0x000607bd -> DSound_CRefCount_AddRef
SymbolCache: 0x000607ca -> DSound_CRefCount_Release
SymbolCache: 0x00055540 -> Direct3D_CreateDevice
SymbolCache: 0x000630d6 -> DirectSoundCreate
SymbolCache: 0x0006311d -> DirectSoundCreateStream
SymbolCache: 0x00061b02 -> DirectSoundDoWork
SymbolCache: 0x000607f1 -> DirectSoundEnterCriticalSection
SymbolCache: 0x0001ca67 -> ExitThread
SymbolCache: 0x0004ec40 -> Get2DSurfaceDesc
SymbolCache: 0x0001e2e3 -> GetOverlappedResult
SymbolCache: 0x000e462e -> GetTypeInformation
SymbolCache: 0x00061a5b -> IDirectSoundBuffer_GetCurrentPosition
SymbolCache: 0x00061a3f -> IDirectSoundBuffer_GetStatus
SymbolCache: 0x00061a97 -> IDirectSoundBuffer_Lock
SymbolCache: 0x000619bf -> IDirectSoundBuffer_Play
SymbolCache: 0x0006084d -> IDirectSoundBuffer_Release
SymbolCache: 0x00062bd2 -> IDirectSoundBuffer_SetBufferData
SymbolCache: 0x000625d1 -> IDirectSoundBuffer_SetConeAngles
SymbolCache: 0x000625f5 -> IDirectSoundBuffer_SetConeOrientation
SymbolCache: 0x0006262a -> IDirectSoundBuffer_SetConeOutsideVolume
SymbolCache: 0x00061a7b -> IDirectSoundBuffer_SetCurrentPosition
SymbolCache: 0x000626b2 -> IDirectSoundBuffer_SetDistanceFactor
SymbolCache: 0x000626d6 -> IDirectSoundBuffer_SetDopplerFactor
SymbolCache: 0x00061933 -> IDirectSoundBuffer_SetEG
SymbolCache: 0x0006194f -> IDirectSoundBuffer_SetFilter
SymbolCache: 0x0006257d -> IDirectSoundBuffer_SetFormat
SymbolCache: 0x00062599 -> IDirectSoundBuffer_SetFrequency
SymbolCache: 0x0006196b -> IDirectSoundBuffer_SetHeadroom
SymbolCache: 0x00061917 -> IDirectSoundBuffer_SetLFO
SymbolCache: 0x00061a1f -> IDirectSoundBuffer_SetLoopRegion
SymbolCache: 0x0006264a -> IDirectSoundBuffer_SetMaxDistance
SymbolCache: 0x0006266e -> IDirectSoundBuffer_SetMinDistance
SymbolCache: 0x000619a3 -> IDirectSoundBuffer_SetMixBinVolumes_8
SymbolCache: 0x00061987 -> IDirectSoundBuffer_SetMixBins
SymbolCache: 0x00062692 -> IDirectSoundBuffer_SetMode
SymbolCache: 0x000625b5 -> IDirectSoundBuffer_SetOutputBuffer
SymbolCache: 0x000618fb -> IDirectSoundBuffer_SetPitch
SymbolCache: 0x0006271e -> IDirectSoundBuffer_SetPlayRegion
SymbolCache: 0x000626fa -> IDirectSoundBuffer_SetRolloffFactor
SymbolCache: 0x000618df -> IDirectSoundBuffer_SetVolume
SymbolCache: 0x000619e3 -> IDirectSoundBuffer_Stop
SymbolCache: 0x000619fb -> IDirectSoundBuffer_StopEx
SymbolCache: 0x00060848 -> IDirectSoundBuffer_Unlock
SymbolCache: 0x00061aea -> IDirectSoundStream_FlushEx
SymbolCache: 0x00061ae5 -> IDirectSoundStream_Pause
SymbolCache: 0x00061ad6 -> IDirectSoundStream_SetEG
SymbolCache: 0x00061adb -> IDirectSoundStream_SetFilter
SymbolCache: 0x0006273e -> IDirectSoundStream_SetFormat
SymbolCache: 0x00061ae0 -> IDirectSoundStream_SetHeadroom
SymbolCache: 0x00061ad1 -> IDirectSoundStream_SetLFO
SymbolCache: 0x00062743 -> IDirectSoundStream_SetOutputBuffer
SymbolCache: 0x00061acc -> IDirectSoundStream_SetPitch
SymbolCache: 0x00061ac7 -> IDirectSoundStream_SetVolume
SymbolCache: 0x00062565 -> IDirectSound_CommitDeferredSettings
SymbolCache: 0x00062f0c -> IDirectSound_CreateSoundBuffer
SymbolCache: 0x00062e31 -> IDirectSound_CreateSoundStream
SymbolCache: 0x00060832 -> IDirectSound_Release
SymbolCache: 0x000618a7 -> IDirectSound_SetMixBinHeadroom
SymbolCache: 0x000618c7 -> IDirectSound_SynchPlayback
SymbolCache: 0x0005b9fa -> IXACTSoundBank_GetSoundCueIndexFromFriendlyName
SymbolCache: 0x0004ef40 -> Lock2DSurface
SymbolCache: 0x0001e348 -> OutputDebugStringA
SymbolCache: 0x00047d90 -> QueryPerformanceCounter
SymbolCache: 0x0001c9fe -> RaiseException
SymbolCache: 0x0001ca54 -> SwitchToThread
SymbolCache: 0x0005b716 -> XACTEngineDoWork
SymbolCache: 0x0005f0f8 -> XACT_CSoundBank_GetSoundCueIndexFromFriendlyName
SymbolCache: 0x00060863 -> XAudioCalculatePitch
SymbolCache: 0x00063320 -> XAudioCreateAdpcmFormat
SymbolCache: 0x000632d6 -> XAudioCreatePcmFormat
SymbolCache: 0x00020eb4 -> XAutoPowerDownResetTimer
SymbolCache: 0x00084fc9 -> XGIsSwizzledFormat
SymbolCache: 0x00085484 -> XGSwizzleRect
SymbolCache: 0x000e0eff -> XGetDeviceChanges
SymbolCache: 0x000e030a -> XGetDeviceEnumerationStatus
SymbolCache: 0x000e0edd -> XGetDevices
SymbolCache: 0x0001c60d -> XGetLaunchInfo
SymbolCache: 0x000e5e81 -> XID_fCloseDevice
SymbolCache: 0x000df4b2 -> XInitDevices
SymbolCache: 0x000e457f -> XInputClose
SymbolCache: 0x000e458b -> XInputGetState
SymbolCache: 0x000e4529 -> XInputOpen
SymbolCache: 0x0001c6b8 -> XLaunchNewImageA
SymbolCache: 0x0001d4f8 -> XMountUtilityDrive
SymbolCache: 0x0001ca8b -> XRegisterThreadNotifyRoutine
SymbolCache: 0x000204b2 -> XapiBootDash
SymbolCache: 0x00020606 -> XapiInitProcess
SymbolCache: 0x0001cb10 -> XapiThreadStartup
HLE: CDirectSoundStream_AddRef Patched
HLE: CDirectSoundStream_Discontinuity Patched
HLE: CDirectSoundStream_Flush Patched
HLE: CDirectSoundStream_FlushEx Patched
HLE: CDirectSoundStream_GetInfo Patched
HLE: CDirectSoundStream_GetStatus Patched
HLE: CDirectSoundStream_Pause Patched
HLE: CDirectSoundStream_Process Patched
HLE: CDirectSoundStream_Release Patched
HLE: CDirectSoundStream_SetEG Patched
HLE: CDirectSoundStream_SetFilter Patched
HLE: CDirectSoundStream_SetFormat Patched
HLE: CDirectSoundStream_SetHeadroom Patched
HLE: CDirectSoundStream_SetLFO Patched
HLE: CDirectSoundStream_SetOutputBuffer Patched
HLE: CDirectSoundStream_SetPitch Patched
HLE: CDirectSoundStream_SetVolume Patched
HLE: CDirectSound_CommitDeferredSettings Patched
HLE: CDirectSound_SynchPlayback Patched
HLE: D3DDevice_Begin Patched
HLE: D3DDevice_BlockUntilVerticalBlank Patched
HLE: D3DDevice_Clear Patched
HLE: D3DDevice_CopyRects Patched
HLE: D3DDevice_DrawVerticesUP Patched
HLE: D3DDevice_End Patched
HLE: D3DDevice_GetBackBuffer2 Patched
HLE: D3DDevice_GetDisplayFieldStatus Patched
HLE: D3DDevice_IsBusy Patched
HLE: D3DDevice_LoadVertexShader Patched
HLE: D3DDevice_PersistDisplay Patched
HLE: D3DDevice_SelectVertexShader Patched
HLE: D3DDevice_SetFlickerFilter Patched
HLE: D3DDevice_SetGammaRamp Patched
HLE: D3DDevice_SetPixelShader Patched
HLE: D3DDevice_SetRenderState_Simple Patched
HLE: D3DDevice_SetRenderTarget Patched
HLE: D3DDevice_SetScreenSpaceOffset Patched
HLE: D3DDevice_SetShaderConstantMode Patched
HLE: D3DDevice_SetSoftDisplayFilter Patched
HLE: D3DDevice_SetTexture Patched
HLE: D3DDevice_SetTransform Patched
HLE: D3DDevice_SetVertexData2f Patched
HLE: D3DDevice_SetVertexData4f Patched
HLE: D3DDevice_SetVertexShader Patched
HLE: D3DDevice_SetViewport Patched
HLE: D3DDevice_Swap Patched
HLE: D3D_BlockOnTime Patched
HLE: D3D_DestroyResource Patched
HLE: D3D_LazySetPointParams Patched
HLE: Direct3D_CreateDevice Patched
HLE: DirectSoundCreate Patched
HLE: DirectSoundCreateStream Patched
HLE: DirectSoundDoWork Patched
HLE: IDirectSoundBuffer_GetCurrentPosition Patched
HLE: IDirectSoundBuffer_GetStatus Patched
HLE: IDirectSoundBuffer_Lock Patched
HLE: IDirectSoundBuffer_Play Patched
HLE: IDirectSoundBuffer_Release Patched
HLE: IDirectSoundBuffer_SetBufferData Patched
HLE: IDirectSoundBuffer_SetConeAngles Patched
HLE: IDirectSoundBuffer_SetConeOrientation Patched
HLE: IDirectSoundBuffer_SetConeOutsideVolume Patched
HLE: IDirectSoundBuffer_SetCurrentPosition Patched
HLE: IDirectSoundBuffer_SetDistanceFactor Patched
HLE: IDirectSoundBuffer_SetDopplerFactor Patched
HLE: IDirectSoundBuffer_SetEG Patched
HLE: IDirectSoundBuffer_SetFilter Patched
HLE: IDirectSoundBuffer_SetFormat Patched
HLE: IDirectSoundBuffer_SetFrequency Patched
HLE: IDirectSoundBuffer_SetHeadroom Patched
HLE: IDirectSoundBuffer_SetLFO Patched
HLE: IDirectSoundBuffer_SetLoopRegion Patched
HLE: IDirectSoundBuffer_SetMaxDistance Patched
HLE: IDirectSoundBuffer_SetMinDistance Patched
HLE: IDirectSoundBuffer_SetMixBinVolumes_8 Patched
HLE: IDirectSoundBuffer_SetMixBins Patched
HLE: IDirectSoundBuffer_SetMode Patched
HLE: IDirectSoundBuffer_SetOutputBuffer Patched
HLE: IDirectSoundBuffer_SetPitch Patched
HLE: IDirectSoundBuffer_SetPlayRegion Patched
HLE: IDirectSoundBuffer_SetRolloffFactor Patched
HLE: IDirectSoundBuffer_SetVolume Patched
HLE: IDirectSoundBuffer_Stop Patched
HLE: IDirectSoundBuffer_StopEx Patched
HLE: IDirectSoundBuffer_Unlock Patched
HLE: IDirectSoundStream_SetEG Patched
HLE: IDirectSoundStream_SetFilter Patched
HLE: IDirectSoundStream_SetHeadroom Patched
HLE: IDirectSoundStream_SetLFO Patched
HLE: IDirectSoundStream_SetPitch Patched
HLE: IDirectSoundStream_SetVolume Patched
HLE: IDirectSound_CommitDeferredSettings Patched
HLE: IDirectSound_CreateSoundBuffer Patched
HLE: IDirectSound_CreateSoundStream Patched
HLE: IDirectSound_Release Patched
HLE: IDirectSound_SetMixBinHeadroom Patched
HLE: IDirectSound_SynchPlayback Patched
HLE: Lock2DSurface Patched
HLE: OutputDebugStringA Patched
HLE: RaiseException Patched
HLE: XGetDeviceChanges Patched
HLE: XGetDeviceEnumerationStatus Patched
HLE: XGetDevices Patched
HLE: XInitDevices Patched
HLE: XInputClose Patched
HLE: XInputGetState Patched
HLE: XInputOpen Patched
Deriving XDEVICE_TYPE_GAMEPAD from DeviceTable (via GetTypeInformation)
DeviceTableStart: 0x000DEEC4
DeviceTableEnd: 0x000DEECC
DeviceTable Entires: 2
----------------------------------------
DeviceTable[0]->ucType = 1
DeviceTable[0]->XppType = 0x000DEF94 (XDEVICE_TYPE_GAMEPAD)
----------------------------------------
DeviceTable[1]->ucType = 3
DeviceTable[1]->XppType = 0x000DEFF8 (Unknown device type)
XAPI: XDEVICE_TYPE_GAMEPAD Found at 0x000DEF94
[0x73D8] INIT: Reserved 16 MiB of Xbox NV2A memory at 0xFD000000 to 0xFDFFFFFF
[0x73D8] INIT: Allocated 1 MiB of Xbox NV2A PRAMIN memory at 0xFD700000 to 0xFD7FFFFF
[0x73D8] DEBUG: INIT    Initializing Direct3D.
----------------------------------------
Host D3DCaps :
   .DeviceType           : (D3DDEVTYPE)0x00000001 = D3DDEVTYPE_HAL
   .AdapterOrdinal       : 0
   .Caps                 : (_D3DCAPS)0x00020000 = D3DCAPS_READ_SCANLINE
   .Caps2                : (D3DCAPS2)0xE0020000 = D3DCAPS2_FULLSCREENGAMMA|D3DCAPS2_DYNAMICTEXTURES|D3DCAPS2_CANAUTOGENMIPMAP|D3DCAPS2_CANSHARERESOURCE
   .Caps3                : (D3DCAPS3)0x000003A0 = D3DCAPS3_ALPHA_FULLSCREEN_FLIP_OR_DISCARD|D3DCAPS3_LINEAR_TO_SRGB_PRESENTATION|D3DCAPS3_COPY_TO_VIDMEM|D3DCAPS3_COPY_TO_SYSTEMMEM
   .PresentationIntervals  : (D3DPRESENT_INTERVAL)0x8000000F = D3DPRESENT_INTERVAL_DEFAULT|D3DPRESENT_INTERVAL_ONE|D3DPRESENT_INTERVAL_TWO|D3DPRESENT_INTERVAL_THREE|D3DPRESENT_INTERVAL_FOUR|D3DPRESENT_INTERVAL_IMMEDIATE
   .CursorCaps           : (D3DCURSORCAPS)0x00000001 = D3DCURSORCAPS_COLOR
   .DevCaps              : (D3DDEVCAPS)0x001BBEF0 = D3DDEVCAPS_EXECUTESYSTEMMEMORY|D3DDEVCAPS_EXECUTEVIDEOMEMORY|D3DDEVCAPS_TLVERTEXSYSTEMMEMORY|D3DDEVCAPS_TLVERTEXVIDEOMEMORY|D3DDEVCAPS_TEXTUREVIDEOMEMORY|D3DDEVCAPS_DRAWPRIMTLVERTEX|D3DDEVCAPS_CANRENDERAFTERFLIP|D3DDEVCAPS_TEXTURENONLOCALVIDMEM|D3DDEVCAPS_DRAWPRIMITIVES2|D3DDEVCAPS_DRAWPRIMITIVES2EX|D3DDEVCAPS_HWTRANSFORMANDLIGHT|D3DDEVCAPS_CANBLTSYSTONONLOCAL|D3DDEVCAPS_HWRASTERIZATION|D3DDEVCAPS_PUREDEVICE
   .PrimitiveMiscCaps    : (D3DPMISCCAPS)0x002FCEF2 = D3DPMISCCAPS_MASKZ|D3DPMISCCAPS_CULLNONE|D3DPMISCCAPS_CULLCW|D3DPMISCCAPS_CULLCCW|D3DPMISCCAPS_COLORWRITEENABLE|D3DPMISCCAPS_CLIPTLVERTS|D3DPMISCCAPS_TSSARGTEMP|D3DPMISCCAPS_BLENDOP|D3DPMISCCAPS_INDEPENDENTWRITEMASKS|D3DPMISCCAPS_PERSTAGECONSTANT|D3DPMISCCAPS_FOGANDSPECULARALPHA|D3DPMISCCAPS_SEPARATEALPHABLEND|D3DPMISCCAPS_MRTINDEPENDENTBITDEPTHS|D3DPMISCCAPS_MRTPOSTPIXELSHADERBLENDING|D3DPMISCCAPS_POSTBLENDSRGBCONVERT
   .RasterCaps           : (D3DPRASTERCAPS)0x07732191 = D3DPRASTERCAPS_DITHER|D3DPRASTERCAPS_ZTEST|D3DPRASTERCAPS_FOGVERTEX|D3DPRASTERCAPS_FOGTABLE|D3DPRASTERCAPS_MIPMAPLODBIAS|D3DPRASTERCAPS_FOGRANGE|D3DPRASTERCAPS_ANISOTROPY|D3DPRASTERCAPS_WFOG|D3DPRASTERCAPS_ZFOG|D3DPRASTERCAPS_COLORPERSPECTIVE|D3DPRASTERCAPS_SCISSORTEST|D3DPRASTERCAPS_SLOPESCALEDEPTHBIAS|D3DPRASTERCAPS_DEPTHBIAS
   .ZCmpCaps             : (D3DPCMPCAPS)0x000000FF = D3DPCMPCAPS_NEVER|D3DPCMPCAPS_LESS|D3DPCMPCAPS_EQUAL|D3DPCMPCAPS_LESSEQUAL|D3DPCMPCAPS_GREATER|D3DPCMPCAPS_NOTEQUAL|D3DPCMPCAPS_GREATEREQUAL|D3DPCMPCAPS_ALWAYS
   .SrcBlendCaps         : (D3DPBLENDCAPS)0x00003FFF = D3DPBLENDCAPS_ZERO|D3DPBLENDCAPS_ONE|D3DPBLENDCAPS_SRCCOLOR|D3DPBLENDCAPS_INVSRCCOLOR|D3DPBLENDCAPS_SRCALPHA|D3DPBLENDCAPS_INVSRCALPHA|D3DPBLENDCAPS_DESTALPHA|D3DPBLENDCAPS_INVDESTALPHA|D3DPBLENDCAPS_DESTCOLOR|D3DPBLENDCAPS_INVDESTCOLOR|D3DPBLENDCAPS_SRCALPHASAT|D3DPBLENDCAPS_BOTHSRCALPHA|D3DPBLENDCAPS_BOTHINVSRCALPHA|D3DPBLENDCAPS_BLENDFACTOR
   .DestBlendCaps        : (D3DPBLENDCAPS)0x00003FFF = D3DPBLENDCAPS_ZERO|D3DPBLENDCAPS_ONE|D3DPBLENDCAPS_SRCCOLOR|D3DPBLENDCAPS_INVSRCCOLOR|D3DPBLENDCAPS_SRCALPHA|D3DPBLENDCAPS_INVSRCALPHA|D3DPBLENDCAPS_DESTALPHA|D3DPBLENDCAPS_INVDESTALPHA|D3DPBLENDCAPS_DESTCOLOR|D3DPBLENDCAPS_INVDESTCOLOR|D3DPBLENDCAPS_SRCALPHASAT|D3DPBLENDCAPS_BOTHSRCALPHA|D3DPBLENDCAPS_BOTHINVSRCALPHA|D3DPBLENDCAPS_BLENDFACTOR
   .AlphaCmpCaps         : (D3DPCMPCAPS)0x000000FF = D3DPCMPCAPS_NEVER|D3DPCMPCAPS_LESS|D3DPCMPCAPS_EQUAL|D3DPCMPCAPS_LESSEQUAL|D3DPCMPCAPS_GREATER|D3DPCMPCAPS_NOTEQUAL|D3DPCMPCAPS_GREATEREQUAL|D3DPCMPCAPS_ALWAYS
   .ShadeCaps            : (D3DPSHADECAPS)0x00084208 = D3DPSHADECAPS_COLORGOURAUDRGB|D3DPSHADECAPS_SPECULARGOURAUDRGB|D3DPSHADECAPS_ALPHAGOURAUDBLEND|D3DPSHADECAPS_FOGGOURAUD
   .TextureCaps          : (D3DPTEXTURECAPS)0x0001ECC5 = D3DPTEXTURECAPS_PERSPECTIVE|D3DPTEXTURECAPS_ALPHA|D3DPTEXTURECAPS_TEXREPEATNOTSCALEDBYSIZE|D3DPTEXTURECAPS_ALPHAPALETTE|D3DPTEXTURECAPS_PROJECTED|D3DPTEXTURECAPS_CUBEMAP|D3DPTEXTURECAPS_VOLUMEMAP|D3DPTEXTURECAPS_MIPMAP|D3DPTEXTURECAPS_MIPVOLUMEMAP|D3DPTEXTURECAPS_MIPCUBEMAP
   .TextureFilterCaps    : (D3DPTFILTERCAPS)0x03030700 = D3DPTFILTERCAPS_MINFPOINT|D3DPTFILTERCAPS_MINFLINEAR|D3DPTFILTERCAPS_MINFANISOTROPIC|D3DPTFILTERCAPS_MIPFPOINT|D3DPTFILTERCAPS_MIPFLINEAR|D3DPTFILTERCAPS_MAGFPOINT|D3DPTFILTERCAPS_MAGFLINEAR
   .CubeTextureFilterCaps  : (D3DPTFILTERCAPS)0x03030300 = D3DPTFILTERCAPS_MINFPOINT|D3DPTFILTERCAPS_MINFLINEAR|D3DPTFILTERCAPS_MIPFPOINT|D3DPTFILTERCAPS_MIPFLINEAR|D3DPTFILTERCAPS_MAGFPOINT|D3DPTFILTERCAPS_MAGFLINEAR
   .VolumeTextureFilterCaps  : (D3DPTFILTERCAPS)0x03030300 = D3DPTFILTERCAPS_MINFPOINT|D3DPTFILTERCAPS_MINFLINEAR|D3DPTFILTERCAPS_MIPFPOINT|D3DPTFILTERCAPS_MIPFLINEAR|D3DPTFILTERCAPS_MAGFPOINT|D3DPTFILTERCAPS_MAGFLINEAR
   .TextureAddressCaps   : (D3DPTADDRESSCAPS)0x0000003F = D3DPTADDRESSCAPS_WRAP|D3DPTADDRESSCAPS_MIRROR|D3DPTADDRESSCAPS_CLAMP|D3DPTADDRESSCAPS_BORDER|D3DPTADDRESSCAPS_INDEPENDENTUV|D3DPTADDRESSCAPS_MIRRORONCE
   .VolumeTextureAddressCaps  : (D3DPTADDRESSCAPS)0x0000003F = D3DPTADDRESSCAPS_WRAP|D3DPTADDRESSCAPS_MIRROR|D3DPTADDRESSCAPS_CLAMP|D3DPTADDRESSCAPS_BORDER|D3DPTADDRESSCAPS_INDEPENDENTUV|D3DPTADDRESSCAPS_MIRRORONCE
   .LineCaps             : (D3DLINECAPS)0x0000001F = D3DLINECAPS_TEXTURE|D3DLINECAPS_ZTEST|D3DLINECAPS_BLEND|D3DLINECAPS_ALPHACMP|D3DLINECAPS_FOG
   .MaxTextureWidth      : 4000
   .MaxTextureHeight     : 4000
   .MaxVolumeExtent      : 800
   .MaxTextureRepeat     : 2000
   .MaxTextureAspectRatio  : 4000
   .MaxAnisotropy        : 10
   .MaxVertexW           : 1E+10
   .GuardBandLeft        : -1E+08
   .GuardBandTop         : -1E+08
   .GuardBandRight       : 1E+08
   .GuardBandBottom      : 1E+08
   .ExtentsAdjust        : 0
   .StencilCaps          : (D3DSTENCILCAPS)0x000001FF = D3DSTENCILCAPS_KEEP|D3DSTENCILCAPS_ZERO|D3DSTENCILCAPS_REPLACE|D3DSTENCILCAPS_INCRSAT|D3DSTENCILCAPS_DECRSAT|D3DSTENCILCAPS_INVERT|D3DSTENCILCAPS_INCR|D3DSTENCILCAPS_DECR|D3DSTENCILCAPS_TWOSIDED
   .FVFCaps              : (D3DFVFCAPS)0x00180008 = D3DFVFCAPS_TEXCOORDCOUNTMASK=8|D3DFVFCAPS_DONOTSTRIPELEMENTS|D3DFVFCAPS_PSIZE
   .TextureOpCaps        : (D3DTEXOPCAPS)0x03FEFFFF = D3DTEXOPCAPS_DISABLE|D3DTEXOPCAPS_SELECTARG1|D3DTEXOPCAPS_SELECTARG2|D3DTEXOPCAPS_MODULATE|D3DTEXOPCAPS_MODULATE2X|D3DTEXOPCAPS_MODULATE4X|D3DTEXOPCAPS_ADD|D3DTEXOPCAPS_ADDSIGNED|D3DTEXOPCAPS_ADDSIGNED2X|D3DTEXOPCAPS_SUBTRACT|D3DTEXOPCAPS_ADDSMOOTH|D3DTEXOPCAPS_BLENDDIFFUSEALPHA|D3DTEXOPCAPS_BLENDTEXTUREALPHA|D3DTEXOPCAPS_BLENDFACTORALPHA|D3DTEXOPCAPS_BLENDTEXTUREALPHAPM|D3DTEXOPCAPS_BLENDCURRENTALPHA|D3DTEXOPCAPS_MODULATEALPHA_ADDCOLOR|D3DTEXOPCAPS_MODULATECOLOR_ADDALPHA|D3DTEXOPCAPS_MODULATEINVALPHA_ADDCOLOR|D3DTEXOPCAPS_MODULATEINVCOLOR_ADDALPHA|D3DTEXOPCAPS_BUMPENVMAP|D3DTEXOPCAPS_BUMPENVMAPLUMINANCE|D3DTEXOPCAPS_DOTPRODUCT3|D3DTEXOPCAPS_MULTIPLYADD|D3DTEXOPCAPS_LERP
   .MaxTextureBlendStages  : 8
   .MaxSimultaneousTextures  : 8
   .VertexProcessingCaps  : (D3DVTXPCAPS)0x0000013B = D3DVTXPCAPS_TEXGEN|D3DVTXPCAPS_MATERIALSOURCE7|D3DVTXPCAPS_DIRECTIONALLIGHTS|D3DVTXPCAPS_POSITIONALLIGHTS|D3DVTXPCAPS_LOCALVIEWER|D3DVTXPCAPS_TEXGEN_SPHEREMAP
   .MaxActiveLights      : 8
   .MaxUserClipPlanes    : 8
   .MaxVertexBlendMatrices  : 4
   .MaxVertexBlendMatrixIndex  : 0
   .MaxPointSize         : 8192
   .MaxPrimitiveCount    : FFFFFF
   .MaxVertexIndex       : FFFFFF
   .MaxStreams           : 10
   .MaxStreamStride      : FF
   .VertexShaderVersion  : FFFE0300
   .MaxVertexShaderConst  : 100
   .PixelShaderVersion   : FFFF0300
   .PixelShader1xMaxValue  : 65504
   .DevCaps2             : (D3DDEVCAPS2)0x00000051 = D3DDEVCAPS2_STREAMOFFSET|D3DDEVCAPS2_CAN_STRETCHRECT_FROM_TEXTURES|D3DDEVCAPS2_VERTEXELEMENTSCANSHARESTREAMOFFSET
   .MaxNpatchTessellationLevel  : 0
   .Reserved5            : 0
   .MasterAdapterOrdinal  : 0
   .AdapterOrdinalInGroup  : 0
   .NumberOfAdaptersInGroup  : 2
   .DeclTypes            : (D3DDTCAPS)0x0000030F = D3DDTCAPS_UBYTE4|D3DDTCAPS_UBYTE4N|D3DDTCAPS_SHORT2N|D3DDTCAPS_SHORT4N|D3DDTCAPS_FLOAT16_2|D3DDTCAPS_FLOAT16_4
   .NumSimultaneousRTs   : 4
   .StretchRectFilterCaps  : (D3DPTFILTERCAPS)0x03000300 = D3DPTFILTERCAPS_MINFPOINT|D3DPTFILTERCAPS_MINFLINEAR|D3DPTFILTERCAPS_MAGFPOINT|D3DPTFILTERCAPS_MAGFLINEAR
   .VS20Caps             :
   .Caps                 : (D3DVS20CAPS)0x00000001 = D3DVS20CAPS_PREDICATION
   .DynamicFlowControlDepth  : 18
   .NumTemps             : 20
   .StaticFlowControlDepth  : 4
   .PS20Caps             :
   .Caps                 : (D3DPS20CAPS)0x0000001F = D3DPS20CAPS_ARBITRARYSWIZZLE|D3DPS20CAPS_GRADIENTINSTRUCTIONS|D3DPS20CAPS_PREDICATION|D3DPS20CAPS_NODEPENDENTREADLIMIT|D3DPS20CAPS_NOTEXINSTRUCTIONLIMIT
   .DynamicFlowControlDepth  : 18
   .NumTemps             : 20
   .StaticFlowControlDepth  : 4
   .NumInstructionSlots  : 200
   .VertexTextureFilterCaps  : (D3DPTFILTERCAPS)0x03030700 = D3DPTFILTERCAPS_MINFPOINT|D3DPTFILTERCAPS_MINFLINEAR|D3DPTFILTERCAPS_MINFANISOTROPIC|D3DPTFILTERCAPS_MIPFPOINT|D3DPTFILTERCAPS_MIPFLINEAR|D3DPTFILTERCAPS_MAGFPOINT|D3DPTFILTERCAPS_MAGFLINEAR
   .MaxVShaderInstructionsExecuted  : FFFF
   .MaxPShaderInstructionsExecuted  : FFFF
   .MaxVertexShader30InstructionSlots  : 1000
   .MaxPixelShader30InstructionSlots  : 1000
----------------------------------------
[0x73D8] INFO : INIT    Searching for rdtsc in section .text
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000192EB
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x00019493
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000194AE
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x00019FB6
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x0001A150
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x0001A31B
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x0001A6FC
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x0001AAB4
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x0001AB5D
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x00027D8E
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x0002889A
[0x73D8] INFO : INIT    Skipped potential rdtsc: Unknown opcode pattern  0xA3, @ 0x000288E1
[0x73D8] INFO : INIT    Skipped potential rdtsc: Unknown opcode pattern  0xA3, @ 0x00028913
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x00028D0B
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x00028ED7
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x00028F95
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x00047D94
[0x73D8] INFO : INIT    Searching for rdtsc in section D3D
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x0004F930
[0x73D8] INFO : INIT    Searching for rdtsc in section XACTENG
[0x73D8] INFO : INIT    Searching for rdtsc in section WMADEC
[0x73D8] INFO : INIT    Searching for rdtsc in section D3DX
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000CD43F
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000CD456
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000CD48F
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000CD4A6
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000CD95F
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000CDCEC
[0x73D8] DEBUG: INIT    Patching rdtsc opcode at 0x000CE6B6
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK32
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK32A
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK16
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK4444
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK5551
[0x73D8] INFO : INIT    Searching for rdtsc in section BINKYUY2
[0x73D8] INFO : INIT    Searching for rdtsc in section BINKYUY2
[0x73D8] INFO : INIT    Searching for rdtsc in section BINKYUY2
[0x73D8] INFO : INIT    Searching for rdtsc in section BINKYUY2
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK16MX
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK16X2
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK16M
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK32MX
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK32X2
[0x73D8] INFO : INIT    Searching for rdtsc in section BINK32M
[0x73D8] INFO : INIT    Searching for rdtsc in section XPP
[0x73D8] INFO : INIT    Searching for rdtsc in section DOLBY
[0x73D8] INFO : INIT    Searching for rdtsc in section BINKDATA
[0x73D8] INFO : INIT    INIT: Done patching rdtsc, total 23 rdtsc instructions patched
[0x73D8] DEBUG: INIT    Calling XBE entry point...
vga: read CR1f = 0x00
vga: write CR1f = 0x57
vga: read CR52 = 0x00
vga: write CR52 = 0x04
vga: write CR20 = 0x29
vga: write CR1b = 0x05
vga: write CR1f = 0x99
PCIDevice::WriteConfigRegister: Unhandled Register 0
```
</details>