### PR TITLE
LOADER: Initialize Max Reserve Address Ranges plus System Type Support in CLI

### DIFF
--- a/src/common/AddressRanges.cpp
+++ b/src/common/AddressRanges.cpp
@@ -27,7 +27,7 @@
 
 #include "AddressRanges.h"
 
-bool AddressRangeMatchesFlags(const int index, const int flags)
+bool AddressRangeMatchesFlags(const int index, const unsigned int flags)
 {
 	return XboxAddressRanges[index].RangeFlags & flags;
 }
@@ -35,6 +35,11 @@ bool AddressRangeMatchesFlags(const int index, const int flags)
 bool IsOptionalAddressRange(const int index)
 {
 	return AddressRangeMatchesFlags(index, MAY_FAIL);
+}
+
+int AddressRangeGetSystemFlags(const int index)
+{
+	return XboxAddressRanges[index].RangeFlags & SYSTEM_ALL;
 }
 
 bool VerifyWow64()

--- a/src/common/ReserveAddressRanges.cpp
+++ b/src/common/ReserveAddressRanges.cpp
@@ -26,6 +26,12 @@
 // *
 // ******************************************************************
 
+// NOTE: Cannot be use in loader project due to force exclude std libraries.
+//#define DEBUG // Uncomment whenever need to verify memory leaks or bad configure.
+
+#ifdef DEBUG
+#include <cstdio> // For printf
+#endif
 #include <cstdint> // For uint32_t
 
 #include "AddressRanges.h"
@@ -43,6 +49,10 @@ bool ReserveMemoryRange(int index, uint32_t blocks_reserved[384])
 	const DWORD Protect = XboxAddressRanges[index].InitialMemoryProtection;
 	bool NeedsReservationTracking = false;
 	unsigned int arr_index = BLOCK_REGION_DEVKIT_INDEX_BEGIN;
+#ifdef DEBUG
+	std::printf("DEBUG: ReserveMemoryRange call begin\n");
+	std::printf("     : Comment = %s\n", XboxAddressRanges[index].Comment);
+#endif
 	switch (Start) {
 		case 0x80000000:
 		case 0x84000000:
@@ -71,6 +81,9 @@ bool ReserveMemoryRange(int index, uint32_t blocks_reserved[384])
 				0,
 				Size,
 				(LPVOID)Start);
+#ifdef DEBUG
+			std::printf("     : MapViewOfFile; Start = 0x%08X; Result = %p\n", Start, Result);
+#endif
 			if (Result == nullptr) {
 				HadAnyFailure = true;
 			}
@@ -97,18 +110,28 @@ bool ReserveMemoryRange(int index, uint32_t blocks_reserved[384])
 				if (Result == nullptr) {
 					HadAnyFailure = true;
 				}
+#ifdef DEBUG
+				std::printf("     : Start = %08X; Result = %p;\n", Start, Result);
+#endif
 				// Handle the next block
 				Start += BLOCK_SIZE;
 				Size -= BLOCK_SIZE;
 				if (NeedsReservationTracking) {
 					if (Result != nullptr) {
 						blocks_reserved[arr_index / 32] |= (1 << (arr_index % 32));
+#ifdef DEBUG
+						std::printf("     : arr_index = 0x%08X; set bit = 0x%08X;\n", arr_index, (1 << (arr_index % 32)));
+						std::printf("     : blocks_reserved[%08X] = 0x%08X\n", arr_index/32, blocks_reserved[arr_index/32]);
+#endif
 					}
 					arr_index++;
 				}
 			}
 		}
 	}
+#ifdef DEBUG
+	std::printf("     : ReserveMemoryRange call end: HadAnyFailure = %d\n\n", HadAnyFailure);
+#endif
 
 	// Only a complete success when the entire request was reserved in a single range
 	// (Otherwise, we have either a complete failure, or reserved it partially over multiple ranges)
