### PR TITLE
Display warning message when activating the all cores hack

### DIFF
--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -1265,6 +1265,13 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				break;
 
 			case ID_HACKS_RUNXBOXTHREADSONALLCORES:
+				if (g_Settings->m_hacks.UseAllCores == false) {
+					int ret = MessageBox(hwnd, "Activating this hack will make the emulator more likely to crash and/or hang. \
+Please do not report issues with games while this hack is active. Are you sure you want to turn it on?", "Cxbx-Reloaded", MB_YESNO | MB_ICONWARNING | MB_APPLMODAL);
+					if (ret == IDNO) {
+						break;
+					}
+				}
 				g_Settings->m_hacks.UseAllCores = !g_Settings->m_hacks.UseAllCores;
 				RefreshMenus();
 				break;


### PR DESCRIPTION
This adds a warning message which is displayed whenever the user tries to activate the "all cores" speed hack. This is intended to hopefully reduce the number of users which report invalid issues which are actually caused by the hack instead.