### PR TITLE
Add a new rdtsc pattern based on NASCAR Heat 2002 logs

### DIFF
--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -487,7 +487,8 @@ const uint8_t rdtsc_pattern[] = {
     0xEB,
     0xF6,
     0xA1,
-    0x01                       // one false positive in Group S Challenge [1.05] .text E8 0F 31 01 00
+    0x01,                      // one false positive in Group S Challenge [1.05] .text E8 0F 31 01 00
+    0xA3
 };
 const int sizeof_rdtsc_pattern = sizeof(rdtsc_pattern);
 


### PR DESCRIPTION
Based off

```
[0x0B04] INFO : INIT    Skipped potential rdtsc: Unknown opcode pattern  0xA3, @ 0x00103A18
```

being a sequence as follows:

```
.text:00103A18 010 0F 31                                   rdtsc
.text:00103A1A 010 A3 20 65 17 00                          mov     dword_176520, eax
```

**I have not verified this against false positives in other games so it would be good to check with with at least a handful.**