@@ -122,11 +145,18 @@ void FreeMemoryRange(int index, uint32_t blocks_reserved[384])
 	int Size = XboxAddressRanges[index].Size;
 	bool NeedsReservationTracking = false;
 	unsigned int arr_index = BLOCK_REGION_DEVKIT_INDEX_BEGIN;
+#ifdef DEBUG
+	std::printf("DEBUG: FreeMemoryRange call begin\n");
+	std::printf("     : Comment = %s\n", XboxAddressRanges[index].Comment);
+#endif
 	switch (Start) {
 		case 0x80000000:
 		case 0x84000000:
 		case 0xF0000000: {
 			(void)UnmapViewOfFile((LPVOID)Start);
+#ifdef DEBUG
+			std::printf("     : UnmapViewOfFile; Start = 0x%08X\n", Start);
+#endif
 		}
 		break;
 
@@ -147,18 +177,28 @@ void FreeMemoryRange(int index, uint32_t blocks_reserved[384])
 			while (Size > 0) {
 				_Start = Start; // Require to silence C6001's warning complaint
 				BOOL Result = VirtualFree((LPVOID)_Start, 0, MEM_RELEASE);
+#ifdef DEBUG
+				std::printf("     : Start = %08X; Result = %d;\n", Start, Result);
+#endif
 				// Handle the next block
 				Start += BLOCK_SIZE;
 				Size -= BLOCK_SIZE;
 				if (NeedsReservationTracking) {
 					if (Result != 0) {
 						blocks_reserved[arr_index / 32] &= ~(1 << (arr_index % 32));
+#ifdef DEBUG
+						std::printf("     : arr_index = 0x%08X; clear bit = 0x%08X;\n", arr_index, (1 << (arr_index % 32)));
+						std::printf("     : blocks_reserved[%08X] = 0x%08X\n", arr_index/32, blocks_reserved[arr_index/32]);
+#endif
 					}
 					arr_index++;
 				}
 			}
 		}
 	}
