### PR TITLE
Improve SEH/VEH support for compilers

### DIFF
--- a/src/common/win32/Threads.cpp
+++ b/src/common/win32/Threads.cpp
@@ -52,6 +52,7 @@ void SetThreadName(DWORD dwThreadID, const char* szThreadName)
 	info.szName = szThreadName;
 	info.dwThreadID = dwThreadID;
 	info.dwFlags = 0;
+	// NOTE: Require to support Windows platform older than Windows 10 version 1607. Or alternative method will require Windows 10. (see link at top of source file)
 	__try {
 		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
 	}

--- a/src/core/hle/XAPI/Xapi.cpp
+++ b/src/core/hle/XAPI/Xapi.cpp
@@ -986,15 +986,8 @@ typedef struct {
 
 void WINAPI EmuFiberStartup(fiber_context_t* context)
 {
-	__try
-	{
-		LPFIBER_START_ROUTINE pfStartRoutine = (LPFIBER_START_ROUTINE)context->lpStartRoutine;
-		pfStartRoutine(context->lpParameter);
-	}
-	__except (EmuException(GetExceptionInformation()))
-	{
-		EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter");
-	}
+	LPFIBER_START_ROUTINE pfStartRoutine = (LPFIBER_START_ROUTINE)context->lpStartRoutine;
+	pfStartRoutine(context->lpParameter);
 }
 
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnl.h
+++ b/src/core/kernel/exports/EmuKrnl.h
@@ -88,14 +88,8 @@ public:
 			m_Pending = false;
 		}
 
-		__try {
-			BOOLEAN(__stdcall *ServiceRoutine)(xboxkrnl::PKINTERRUPT, void*) = (BOOLEAN(__stdcall *)(xboxkrnl::PKINTERRUPT, void*))Interrupt->ServiceRoutine;
-			BOOLEAN result = ServiceRoutine(Interrupt, Interrupt->ServiceContext);
-		}
-		__except (EmuException(GetExceptionInformation()))
-		{
-			EmuLogEx(CXBXR_MODULE::KRNL, LOG_LEVEL::WARNING, "Problem with ExceptionFilter!");
-		}
+		BOOLEAN(__stdcall *ServiceRoutine)(xboxkrnl::PKINTERRUPT, void*) = (BOOLEAN(__stdcall *)(xboxkrnl::PKINTERRUPT, void*))Interrupt->ServiceRoutine;
+		BOOLEAN result = ServiceRoutine(Interrupt, Interrupt->ServiceContext);
 	}
 private:
 	bool m_Asserted = false;

--- a/src/core/kernel/exports/EmuKrnlKe.cpp
+++ b/src/core/kernel/exports/EmuKrnlKe.cpp
@@ -301,17 +301,13 @@ void ExecuteDpcQueue()
 		// Set DpcRoutineActive to support KeIsExecutingDpc:
 		KeGetCurrentPrcb()->DpcRoutineActive = TRUE; // Experimental
 		EmuLog(LOG_LEVEL::DEBUG, "Global DpcQueue, calling DPC at 0x%.8X", pkdpc->DeferredRoutine);
-		__try {
-			// Call the Deferred Procedure  :
-			pkdpc->DeferredRoutine(
-				pkdpc,
-				pkdpc->DeferredContext,
-				pkdpc->SystemArgument1,
-				pkdpc->SystemArgument2);
-		} __except (EmuException(GetExceptionInformation()))
-		{
-			EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter!");
-		}
+
+		// Call the Deferred Procedure  :
+		pkdpc->DeferredRoutine(
+			pkdpc,
+			pkdpc->DeferredContext,
+			pkdpc->SystemArgument1,
+			pkdpc->SystemArgument2);
 
 		KeGetCurrentPrcb()->DpcRoutineActive = FALSE; // Experimental
 	}

