### PR TITLE
prevent missing polygons with AMD GPU

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
@@ -48,11 +48,16 @@ float4 c(int register_number)
 	// Map Xbox [-96, 95] to Host [0, 191]
 	// Account for Xbox's negative constant indexes
     register_number += X_D3DSCM_CORRECTION;
-    if (register_number < 0)
-        return 0;
-    
+
+    // Like Xbox, out-of-range indices are guaranteed to be zero in HLSL
+    // so no need to bounds check negative numbers
+    // if (register_number < 0)
+    //    return 0;
+
+    // If the index is too large, set it to -1 so 0 is returned
+    // Note: returning 0 directly requires many more instructions
     if (register_number >= X_D3DVS_CONSTREG_COUNT) // X_D3DVS_CONSTREG_COUNT
-        return 0;
+        register_number = -1;
 
     return C[register_number];
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1670,7 +1670,7 @@ VOID EmuD3DInit()
 		// 1002 and 1022 are vendor ids of AMD gpus
 		if (status == D3D_OK && (adapter_info.VendorId == 0x1002 || adapter_info.VendorId == 0x1022)) {
 			g_vs_model = vs_model_2_a;
-			EmuLog(LOG_LEVEL::WARNING, "AMD GPU Detected, falling back to shader model 2.X to prevent missing polygons");
+			EmuLogInit(LOG_LEVEL::WARNING, "AMD GPU Detected, falling back to shader model 2.X to prevent missing polygons");
 		}
 	}
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1662,6 +1662,17 @@ VOID EmuD3DInit()
 		std::cout << "Host D3DCaps : " << g_D3DCaps << "\n";
 		std::cout << "----------------------------------------\n";
 	}
+
+	// AMD compatibility workaround since VS model 3.0 doesn't work as intended with Direct3D9.
+	{
+		D3DADAPTER_IDENTIFIER9 adapter_info;
+		HRESULT status = g_pDirect3D->GetAdapterIdentifier(g_EmuCDPD.Adapter, 0, &adapter_info);
+		// 1002 and 1022 are vendor ids of AMD gpus
+		if (status == D3D_OK && (adapter_info.VendorId == 0x1002 || adapter_info.VendorId == 0x1022)) {
+			g_vs_model = vs_model_2_a;
+			EmuLog(LOG_LEVEL::WARNING, "AMD GPU Detected, falling back to shader model 2.X to prevent missing polygons");
+		}
+	}
 }
 
 // cleanup Direct3D

--- a/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
+++ b/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
@@ -6,6 +6,8 @@
 
 #include <sstream>
 
+extern const char* g_vs_model = vs_model_3_0;
+
 // HLSL generation
 void OutputHlsl(std::stringstream& hlsl, VSH_IMD_OUTPUT& dest)
 {
@@ -247,9 +249,8 @@ extern HRESULT EmuCompileShader
 	EmuLog(LOG_LEVEL::DEBUG, DebugPrependLineNumbers(hlsl_str).c_str());
 	EmuLog(LOG_LEVEL::DEBUG, "-----------------------");
 
-	// Level 0 for fastest runtime compilation
-	// TODO Can we recompile an optimized shader in the background?
-	UINT flags1 = D3DCOMPILE_OPTIMIZATION_LEVEL0;
+
+	UINT flags1 = D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE_AVOID_FLOW_CONTROL;
 
 	hRet = D3DCompile(
 		hlsl_str.c_str(),
@@ -258,7 +259,7 @@ extern HRESULT EmuCompileShader
 		nullptr, // pDefines
 		nullptr, // pInclude // TODO precompile x_* HLSL functions?
 		"main", // shader entry poiint
-		"vs_3_0", // shader profile
+		g_vs_model, // shader profile
 		flags1, // flags1
 		0, // flags2
 		ppHostShader, // out
@@ -275,7 +276,7 @@ extern HRESULT EmuCompileShader
 			nullptr, // pDefines
 			nullptr, // pInclude // TODO precompile x_* HLSL functions?
 			"main", // shader entry poiint
-			"vs_3_0", // shader profile
+			g_vs_model, // shader profile
 			flags1, // flags1
 			0, // flags2
 			ppHostShader, // out

--- a/src/core/hle/D3D8/Direct3D9/VertexShader.h
+++ b/src/core/hle/D3D8/Direct3D9/VertexShader.h
@@ -10,6 +10,10 @@ enum class ShaderType {
 	Unsupported,
 };
 
+static const char* vs_model_2_a = "vs_2_a";
+static const char* vs_model_3_0 = "vs_3_0";
+extern const char* g_vs_model;
+
 extern ShaderType EmuGetShaderInfo(IntermediateVertexShader* pIntermediateShader);
 
 extern HRESULT EmuCompileShader


### PR DESCRIPTION
AMD's current GPU drivers seem to have problems when using Shader Model 3.0 with DirectX9

This work-around falls back to Shader Model 2.0 when AMD hardware is detected.

Partial fix/workaround for #1803 

Before:
![image](https://user-images.githubusercontent.com/740003/78930107-70d8d700-7a9b-11ea-9c85-441488c4849c.png)

After:
![image](https://user-images.githubusercontent.com/740003/78930077-6585ab80-7a9b-11ea-8f71-9b529a45d6a1.png)
