### PR TITLE
Fix Symbol Scan's Kernel Thunk Bug

### DIFF
--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -192,10 +192,7 @@ void CDECL EmuOutputMessage(xb_output_message mFlag,
         }
         case XB_OUTPUT_MESSAGE_DEBUG:
         default: {
-#ifdef _DEBUG_TRACE
-            printf("%s\n", message);
-#endif
-
+            EmuLog(LOG_LEVEL::DEBUG, "%s", message);
             break;
         }
     }

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -387,7 +387,7 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	std::stringstream sstream;
 	char tAsciiTitle[40] = "Unknown";
 	std::setlocale(LC_ALL, "English");
-	std::wcstombs(tAsciiTitle, g_pCertificate->wszTitleName, sizeof(tAsciiTitle));
+	std::wcstombs(tAsciiTitle, CxbxKrnl_Xbe->m_Certificate.wszTitleName, sizeof(tAsciiTitle));
 	std::string szTitleName(tAsciiTitle);
 	CxbxKrnl_Xbe->PurgeBadChar(szTitleName);
 	sstream << cachePath << szTitleName << "-" << std::hex << uiHash << ".ini";
@@ -510,9 +510,9 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 
 	// Store Certificate Details
 	symbolCacheData.SetValue(section_certificate, sect_certificate_keys.Name, tAsciiTitle);
-	symbolCacheData.SetValue(section_certificate, sect_certificate_keys.TitleID, FormatTitleId(g_pCertificate->dwTitleId).c_str());
-	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.TitleIDHex, g_pCertificate->dwTitleId, nullptr, /*UseHex =*/true);
-	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.Region, g_pCertificate->dwGameRegion, nullptr, /*UseHex =*/true);
+	symbolCacheData.SetValue(section_certificate, sect_certificate_keys.TitleID, FormatTitleId(CxbxKrnl_Xbe->m_Certificate.dwTitleId).c_str());
+	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.TitleIDHex, CxbxKrnl_Xbe->m_Certificate.dwTitleId, nullptr, /*UseHex =*/true);
+	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.Region, CxbxKrnl_Xbe->m_Certificate.dwGameRegion, nullptr, /*UseHex =*/true);
 
 	// Store Library Details
 	for (unsigned int i = 0; i < pXbeHeader->dwLibraryVersions; i++) {


### PR DESCRIPTION
Some improvements for HLE's initialization usage.

* Don't treat EmuOutputMessage's debug message as trace, let it handle from EmuLog's functionality.
* Fix a crash if move EmuHLEIntercept before MapThunkTable call. Now it will be easy to relocate if necessary.
* Fix hidden xbeType bug for kernel thunk and entry point look up. It should be checking against xbe than system type.
* Finally, resolve symbol scan unable to register kernel thunk addresses properly due to MapThunkTable was called first.