### PR TITLE
Add several D3D8LTCG function variations for xdk-3911

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4318,7 +4318,6 @@ xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInli
 
 // LTCG specific D3DDevice_SetTexture function...
 // This uses a custom calling convention where parameter is passed in EAX
-// TODO: XB_trampoline plus Log function is not working due lost parameter in EAX.
 // Test-case: Metal Wolf Chaos
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4)
 (
@@ -4335,7 +4334,11 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4)
 	EmuLog(LOG_LEVEL::DEBUG, "D3DDevice_SetTexture_4(Stage : %d pTexture : %08x);", Stage, pTexture);
 
 	// Call the Xbox implementation of this function, to properly handle reference counting for us
-	//XB_TRMP(D3DDevice_SetTexture_4)(pTexture);
+	__asm {
+		mov eax, Stage
+		push pTexture
+		call XB_TRMP(D3DDevice_SetTexture_4)
+	}
 
 	g_pXbox_SetTexture[Stage] = pTexture;
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4189,26 +4189,23 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(D3DDevice_CreateVertexShader)
 }
 
 // LTCG specific D3DDevice_SetVertexShaderConstant function...
-// This uses a custom calling convention where parameter is passed in EDX
+// This uses a custom calling convention where ConstantCount parameter is passed in EDX
 // Test-case: Murakumo
-xbox::void_xt __stdcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant_8)
+xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant_8)
 (
+    void*,
+    dword_xt    ConstantCount,
+    int_xt      Register,
+    CONST PVOID pConstantData
 )
 {
-	static uint32_t returnAddr;
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Register)
+		LOG_FUNC_ARG(pConstantData)
+		LOG_FUNC_ARG(ConstantCount)
+		LOG_FUNC_END;
 
-#ifdef _DEBUG_TRACE
-		__asm add esp, 4
-#endif
-
-	__asm {
-		pop returnAddr
-		push edx
-		call EmuPatch_D3DDevice_SetVertexShaderConstant
-		mov eax, 0
-		push returnAddr
-		ret
-	}
+	CxbxImpl_SetVertexShaderConstant(Register, pConstantData, ConstantCount);
 }
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6702,6 +6702,20 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexShader)
 	UpdateViewPortOffsetAndScaleConstants();
 }
 
+// This uses a custom calling convention where Handle is passed in EBX
+// Test-case: NASCAR Heat 2002
+xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexShader_0)()
+{
+	dword_xt Handle;
+	__asm mov Handle, ebx
+
+	LOG_FUNC_ONE_ARG(Handle);
+
+	CxbxImpl_SetVertexShader(Handle);
+
+	UpdateViewPortOffsetAndScaleConstants();
+}
+
 // TODO : Move to own file
 constexpr unsigned int IndicesPerPage = PAGE_SIZE / sizeof(INDEX16);
 constexpr unsigned int InputQuadsPerPage = ((IndicesPerPage * VERTICES_PER_QUAD) / VERTICES_PER_TRIANGLE) / TRIANGLES_PER_QUAD;

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -294,6 +294,7 @@ g_EmuCDPD = {0};
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetStreamSource,         (xbox::uint_xt, xbox::X_D3DVertexBuffer*, xbox::uint_xt)                                              );  \
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetStreamSource_4,       (xbox::uint_xt, xbox::X_D3DVertexBuffer*, xbox::uint_xt)                                              );  \
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetStreamSource_8,       (xbox::X_D3DVertexBuffer*, xbox::uint_xt)                                                    );  \
+    XB_MACRO(xbox::void_xt,               __fastcall, D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber, (void*, xbox::uint_xt, xbox::X_D3DVertexBuffer*, xbox::uint_xt)                         );  \
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetTexture,              (xbox::dword_xt, xbox::X_D3DBaseTexture*)                                                    );  \
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetTexture_4__LTCG_eax_pTexture, (xbox::dword_xt)                                                                             );  \
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetTexture_4,            (xbox::X_D3DBaseTexture*)                                                                    );  \
@@ -6638,6 +6639,29 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetStreamSource_8)
 	// TODO : Forward to Xbox implementation
 	// This should stop us having to patch GetStreamSource!
 	//XB_TRMP(D3DDevice_SetStreamSource_8)(pStreamData, Stride);
