### PR TITLE
fix compilation on new installs of vs2019

### DIFF
--- a/src/common/Timer.cpp
+++ b/src/common/Timer.cpp
@@ -54,7 +54,7 @@ std::mutex TimerMtx;
 
 
 // Returns the current time of the timer
-inline uint64_t GetTime_NS(TimerObject* Timer)
+uint64_t GetTime_NS(TimerObject* Timer)
 {
 #ifdef _WIN32
 	LARGE_INTEGER li;

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -60,7 +60,7 @@ TimerObject* Timer_Create(TimerCB Callback, void* Arg, std::string Name, unsigne
 void Timer_Start(TimerObject* Timer, uint64_t Expire_MS);
 void Timer_Exit(TimerObject* Timer);
 void Timer_ChangeExpireTime(TimerObject* Timer, uint64_t Expire_ms);
-inline uint64_t GetTime_NS(TimerObject* Timer);
+uint64_t GetTime_NS(TimerObject* Timer);
 void Timer_Init();
 
 #endif


### PR DESCRIPTION
This resolves an "undefined reference" linker error that can occur on new installations of Visual Studio 2019 (with the latest Windows SDK)
