### PR TITLE
Migrate Customs in One Batch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,30 +29,12 @@ endif()
 # Cxbx-Reloaded projects
 set(CXBXR_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
-add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/libtom")
-
-find_package(Git)
-
-if(Git_FOUND)
- message("Git found: ${GIT_EXECUTABLE}")
-
- execute_process(
-  COMMAND git describe --always --tags --first-parent
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE _GIT_VERSION
-  OUTPUT_STRIP_TRAILING_WHITESPACE
- )
-
- message("Git version: " ${_GIT_VERSION})
-else()
- set(_GIT_VERSION "unknown")
-endif()
-
-# Appears to update whenever define has changed.
-configure_file(
- "${CXBXR_ROOT_DIR}/src/version.h.in" "${CXBXR_ROOT_DIR}/src/version.h" @ONLY
- NEWLINE_STYLE LF
+add_custom_target(misc-batch
+  ${CMAKE_COMMAND} -P ${CXBXR_ROOT_DIR}/projects/misc/batch.cmake
+  WORKING_DIRECTORY ${CXBXR_ROOT_DIR}
 )
+
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/libtom")
 
 #add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/vsbc")
 
@@ -416,6 +398,6 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
 endif()
 
 # Cxbx-Reloaded project with third-party libraries
-set_target_properties(cxbx cxbxr-ldr cxbxr-emu subhook XbSymbolDatabase libtommath libtomcrypt
+set_target_properties(cxbx cxbxr-ldr cxbxr-emu misc-batch subhook XbSymbolDatabase libtommath libtomcrypt
  PROPERTIES FOLDER Cxbx-Reloaded
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,8 @@ endif()
 set(CXBXR_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 add_custom_target(misc-batch
-  ${CMAKE_COMMAND} -P ${CXBXR_ROOT_DIR}/projects/misc/batch.cmake
+  ${CMAKE_COMMAND} -DTargetRunTimeDir=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>
+  -P ${CXBXR_ROOT_DIR}/projects/misc/batch.cmake
   WORKING_DIRECTORY ${CXBXR_ROOT_DIR}
 )
 

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -193,10 +193,3 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
 endif()
 
 add_dependencies(cxbx cxbxr-ldr cxbxr-emu misc-batch)
-
-set(CXBXR_GLEW_DLL "${CXBXR_ROOT_DIR}/import/glew-2.0.0/bin/Release/Win32/glew32.dll")
-
-# Copy glew32.dll to build type's folder after build.
-add_custom_command(TARGET cxbx POST_BUILD
- COMMAND ${CMAKE_COMMAND} -E copy ${CXBXR_GLEW_DLL} $<TARGET_FILE_DIR:cxbx>
-)

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -192,7 +192,7 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
   add_dependencies(cxbx cxbxr-debugger)
 endif()
 
-add_dependencies(cxbx cxbxr-ldr cxbxr-emu)
+add_dependencies(cxbx cxbxr-ldr cxbxr-emu misc-batch)
 
 set(CXBXR_GLEW_DLL "${CXBXR_ROOT_DIR}/import/glew-2.0.0/bin/Release/Win32/glew32.dll")
 

--- a/projects/cxbxr-emu/CMakeLists.txt
+++ b/projects/cxbxr-emu/CMakeLists.txt
@@ -165,10 +165,3 @@ target_link_libraries(cxbxr-emu
 )
 
 add_dependencies(cxbxr-emu cxbxr-ldr misc-batch)
-
-set(CXBXR_GLEW_DLL "${CXBXR_ROOT_DIR}/import/glew-2.0.0/bin/Release/Win32/glew32.dll")
-
-# Copy glew32.dll to build type's folder after build.
-add_custom_command(TARGET cxbxr-emu POST_BUILD
- COMMAND ${CMAKE_COMMAND} -E copy ${CXBXR_GLEW_DLL} $<TARGET_FILE_DIR:cxbxr-emu>
-)

--- a/projects/cxbxr-emu/CMakeLists.txt
+++ b/projects/cxbxr-emu/CMakeLists.txt
@@ -164,7 +164,7 @@ target_link_libraries(cxbxr-emu
  ${WINS_LIB}
 )
 
-add_dependencies(cxbxr-emu cxbxr-ldr)
+add_dependencies(cxbxr-emu cxbxr-ldr misc-batch)
 
 set(CXBXR_GLEW_DLL "${CXBXR_ROOT_DIR}/import/glew-2.0.0/bin/Release/Win32/glew32.dll")
 

--- a/projects/misc/batch.cmake
+++ b/projects/misc/batch.cmake
@@ -20,3 +20,10 @@ configure_file(
  "${CMAKE_SOURCE_DIR}/src/version.h.in" "${CMAKE_SOURCE_DIR}/src/version.h" @ONLY
  NEWLINE_STYLE LF
 )
+
+
+message("Runtime Build Directory: ${TargetRunTimeDir}")
+
+# Copy glew32.dll to build type's folder.
+set(CXBXR_GLEW_DLL "${CMAKE_SOURCE_DIR}/import/glew-2.0.0/bin/Release/Win32/glew32.dll")
+file(COPY ${CXBXR_GLEW_DLL} DESTINATION  ${TargetRunTimeDir})

--- a/projects/misc/batch.cmake
+++ b/projects/misc/batch.cmake
@@ -1,0 +1,22 @@
+
+find_package(Git)
+
+if(Git_FOUND)
+ message("Git found: ${GIT_EXECUTABLE}")
+
+ execute_process(
+  COMMAND git describe --always --tags --first-parent --dirty
+  OUTPUT_VARIABLE _GIT_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+ )
+
+ message("Git version: " ${_GIT_VERSION})
+else()
+ set(_GIT_VERSION "unknown")
+endif()
+
+# Appears to update whenever define has changed.
+configure_file(
+ "${CMAKE_SOURCE_DIR}/src/version.h.in" "${CMAKE_SOURCE_DIR}/src/version.h" @ONLY
+ NEWLINE_STYLE LF
+)


### PR DESCRIPTION
Following changes are:
- New project, misc-batch, to enforce always run on any build.
- Move git versioning into misc batch project.
  - Plus add dirty flag for aware of difference of some changes are not committed.
- Move duplicate glew32.dll copy into misc batch project.
  - Plus copy only if file is different. Since we're using pre-compiled build, it will only copy once than repeat per cxbx and cxbxr-emu projects.

close #1886

Thanks to @LukeUsher for git versioning's fix suggestion.