### PR TITLE
Fix an issue where with CreateDevice LOG_TEST_CASE

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -2962,7 +2962,7 @@ void Direct3D_CreateDevice_End()
     // We fix the situation by calling the Xbox GetRenderTarget function, which immediately after CreateDevice
     // WILL always return the Backbuffer!
     // Test Case: Shin Megami Tensei: Nine
-    if (g_pXbox_BackBufferSurface == xbnullptr || g_pXbox_DefaultDepthStencilSurface == xbnullptr) {
+    if (g_pXbox_BackBufferSurface == xbnullptr && g_pXbox_DefaultDepthStencilSurface == xbnullptr) {
         // First, log the test case
         LOG_TEST_CASE("Xbox CreateDevice did not call SetRenderTarget");
     }


### PR DESCRIPTION
Fix an issue where the 'Xbox CreateDevice did not call SetRenderTarget' test case would be incorrectly flagged if no depth stencil was provided