### PR TITLE
HOTFIX: Another fixup to FlushEx

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.cpp
@@ -349,17 +349,14 @@ void DSStream_Packet_FlushEx_Reset(
     )
 {
     // Remove flags only (This is the only place it will remove other than FlushEx perform set/remove the flags.)
-    pThis->EmuFlags &= ~(DSE_FLAG_FLUSH_ASYNC | DSE_FLAG_ENVELOPE | DSE_FLAG_ENVELOPE2 | DSE_FLAG_PAUSE);
+    pThis->EmuFlags &= ~(DSE_FLAG_FLUSH_ASYNC | DSE_FLAG_ENVELOPE | DSE_FLAG_ENVELOPE2);
     pThis->Xb_rtFlushEx = 0LL;
-    pThis->Xb_Status = 0;
 }
 
 bool DSStream_Packet_Flush(
     XTL::X_CDirectSoundStream* pThis
     )
 {
-    DSStream_Packet_FlushEx_Reset(pThis);
-
     // If host's audio is still playing then return busy-state until buffer has stop playing.
     DWORD dwStatus;
     pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);
@@ -376,5 +373,9 @@ bool DSStream_Packet_Flush(
     for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
         DSStream_Packet_Clear(buffer, XMP_STATUS_FLUSHED, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis);
     }
+    // Clear flags and set status to zero.
+    DSStream_Packet_FlushEx_Reset(pThis);
+    pThis->EmuFlags &= ~DSE_FLAG_PAUSE;
+    pThis->Xb_Status = 0;
     return false;
 }

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
@@ -147,7 +147,7 @@ ULONG WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Release)
         }
     //}
 
-    return uRet;
+    RETURN(uRet);
 }
 
 // ******************************************************************

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundStream.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundStream.cpp
@@ -172,7 +172,7 @@ ULONG WINAPI XTL::EMUPATCH(CDirectSoundStream_Release)
         }
     }
 
-    return uRet;
+    RETURN(uRet);
 }
 
 // ******************************************************************


### PR DESCRIPTION
Thanks to @LukeUsher for bring this to my attention, I notice couple introduced bugs.

- Call `DSStream_Packet_Flush` once in FlushEx function only if `rtTimeStamp` is zero. Whenever flush call is busy, submit it to worker thread for continue flush process.
  - Resolve Obscure's regression.
- Clear `Xb_Status` in `DSStream_Packet_Flush` after completion.
- Also remove `DSE_FLAG_PAUSE` flag in `DSStream_Packet_Flush` after completion.
- Change buffer/stream classes release function's returns to include verbose result.