--- a/src/core/kernel/exports/EmuKrnlKi.cpp
+++ b/src/core/kernel/exports/EmuKrnlKi.cpp
@@ -643,19 +643,14 @@ xboxkrnl::VOID NTAPI xboxkrnl::KiTimerExpiration
 					{
 						/* Call the DPC */
 						EmuLog(LOG_LEVEL::DEBUG, "%s, calling DPC at 0x%.8X", __func__, DpcEntry[i].Routine);
-						__try {
-							// Call the Deferred Procedure  :
-							DpcEntry[i].Routine(
-								DpcEntry[i].Dpc,
-								DpcEntry[i].Context,
-								UlongToPtr(SystemTime.u.LowPart),
-								UlongToPtr(SystemTime.u.HighPart)
-							);
-						}
-						__except (EmuException(GetExceptionInformation()))
-						{
-							EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter!");
-						}
+
+						// Call the Deferred Procedure  :
+						DpcEntry[i].Routine(
+							DpcEntry[i].Dpc,
+							DpcEntry[i].Context,
+							UlongToPtr(SystemTime.u.LowPart),
+							UlongToPtr(SystemTime.u.HighPart)
+						);
 					}
 
 					/* Reset accounting */
@@ -691,19 +686,14 @@ xboxkrnl::VOID NTAPI xboxkrnl::KiTimerExpiration
 					{
 						/* Call the DPC */
 						EmuLog(LOG_LEVEL::DEBUG, "%s, calling DPC at 0x%.8X", __func__, DpcEntry[i].Routine);
-						__try {
-							// Call the Deferred Procedure  :
-							DpcEntry[i].Routine(
-								DpcEntry[i].Dpc,
-								DpcEntry[i].Context,
-								UlongToPtr(SystemTime.u.LowPart),
-								UlongToPtr(SystemTime.u.HighPart)
-							);
-						}
-						__except (EmuException(GetExceptionInformation()))
-						{
-							EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter!");
-						}
+
+						// Call the Deferred Procedure  :
+						DpcEntry[i].Routine(
+							DpcEntry[i].Dpc,
+							DpcEntry[i].Context,
+							UlongToPtr(SystemTime.u.LowPart),
+							UlongToPtr(SystemTime.u.HighPart)
+						);
 					}
 
 					/* Reset accounting */
@@ -736,19 +726,14 @@ xboxkrnl::VOID NTAPI xboxkrnl::KiTimerExpiration
 		{
 			/* Call the DPC */
 			EmuLog(LOG_LEVEL::DEBUG, "%s, calling DPC at 0x%.8X", __func__, DpcEntry[i].Routine);
-			__try {
-				// Call the Deferred Procedure  :
-				DpcEntry[i].Routine(
-					DpcEntry[i].Dpc,
-					DpcEntry[i].Context,
-					UlongToPtr(SystemTime.u.LowPart),
-					UlongToPtr(SystemTime.u.HighPart)
-				);
-			}
-			__except (EmuException(GetExceptionInformation()))
-			{
-				EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter!");
-			}
+
+			// Call the Deferred Procedure  :
+			DpcEntry[i].Routine(
+				DpcEntry[i].Dpc,
+				DpcEntry[i].Context,
+				UlongToPtr(SystemTime.u.LowPart),
+				UlongToPtr(SystemTime.u.HighPart)
+			);
 		}
 
 		/* Lower IRQL if we need to */
@@ -851,19 +836,14 @@ xboxkrnl::VOID FASTCALL xboxkrnl::KiTimerListExpire
 		{
 			/* Call the DPC */
 			EmuLog(LOG_LEVEL::DEBUG, "%s, calling DPC at 0x%.8X", __func__, DpcEntry[i].Routine);
-			__try {
-				// Call the Deferred Procedure  :
-				DpcEntry[i].Routine(
-					DpcEntry[i].Dpc,
-					DpcEntry[i].Context,
-					UlongToPtr(SystemTime.u.LowPart),
-					UlongToPtr(SystemTime.u.HighPart)
-				);
-			}
-			__except (EmuException(GetExceptionInformation()))
-			{
-				EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter!");
-			}
+
+			// Call the Deferred Procedure  :
+			DpcEntry[i].Routine(
+				DpcEntry[i].Dpc,
+				DpcEntry[i].Context,
+				UlongToPtr(SystemTime.u.LowPart),
+				UlongToPtr(SystemTime.u.HighPart)
+			);
 		}
 
 		/* Lower IRQL */

