### PR TITLE
Add Settings Structure Assert Checks

### DIFF
--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -59,8 +59,9 @@ uint16_t g_LibVersion_DSOUND = 0;
 // * 4: (LukeUsher), added network settings
 // * 5: (ergo720),   added new input gui settings and revision to core
 // * 6: (RadWolfie), added loader executable member to core, only for clean up loader expertimental setting
+// * 7: (RadWolfie), fix allowAdminPrivilege not align with other boolean members
 ///////////////////////////
-const unsigned int settings_version = 6;
+const unsigned int settings_version = 7;
 
 Settings* g_Settings = nullptr;
 

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -58,6 +58,7 @@ uint16_t g_LibVersion_DSOUND = 0;
 // * 3: (ergo720),   added logging settings
 // * 4: (LukeUsher), added network settings
 // * 5: (ergo720),   added new input gui settings and revision to core
+// * 6: (RadWolfie), added loader executable member to core, only for clean up loader expertimental setting
 ///////////////////////////
 const unsigned int settings_version = 6;
 

--- a/src/common/Settings.hpp
+++ b/src/common/Settings.hpp
@@ -98,15 +98,15 @@ public:
 		DebugMode KrnlDebugMode;
 		char szKrnlDebug[MAX_PATH] = "";
 		char szStorageLocation[MAX_PATH] = "";
-		bool allowAdminPrivilege;
         unsigned int LoggedModules[NUM_INTEGERS_LOG];
 		int LogLevel = 1;
 		bool bUseLoaderExec;
+		bool allowAdminPrivilege;
 		bool Reserved3 = 0;
 		bool Reserved4 = 0;
 		int  Reserved99[10] = { 0 };
 	} m_core;
-	static_assert(sizeof(s_core) == 0x250, assert_check_shared_memory(s_core));
+	static_assert(sizeof(s_core) == 0x24C, assert_check_shared_memory(s_core));
 
 	// Video settings
 	struct s_video {

--- a/src/common/Settings.hpp
+++ b/src/common/Settings.hpp
@@ -41,6 +41,9 @@ extern uint16_t g_LibVersion_D3D8;
 extern uint16_t g_LibVersion_DSOUND;
 
 #define szSettings_alloc_error "ERROR: Unable to allocate Settings class."
+#define assert_check_shared_memory(type) \
+ "Invalid "#type" size, please verify structure is align, not adding new member, or is using placeholder reserves." \
+ " Otherwise, please perform versioning upgrade and update "#type" sizeof check."
 
 // Cxbx-Reloaded's data storage location.
 typedef enum _CXBX_DATA {
@@ -103,6 +106,7 @@ public:
 		bool Reserved4 = 0;
 		int  Reserved99[10] = { 0 };
 	} m_core;
+	static_assert(sizeof(s_core) == 0x250, assert_check_shared_memory(s_core));
 
 	// Video settings
 	struct s_video {
@@ -116,6 +120,7 @@ public:
 		int  renderScaleFactor = 1;
 		int  Reserved99[9] = { 0 };
 	} m_video;
+	static_assert(sizeof(s_video) == 0x98, assert_check_shared_memory(s_video));
 
 	// Audio settings
 	struct s_audio {
@@ -126,6 +131,7 @@ public:
 		bool mute_on_unfocus;
 		int  Reserved99[14] = { 0 };
 	} m_audio;
+	static_assert(sizeof(s_audio) == 0x4C, assert_check_shared_memory(s_audio));
 
 	struct s_input {
 		int Type;
@@ -146,6 +152,7 @@ public:
 	struct s_network {
 		char adapter_name[MAX_PATH] = "";
 	} m_network;
+	static_assert(sizeof(s_network) == 0x104, assert_check_shared_memory(s_network));
 
 	// Hack settings
 	// NOTE: When removing fields, replace them with place-holders
@@ -162,6 +169,7 @@ public:
 		bool Reserved8 = 0;
 		int  Reserved99[8] = { 0 };
 	} m_hacks;
+	static_assert(sizeof(s_hack) == 0x28, assert_check_shared_memory(s_hack));
 
 private:
 	void RemoveLegacyConfigs(unsigned int CurrentRevision);


### PR DESCRIPTION
With enforce verify settings' structure are align properly, we can ensure nothing can go wrong over time until we need to do versioning upgrade to add new member or certain situation requirement to change how internal method works.

Of course with this pull request, we can worry less and be aware of our change occur in the future.