### PR TITLE
Update FscSetCacheSize to match original kernel

### DIFF
--- a/import/OpenXDK/include/xboxkrnl/xbox.h
+++ b/import/OpenXDK/include/xboxkrnl/xbox.h
@@ -73,6 +73,8 @@
 #define AV_OPTION_CGMS                    18
 #define AV_OPTION_WIDESCREEN              19
 
+VOID InitializeFscCacheEvent();
+
 // ******************************************************************
 // * 0x0001 - AvGetSavedDataAddress()
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnlFs.cpp
+++ b/src/core/kernel/exports/EmuKrnlFs.cpp
@@ -70,11 +70,11 @@ XBSYSAPI EXPORTNUM(36) xboxkrnl::VOID NTAPI xboxkrnl::FscInvalidateIdleBlocks()
 	LOG_UNIMPLEMENTED();
 }
 
-static xboxkrnl::KEVENT FscCacheEvent;
+static xboxkrnl::KEVENT g_FscCacheEvent;
 
 xboxkrnl::VOID xboxkrnl::InitializeFscCacheEvent()
 {
-    KeInitializeEvent(&FscCacheEvent, SynchronizationEvent, TRUE);
+    KeInitializeEvent(&g_FscCacheEvent, SynchronizationEvent, TRUE);
 }
 
 // ******************************************************************
@@ -88,7 +88,7 @@ XBSYSAPI EXPORTNUM(37) xboxkrnl::NTSTATUS NTAPI xboxkrnl::FscSetCacheSize
 	LOG_FUNC_ONE_ARG(NumberOfCachePages);
 
 	NTSTATUS ret = STATUS_SUCCESS;
-	KeWaitForSingleObject(&FscCacheEvent, Executive, 0, 0, 0);
+	KeWaitForSingleObject(&g_FscCacheEvent, Executive, 0, 0, 0);
 	UCHAR orig_irql = KeRaiseIrqlToDpcLevel();
 
 	if (NumberOfCachePages > FSCACHE_MAXIMUM_NUMBER_OF_CACHE_PAGES) {
@@ -108,7 +108,7 @@ XBSYSAPI EXPORTNUM(37) xboxkrnl::NTSTATUS NTAPI xboxkrnl::FscSetCacheSize
 	}
 
 	KfLowerIrql(orig_irql);
-	KeSetEvent(&FscCacheEvent, 0, 0);
+	KeSetEvent(&g_FscCacheEvent, 0, 0);
 	RETURN(ret);
 }
 

--- a/src/core/kernel/exports/EmuKrnlFs.cpp
+++ b/src/core/kernel/exports/EmuKrnlFs.cpp
@@ -70,6 +70,9 @@ XBSYSAPI EXPORTNUM(36) xboxkrnl::VOID NTAPI xboxkrnl::FscInvalidateIdleBlocks()
 	LOG_UNIMPLEMENTED();
 }
 
+static xboxkrnl::KEVENT FscCacheEvent;
+static xboxkrnl::PKEVENT FscCacheEventPtr = nullptr;
+
 // ******************************************************************
 // * 0x0025 - FscSetCacheSize()
 // ******************************************************************
@@ -80,18 +83,33 @@ XBSYSAPI EXPORTNUM(37) xboxkrnl::NTSTATUS NTAPI xboxkrnl::FscSetCacheSize
 {
 	LOG_FUNC_ONE_ARG(NumberOfCachePages);
 
-	NTSTATUS ret = STATUS_SUCCESS;
+	if (FscCacheEventPtr == nullptr) {
+		KeInitializeEvent(&FscCacheEvent, SynchronizationEvent, 1);
+		FscCacheEventPtr = &FscCacheEvent;
+	}
 
-	if (NumberOfCachePages > FSCACHE_MAXIMUM_NUMBER_OF_CACHE_PAGES)
+	NTSTATUS ret = STATUS_SUCCESS;
+	KeWaitForSingleObject(FscCacheEventPtr, Executive, 0, 0, 0);
+	UCHAR orig_irql = KeRaiseIrqlToDpcLevel();
+
+	if (NumberOfCachePages > FSCACHE_MAXIMUM_NUMBER_OF_CACHE_PAGES) {
 		ret = STATUS_INVALID_PARAMETER;
-	else
-	{
-		// TODO : Actually allocate file system cache pages, for example do something like this :
-		// if (NumberOfCachePages < g_FscNumberOfCachePages) FscShrinkCacheSize(NumberOfCachePages)
-		// if (NumberOfCachePages > g_FscNumberOfCachePages) FscGrowCacheSize(NumberOfCachePages), possibly return STATUS_INSUFFICIENT_RESOURCES
+	}
+	else {
+		// TODO : Actually allocate file system cache pages.
+#if 0
+		if (NumberOfCachePages > g_FscNumberOfCachePages) {
+			ret = FscGrowCacheSize(NumberOfCachePages);
+		}
+		else if (NumberOfCachePages < g_FscNumberOfCachePages) {
+			ret = FscShrinkCacheSize(NumberOfCachePages);
+		}
+#endif
 		g_FscNumberOfCachePages = NumberOfCachePages;
 	}
 
+	KfLowerIrql(orig_irql);
+	KeSetEvent(FscCacheEventPtr, 0, 0);
 	RETURN(ret);
 }
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1285,6 +1285,8 @@ __declspec(noreturn) void CxbxKrnlInit
     // But with this, we can replace some busy loops with sleeps.
     timeBeginPeriod(1);
 
+    xboxkrnl::InitializeFscCacheEvent();
+
 	// update caches
 	CxbxKrnl_TLS = pTLS;
 	CxbxKrnl_TLSData = pTLSData;


### PR DESCRIPTION
I used my kernel dump to rewrite this function to have a better skeleton. The underlying functions that do all the real work are still missing but those can be added in the future.