### PR TITLE
Add Argument Results Verbose

### DIFF
--- a/src/common/Logging.h
+++ b/src/common/Logging.h
@@ -393,6 +393,44 @@ extern thread_local std::string _logThreadPrefix;
 		} } while (0); \
 	}
 
+#define LOG_FUNC_BEGIN_ARG_RESULT_NO_INIT \
+	do { if(g_bPrintfOn) { \
+		bool _had_arg = false; \
+		std::stringstream msg; \
+		msg << _logThreadPrefix << _logFuncPrefix << " returns OUT {";
+
+#define LOG_FUNC_BEGIN_ARG_RESULT \
+		LOG_CHECK_ENABLED(LOG_LEVEL::DEBUG) { \
+			LOG_FUNC_BEGIN_ARG_RESULT_NO_INIT
+
+// LOG_FUNC_ARG_RESULT writes output via all available ostream << operator overloads, sanitizing and adding detail where possible
+#define LOG_FUNC_ARG_RESULT(arg) \
+		_had_arg = true; \
+		msg << LOG_ARG_START << "*"#arg << " : "; \
+		if (arg != nullptr) { \
+			msg << _log_sanitize(*arg); \
+		} else { \
+			msg << "NOT SET"; \
+		}
+
+// LOG_FUNC_ARG_RESULT_TYPE writes result output using the overloaded << operator of the given type
+#define LOG_FUNC_ARG_RESULT_TYPE(type, arg) \
+		_had_arg = true; \
+		msg << LOG_ARG_START << "*"#arg << " : "; \
+		if (arg != nullptr) { \
+			msg << (type)*arg; \
+		} else { \
+			msg << "NOT SET"; \
+		}
+
+// LOG_FUNC_END_ARG_RESULT closes off function and optional argument result logging
+#define LOG_FUNC_END_ARG_RESULT \
+			if (_had_arg) msg << "\n"; \
+			msg << "};\n"; \
+			std::cout << msg.str(); \
+		} } while (0); \
+	}
+
 // LOG_FUNC_RESULT logs the function return result
 #define LOG_FUNC_RESULT(r) \
 	std::cout << _logThreadPrefix << _logFuncPrefix << " returns " << _log_sanitize(r) << "\n";

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -245,6 +245,10 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreate)
         *ppDirectSound = g_pDSound8;
     }
 
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT_TYPE(void*, ppDirectSound)
+    LOG_FUNC_END_ARG_RESULT;
+
     RETURN_RESULT_CHECK(hRet);
 }
 
@@ -594,9 +598,11 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSound_GetCaps)
         // TODO: What are the max values for 2D and 3D Buffers? Once discover, then perform real time update in global variable.
         pDSCaps->dwFree2DBuffers = (pDSCaps->dwFreeBufferSGEs == 0 ? 0 : 0x200 /* TODO: Replace me to g_dwFree2DBuffers*/ );
         pDSCaps->dwFree3DBuffers = (pDSCaps->dwFreeBufferSGEs == 0 ? 0 : 0x200 /* TODO: Replace me to g_dwFree3DBuffers*/ );
-
-        EmuLog(LOG_LEVEL::DEBUG, "X_DSCAPS: dwFree2DBuffers = %8X | dwFree3DBuffers = %8X | dwFreeBufferSGEs = %08X | dwMemAlloc = %08X", pDSCaps->dwFree2DBuffers, pDSCaps->dwFree3DBuffers, pDSCaps->dwFreeBufferSGEs, pDSCaps->dwMemoryAllocated);
     }
+
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT(pDSCaps)
+    LOG_FUNC_END_ARG_RESULT;
 
     return S_OK;
 }
@@ -644,6 +650,10 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSound_GetSpeakerConfig)
 
     // TODO: Fix me!
     *pdwSpeakerConfig = 0; // STEREO
+
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT(pdwSpeakerConfig)
+    LOG_FUNC_END_ARG_RESULT;
 
     return S_OK;
 }

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
@@ -231,7 +231,7 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
                           pHybridBuffer->p_CDSVoice);
         pEmuBuffer->EmuBufferDesc = DSBufferDesc;
 
-        EmuLog(LOG_LEVEL::DEBUG, "DirectSoundCreateBuffer, *ppBuffer := 0x%08X, bytes := 0x%08X", *ppBuffer, pEmuBuffer->EmuBufferDesc.dwBufferBytes);
+        EmuLog(LOG_LEVEL::DEBUG, "DirectSoundCreateBuffer: bytes := 0x%08X", pEmuBuffer->EmuBufferDesc.dwBufferBytes);
 
         hRet = DSoundBufferCreate(&DSBufferDesc, pEmuBuffer->EmuDirectSoundBuffer8);
         if (FAILED(hRet)) {
@@ -258,7 +258,11 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateBuffer)
         }
     }
 
