### PR TITLE
MSAA improvements basing on xdk-3911 behaviour

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
@@ -32,6 +32,8 @@
 #include "core/hle/D3D8/Direct3D9/Direct3D9.h" // For g_pD3DDevice
 #include "core/hle/D3D8/XbConvert.h"
 
+void SetXboxMultiSampleType(xbox::X_D3DMULTISAMPLE_TYPE value);
+
 bool XboxRenderStateConverter::Init()
 {
     if (g_SymbolAddresses.find("D3DDeferredRenderState") != g_SymbolAddresses.end()) {
@@ -456,6 +458,9 @@ void XboxRenderStateConverter::ApplyComplexRenderState(uint32_t State, uint32_t 
         case xbox::X_D3DRS_EDGEANTIALIAS:
         case xbox::X_D3DRS_MULTISAMPLEANTIALIAS:
         case xbox::X_D3DRS_MULTISAMPLEMASK:
+            break;
+        case xbox::X_D3DRS_MULTISAMPLETYPE:
+            SetXboxMultiSampleType(Value);
             break;
         default:
             // Only log missing state if it has a PC counterpart

--- a/src/core/hle/D3D8/XbD3D8Types.h
+++ b/src/core/hle/D3D8/XbD3D8Types.h
@@ -480,10 +480,10 @@ const int X_D3DMULTISAMPLE_9_SAMPLES_MULTISAMPLE_GAUSSIAN          = 0x1233;
 const int X_D3DMULTISAMPLE_9_SAMPLES_SUPERSAMPLE_GAUSSIAN          = 0x2233;
 
 // Multisample masks (Cxbx additions)
-const int X_D3DMULTISAMPLE_YSCALE_MASK                             = 0x0003;
+const int X_D3DMULTISAMPLE_YSCALE_MASK                             = 0x000F;
 const int X_D3DMULTISAMPLE_YSCALE_SHIFT = 0;
 
-const int X_D3DMULTISAMPLE_XSCALE_MASK                             = 0x0030;
+const int X_D3DMULTISAMPLE_XSCALE_MASK                             = 0x00F0;
 const int X_D3DMULTISAMPLE_XSCALE_SHIFT = 4;
 
 const int X_D3DMULTISAMPLE_ALGO_LINEAR                           = 0x0000;


### PR DESCRIPTION
Introduces those changes to MSAA scaling:

* Scaling should be performed on `Clear` calls too.
* Scaling factors should be recalculated when binding a render target, and should be derived from multisampling type only when binding the back buffer.

The code contains a code path checking for `X_D3DMULTISAMPLE_SAMPLING_MULTI` sampling type and divides scaling by 2 if that is the case. **This is how xdk-3911 runtime does it**, but it seems to result in half-width rendering at the moment (possibly due to something else assuming that multisampling and supersampling are the same), so I left it commented out. It can be re-enabled once that issue is identified.

When combined with #1976, makes rendering in NASCAR Heat 2002 close to perfect:
![image](https://user-images.githubusercontent.com/7947461/95507764-31d7ff80-09b2-11eb-9831-72ed5a6c9ad1.png)

Known regressions:
- [x] ~~Star Wars - Knights of the Old Republic [LA-003] - yellow screen; seems to happen only with VS2019 and not VS2017, so possibly a bad codegen and not a functional regression; needs further investigation.~~ Unrelated bug, fixed by #1981
