### PR TITLE
Treat X_D3DSCM_NORESERVEDCONSTANTS as a flag

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3905,8 +3905,9 @@ void UpdateViewPortOffsetAndScaleConstants()
 	// Store viewport offset and scale in constant registers 58 (c-38) and
 	// 59 (c-37) used for screen space transformation.
 	// We only do this if X_D3DSCM_NORESERVEDCONSTANTS is not set, since enabling this flag frees up these registers for shader used
-	if (g_Xbox_VertexShaderConstantMode != X_D3DSCM_NORESERVEDCONSTANTS)
-	{
+	// Treat this as a flag
+	// Test Case: GTA III, Soldier of Fortune II
+	if (!(g_Xbox_VertexShaderConstantMode & X_D3DSCM_NORESERVEDCONSTANTS)) {
 		g_pD3DDevice->SetVertexShaderConstantF(X_D3DSCM_RESERVED_CONSTANT_SCALE + X_D3DSCM_CORRECTION, vScale, 1);
 		g_pD3DDevice->SetVertexShaderConstantF(X_D3DSCM_RESERVED_CONSTANT_OFFSET + X_D3DSCM_CORRECTION, vOffset, 1);
 	}


### PR DESCRIPTION
For example, GTA III sets the constant mode to `0x11`, but we check for `constantMode == 0x10`
And proceed to overwrite some normally reserved constants that the title should be in control of

Fixes Soldier of Fortune II
(GTA III unchanged in master)

Before:
![image](https://user-images.githubusercontent.com/9897874/83519063-74cf2580-a52f-11ea-939c-cf1bd4effd3e.png)

After:
![image](https://user-images.githubusercontent.com/9897874/83518841-15711580-a52f-11ea-89c2-697cb6d708a4.png)