+}
+
+// This uses a custom calling convention where StreamNumber parameter is passed in EDX
+// Test-case: NASCAR Heat 2002
+xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber)
+(
+    void*,
+    uint_xt                StreamNumber,
+    X_D3DVertexBuffer  *pStreamData,
+    uint_xt                Stride
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(StreamNumber)
+		LOG_FUNC_ARG(pStreamData)
+		LOG_FUNC_ARG(Stride)
+		LOG_FUNC_END;
+
+	CxbxImpl_SetStreamSource(StreamNumber, pStreamData, Stride);
+
+	// Forward to Xbox implementation
+	// This should stop us having to patch GetStreamSource!
+	XB_TRMP(D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber)(nullptr, StreamNumber, pStreamData, Stride);
 }
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -7489,6 +7489,24 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVerticesUP)
 	CxbxHandleXboxCallbacks();
 }
 
+// LTCG specific D3DDevice_DrawVerticesUP function...
+// This uses a custom calling convention where pVertexStreamZeroData is passed in EBX
+// Test-case: NASCAR Heat 20002
+xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVerticesUP_12)
+(
+    X_D3DPRIMITIVETYPE  PrimitiveType,
+    uint_xt                VertexCount,
+    uint_xt                VertexStreamZeroStride
+)
+{
+	PVOID         pVertexStreamZeroData;
+	__asm mov pVertexStreamZeroData, ebx
+
+	LOG_FORWARD("D3DDevice_DrawVerticesUP");
+
+	EMUPATCH(D3DDevice_DrawVerticesUP)(PrimitiveType, VertexCount, pVertexStreamZeroData, VertexStreamZeroStride);
+}
+
 // ******************************************************************
 // * patch: D3DDevice_DrawIndexedVertices
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -295,7 +295,8 @@ g_EmuCDPD = {0};
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetStreamSource_4,       (xbox::uint_xt, xbox::X_D3DVertexBuffer*, xbox::uint_xt)                                              );  \
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetStreamSource_8,       (xbox::X_D3DVertexBuffer*, xbox::uint_xt)                                                    );  \
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetTexture,              (xbox::dword_xt, xbox::X_D3DBaseTexture*)                                                    );  \
-    XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetTexture_4,            (xbox::X_D3DBaseTexture*)                                                           );  \
+    XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetTexture_4__LTCG_eax_pTexture, (xbox::dword_xt)                                                                             );  \
+    XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetTexture_4,            (xbox::X_D3DBaseTexture*)                                                                    );  \
   /*XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetVertexShader,         (xbox::dword_xt)                                                                            );*/\
   /*XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetVertexShaderInput,    (xbox::dword_xt, xbox::uint_xt, xbox::X_STREAMINPUT*)                                                 );*/\
     XB_MACRO(xbox::void_xt,               WINAPI,     D3DDevice_SetViewport,             (CONST xbox::X_D3DVIEWPORT8*)                                                       );  \
@@ -4317,7 +4318,34 @@ xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInli
 }
 
 // LTCG specific D3DDevice_SetTexture function...
-// This uses a custom calling convention where parameter is passed in EAX
+// This uses a custom calling convention where pTexture is passed in EAX
+// Test-case: NASCAR Heat 2002
+xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4__LTCG_eax_pTexture)
+(
+	dword_xt           Stage
+)
+{
+	X_D3DBaseTexture  *pTexture;
+	__asm mov pTexture, eax;
+
+	//LOG_FUNC_BEGIN
+	//	LOG_FUNC_ARG(Stage)
+	//	LOG_FUNC_ARG(pTexture)
+	//	LOG_FUNC_END;
+	EmuLog(LOG_LEVEL::DEBUG, "D3DDevice_SetTexture_4__LTCG_eax_pTexture(Stage : %d pTexture : %08x);", Stage, pTexture);
+
+	// Call the Xbox implementation of this function, to properly handle reference counting for us
+	__asm {
+		mov eax, pTexture
+		push Stage
+		call XB_TRMP(D3DDevice_SetTexture_4__LTCG_eax_pTexture)
+	}
+
+	g_pXbox_SetTexture[Stage] = pTexture;
+}
+
+// LTCG specific D3DDevice_SetTexture function...
+// This uses a custom calling convention where Stage is passed in EAX
 // Test-case: Metal Wolf Chaos
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4)
 (

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -444,7 +444,14 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexShaderConstant)
     dword_xt       ConstantCount
 );
 