--- a/src/core/kernel/exports/EmuKrnlPs.cpp
+++ b/src/core/kernel/exports/EmuKrnlPs.cpp
@@ -137,19 +137,12 @@ static unsigned int WINAPI PCSTProxy
 		SuspendThread(GetCurrentThread());
 	}
 
-	__try
-	{
-		auto routine = (xboxkrnl::PKSYSTEM_ROUTINE)SystemRoutine;
-		// Debugging notice : When the below line shows up with an Exception dialog and a
-		// message like: "Exception thrown at 0x00026190 in cxbx.exe: 0xC0000005: Access
-		// violation reading location 0xFD001804.", then this is AS-DESIGNED behaviour!
-		// (To avoid repetitions, uncheck "Break when this exception type is thrown").
-		routine(xboxkrnl::PKSTART_ROUTINE(StartRoutine), StartContext);
-	}
-	__except (EmuException(GetExceptionInformation()))
-	{
-		EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter!");
-	}
+	auto routine = (xboxkrnl::PKSYSTEM_ROUTINE)SystemRoutine;
+	// Debugging notice : When the below line shows up with an Exception dialog and a
+	// message like: "Exception thrown at 0x00026190 in cxbx.exe: 0xC0000005: Access
+	// violation reading location 0xFD001804.", then this is AS-DESIGNED behaviour!
+	// (To avoid repetitions, uncheck "Break when this exception type is thrown").
+	routine(xboxkrnl::PKSTART_ROUTINE(StartRoutine), StartContext);
 
 	// This will also handle thread notification :
 	LOG_TEST_CASE("Thread returned from SystemRoutine");
@@ -165,15 +158,8 @@ void PspSystemThreadStartup
 	IN PVOID StartContext
 )
 {
-	__try
-	{
-		(StartRoutine)(StartContext);
-	}
-	__except (EmuException(GetExceptionInformation()))
 	// TODO : Call PspUnhandledExceptionInSystemThread(GetExceptionInformation())
-	{
-		EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter!"); // TODO : Disable?
-	}
+	(StartRoutine)(StartContext);
 
 	xboxkrnl::PsTerminateSystemThread(STATUS_SUCCESS);
 }

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -171,14 +171,7 @@ void SetupPerTitleKeys()
 
 void CxbxLaunchXbe(void(*Entry)())
 {
-	__try
-	{
-		Entry();
-	}
-	__except (EmuException(GetExceptionInformation()))
-	{
-		EmuLog(LOG_LEVEL::WARNING, "Problem with ExceptionFilter");
-	}
+	Entry();
 }
 
 // Entry point address XOR keys per Xbe type (Retail, Debug or Chihiro) :
@@ -1205,6 +1198,8 @@ void CxbxKrnlEmulate(unsigned int reserved_systems, blocks_reserved_t blocks_res
 		ImportLibraries((XbeImportEntry*)CxbxKrnl_Xbe->m_Header.dwNonKernelImportDirAddr);
 	}
 
+	g_ExceptionManager = new ExceptionManager(); // If in need to add VEHs, move this line earlier. (just in case)
+
 	// Launch the XBE :
 	{
 		// Load TLS
@@ -1822,6 +1817,12 @@ void CxbxKrnlShutDown()
 	}
 
 	EmuShared::Cleanup();
+
+	if (g_ExceptionManager) {
+		delete g_ExceptionManager;
+		g_ExceptionManager = nullptr;
+	}
+
 	TerminateProcess(g_CurrentProcessHandle, 0);
 }
 

