### PR TITLE
Update issue template + add action to automatically close issues not following the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -4,11 +4,40 @@ about: Issue template.
 title: ''
 labels: ''
 assignees: ''
-
 ---
-
 <!--
-Questions can be asked on Discord: https://discord.gg/26Xjx23
-If this is an issue specifically related to one game, please report it at https://github.com/Cxbx-Reloaded/game-compatibility
-Any emulation/general issues like crashes when a controller is connected, or regressions across several titles can be reported here.
+ISSUES NOT UTILIZING THE TEMPLATE BELOW WILL BE CLOSED!
+-->
+<!--
+Please read https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/blob/master/README.md and https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/wiki/Frequently-Asked-Questions-(FAQ) before opening an issue.
+Remember, the GitHub Issue Tracker is not the place to ask for support or to submit game compatibility https://github.com/Cxbx-Reloaded/game-compatibility/blob/master/README.md reports.
+You must use our forum on Discord https://discord.gg/26Xjx23 for that.
+Otherwise, for any other emulation/general issues like crashes when a controller is connected, or regressions across several titles, feel free to report your issue here.
+-->
+
+
+## Quick summary
+<!--
+Please briefly describe what is not working correctly.
+-->
+
+
+## Details
+<!--
+Please describe the problem as accurately as possible.
+-->
+
+
+### System Configuration:
+<!--
+Please provide your system configuration
+-->
+* OS
+* CPU
+* GPU
+* etc.
+
+### Additional Information (if any):
+<!--
+Anything else you deem to be important
 -->

--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -1,0 +1,16 @@
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  auto_close_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Automatically close issues that don't follow the issue template
+        uses: ergo720/auto-close-issues@v1.0.4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-close-message: "@${issue.user.login}: your issue has been automatically closed because it does not follow the issue template."  # optional property
+          closed-issues-label: "invalid"  # optional property

--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -1,6 +1,6 @@
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   auto_close_issues:


### PR DESCRIPTION
This adds a github action which compares the issue body with the template and automatically closes it if it does not follow the template and adds the invalid label. ~~It can also automatically reopen the issue if this is edited later and now follows the template.~~ The intent of this is to reduce the burden on the maintainers of manually closing invalid issues (which happens fairly often on this repository).