+#ifdef DEBUG
+	std::printf("     : FreeMemoryRange call end\n\n");
+#endif
 }
 
 bool ReserveAddressRanges(const unsigned int system, uint32_t blocks_reserved[384]) {

--- a/src/common/ReserveAddressRanges.cpp
+++ b/src/common/ReserveAddressRanges.cpp
@@ -42,8 +42,10 @@ bool ReserveMemoryRange(int index, uint32_t blocks_reserved[384])
 
 	const DWORD Protect = XboxAddressRanges[index].InitialMemoryProtection;
 	bool NeedsReservationTracking = false;
+	unsigned int arr_index = BLOCK_REGION_DEVKIT_INDEX_BEGIN;
 	switch (Start) {
 		case 0x80000000:
+		case 0x84000000:
 		case 0xF0000000: {
 			static bool NeedsInitialization = true;
 			static	HANDLE hFileMapping;
@@ -63,7 +65,7 @@ bool ReserveMemoryRange(int index, uint32_t blocks_reserved[384])
 			}
 			LPVOID Result = MapViewOfFileEx(
 				hFileMapping,
-				Start == 0x80000000 ?
+				(Start == 0x80000000 || Start == 0x84000000) ?
 				(FILE_MAP_READ | FILE_MAP_WRITE | FILE_MAP_EXECUTE) : (FILE_MAP_READ | FILE_MAP_WRITE),
 				0,
 				0,
@@ -75,15 +77,21 @@ bool ReserveMemoryRange(int index, uint32_t blocks_reserved[384])
 		}
 		break;
 
-		case 0xB0000000:
-		case 0xD0000000: {
+		case 0xD0000000:
+			// If additional addresses need to be assign in region's block.
+			// Then check for nonzero value.
+			arr_index = BLOCK_REGION_SYSTEM_INDEX_BEGIN;
+		[[fallthrough]];
+		case 0xB0000000: {
+			// arr_index's default is BLOCK_REGION_DEVKIT_INDEX_BEGIN which is zero.
+			// Any block region above zero should be place above this case to override zero value.
+			//arr_index = BLOCK_REGION_DEVKIT_INDEX_BEGIN;
 			NeedsReservationTracking = true;
 		}
 		[[fallthrough]];
 
 		default: {
 			while (Size > 0) {
-				static int arr_index = 0;
 				SIZE_T BlockSize = (SIZE_T)(Size > BLOCK_SIZE) ? BLOCK_SIZE : Size;
 				LPVOID Result = VirtualAlloc((LPVOID)Start, BlockSize, MEM_RESERVE, Protect);
 				if (Result == nullptr) {
@@ -107,7 +115,53 @@ bool ReserveMemoryRange(int index, uint32_t blocks_reserved[384])
 	return !HadAnyFailure;
 }
 
-bool ReserveAddressRanges(const int system, uint32_t blocks_reserved[384]) {
+// Free address range from the host.
+void FreeMemoryRange(int index, uint32_t blocks_reserved[384])
+{
+	uint32_t Start = XboxAddressRanges[index].Start, _Start;
+	int Size = XboxAddressRanges[index].Size;
+	bool NeedsReservationTracking = false;
+	unsigned int arr_index = BLOCK_REGION_DEVKIT_INDEX_BEGIN;
+	switch (Start) {
+		case 0x80000000:
+		case 0x84000000:
+		case 0xF0000000: {
+			(void)UnmapViewOfFile((LPVOID)Start);
+		}
+		break;
+
+		case 0xD0000000:
+			// If additional addresses need to be assign in region's block.
+			// Then check for nonzero value.
+			arr_index = BLOCK_REGION_SYSTEM_INDEX_BEGIN;
+		[[fallthrough]];
+		case 0xB0000000: {
+			// arr_index's default is BLOCK_REGION_DEVKIT_INDEX_BEGIN which is zero.
+			// Any block region above zero should be place above this case to override zero value.
+			//arr_index = BLOCK_REGION_DEVKIT_INDEX_BEGIN;
+			NeedsReservationTracking = true;
+		}
+		[[fallthrough]];
+
+		default: {
+			while (Size > 0) {
+				_Start = Start; // Require to silence C6001's warning complaint
+				BOOL Result = VirtualFree((LPVOID)_Start, 0, MEM_RELEASE);
+				// Handle the next block
+				Start += BLOCK_SIZE;
+				Size -= BLOCK_SIZE;
+				if (NeedsReservationTracking) {
+					if (Result != 0) {
+						blocks_reserved[arr_index / 32] &= ~(1 << (arr_index % 32));
+					}
+					arr_index++;
+				}
+			}
+		}
+	}
+}
+
+bool ReserveAddressRanges(const unsigned int system, uint32_t blocks_reserved[384]) {
 	// Loop over all Xbox address ranges
 	for (int i = 0; i < ARRAY_SIZE(XboxAddressRanges); i++) {
 		// Skip address ranges that don't match the given flags
@@ -124,5 +178,76 @@ bool ReserveAddressRanges(const int system, uint32_t blocks_reserved[384]) {
 		}
 	}
 
+	return true;
+}
+
+void FreeAddressRanges(const unsigned int system, unsigned int release_systems, uint32_t blocks_reserved[384]) {
+	// If reserved_systems is empty, then there's nothing to be freed up.
+	if (release_systems == 0) {
+		return;
+	}
+	// Loop over all Xbox address ranges
+	for (int i = 0; i < ARRAY_SIZE(XboxAddressRanges); i++) {
+		// Skip address ranges that do match specific flag
+		if (AddressRangeMatchesFlags(i, system))
+			continue;
+
+		// Skip address ranges that doesn't match the reserved flags
+		if (!AddressRangeMatchesFlags(i, release_systems))
+			continue;
+
+		FreeMemoryRange(i, blocks_reserved);
+	}
+
+}
+
+bool AttemptReserveAddressRanges(unsigned int* p_reserved_systems, uint32_t blocks_reserved[384]) {
+
+	int iLast = 0;
+	unsigned int reserved_systems = *p_reserved_systems, clear_systems = 0;
+	// Loop over all Xbox address ranges
+	for (int i = 0; i < ARRAY_SIZE(XboxAddressRanges); i++) {
+
+		// Once back to original spot, let's resume.
+		if (i == iLast && clear_systems) {
+			reserved_systems &= ~clear_systems;
+			if (reserved_systems == 0) {
+				*p_reserved_systems = 0;
+				return false;
+			}
+			// Resume virtual allocated range.
+			clear_systems = 0;
+			continue;
+		}
+
+		if (clear_systems) {
+			// Skip address ranges that doesn't match the given flags
+			if (!AddressRangeMatchesFlags(i, clear_systems))
+				continue;
+
+			// Release incompatible system's memory range
+			FreeMemoryRange(i, blocks_reserved);
+		}
+		else {
+			// Skip address ranges that don't match the given flags
+			if (!AddressRangeMatchesFlags(i, reserved_systems))
+				continue;
+
+			// Try to reserve each address range
+			if (ReserveMemoryRange(i, blocks_reserved))
+				continue;
+
+			// Some ranges are allowed to fail reserving
+			if (!IsOptionalAddressRange(i)) {
+				// If not, then let's free them and downgrade host's limitation.
+				iLast = i;
+				i = -1; // Reset index back to zero after for statement's increment.
+				clear_systems = AddressRangeGetSystemFlags(i);
+				continue;
+			}
+		}
+	}
+
+	*p_reserved_systems = reserved_systems;
 	return true;
 }

--- a/src/common/ReserveAddressRanges.h
+++ b/src/common/ReserveAddressRanges.h
@@ -26,4 +26,8 @@
 // ******************************************************************
 #pragma once
 
-extern bool ReserveAddressRanges(const int system, uint32_t blocks_reserved[384]);
+extern bool ReserveAddressRanges(const unsigned int system, uint32_t blocks_reserved[384]);
+
+extern void FreeAddressRanges(const unsigned int system, unsigned int release_systems, uint32_t blocks_reserved[384]);
+
+extern bool AttemptReserveAddressRanges(unsigned int* p_reserved_systems, uint32_t blocks_reserved[384]);

--- a/src/common/util/cliConfig.cpp
+++ b/src/common/util/cliConfig.cpp
@@ -163,4 +163,20 @@ long long GetSessionID()
     return sessionID;
 }
 
+void SetSystemType(const std::string value)
+{
+    // If system types key exist, then do not replace old one.
+    if (hasKey(cli_config::system_retail)
+        || hasKey(cli_config::system_devkit)
+        || hasKey(cli_config::system_chihiro)) {
+        return;
+    }
+    // If one of system types match, then set it.
+    if (value.compare(cli_config::system_retail) == 0
+        || value.compare(cli_config::system_devkit) == 0
+        || value.compare(cli_config::system_chihiro) == 0) {
+        SetValue(value, "");
+    }
+}
+
 }

--- a/src/common/util/cliConfig.hpp
+++ b/src/common/util/cliConfig.hpp
@@ -38,6 +38,9 @@ static constexpr char hwnd[] = "hwnd";
 static constexpr char debug_mode[] = "dm";
 static constexpr char debug_file[] = "df";
 static constexpr char sid[] = "sid";
+static constexpr char system_retail[] = "retail";
+static constexpr char system_devkit[] = "devkit";
+static constexpr char system_chihiro[] = "chihiro";
 
 bool GenConfig(char** argv, int argc);
 size_t ConfigSize();
@@ -52,5 +55,7 @@ long long GetSessionID();
 
 // Change xbe path to launch.
 void SetLoad(const std::string value);
+
+void SetSystemType(const std::string value);
 
 }

--- a/src/common/win32/EmuShared.h
+++ b/src/common/win32/EmuShared.h
@@ -195,8 +195,8 @@ class EmuShared : public Mutex
 		// ******************************************************************
 		// * Previous Memory Layout value Accessors
 		// ******************************************************************
-		void GetMmLayout(int* value) { Lock(); *value = m_PreviousMmLayout; Unlock(); }
-		void SetMmLayout(int* value) { Lock(); m_PreviousMmLayout = *value; Unlock(); }
+		void GetMmLayout(unsigned int* value) { Lock(); *value = m_PreviousMmLayout; Unlock(); }
+		void SetMmLayout(unsigned int* value) { Lock(); m_PreviousMmLayout = *value; Unlock(); }
 #endif
 		// ******************************************************************
 		// * Log Level value Accessors
@@ -272,7 +272,7 @@ class EmuShared : public Mutex
 		bool         m_bReady_status;
 		bool         m_bEmulating_status;
 #ifndef CXBX_LOADER // Temporary usage for cxbx.exe's emu
-		int          m_PreviousMmLayout;
+		unsigned int m_PreviousMmLayout;
 		int          m_Reserved7[3];
 #else
 		int          m_Reserved7[4];

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -118,6 +118,7 @@ ULONG g_CxbxFatalErrorCode = FATAL_ERROR_NONE;
 // Define function located in EmuXApi so we can call it from here
 void SetupXboxDeviceTypes();
 
+// TODO: Move below function into a common(?) file
 // ported from Dxbx's XbeExplorer
 XbeType GetXbeType(Xbe::Header *pXbeHeader)
 {
@@ -135,6 +136,7 @@ XbeType GetXbeType(Xbe::Header *pXbeHeader)
 	return xtRetail;
 }
 
+// TODO: Move below function into a common(?) file
 const char* GetSystemTypeToStr(unsigned int system)
 {
 	if (system == SYSTEM_CHIHIRO) {
@@ -152,6 +154,7 @@ const char* GetSystemTypeToStr(unsigned int system)
 	return nullptr;
 }
 
+// TODO: Move below function into a common(?) file
 const char* GetXbeTypeToStr(XbeType xbe_type)
 {
 	if (xbe_type == xtChihiro) {

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -54,6 +54,7 @@ namespace xboxkrnl
 #include "CxbxDebugger.h"
 #include "common/util/cliConfig.hpp"
 #include "common/util/xxhash.h"
+#include "common/ReserveAddressRanges.h"
 
 #include <clocale>
 #include <process.h>
@@ -132,6 +133,36 @@ XbeType GetXbeType(Xbe::Header *pXbeHeader)
 
 	// Otherwise, the XBE is a Retail build :
 	return xtRetail;
+}
+
+const char* GetSystemTypeToStr(unsigned int system)
+{
+	if (system == SYSTEM_CHIHIRO) {
+		return cli_config::system_chihiro;
+	}
+
+	if (system == SYSTEM_DEVKIT) {
+		return cli_config::system_devkit;
+	}
+
+	if (system == SYSTEM_XBOX) {
+		return cli_config::system_retail;
+	}
+
+	return nullptr;
+}
+
+const char* GetXbeTypeToStr(XbeType xbe_type)
+{
+	if (xbe_type == xtChihiro) {
+		return "chihiro";
+	}
+
+	if (xbe_type == xtDebug) {
+		return "debug";
+	}
+
+	return "retail";
 }
 
 void ApplyMediaPatches()
@@ -724,7 +755,23 @@ bool HandleFirstLaunch()
 	return true;
 }
 
-void CxbxKrnlEmulate(uint32_t blocks_reserved[384])
+// TODO: Need to move isSystemFlagSupport function somewhere other than CxbxKrnl.cpp file.
+bool isSystemFlagSupport(int reserved_systems, int assign_system)
+{
+	if (reserved_systems & assign_system) {
+		return true;
+	}
+// TODO: Once host's standalone emulation is remove from GUI, remove below as well.
+#ifndef CXBXR_EMU
+	if (reserved_systems == 0) {
+		return true;
+	}
+#endif
+
+	return false;
+}
+
+void CxbxKrnlEmulate(unsigned int reserved_systems, uint32_t blocks_reserved[384])
 {
 	std::string tempStr;
 
@@ -1075,8 +1122,51 @@ void CxbxKrnlEmulate(uint32_t blocks_reserved[384])
 			}
 		}
 
-		// Detect XBE type :
-		g_XbeType = GetXbeType(&CxbxKrnl_Xbe->m_Header);
+		// If CLI has given console type, then enforce it.
+		if (cli_config::hasKey(cli_config::system_chihiro)) {
+			EmuLogInit(LOG_LEVEL::INFO, "Auto detect is disabled, running as chihiro.");
+			g_XbeType = xtChihiro;
+		}
+		else if (cli_config::hasKey(cli_config::system_devkit)) {
+			EmuLogInit(LOG_LEVEL::INFO, "Auto detect is disabled, running as devkit.");
+			g_XbeType = xtDebug;
+		}
+		else if (cli_config::hasKey(cli_config::system_retail)) {
+			EmuLogInit(LOG_LEVEL::INFO, "Auto detect is disabled, running as retail.");
+			g_XbeType = xtRetail;
+		}
+		// Otherwise, use auto detect method.
+		else {
+			// Detect XBE type :
+			g_XbeType = GetXbeType(&CxbxKrnl_Xbe->m_Header);
+			EmuLogInit(LOG_LEVEL::INFO, "Auto detect: XbeType = %s", GetXbeTypeToStr(g_XbeType));
+		}
+
+		EmuLogInit(LOG_LEVEL::INFO, "Host's compatible system types: %2X", reserved_systems);
+		unsigned int emulate_system = 0;
+		// Set reserved_systems which system we will about to emulate.
+		if (isSystemFlagSupport(reserved_systems, SYSTEM_CHIHIRO) && g_XbeType == xtChihiro) {
+			emulate_system = SYSTEM_CHIHIRO;
+		}
+		else if (isSystemFlagSupport(reserved_systems, SYSTEM_DEVKIT) && g_XbeType == xtDebug) {
+			emulate_system = SYSTEM_DEVKIT;
+		}
+		else if (isSystemFlagSupport(reserved_systems, SYSTEM_XBOX) && g_XbeType == xtRetail) {
+			emulate_system = SYSTEM_XBOX;
+		}
+		// If none of system type requested to emulate isn't supported on host's end. Then enforce failure.
+		else {
+			CxbxKrnlCleanup("Unable to emulate system type due to host is not able to reserve required memory ranges.");
+			return;
+		}
+		// Clear emulation system from reserved systems to be free.
+		reserved_systems &= ~emulate_system;
+
+		// Once we have determine which system type to run as, enforce it in future reboots.
+		if ((BootFlags & BOOT_QUICK_REBOOT) == 0) {
+			const char* system_str = GetSystemTypeToStr(emulate_system);
+			cli_config::SetSystemType(system_str);
+		}
 
 		// Register if we're running an Chihiro executable or a debug xbe, otherwise it's an Xbox retail executable
 		g_bIsChihiro = (g_XbeType == xtChihiro);
@@ -1106,9 +1196,9 @@ void CxbxKrnlEmulate(uint32_t blocks_reserved[384])
 		uint32_t SystemDevBlocksReserved[384] = { 0 };
 		g_VMManager.Initialize(0, BootFlags, SystemDevBlocksReserved);
 #else
-		// TODO: Retrieve the system type from the loader and be sure that it doesn't change between quick reboots
+		FreeAddressRanges(emulate_system, reserved_systems, blocks_reserved);
 		// Initialize the memory manager
-		g_VMManager.Initialize(SYSTEM_XBOX, BootFlags, blocks_reserved);
+		g_VMManager.Initialize(emulate_system, BootFlags, blocks_reserved);
 #endif
 
 		// Commit the memory used by the xbe header

--- a/src/core/kernel/init/CxbxKrnl.h
+++ b/src/core/kernel/init/CxbxKrnl.h
@@ -237,7 +237,7 @@ bool CreateSettings();
 bool HandleFirstLaunch();
 
 /*! Cxbx Kernel Entry Point */
-void CxbxKrnlEmulate(uint32_t blocks_reserved[384]);
+void CxbxKrnlEmulate(unsigned int system, uint32_t blocks_reserved[384]);
 
 /*! initialize emulation */
 __declspec(noreturn) void CxbxKrnlInit(void *pTLSData, Xbe::TLS *pTLS, Xbe::LibraryVersion *LibraryVersion, DebugMode DbgMode, const char *szDebugFilename, Xbe::Header *XbeHeader, uint32_t XbeHeaderSize, void (*Entry)(), int BootFlags);

--- a/src/core/kernel/memory-manager/VMManager.h
+++ b/src/core/kernel/memory-manager/VMManager.h
@@ -28,9 +28,15 @@
 #ifndef VMMANAGER_H
 #define VMMANAGER_H
 
+// TODO: Need to move defines below into one header files.
 #define SYSTEM_XBOX    (1 << 1)
 #define SYSTEM_DEVKIT  (1 << 2)
 #define SYSTEM_CHIHIRO (1 << 3)
+
+#define BLOCK_REGION_DEVKIT_INDEX_BEGIN 0
+#define BLOCK_REGION_DEVKIT_INDEX_END   4096
+#define BLOCK_REGION_SYSTEM_INDEX_BEGIN 4096
+#define BLOCK_REGION_SYSTEM_INDEX_END   12288
 
 #include "PhysicalMemory.h"
 
@@ -103,7 +109,7 @@ class VMManager : public PhysicalMemory
 		// shutdown routine
 		void Shutdown();
 		// initializes the memory manager to the default configuration
-		void Initialize(int SystemType, int BootFlags, uint32_t blocks_reserved[384]);
+		void Initialize(unsigned int SystemType, int BootFlags, uint32_t blocks_reserved[384]);
 		// retrieves memory statistics
 		void MemoryStatistics(xboxkrnl::PMM_STATISTICS memory_statistics);
 		// allocates memory in the user region

--- a/src/emulator/cxbxr-emu.cpp
+++ b/src/emulator/cxbxr-emu.cpp
@@ -122,7 +122,7 @@ CommandLineToArgvA(
 	return argv;
 }
 
-DWORD WINAPI Emulate(int system, uint32_t blocks_reserved[384])
+DWORD WINAPI Emulate(unsigned int reserved_systems, uint32_t blocks_reserved[384])
 {
 	FUNC_EXPORTS
 
@@ -170,7 +170,13 @@ DWORD WINAPI Emulate(int system, uint32_t blocks_reserved[384])
 		return EXIT_FAILURE;
 	}
 
-	CxbxKrnlEmulate(blocks_reserved);
+	if (!reserved_systems) {
+		CxbxShowError("Unable to preserve any system's memory ranges!");
+		EmuShared::Cleanup();
+		return EXIT_FAILURE;
+	}
+
+	CxbxKrnlEmulate(reserved_systems, blocks_reserved);
 
 	/*! cleanup shared memory */
 	EmuShared::Cleanup();

--- a/src/gui/WinMain.cpp
+++ b/src/gui/WinMain.cpp
@@ -82,7 +82,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 	if (cli_config::hasKey("load")) {
 #ifndef CXBXR_EMU
-		CxbxKrnlEmulate(nullptr);
+		CxbxKrnlEmulate(0, nullptr);
 		EmuShared::Cleanup();
 		return EXIT_SUCCESS;
 #else


### PR DESCRIPTION
Proper implementation:
- Reserve all address ranges for all system types.
- CLI for system types enforcement within kernel's emulation.
- Auto-assign system type base on xbe type. If above is not enforce.
- Free up console type(s)
- Assign system type in CLI for future reboot enforcement


With this change, experimental loader project shows a lot of potential to mimic virtual emulation as host emulation.

---

**NOTE:** At this stage, it is possible to run loader emulation without any hardcode modification.
(Beside edit the `settings.ini` file to enable/disable loader experimental.)