### PR TITLE
Use std::vector for g_InlineVertexBuffer_Table instead of realloc

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4614,7 +4614,7 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f)
 		}
 
 		for (unsigned i = 0; i < (g_InlineVertexBuffer_TableLength - InlineVertexBuffer_TableLength_Original); ++i) {
-			g_InlineVertexBuffer_Table.emplace_back(_D3DIVB{});
+			g_InlineVertexBuffer_Table.emplace_back();
 		}
 
 		EmuLog(LOG_LEVEL::DEBUG, "Expanded g_InlineVertexBuffer_Table to %u entries", g_InlineVertexBuffer_TableLength);

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -47,7 +47,7 @@
 // Inline vertex buffer emulation
 extern xbox::X_D3DPRIMITIVETYPE g_InlineVertexBuffer_PrimitiveType = xbox::X_D3DPT_INVALID;
 extern DWORD                   g_InlineVertexBuffer_FVF = 0;
-extern struct _D3DIVB         *g_InlineVertexBuffer_Table = nullptr;
+       std::vector<_D3DIVB>    g_InlineVertexBuffer_Table;
 extern UINT                    g_InlineVertexBuffer_TableLength = 0;
 extern UINT                    g_InlineVertexBuffer_TableOffset = 0;
 
@@ -68,6 +68,58 @@ bool GetHostRenderTargetDimensions(DWORD* pHostWidth, DWORD* pHostHeight, IDirec
 uint32_t GetPixelContainerWidth(xbox::X_D3DPixelContainer* pPixelContainer);
 uint32_t GetPixelContainerHeight(xbox::X_D3DPixelContainer* pPixelContainer);
 void ApplyXboxMultiSampleOffsetAndScale(float& x, float& y);
+
+_D3DIVB::_D3DIVB()
+{
+	Position.x = 0.0f;
+	Position.y = 0.0f;
+	Position.z = 0.0f;
+	Rhw = 0.0f;
+	for (unsigned i = 0; i < 4; ++i) {
+		Blend[i] = 0.0f;
+	}
+	Normal.x = 0.0f;
+	Normal.y = 0.0f;
+	Normal.z = 0.0f;
+	Diffuse = 0u;
+	Specular = 0u;
+	Fog = 0.0f;
+	BackDiffuse = 0u;
+	BackSpecular = 0u;
+	for (unsigned i = 0; i < 4; ++i) {
+		TexCoord[i].x = 0.0f;
+		TexCoord[i].y = 0.0f;
+		TexCoord[i].z = 0.0f;
+		TexCoord[i].w = 0.0f;
+	}
+}
+
+struct _D3DIVB &_D3DIVB::operator=(const struct _D3DIVB &Val)
+{
+	Position.x = Val.Position.x;
+	Position.y = Val.Position.y;
+	Position.z = Val.Position.z;
+	Rhw = Val.Rhw;
+	for (unsigned i = 0; i < 4; ++i) {
+		Blend[i] = Val.Blend[i];
+	}
+	Normal.x = Val.Normal.x;
+	Normal.y = Val.Normal.y;
+	Normal.z = Val.Normal.z;
+	Diffuse = Val.Diffuse;
+	Specular = Val.Specular;
+	Fog = Val.Fog;
+	BackDiffuse = Val.BackDiffuse;
+	BackSpecular = Val.BackSpecular;
+	for (unsigned i = 0; i < 4; ++i) {
+		TexCoord[i].x = Val.TexCoord[i].x;
+		TexCoord[i].y = Val.TexCoord[i].y;
+		TexCoord[i].z = Val.TexCoord[i].z;
+		TexCoord[i].w = Val.TexCoord[i].w;
+	}
+
+	return *this;
+}
 
 void CxbxPatchedStream::Activate(CxbxDrawContext *pDrawContext, UINT uiStream) const
 {

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -75,9 +75,7 @@ _D3DIVB::_D3DIVB()
 	Position.y = 0.0f;
 	Position.z = 0.0f;
 	Rhw = 0.0f;
-	for (unsigned i = 0; i < 4; ++i) {
-		Blend[i] = 0.0f;
-	}
+	std::fill(std::begin(Blend), std::end(Blend), 0.0f);
 	Normal.x = 0.0f;
 	Normal.y = 0.0f;
 	Normal.z = 0.0f;
@@ -86,12 +84,7 @@ _D3DIVB::_D3DIVB()
 	Fog = 0.0f;
 	BackDiffuse = 0u;
 	BackSpecular = 0u;
-	for (unsigned i = 0; i < 4; ++i) {
-		TexCoord[i].x = 0.0f;
-		TexCoord[i].y = 0.0f;
-		TexCoord[i].z = 0.0f;
-		TexCoord[i].w = 0.0f;
-	}
+	std::fill(std::begin(TexCoord), std::end(TexCoord), D3DXVECTOR4{ 0.0f , 0.0f, 0.0f, 0.0f });
 }
 
 struct _D3DIVB &_D3DIVB::operator=(const struct _D3DIVB &Val)
@@ -100,9 +93,7 @@ struct _D3DIVB &_D3DIVB::operator=(const struct _D3DIVB &Val)
 	Position.y = Val.Position.y;
 	Position.z = Val.Position.z;
 	Rhw = Val.Rhw;
-	for (unsigned i = 0; i < 4; ++i) {
-		Blend[i] = Val.Blend[i];
-	}
+	std::copy(std::begin(Val.Blend), std::end(Val.Blend), std::begin(Blend));
 	Normal.x = Val.Normal.x;
 	Normal.y = Val.Normal.y;
 	Normal.z = Val.Normal.z;
@@ -111,12 +102,7 @@ struct _D3DIVB &_D3DIVB::operator=(const struct _D3DIVB &Val)
 	Fog = Val.Fog;
 	BackDiffuse = Val.BackDiffuse;
 	BackSpecular = Val.BackSpecular;
-	for (unsigned i = 0; i < 4; ++i) {
-		TexCoord[i].x = Val.TexCoord[i].x;
-		TexCoord[i].y = Val.TexCoord[i].y;
-		TexCoord[i].z = Val.TexCoord[i].z;
-		TexCoord[i].w = Val.TexCoord[i].w;
-	}
+	std::copy(std::begin(Val.TexCoord), std::end(Val.TexCoord), std::begin(TexCoord));
 
 	return *this;
 }

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -103,25 +103,28 @@ class CxbxVertexBufferConverter
 extern xbox::X_D3DPRIMITIVETYPE      g_InlineVertexBuffer_PrimitiveType;
 extern DWORD                   g_InlineVertexBuffer_FVF;
 