-xbox::void_xt __stdcall EMUPATCH(D3DDevice_SetVertexShaderConstant_8)();
+xbox::void_xt __fastcall EMUPATCH(D3DDevice_SetVertexShaderConstant_8)
+(
+    void*,
+    dword_xt    ConstantCount,
+    int_xt      Register,
+    CONST PVOID pConstantData
+);
+
 
 // ******************************************************************
 // * patch: D3DDevice_SetVertexShaderConstant1

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -619,6 +619,11 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetTexture)
 	X_D3DBaseTexture  *pTexture
 );
 
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetTexture_4__LTCG_eax_pTexture)
+(
+	dword_xt           Stage
+);
+
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetTexture_4)
 (
 	X_D3DBaseTexture  *pTexture

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1400,6 +1400,8 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexShader)
     dword_xt            Handle
 );
 
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexShader_0)();
+
 // ******************************************************************
 // * patch: D3DDevice_DrawVertices
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1384,6 +1384,14 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetStreamSource_8)
     uint_xt                Stride
 );
 
+xbox::void_xt __fastcall EMUPATCH(D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber)
+(
+    void*,
+    uint_xt                StreamNumber,
+    X_D3DVertexBuffer  *pStreamData,
+    uint_xt                Stride
+);
+
 // ******************************************************************
 // * patch: D3DDevice_SetVertexShader
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1429,6 +1429,14 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_DrawVerticesUP)
     uint_xt                VertexStreamZeroStride
 );
 
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_DrawVerticesUP_12)
+(
+    X_D3DPRIMITIVETYPE  PrimitiveType,
+    uint_xt                VertexCount,
+    uint_xt                VertexStreamZeroStride
+);
+
+
 // ******************************************************************
 // * patch: D3DDevice_DrawIndexedVertices
 // ******************************************************************

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -147,6 +147,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_SetStreamSource", xbox::EMUPATCH(D3DDevice_SetStreamSource), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetStreamSource_4", xbox::EMUPATCH(D3DDevice_SetStreamSource_4), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetStreamSource_8", xbox::EMUPATCH(D3DDevice_SetStreamSource_8), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber", xbox::EMUPATCH(D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetSwapCallback", xbox::EMUPATCH(D3DDevice_SetSwapCallback), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetTexture", xbox::EMUPATCH(D3DDevice_SetTexture), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetTexture_4__LTCG_eax_pTexture", xbox::EMUPATCH(D3DDevice_SetTexture_4__LTCG_eax_pTexture), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -163,6 +163,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_SetVertexData4ub", xbox::EMUPATCH(D3DDevice_SetVertexData4ub), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexDataColor", xbox::EMUPATCH(D3DDevice_SetVertexDataColor), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShader", xbox::EMUPATCH(D3DDevice_SetVertexShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShader_0", xbox::EMUPATCH(D3DDevice_SetVertexShader_0), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant1", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant1Fast", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant1Fast), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -74,6 +74,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_DrawVertices", xbox::EMUPATCH(D3DDevice_DrawVertices), PATCH_HLE_D3D),
     PATCH_ENTRY("D3DDevice_DrawVertices_4", xbox::EMUPATCH(D3DDevice_DrawVertices_4), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_DrawVerticesUP", xbox::EMUPATCH(D3DDevice_DrawVerticesUP), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_DrawVerticesUP_12", xbox::EMUPATCH(D3DDevice_DrawVerticesUP_12), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_EnableOverlay", xbox::EMUPATCH(D3DDevice_EnableOverlay), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_End", xbox::EMUPATCH(D3DDevice_End), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_EndPush", xbox::EMUPATCH(D3DDevice_EndPush), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -149,6 +149,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_SetStreamSource_8", xbox::EMUPATCH(D3DDevice_SetStreamSource_8), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetSwapCallback", xbox::EMUPATCH(D3DDevice_SetSwapCallback), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetTexture", xbox::EMUPATCH(D3DDevice_SetTexture), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetTexture_4__LTCG_eax_pTexture", xbox::EMUPATCH(D3DDevice_SetTexture_4__LTCG_eax_pTexture), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetTexture_4", xbox::EMUPATCH(D3DDevice_SetTexture_4), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetTransform", xbox::EMUPATCH(D3DDevice_SetTransform), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetTransform_0", xbox::EMUPATCH(D3DDevice_SetTransform_0), PATCH_HLE_D3D),


### PR DESCRIPTION
Requires https://github.com/Cxbx-Reloaded/XbSymbolDatabase/pull/117 - as far as I understand, it must be merged first, and then this PR has to be rebased.

This variation puts Stage on the stack and pTexture in `eax`. The existing implementation was shared with xdk-4721 with a wrong assumption that both functions are the same, but they were not.

Test case: NASCAR Heat 2002

Gets NASCAR Heat 2002 from instantly crashing on startup to reaching invisible intro movies and menus.
![image](https://user-images.githubusercontent.com/7947461/95132173-a0714f00-075f-11eb-8d99-c780f8823a98.png)

