### PR TITLE
PsCreateSystemThreadEx: Fill dwThreadId immediately after creating the thread

### DIFF
--- a/src/core/kernel/exports/EmuKrnlPs.cpp
+++ b/src/core/kernel/exports/EmuKrnlPs.cpp
@@ -285,6 +285,9 @@ XBSYSAPI EXPORTNUM(255) xbox::NTSTATUS NTAPI xbox::PsCreateSystemThreadEx
 		}*/
 
         *ThreadHandle = (HANDLE)_beginthreadex(NULL, KernelStackSize, PCSTProxy, iPCSTProxyParam, NULL, (unsigned int*)&dwThreadId);
+        if (ThreadId != NULL)
+            *ThreadId = (xbox::HANDLE)dwThreadId;
+
 		// Note : DO NOT use iPCSTProxyParam anymore, since ownership is transferred to the proxy (which frees it too)
 
 		EmuLog(LOG_LEVEL::DEBUG, "Waiting for Xbox proxy thread to start...");
@@ -322,9 +325,6 @@ XBSYSAPI EXPORTNUM(255) xbox::NTSTATUS NTAPI xbox::PsCreateSystemThreadEx
 		EmuLog(LOG_LEVEL::DEBUG, "Created Xbox proxy thread. Handle : 0x%X, ThreadId : [0x%.4X]", *ThreadHandle, dwThreadId);
 
 		CxbxKrnlRegisterThread(*ThreadHandle);
-
-		if (ThreadId != NULL)
-			*ThreadId = (xbox::HANDLE)dwThreadId;
 	}
 
 	SwitchToThread();


### PR DESCRIPTION
In `xbox::PsCreateSystemThreadEx`, `ThreadHandle` is filled immediately after the host thread creation. However, `ThreadId` is filled after the thread has started, and that creates a window for a race if `ThreadId` is used by the newly spawned thread.

This is exactly what NASCAR Heat 2002 was doing, and the newly spawned guest thread ended up looking for the value `ThreadId` should have filled.

Filling the output value immediately after the guest thread is threaded alleviates the issue, and also makes more sense from a logical perspective.