### PR TITLE
Memory manager fixes

### DIFF
--- a/src/core/kernel/memory-manager/VMManager.cpp
+++ b/src/core/kernel/memory-manager/VMManager.cpp
@@ -336,17 +336,17 @@ void VMManager::RestorePersistentMemory()
 		memcpy(GetPteAddress(persisted_mem->Data[i]), &pte.Default, sizeof(MMPTE));
 		RemoveFree(1, &pfn, 0, pte.Hardware.PFN, pte.Hardware.PFN);
 		if (m_MmLayoutChihiro) {
-			memcpy(CHIHIRO_PFN_ELEMENT(pte.Hardware.PFN),
-				&((PXBOX_PFN)&persisted_mem->Data[(persisted_mem->NumOfPtes * 2) + (persisted_mem->NumOfPtes - 32) * KiB(1)])[pte.Hardware.PFN],
-				sizeof(XBOX_PFN));
+			PXBOX_PFN temp_pfn = &((PXBOX_PFN)&persisted_mem->Data[(persisted_mem->NumOfPtes * 2) + (persisted_mem->NumOfPtes - 32) * KiB(1)])[pte.Hardware.PFN];
+			m_PagesByUsage[temp_pfn->Busy.BusyType]++;
+			memcpy(CHIHIRO_PFN_ELEMENT(pte.Hardware.PFN), temp_pfn, sizeof(XBOX_PFN));
 			if ((uint32_t*)persisted_mem->Data[i] < (uint32_t*)CHIHIRO_PFN_ADDRESS) {
 				memcpy((void*)(persisted_mem->Data[i]), &persisted_mem->Data[persisted_mem->NumOfPtes * 2 + i * KiB(1)], PAGE_SIZE);
 			}
 		}
 		else {
-			memcpy(XBOX_PFN_ELEMENT(pte.Hardware.PFN),
-				&((PXBOX_PFN)&persisted_mem->Data[(persisted_mem->NumOfPtes * 2) + (persisted_mem->NumOfPtes - 16) * KiB(1)])[pte.Hardware.PFN],
-				sizeof(XBOX_PFN));
+			PXBOX_PFN temp_pfn = &((PXBOX_PFN)&persisted_mem->Data[(persisted_mem->NumOfPtes * 2) + (persisted_mem->NumOfPtes - 16) * KiB(1)])[pte.Hardware.PFN];
+			m_PagesByUsage[temp_pfn->Busy.BusyType]++;
+			memcpy(XBOX_PFN_ELEMENT(pte.Hardware.PFN), temp_pfn, sizeof(XBOX_PFN));
 			if ((uint32_t*)persisted_mem->Data[i] < (uint32_t*)XBOX_PFN_ADDRESS) {
 				memcpy((void*)(persisted_mem->Data[i]), &persisted_mem->Data[persisted_mem->NumOfPtes * 2 + i * KiB(1)], PAGE_SIZE);
 			}

--- a/src/core/kernel/memory-manager/VMManager.cpp
+++ b/src/core/kernel/memory-manager/VMManager.cpp
@@ -248,7 +248,7 @@ void VMManager::InitializeSystemAllocations()
 	}
 	addr = (VAddr)CONVERT_PFN_TO_CONTIGUOUS_PHYSICAL(pfn);
 
-	AllocateContiguousMemoryInternal(pfn_end - pfn + 1, pfn, pfn_end, 1, XBOX_PAGE_READWRITE);
+	AllocateContiguousMemoryInternal(pfn_end - pfn + 1, pfn, pfn_end, 1, XBOX_PAGE_READWRITE, UnknownType);
 	PersistMemory(addr, (pfn_end - pfn + 1) << PAGE_SHIFT, true);
 	if (m_MmLayoutDebug) { m_PhysicalPagesAvailable += 16; m_DebuggerPagesAvailable -= 16; }
 
@@ -855,7 +855,7 @@ VAddr VMManager::AllocateContiguousMemory(size_t Size, PAddr LowestAddress, PAdd
 	RETURN(Addr);
 }
 
-VAddr VMManager::AllocateContiguousMemoryInternal(PFN_COUNT NumberOfPages, PFN LowestPfn, PFN HighestPfn, PFN PfnAlignment, DWORD Perms)
+VAddr VMManager::AllocateContiguousMemoryInternal(PFN_COUNT NumberOfPages, PFN LowestPfn, PFN HighestPfn, PFN PfnAlignment, DWORD Perms, PageType BusyType)
 {
 	MMPTE TempPte;
 	PMMPTE PointerPte;
@@ -884,7 +884,7 @@ VAddr VMManager::AllocateContiguousMemoryInternal(PFN_COUNT NumberOfPages, PFN L
 	EndingPte = PointerPte + NumberOfPages - 1;
 
 	WritePte(PointerPte, EndingPte, TempPte, pfn);
-	WritePfn(pfn, EndingPfn, PointerPte, ContiguousType);
+	WritePfn(pfn, EndingPfn, PointerPte, BusyType);
 	EndingPte->Hardware.GuardOrEnd = 1;
 
 	ConstructVMA(addr, NumberOfPages << PAGE_SHIFT, ContiguousRegion, AllocatedVma, false);

--- a/src/core/kernel/memory-manager/VMManager.h
+++ b/src/core/kernel/memory-manager/VMManager.h
@@ -167,7 +167,7 @@ class VMManager : public PhysicalMemory
 		void* m_PersistentMemoryHandle = nullptr;
 
 		// same as AllocateContiguousMemory, but it allows to allocate beyond m_MaxContiguousPfn
-		VAddr AllocateContiguousMemoryInternal(PFN_COUNT NumberOfPages, PFN LowestPfn, PFN HighestPfn, PFN PfnAlignment, DWORD Perms);
+		VAddr AllocateContiguousMemoryInternal(PFN_COUNT NumberOfPages, PFN LowestPfn, PFN HighestPfn, PFN PfnAlignment, DWORD Perms, PageType BusyType = ContiguousType);
 		// set up the system allocations
 		void InitializeSystemAllocations();
 		// initializes a memory region struct


### PR DESCRIPTION
This fixes three problems I recently discovered in the VMManager introduced during the loader transition:
1. the `UnknownType` type was never used for the pfn database pages, which caused incorrect statistics for this page type. Shouldn't affect anything since this type is not reported by `MmQueryStatistics`.
2. upon xbe reboot, the page statistics were not restored at all. Potentially affects titles since `MmQueryStatistics` reports some of these page types.
3. when an xbe reboot occurs while using the debug memory layout, the pfn database was restored from the wrong address, thus restoring inconsistent values. Affects chihiro titles because they are signed with the debug key and thus they will (erroneously) use the debug memory layout.