### PR TITLE
Rewrite HalReadSMCTrayState to match original kernel implementation.

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/hal.h
+++ b/import/OpenXDK/include/xboxkrnl/hal.h
@@ -15,7 +15,7 @@
 // ******************************************************************
 // * HalReadSMCTrayState
 // ******************************************************************
-XBSYSAPI EXPORTNUM(9) VOID NTAPI HalReadSMCTrayState
+XBSYSAPI EXPORTNUM(9) NTSTATUS NTAPI HalReadSMCTrayState
 (
 	DWORD*	State,
 	DWORD*	Count

--- a/src/devices/SMCDevice.h
+++ b/src/devices/SMCDevice.h
@@ -44,20 +44,20 @@
 
 // From https://web.archive.org/web/20100617022549/https://www.xbox-linux.org/wiki/PIC :
 // Command	Description
-#define SMC_COMMAND_VERSION 0x01	// PIC version string
-//0x03	tray state
-#define SMC_COMMAND_AV_PACK 0x04	// A / V Pack state
-#define SMC_COMMAND_CPU_TEMP 0x09 // CPU temperature (°C)
-#define SMC_COMMAND_MOTHERBOARD_TEMP 0x0A // motherboard temperature (°C)
+#define SMC_COMMAND_VERSION            0x01	// PIC version string
+#define SMC_COMMAND_TRAY_STATE         0x03 //tray state
+#define SMC_COMMAND_AV_PACK            0x04	// A / V Pack state
+#define SMC_COMMAND_CPU_TEMP           0x09 // CPU temperature (°C)
+#define SMC_COMMAND_MOTHERBOARD_TEMP   0x0A // motherboard temperature (°C)
 //0x0F	reads scratch register written with 0x0E
 #define SMC_COMMAND_POWER_FAN_READBACK 0x10 // Current power fan speed (0-50)
 //0x11	interrupt reason
 //0x18	reading this reg locks up xbox in "overheated" state
-#define SMC_COMMAND_SCRATCH 0x1B	// scratch register for the original kernel
-#define SMC_COMMAND_CHALLENGE_1C 0x1C	// random number for boot challenge
-#define SMC_COMMAND_CHALLENGE_1D 0x1D	// random number for boot challenge
-#define SMC_COMMAND_CHALLENGE_1E 0x1E	// random number for boot challenge
-#define SMC_COMMAND_CHALLENGE_1F 0x1F	// random number for boot challenge
+#define SMC_COMMAND_SCRATCH            0x1B	// scratch register for the original kernel
+#define SMC_COMMAND_CHALLENGE_1C       0x1C	// random number for boot challenge
+#define SMC_COMMAND_CHALLENGE_1D       0x1D	// random number for boot challenge
+#define SMC_COMMAND_CHALLENGE_1E       0x1E	// random number for boot challenge
+#define SMC_COMMAND_CHALLENGE_1F       0x1F	// random number for boot challenge
 //
 // Writing:
 //


### PR DESCRIPTION
As always I used my kernel dump as reference to create the function. I left the TRAY_OPEN hack in place to be fixed in the future once the Hal library is more robust.