### PR TITLE
Update XbSymbolDatabase Submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,6 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
 endif()
 
 # Cxbx-Reloaded project with third-party libraries
-set_target_properties(cxbx cxbxr-ldr cxbxr-emu misc-batch subhook XbSymbolDatabase libtommath libtomcrypt
+set_target_properties(cxbx cxbxr-ldr cxbxr-emu misc-batch subhook libXbSymbolDatabase libtommath libtomcrypt
  PROPERTIES FOLDER Cxbx-Reloaded
 )

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -180,7 +180,7 @@ set(WINS_LIB
 )
 
 target_link_libraries(cxbx
- PUBLIC XbSymbolDatabase
+ PUBLIC libXbSymbolDatabase
  subhook
  libtomcrypt
  SDL2

--- a/projects/cxbxr-emu/CMakeLists.txt
+++ b/projects/cxbxr-emu/CMakeLists.txt
@@ -156,7 +156,7 @@ set(WINS_LIB
 )
 
 target_link_libraries(cxbxr-emu
- PUBLIC XbSymbolDatabase
+ PUBLIC libXbSymbolDatabase
  subhook
  libtomcrypt
  SDL2

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -40,8 +40,7 @@
 #include "EmuShared.h"
 #include "common\CxbxDebugger.h"
 #include "Logging.h"
-#pragma comment(lib, "XbSymbolDatabase.lib")
-#include "..\..\import\XbSymbolDatabase\XbSymbolDatabase.h"
+#include <libXbSymbolDatabase.h>
 #include "Intercept.hpp"
 #include "Patches.hpp"
 #include "common\util\hasher.h"


### PR DESCRIPTION
* General improvements for CMake.
* Fixed broken mutex initialization.
* Fixed bypass limit setter before scan. (unaffected in Cxbx-Reloaded)

This update is only low risk merge. Plus help prepare to have multi-projects ready support without need to re-update our source files. With this update, we can check out future pull requests, from XbSymbolDatabase end, to verify signatures.