--- a/src/core/kernel/support/Emu.cpp
+++ b/src/core/kernel/support/Emu.cpp
@@ -217,7 +217,14 @@ bool IsXboxCodeAddress(xbaddr addr)
 	// Note : Not IS_USER_ADDRESS(), that would include host DLL code
 }
 
+#include "distorm.h"
+bool EmuX86_DecodeOpcode(const uint8_t* Eip, _DInst& info);
+void EmuX86_DistormLogInstruction(const uint8_t* Eip, _DInst& info, LOG_LEVEL log_level);
 void genericException(EXCEPTION_POINTERS *e) {
+	_DInst info;
+	if (EmuX86_DecodeOpcode((uint8_t*)e->ContextRecord->Eip, info)) {
+		EmuX86_DistormLogInstruction((uint8_t*)e->ContextRecord->Eip, info, LOG_LEVEL::FATAL);
+	}
 	// Try to report this exception to the debugger, which may allow handling of this exception
 	if (CxbxDebugger::CanReport()) {
 		bool DebuggerHandled = false;
@@ -278,8 +285,6 @@ bool lleTryHandleException(EXCEPTION_POINTERS *e)
 		return true;
 	}
 
-	genericException(e);
-
 	// We do not need EmuException to handle it again.
 	bOverrideException = true;
 
@@ -288,7 +293,7 @@ bool lleTryHandleException(EXCEPTION_POINTERS *e)
 }
 
 // Only for LLE emulation coding (to help performance a little bit better)
-LONG NTAPI lleException(EXCEPTION_POINTERS *e)
+LONG WINAPI lleException(EXCEPTION_POINTERS *e)
 {
 	g_bEmuException = true;
 	LONG result = lleTryHandleException(e) ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
@@ -302,6 +307,7 @@ bool EmuTryHandleException(EXCEPTION_POINTERS *e)
 
 	// Check if lle exception is already called first before emu exception.
 	if (bOverrideException) {
+		genericException(e);
 		return false;
 	}
 
@@ -346,7 +352,7 @@ bool EmuTryHandleException(EXCEPTION_POINTERS *e)
 	return false;
 }
 
-int EmuException(EXCEPTION_POINTERS *e)
+long WINAPI EmuException(struct _EXCEPTION_POINTERS* e)
 {
 	g_bEmuException = true;
 	LONG result = EmuTryHandleException(e) ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
@@ -355,6 +361,7 @@ int EmuException(EXCEPTION_POINTERS *e)
 }
 
 // exception handle for that tough final exit :)
