### PR TITLE
Fix couple chrono usage due to variety of systems may behave differently

### DIFF
--- a/src/common/util/cliConfig.cpp
+++ b/src/common/util/cliConfig.cpp
@@ -155,7 +155,7 @@ long long GetSessionID()
 
     // Check if previous session ID had been set then use it.
     if (!GetValue(cli_config::sid, &sessionID)) {
-        sessionID = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        sessionID = std::chrono::steady_clock::now().time_since_epoch().count();
         // From now and the future will continue to use the same sessionID until all processes end.
         SetSID(sessionID);
     }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5217,7 +5217,7 @@ DWORD WINAPI XTL::EMUPATCH(D3DDevice_Swap)
         // Only enter the wait loop if the frame took too long
         if (actualDuration < targetDuration) {
             // If we need to wait for a larger amount of time (>= 1 frame at 60FPS), we can just sleep
-            if (std::chrono::duration_cast<std::chrono::milliseconds>(targetTimestamp - std::chrono::steady_clock::now()).count() > 16) {
+            if ((targetTimestamp - std::chrono::steady_clock::now()) > std::chrono::duration<double, std::milli>(16.0)) {
                 std::this_thread::sleep_until(targetTimestamp);
             } else {
                 // Otherwise, we fall-through and just keep polling

--- a/src/devices/video/EmuNV2A_PTIMER.cpp
+++ b/src/devices/video/EmuNV2A_PTIMER.cpp
@@ -41,7 +41,7 @@
 static uint64_t ptimer_get_clock(NV2AState * d)
 {
 	// Get time in nanoseconds
-    uint64_t time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+    uint64_t time = std::chrono::duration<uint64_t, std::nano>(std::chrono::steady_clock::now().time_since_epoch()).count();
 
 	return Muldiv64(Muldiv64(time,
 					(uint32_t)d->pramdac.core_clock_freq, // TODO : Research how this can be updated to accept uint64_t

--- a/src/devices/video/EmuNV2A_PTIMER.cpp
+++ b/src/devices/video/EmuNV2A_PTIMER.cpp
@@ -41,8 +41,8 @@
 static uint64_t ptimer_get_clock(NV2AState * d)
 {
 	// Get time in nanoseconds
-    uint64_t time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
-	
+    uint64_t time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+
 	return Muldiv64(Muldiv64(time,
 					(uint32_t)d->pramdac.core_clock_freq, // TODO : Research how this can be updated to accept uint64_t
 					NANOSECONDS_PER_SECOND), // Was CLOCKS_PER_SEC


### PR DESCRIPTION
Base on chrono library author post on [stackoverflow](https://stackoverflow.com/a/37440647). It is advise to use steady_clock than high_resolution_clock and avoid use duration_cast.

Tested and confirmed no noticeable difference with several titles.

Credit to @LukeUsher for finding this issue from author's advice of do and don't.