### PR TITLE
Actually zero g_InlineVertexBuffer_Table[0]

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4576,7 +4576,7 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f)
 	// Is this the initial call after D3DDevice_Begin() ?
 	if (g_InlineVertexBuffer_FVF == 0) {
 		// Set first vertex to zero (preventing leaks from prior Begin/End calls)
-		g_InlineVertexBuffer_Table[0] = {};
+		memset(&g_InlineVertexBuffer_Table[0], 0, sizeof(g_InlineVertexBuffer_Table[0]));
 
 		// Handle persistent vertex attribute flags, by resetting non-persistent colors
 		// to their default value (and leaving the persistent colors alone - see the
@@ -4649,7 +4649,7 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f)
 			// Start a new vertex
 			g_InlineVertexBuffer_TableOffset++;
 			// Copy all attributes of the previous vertex (if any) to the new vertex
-			g_InlineVertexBuffer_Table[g_InlineVertexBuffer_TableOffset] = g_InlineVertexBuffer_Table[o];
+			memcpy(&g_InlineVertexBuffer_Table[g_InlineVertexBuffer_TableOffset], &g_InlineVertexBuffer_Table[o], sizeof(g_InlineVertexBuffer_Table[o]));
 	
 			break;
 		}


### PR DESCRIPTION
`operator=` invoked default constructors where available, and a default constructor for `D3DXVECTOR4` does nothing. `memset`/`memcpy` zeroes and copies the entire structure for real.

Fixes a festival of colours in Star Wars: Knights of the Old Republic depending on random factors such as unrelated code changes, Debug/Release configuration and optimization options (in practice, relying on stale stack values):

Before:
![image](https://user-images.githubusercontent.com/7947461/95628071-9dd36a00-0a7d-11eb-8494-491d453eedd3.png)
![image](https://user-images.githubusercontent.com/7947461/95628080-a166f100-0a7d-11eb-81b9-be6aacd78b61.png)

After:
![image](https://user-images.githubusercontent.com/7947461/95628115-b2affd80-0a7d-11eb-8ef2-2d55e49ad1a2.png)