+// TODO: We might just well as delete this, duplicate of EmuExceptionNonBreakpointUnhandledShow
 int ExitException(LPEXCEPTION_POINTERS e)
 {
     static int count = 0;
@@ -395,15 +402,25 @@ ExceptionManager::ExceptionManager()
 ExceptionManager::~ExceptionManager()
 {
 	for (auto i_handle : veh_handles) {
-		RemoveVectoredExceptionHandler(i_handle);
+		(void)RemoveVectoredExceptionHandler(i_handle);
 	}
 	veh_handles.clear();
+#ifdef _MSC_VER // Windows' C++ exception is using SEH, we cannot use VEH for error reporter system.
+	(void)SetUnhandledExceptionFilter(nullptr);
+#endif
 }
 
 // Require to be set right before we call xbe's entry point.
 void ExceptionManager::EmuX86_Init()
 {
 	accept_request = false; // Do not allow add VEH during emulation.
+	AddVEH(1, lleException, true); // Front line call
+	// Last call plus show exception error than terminate early.
+#ifdef _MSC_VER // Windows' C++ exception is using SEH, we cannot use VEH for error reporter system.
+	(void)SetUnhandledExceptionFilter(EmuException);
+#else // Untested for other platforms, may will behave as expected.
+	AddVEH(0, EmuException, true);
+#endif
 }
 
 bool ExceptionManager::AddVEH(unsigned long first, PVECTORED_EXCEPTION_HANDLER veh_handler)

--- a/src/core/kernel/support/Emu.h
+++ b/src/core/kernel/support/Emu.h
@@ -35,8 +35,6 @@
 std::string FormatTitleId(uint32_t title_id);
 
 // exception handler
-extern LONG NTAPI lleException(EXCEPTION_POINTERS *e);
-int EmuException(EXCEPTION_POINTERS *e);
 class ExceptionManager {
 public:
 	ExceptionManager();

--- a/src/core/kernel/support/Emu.h
+++ b/src/core/kernel/support/Emu.h
@@ -37,6 +37,22 @@ std::string FormatTitleId(uint32_t title_id);
 // exception handler
 extern LONG NTAPI lleException(EXCEPTION_POINTERS *e);
 int EmuException(EXCEPTION_POINTERS *e);
+class ExceptionManager {
+public:
+	ExceptionManager();
+	virtual ~ExceptionManager();
+	// We want to make sure the core's exception is trigger front and last of exception management. For two reasons:
+	// Performance wise for LLE emulation and general emulation, to remove false positive exception from drivers, before we show an actual fatal error message.
+	void EmuX86_Init();
+	// If any custom VEH should be add here than try on their own. See private AddVEH function's comment.
+	bool AddVEH(unsigned long first, PVECTORED_EXCEPTION_HANDLER veh_handler);
+private:
+	std::vector<void*> veh_handles;
+	bool accept_request;
+	// Since Vectored Exception Handlers are global than per thread, we only need to register once.
+	bool AddVEH(unsigned long first, PVECTORED_EXCEPTION_HANDLER veh_handler, bool override_request);
+};
+extern class ExceptionManager* g_ExceptionManager;
 
 // print call stack trace
 #ifdef _DEBUG

--- a/src/devices/EmuNVNet.cpp
+++ b/src/devices/EmuNVNet.cpp
@@ -617,7 +617,9 @@ bool NVNetDevice::PCAPInit()
 	char errorBuffer[PCAP_ERRBUF_SIZE];
 
 	// Open the desired network adapter
+#ifdef _MSC_VER // TODO: Implement loaded pcap driver detection for cross-platform support or make a requirement for non-Windows platform.
 	__try {
+#endif
 		char buffer[MAX_PATH];
 		snprintf(buffer, MAX_PATH, "\\Device\\NPF_%s", m_HostAdapterName.c_str());
 		m_AdapterHandle = pcap_open_live(buffer,
@@ -626,10 +628,12 @@ bool NVNetDevice::PCAPInit()
 			1,		// Read Timeout
 			errorBuffer
 		);
+#ifdef _MSC_VER
 	} __except(EXCEPTION_EXECUTE_HANDLER) {
 		m_AdapterHandle = nullptr;
 		snprintf(errorBuffer, PCAP_ERRBUF_SIZE, "Could not initialize pcap");
 	}
+#endif
 
 	if (m_AdapterHandle == nullptr) {
 		EmuLog(LOG_LEVEL::WARNING, "Unable to open Network Adapter:\n%s\nNetworking will be disabled", errorBuffer);


### PR DESCRIPTION
close #1860 

There's only two codebase does require SEH unfortunately. However, I have implement macro check to enable support for other compilers. Other compilers using VEH for error report system could make false positive report which is untested. If other compilers do produce false positive report, then we need to disable it.

And other SEH requirement is to allow Windows' users without winpcap driver to able run emulation. It may be possible to implement VEH support. Currently, I don't have have a method for it.

---
Since Windows' C++ exception is using SEH, the only solution without apply per thread's SEH method is to use `SetUnhandledExceptionFilter` function. Plus there is a chance error report system does not get caught in unhandled exception filter. With VEH testing, it does get caught every time and working as intended except for Windows' C++ exception's SEH usage conflict.