### PR TITLE
Couple DirectSound Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ file (GLOB CXBXR_HEADER_EMU
  "${CXBXR_ROOT_DIR}/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/DSOUND/DirectSound/DirectSoundLogging.hpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.hpp"
+ "${CXBXR_ROOT_DIR}/src/core/hle/DSOUND/XbDSoundFuncs.hpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/DSOUND/XbDSoundLogging.hpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/DSOUND/XbDSoundTypes.h"
  "${CXBXR_ROOT_DIR}/src/core/hle/DSOUND/common/XbInternalStruct.hpp"

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
@@ -465,8 +465,16 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Lock)
     if (pThis->Host_lock.pLockPtr2 != nullptr) {
         *ppvAudioPtr2 = pThis->X_lock.pLockPtr2 = pThis->X_BufferCache;
         *pdwAudioBytes2 = pThis->X_lock.dwLockBytes2 = DSoundBufferGetXboxBufferSize(pThis->EmuFlags, pThis->Host_lock.dwLockBytes2);
-    } else if (ppvAudioPtr2 != xbnullptr) {
-        *ppvAudioPtr2 = xbnullptr;
+    } else {
+        // If secondary pointers are not used, then set them as zero.
+        // There are applications bug didn't check for audio pointer that is null pointer which should not use invalid audio bytes.
+        // Since internal functions do set them zero. We'll set them here as well.
+        if (ppvAudioPtr2 != xbnullptr) {
+            *ppvAudioPtr2 = xbnullptr;
+        }
+        if (pdwAudioBytes2 != xbnullptr) {
+            *pdwAudioBytes2 = 0;
+        }
     }
 
     RETURN_RESULT_CHECK(hRet);

--- a/src/core/hle/DSOUND/XbDSoundFuncs.hpp
+++ b/src/core/hle/DSOUND/XbDSoundFuncs.hpp
@@ -1,0 +1,42 @@
+// ******************************************************************
+// *
+// *  This file is part of the Cxbx project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// *
+// *  (c) 2020 RadWolfie
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+#pragma once
+
+#include <cstdint>
+#include "XbDSoundTypes.h"
+
+namespace XTL {
+    namespace DSOUND {
+
+    static inline uint16_t PresetChannelDefault(uint32_t Xb_flags)
+    {
+        if (Xb_flags & XTL_DSBCAPS_CTRL3D) {
+            return 1; // 3D audio only accept mono channel
+        }
+        return 2; // Default to stereo channel
+    }
+
+    }
+}

--- a/src/core/hle/DSOUND/common/windows/WFXformat.hpp
+++ b/src/core/hle/DSOUND/common/windows/WFXformat.hpp
@@ -28,6 +28,7 @@
 #include <mmreg.h>
 #include "core/kernel/init/CxbxKrnl.h"
 #include "core/hle/DSOUND/XbDSoundTypes.h"
+#include "core/hle/DSOUND/XbDSoundFuncs.hpp"
 
 #include "Logging.h"
 #include "core/hle/DSOUND/DirectSound/DirectSoundLogging.hpp"
@@ -183,7 +184,7 @@ static void WFXformat_SanityFix(
     // Generic enforcement
     // If Xbox applications supply invalid total channels, enforce to use either mono or stereo channel
     if (Host_pwfxFormat->Format.nChannels == 0 || Host_pwfxFormat->Format.nChannels > 6) {
-        Host_pwfxFormat->Format.nChannels = 2;
+        Host_pwfxFormat->Format.nChannels = XTL::DSOUND::PresetChannelDefault(Xb_flags);
         isNotSanity = true;
     }
     // If nSamplesPerSec is zero'd then use 44.1kHz by default
@@ -265,7 +266,7 @@ static CODEC_FORMAT WFXformat_SyncHostFormat(
 
     // If no format is provided, then use default.
     if (Xb_wfx_ptr == xbnullptr) {
-        WFXformat_GeneratePCMFormat(2, 44100, 16, Host_wfxFormat);
+        WFXformat_GeneratePCMFormat(XTL::DSOUND::PresetChannelDefault(Xb_flags), 44100, 16, Host_wfxFormat);
         require_validate = false;
     }
     // HACK: This is a special sound buffer, create dummy WAVEFORMATEX data.
@@ -274,7 +275,7 @@ static CODEC_FORMAT WFXformat_SyncHostFormat(
     // WAVEFORMATEX structure by default.
     else if ((Xb_flags & (XTL_DSBCAPS_MIXIN | XTL_DSBCAPS_FXIN | XTL_DSBCAPS_FXIN2)) > 0) {
         EmuLog(LOG_LEVEL::WARNING, "Creating dummy WAVEFORMATEX (pdsbd->Xb_lpwfxFormat = xbnullptr)...");
-        WFXformat_GeneratePCMFormat(2, 44100, 16, Host_wfxFormat);
+        WFXformat_GeneratePCMFormat(XTL::DSOUND::PresetChannelDefault(Xb_flags), 44100, 16, Host_wfxFormat);
         require_validate = false;
     }
     // Otherwise, let's process given format.
@@ -305,7 +306,7 @@ static CODEC_FORMAT WFXformat_SyncHostFormat(
             // Both 0 and default will use static structure until given a valid one.
             case 0:
                 // NOTE: This is currently a hack for ability to create buffer class with DSBCAPS_LOCDEFER flag.
-                WFXformat_GeneratePCMFormat(2, 44100, 16, Host_wfxFormat);
+                WFXformat_GeneratePCMFormat(XTL::DSOUND::PresetChannelDefault(Xb_flags), 44100, 16, Host_wfxFormat);
                 require_validate = false;
                 LOG_TEST_CASE("WAVE_FORMAT_(0) found");
                 break;
@@ -331,7 +332,7 @@ static CODEC_FORMAT WFXformat_SyncHostFormat(
         }
         // Any unknown formats will be using default PCM format.
         else {
-            WFXformat_GeneratePCMFormat(2, 44100, 16, Host_wfxFormat);
+            WFXformat_GeneratePCMFormat(XTL::DSOUND::PresetChannelDefault(Xb_flags), 44100, 16, Host_wfxFormat);
         }
     }
     // Forward xbox format to internal XTL::CDirectSoundVoice class.


### PR DESCRIPTION
**low risk**

---
Tester reported Sonic Mega Collection Plus' issue with "DirectSoundBuffer Lock Failed!" popup message. I took a look closer and found out `dwBytes` is way too large which made application perform miscalculation for buffer size to read from. It turn out application doesn't always check `ppvAudioPtr2` for null pointer. With commit 503ce9b fix, title is able to continue further.

Delta Force - Black Hawk Down produce an invalid parameter error from host's sound buffer creation.
Second commit 1a83cc7 resolve invalid parameter since it was missing a check for 3D audio buffer usage which only allow mono channel.