### PR TITLE
Fix for starting with debugger

### DIFF
--- a/src/CxbxDebugger/CMakeLists.txt
+++ b/src/CxbxDebugger/CMakeLists.txt
@@ -42,11 +42,6 @@ file (GLOB SOURCES
  "${CXBXR_DEBUGGER_SRC_DIR}/Form1.resx"
  "${CXBXR_DEBUGGER_SRC_DIR}/PatchManager.cs"
  "${CXBXR_DEBUGGER_SRC_DIR}/Program.cs"
- "${CXBXR_DEBUGGER_SRC_DIR}/Properties/AssemblyInfo.cs"
- "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Resources.Designer.cs"
- "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Resources.resx"
- "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Settings.Designer.cs"
- "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Settings.settings"
  "${CXBXR_DEBUGGER_SRC_DIR}/Resources/BreakpointDisable_16x_24.bmp"
  "${CXBXR_DEBUGGER_SRC_DIR}/Resources/BreakpointEnable_16x_24.bmp"
  "${CXBXR_DEBUGGER_SRC_DIR}/Resources/Pause_16x_24.bmp"
@@ -92,15 +87,23 @@ file (GLOB SOURCES
  "${CXBXR_DEBUGGER_SRC_DIR}/Win32/Windows/NativeMethods.cs"
 )
 
-csharp_set_windows_forms_properties(
- "${CXBXR_DEBUGGER_SRC_DIR}/Form1.Designer.cs"
- "${CXBXR_DEBUGGER_SRC_DIR}/Form1.cs"
- "${CXBXR_DEBUGGER_SRC_DIR}/Form1.resx"
+file (GLOB PROPERTIES
+ "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Settings.settings"
  "${CXBXR_DEBUGGER_SRC_DIR}/Properties/AssemblyInfo.cs"
  "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Resources.Designer.cs"
  "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Resources.resx"
  "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Settings.Designer.cs"
  "${CXBXR_DEBUGGER_SRC_DIR}/Properties/Settings.settings"
+)
+
+csharp_set_windows_forms_properties(
+ "${CXBXR_DEBUGGER_SRC_DIR}/Form1.Designer.cs"
+ "${CXBXR_DEBUGGER_SRC_DIR}/Form1.cs"
+ "${CXBXR_DEBUGGER_SRC_DIR}/Form1.resx"
+)
+
+csharp_set_designer_cs_properties(
+ ${PROPERTIES}
 )
 
 set_source_files_properties("${CXBXR_DEBUGGER_SRC_DIR}/Form1.cs"
@@ -113,7 +116,7 @@ set_source_files_properties("${CXBXR_DEBUGGER_SRC_DIR}/RicherTextBox.cs"
 
 source_group(TREE ${CXBXR_ROOT_DIR} FILES ${SOURCES})
 
-add_executable(cxbxr-debugger WIN32 ${SOURCES} #Test WIN32 like cxbx does if doesn't need compile option set
+add_executable(cxbxr-debugger WIN32 ${SOURCES} ${PROPERTIES} #Test WIN32 like cxbx does if doesn't need compile option set
 )
 
 set_target_properties(cxbxr-debugger PROPERTIES 

--- a/src/CxbxDebugger/Form1.cs
+++ b/src/CxbxDebugger/Form1.cs
@@ -15,7 +15,7 @@ namespace CxbxDebugger
     {
         Thread DebuggerWorkerThread;
         Debugger DebuggerInst;
-        string[] CachedArgs;
+        string[] StartupArgs;
         string CachedTitle = "";
         bool SuspendedOnBp = false;
 
@@ -45,13 +45,9 @@ namespace CxbxDebugger
                 throw new Exception("Incorrect usage");
             }
 
-            var items = new List<string>(args.Length - 1);
-            for (int i = 1; i < args.Length; ++i)
-            {
-                items.Add(args[i]);
-            }
 
-            CachedArgs = items.ToArray();
+            StartupArgs = new string[args.Length - 1];
+            Array.Copy(args, 1, StartupArgs, 0, args.Length - 1);
 
             DebugEvents = new DebuggerFormEvents(this);
 
@@ -104,7 +100,7 @@ namespace CxbxDebugger
             if (Create)
             {
                 // Create debugger instance
-                DebuggerInst = new Debugger(CachedArgs);
+                DebuggerInst = new Debugger(StartupArgs);
                 DebuggerInst.RegisterEventInterfaces(DebugEvents);
                 DebuggerInst.RegisterEventInterfaces(patchMan);
 


### PR DESCRIPTION
The debugger wasn't launching from the main menu due to how it was handling the new CLI options passed to the loader