-    return hRet;
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT(ppBuffer)
+    LOG_FUNC_END_ARG_RESULT;
+
+    RETURN(hRet);
 }
 
 // ******************************************************************
@@ -302,7 +306,12 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetCurrentPosition)
     EmuDirectSoundBuffer* pThis = pHybridThis->emuDSBuffer;
     HRESULT hRet = HybridDirectSoundBuffer_GetCurrentPosition(pThis->EmuDirectSoundBuffer8, pdwCurrentPlayCursor, pdwCurrentWriteCursor, pThis->EmuFlags);
 
-    return hRet;
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT(pdwCurrentPlayCursor)
+        LOG_FUNC_ARG_RESULT(pdwCurrentWriteCursor)
+    LOG_FUNC_END_ARG_RESULT;
+
+    RETURN(hRet);
 }
 
 // ******************************************************************
@@ -370,7 +379,11 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_GetStatus)
         hRet = DSERR_INVALIDPARAM;
     }
 
-    return hRet;
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT_TYPE(DSBSTATUS_FLAG, pdwStatus)
+    LOG_FUNC_END_ARG_RESULT;
+
+    RETURN(hRet);
 }
 
 // ******************************************************************
@@ -450,7 +463,7 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Lock)
     }
 
     if (hRet != DS_OK) {
-        CxbxKrnlCleanup("DirectSoundBuffer Lock Failed!");
+        CxbxKrnlCleanup("IDirectSoundBuffer_Lock Failed!");
     }
 
     // Host lock position
@@ -476,6 +489,13 @@ HRESULT WINAPI XTL::EMUPATCH(IDirectSoundBuffer_Lock)
             *pdwAudioBytes2 = 0;
         }
     }
+
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT(ppvAudioPtr1)
+        LOG_FUNC_ARG_RESULT(pdwAudioBytes1)
+        LOG_FUNC_ARG_RESULT(ppvAudioPtr2)
+        LOG_FUNC_ARG_RESULT(pdwAudioBytes2)
+    LOG_FUNC_END_ARG_RESULT;
 
     RETURN_RESULT_CHECK(hRet);
 }

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundStream.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundStream.cpp
@@ -256,7 +256,9 @@ HRESULT WINAPI XTL::EMUPATCH(DirectSoundCreateStream)
         (*ppStream)->Xb_Status = 0;
         //TODO: Implement mixbin variable support. Or just merge pdssd struct into DS Stream class.
 
-        EmuLog(LOG_LEVEL::DEBUG, "DirectSoundCreateStream, *ppStream := 0x%.08X", *ppStream);
+        LOG_FUNC_BEGIN_ARG_RESULT
+            LOG_FUNC_ARG_RESULT(ppStream)
+        LOG_FUNC_END_ARG_RESULT;
 
         hRet = DSoundBufferCreate(&DSBufferDesc, (*ppStream)->EmuDirectSoundBuffer8);
         if (FAILED(hRet)) {
@@ -486,8 +488,12 @@ HRESULT WINAPI XTL::EMUPATCH(CDirectSoundStream_GetStatus)
         *pdwStatus = 0;
     }
 
-    EmuLog(LOG_LEVEL::DEBUG, "SET dwStatus = %08X; packet array size: %d",
-        *pdwStatus, pThis->Host_BufferPacketArray.size());
+    // Only used for debugging any future issues with custom stream's packet management
+    EmuLog(LOG_LEVEL::DEBUG, "packet array size: %d", pThis->Host_BufferPacketArray.size());
+
+    LOG_FUNC_BEGIN_ARG_RESULT
+        LOG_FUNC_ARG_RESULT_TYPE(DSSSTATUS_FLAG, pdwStatus)
+    LOG_FUNC_END_ARG_RESULT;
 
     return hRet;
 }


### PR DESCRIPTION
With commit 54005aa, we no longer need to create our own verbose result in the middle or end of emulated function. However, we still need to manually add ourselves for any `OUT` parameters we have in the codebase.

Plus updated HLE DirectSound to use new feature.

---
Functional example preview:
```
[0x533C] DSBUFFERIDirectSoundBuffer_GetStatus(
   pHybridThis          : 13B9312C
 OUT pdwStatus          : 0x0D24FCEC
);
[0x533C] DSBUFFERIDirectSoundBuffer_GetStatus returns OUT {
   *pdwStatus           : (DSBSTATUS_FLAG)0x00000001 = X_DSBSTATUS_PLAYING
};
```
and
```
[0x7368] DSBUFFERIDirectSoundBuffer_GetStatus(
   pHybridThis          : 13B93130
 OUT pdwStatus          : 0x00000000
);
[0x7368] DSBUFFERIDirectSoundBuffer_GetStatus returns OUT {
   *pdwStatus           : NOT SET
};
```