-extern struct _D3DIVB
+struct _D3DIVB
 {
     D3DXVECTOR3 Position;     // X_D3DVSDE_POSITION (*) > D3DFVF_XYZ / D3DFVF_XYZRHW
     FLOAT            Rhw;          // X_D3DVSDE_VERTEX (*)   > D3DFVF_XYZ / D3DFVF_XYZRHW
-	FLOAT			 Blend[4];	   // X_D3DVSDE_BLENDWEIGHT  > D3DFVF_XYZB1 (and 3 more up to D3DFVF_XYZB4)
+    FLOAT			 Blend[4];	   // X_D3DVSDE_BLENDWEIGHT  > D3DFVF_XYZB1 (and 3 more up to D3DFVF_XYZB4)
     D3DXVECTOR3 Normal;       // X_D3DVSDE_NORMAL       > D3DFVF_NORMAL
-	D3DCOLOR         Diffuse;      // X_D3DVSDE_DIFFUSE      > D3DFVF_DIFFUSE
-	D3DCOLOR         Specular;     // X_D3DVSDE_SPECULAR     > D3DFVF_SPECULAR
-	FLOAT            Fog;          // X_D3DVSDE_FOG          > D3DFVF_FOG unavailable; TODO : How to handle?
-	D3DCOLOR         BackDiffuse;  // X_D3DVSDE_BACKDIFFUSE  > D3DFVF_BACKDIFFUSE unavailable; TODO : How to handle?
-	D3DCOLOR         BackSpecular; // X_D3DVSDE_BACKSPECULAR > D3DFVF_BACKSPECULAR unavailable; TODO : How to handle?
+    D3DCOLOR         Diffuse;      // X_D3DVSDE_DIFFUSE      > D3DFVF_DIFFUSE
+    D3DCOLOR         Specular;     // X_D3DVSDE_SPECULAR     > D3DFVF_SPECULAR
+    FLOAT            Fog;          // X_D3DVSDE_FOG          > D3DFVF_FOG unavailable; TODO : How to handle?
+    D3DCOLOR         BackDiffuse;  // X_D3DVSDE_BACKDIFFUSE  > D3DFVF_BACKDIFFUSE unavailable; TODO : How to handle?
+    D3DCOLOR         BackSpecular; // X_D3DVSDE_BACKSPECULAR > D3DFVF_BACKSPECULAR unavailable; TODO : How to handle?
     D3DXVECTOR4 TexCoord[4];  // X_D3DVSDE_TEXCOORD0    > D3DFVF_TEX1 (and 4 more up to D3DFVF_TEX4)
 
-	// (*) X_D3DVSDE_POSITION and X_D3DVSDE_VERTEX both set Position, but Rhw seems optional,
-	// hence, selection for D3DFVF_XYZ or D3DFVF_XYZRHW is rather fuzzy. We DO know that once
-	// D3DFVF_NORMAL is given, D3DFVF_XYZRHW is forbidden (see D3DDevice_SetVertexData4f)
-}
-*g_InlineVertexBuffer_Table;
+    // (*) X_D3DVSDE_POSITION and X_D3DVSDE_VERTEX both set Position, but Rhw seems optional,
+    // hence, selection for D3DFVF_XYZ or D3DFVF_XYZRHW is rather fuzzy. We DO know that once
+    // D3DFVF_NORMAL is given, D3DFVF_XYZRHW is forbidden (see D3DDevice_SetVertexData4f)
 
+    _D3DIVB();
+    struct _D3DIVB &operator=(const struct _D3DIVB &Val);
+};
+
+extern std::vector<_D3DIVB> g_InlineVertexBuffer_Table;
 extern UINT g_InlineVertexBuffer_TableLength;
 extern UINT g_InlineVertexBuffer_TableOffset;
 


### PR DESCRIPTION
This PR was triggered after a lengthy discussion among the developers about https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/1981. In short, we don't want to use `memcpy/memset` for `g_InlineVertexBuffer_Table` and instead, we'd prefer a C++ way to do it. This PR turns the `g_InlineVertexBuffer_Table` pointer to a `std::vector` and implements the constructor and the assignment operator for `_D3DIVB`, which removes the need to call `memcpy/memset`. I tested this with Constantine (which also calls `D3DDevice_SetVertexData4f`) and I confirmed that `g_InlineVertexBuffer_Table[0] = {};` indeed sets the first vertex back to zero after a call to `D3DDevice_Begin`. Please also check that Star Wars: Knights of the Old Republic still works correctly, since I don't have that game.