### PR TITLE
IDirectSoundBuffer_SetBufferData: Stop the sound before waiting for finish

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
@@ -756,9 +756,11 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IDirectSoundBuffer_SetBufferData)
     HRESULT hRet = DSERR_OUTOFMEMORY;
     DWORD dwStatus;
 
-    // force wait until buffer is stop playing.
+    // stop and force wait until the buffer has stopped playing.
+    pThis->EmuDirectSoundBuffer8->Stop();
     pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);
-    while ((dwStatus & DSBSTATUS_PLAYING) > 0) {
+    while ((dwStatus & DSBSTATUS_PLAYING) != 0) {
+        // TODO: Add a timeout, like on xbox
         SwitchToThread();
         pThis->EmuDirectSoundBuffer8->GetStatus(&dwStatus);
     }


### PR DESCRIPTION
I checked `CDirectSoundBuffer_SetBufferData` implementations in games using dsound `3925` and `5455` and they both send a stop request before waiting for the buffer to stop playing.

This resolves a sound related deadlock in NASCAR Heat 2002, since it was waiting for a looped sound to finish (which, naturally, never happened).