### PR TITLE
Mention Wine support more prominently in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cxbx-Reloaded is an emulator for running Microsoft Xbox (and eventually, Chihiro
 
 ## System Requirements
 ### Minimum
-  * OS: Windows 7+ x64. 32-bit is not supported.
+  * OS: Windows 7+ x64, or x86-64 Linux with Wine. 32-bit is not supported.
   * GPU: Direct3D 9.0c with Pixel Shader Model 2.x, and Vertex Shader Model 3.0.
 
 ### Prerequisites
@@ -19,7 +19,7 @@ Cxbx-Reloaded is an emulator for running Microsoft Xbox (and eventually, Chihiro
 Cxbx-Reloaded doesn't currently have stable builds, but you can obtain pre-release builds from the Releases tab, or the links below:
 
   * **[Release Builds](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases)**
-    * **WINE users will need to use `CxbxReloaded-Release-VS2017.zip` for it to run correctly.**
+    * **Wine users will need to use `CxbxReloaded-Release-VS2017.zip` for it to run correctly.**
   * *[Full build history](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/actions?query=workflow%3A%22GitHub+CI%22)*
 
 ## Compatibility


### PR DESCRIPTION
Right now the first mention of Wine is down next to the download link, and no mention is made of it under the system requirements. Given that compatibility with Wine has been a goal for this project in the past (in terms of bugfixes that fixed issues that only emerged when using it), I thought it would be a good idea to show that this use case is indeed considered by the developers. As a Linux user myself, if I weren't already a Cxbx user, this kind of thing would be more likely to consider using Cxbx after glancing at the repository, as well as more likely to contribute.