### PR TITLE
d3d: apply aspect ratio correction to the backbuffer

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5060,7 +5060,7 @@ DWORD WINAPI xbox::EMUPATCH(D3DDevice_Swap)
             const auto width = g_AspectRatioScaleWidth * g_AspectRatioScale;
             const auto height = g_AspectRatioScaleHeight * g_AspectRatioScale;
 
-            // Caclulate the centered rectangle
+            // Calculate the centered rectangle
             RECT dest{};
             dest.top = (LONG)((g_HostBackBufferDesc.Height - height) / 2);
             dest.left = (LONG)((g_HostBackBufferDesc.Width - width) / 2);

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5047,7 +5047,8 @@ DWORD WINAPI xbox::EMUPATCH(D3DDevice_Swap)
 	if (hRet == D3D_OK) {
 		assert(pCurrentHostBackBuffer != nullptr);
 
-        // Clear the backbuffer surface
+        // Clear the backbuffer surface, this prevents artifacts when switching aspect-ratio
+        // Test-case: Dashboard
         IDirect3DSurface* pExistingRenderTarget = nullptr;
         hRet = g_pD3DDevice->GetRenderTarget(0, &pExistingRenderTarget);
         if (hRet == D3D_OK) {

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -2852,9 +2852,9 @@ void UpdateHostBackBufferDesc()
 void SetAspectRatioScale(xbox::X_D3DPRESENT_PARAMETERS* pPresentationParameters)
 {
     // NOTE: Some games use anamorphic widesceen (expecting a 4:3 surface to be displayed at 16:9)
-     // For those, we *lie* about the default width, for the scaler
-     // 720p / 1080i are *always* widescreen, and will have the correct backbuffer size, so we only
-     // apply this 'hack' for non-hd resolutions
+    // For those, we *lie* about the default width, for the scaler
+    // 720p / 1080i are *always* widescreen, and will have the correct backbuffer size, so we only
+    // apply this 'hack' for non-hd resolutions
     g_AspectRatioScaleWidth = pPresentationParameters->BackBufferWidth;
     g_AspectRatioScaleHeight = pPresentationParameters->BackBufferHeight;
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5042,10 +5042,26 @@ DWORD WINAPI xbox::EMUPATCH(D3DDevice_Swap)
 	HRESULT hRet = g_pD3DDevice->GetBackBuffer(
 		0, // iSwapChain
 		0, D3DBACKBUFFER_TYPE_MONO, &pCurrentHostBackBuffer);
+
 	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetBackBuffer - Unable to get backbuffer surface!");
 	if (hRet == D3D_OK) {
 		assert(pCurrentHostBackBuffer != nullptr);
 
+        // Clear the backbuffer surface
+        IDirect3DSurface* pExistingRenderTarget = nullptr;
+        hRet = g_pD3DDevice->GetRenderTarget(0, &pExistingRenderTarget);
+        if (hRet == D3D_OK) {
+            g_pD3DDevice->SetRenderTarget(0, pCurrentHostBackBuffer);
+            g_pD3DDevice->Clear(
+                /*Count=*/0,
+                /*pRects=*/nullptr,
+                D3DCLEAR_TARGET | (g_bHasDepth ? D3DCLEAR_ZBUFFER : 0) | (g_bHasStencil ? D3DCLEAR_STENCIL : 0),
+                /*Color=*/0xFF000000, // TODO : Use constant for this
+                /*Z=*/g_bHasDepth ? 1.0f : 0.0f,
+                /*Stencil=*/0);
+            g_pD3DDevice->SetRenderTarget(0, pExistingRenderTarget);
+        }
+        
         // TODO: Implement a hot-key to change the filter?
         // Note: LoadSurfaceFilter Must be D3DTEXF_NONE, D3DTEXF_POINT or D3DTEXF_LINEAR
         // Before StretchRects we used D3DX_FILTER_POINT here, but that gave jagged edges in Dashboard.
@@ -5056,7 +5072,7 @@ DWORD WINAPI xbox::EMUPATCH(D3DDevice_Swap)
 
 		auto pXboxBackBufferHostSurface = GetHostSurface(g_pXbox_BackBufferSurface, D3DUSAGE_RENDERTARGET);
 		if (pXboxBackBufferHostSurface) {
-            // Calculate the aspect ratio scale factor
+            // Calculate the target width/height
             const auto width = g_AspectRatioScaleWidth * g_AspectRatioScale;
             const auto height = g_AspectRatioScaleHeight * g_AspectRatioScale;
 
@@ -5141,17 +5157,32 @@ DWORD WINAPI xbox::EMUPATCH(D3DDevice_Swap)
 				float xScale, yScale;
 				GetMultiSampleScale(xScale, yScale);
 
-                xScale = (float)g_HostBackBufferDesc.Width / ((float)XboxBackBufferWidth / xScale);
-                yScale = (float)g_HostBackBufferDesc.Height / ((float)XboxBackBufferHeight / yScale);
+                const auto width = g_AspectRatioScaleWidth * g_AspectRatioScale;
+                const auto height = g_AspectRatioScaleHeight * g_AspectRatioScale;
+                xScale = (float)width / ((float)XboxBackBufferWidth / xScale);
+                yScale = (float)height / ((float)XboxBackBufferHeight / yScale);
 
+                // Scale the destination co-ordinates by the correct scale factor
                 EmuDestRect.top = (LONG)(EmuDestRect.top * yScale);
                 EmuDestRect.left = (LONG)(EmuDestRect.left * xScale);
                 EmuDestRect.bottom = (LONG)(EmuDestRect.bottom * yScale);
                 EmuDestRect.right = (LONG)(EmuDestRect.right * xScale);
+
+                // Finally, adjust to correct on-screen position (
+                EmuDestRect.top += (LONG)((g_HostBackBufferDesc.Height - height) / 2);
+                EmuDestRect.left += (LONG)((g_HostBackBufferDesc.Width - width) / 2);
+                EmuDestRect.right += (LONG)((g_HostBackBufferDesc.Width - width) / 2);
+                EmuDestRect.bottom += (LONG)((g_HostBackBufferDesc.Height - height) / 2);
 			} else {
 				// Use backbuffer width/height since that may differ from the Window size
-                EmuDestRect.right = g_HostBackBufferDesc.Width;
-                EmuDestRect.bottom = g_HostBackBufferDesc.Height;
+                const auto width = g_AspectRatioScaleWidth * g_AspectRatioScale;
+                const auto height = g_AspectRatioScaleHeight * g_AspectRatioScale;
+
+                // Calculate the centered rectangle
+                EmuDestRect.top = (LONG)((g_HostBackBufferDesc.Height - height) / 2);
+                EmuDestRect.left = (LONG)((g_HostBackBufferDesc.Width - width) / 2);
+                EmuDestRect.right = (LONG)(EmuDestRect.left + width);
+                EmuDestRect.bottom = (LONG)(EmuDestRect.top + height);
 			}
 
 			// load the YUY2 into the backbuffer
@@ -5207,7 +5238,6 @@ DWORD WINAPI xbox::EMUPATCH(D3DDevice_Swap)
                 if (hRet != D3D_OK) {
                     EmuLog(LOG_LEVEL::WARNING, "Couldn't load Xbox overlay to host surface : %X", hRet);
                 } else {
-                    // TODO: Respect aspect ratio
                     hRet = g_pD3DDevice->StretchRect(
                         /* pSourceSurface = */ pTemporaryOverlaySurface,
                         /* pSourceRect = */ &EmuSourRect,


### PR DESCRIPTION
This pull-request implements aspect ratio correction while also correctly handling the case where Xbox games render 16:9 content to a 4:3 buffer (anamorphic widescreen)

NOTE: When using 'Automatic' resolution setting, scaling may still be incorrect. This will be solved in a different pull-request because it requires an overhaul of how our Window creation works. In the interim, for correct aspect ratio scaling, please select a suitable display resolution that matches your screen aspect ratio.

Dashboard in 4:3, within a 16:9 window
![image](https://user-images.githubusercontent.com/740003/91577198-48fde900-e940-11ea-8986-686be73307e3.png)

Dashboard in 16:9, within a 16:9 window
![image](https://user-images.githubusercontent.com/740003/91577296-69c63e80-e940-11ea-8110-14c919577003.png)

Dashboard in 16;9 within a 4:3 window
![image](https://user-images.githubusercontent.com/740003/91577345-78acf100-e940-11ea-8fd0-314a104ddd4d.png)

Jet Set Radio Future (a 4:3 only game, in a 16:9 window)
![image](https://user-images.githubusercontent.com/740003/91577396-882c3a00-e940-11ea-9e89-f29d2771d214.png)


