### PR TITLE
kernel: Clear IRR register on software interrupt processing

### DIFF
--- a/src/core/kernel/exports/EmuKrnl.cpp
+++ b/src/core/kernel/exports/EmuKrnl.cpp
@@ -178,6 +178,8 @@ void CallSoftwareInterrupt(const xboxkrnl::KIRQL SoftwareIrql)
 		}
 		break;
 	}
+
+	HalInterruptRequestRegister ^= (1 << SoftwareIrql);
 }
 
 const DWORD IrqlMasks[] = {


### PR DESCRIPTION
Fixes a hang that can occur due to an infinite loop of interrupts under
certain conditions.

Note: This is the issue that was preventing the Chihiro work from being continued, with this fix, work on Chihiro emulation can finally resume.