### PR TITLE
Add an rdtsc false positive check for Group S Challenge [CC-005] [1.05]

### DIFF
--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -492,7 +492,7 @@ const uint8_t rdtsc_pattern[] = {
     0xEB,
     0xF6,
     0xA1,
-    0x01
+    0x01                       // one false positive in Group S Challenge [1.05] .text E8 0F 31 01 00
 };
 const int sizeof_rdtsc_pattern = sizeof(rdtsc_pattern);
 
@@ -545,6 +545,15 @@ void PatchRdtscInstructions()
 						if (next_byte == 0x50)
 						{
 							if (*(uint8_t*)(addr - 2) == 0x83 && *(uint8_t*)(addr - 1) == 0xE2)
+							{
+								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
+								continue;
+							}
+
+						}
+						if (next_byte == 0x01)
+						{
+							if (*(uint8_t*)(addr - 1) == 0xE8 && *(uint8_t*)(addr + 3) == 0x00)
 							{
 								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
 								continue;


### PR DESCRIPTION
Group S Challenge [1.03] was going ingame for years, but [1.05] crashed on startup. Turns out, it's due to a very funny `rdtsc` false positive which detected the instruction in the middle of a call instruction:

`E8 0F 31 01 00`

This PR adds a check for this false positive for a 0x01 rdtsc pattern (triggered also by the offset, as evidenced).

Group S Challenge [1.05] now goes into menus:
![image](https://user-images.githubusercontent.com/7947461/95125055-b299c000-0754-11eb-8e3c-56134d3c9b16.png)
