### PR TITLE
Fix crash in Stranger's Wrath caused by false rdtsc positives

### DIFF
--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -458,9 +458,9 @@ void PatchRdtsc(xbox::addr_xt addr)
 }
 
 const uint8_t rdtsc_pattern[] = {
-	0x89,//{ 0x0F,0x31,0x89 },
+	0x89,//{ 0x0F,0x31,0x89 },   // two false positives in Stranger's Wrath
 	0xC3,//{ 0x0F,0x31,0xC3 },
-	0x8B,//{ 0x0F,0x31,0x8B },   //one false positive in Sonic Rider .text 88 5C 0F 31
+	0x8B,//{ 0x0F,0x31,0x8B },   // one false positive in Sonic Rider .text 88 5C 0F 31, two false positives in Stranger's Wrath
 	0xB9,//{ 0x0F,0x31,0xB9 },
 	0xC7,//{ 0x0F,0x31,0xC7 },
 	0x8D,//{ 0x0F,0x31,0x8D },
@@ -479,7 +479,7 @@ const uint8_t rdtsc_pattern[] = {
 	0x85,//{ 0x0F,0x31,0x85 },
 	0x83,//{ 0x0F,0x31,0x83 },
 	0x33,//{ 0x0F,0x31,0x33 },
-	0xF7,//{ 0x0F,0x31,0xF7 },
+	0xF7,//{ 0x0F,0x31,0xF7 }, // one false positive in Stranger's Wrath
 	0x8A,//{ 0x0F,0x31,0x8A }, // 8A and 56 only apears in RalliSport 2 .text , need to watch whether any future false positive.
 	0x56,//{ 0x0F,0x31,0x56 }
     0x6A,                      // 6A, 39, EB, F6, A1, 01 only appear in Unreal Championship, 01 is at WMVDEC section
@@ -537,6 +537,20 @@ void PatchRdtscInstructions()
 								continue;
 							}
 
+							if (*(uint8_t *)(addr - 2) == 0x24 && *(uint8_t *)(addr - 1) == 0x0C)
+							{
+								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
+								continue;
+							}
+						}
+						if (next_byte == 0x89)
+						{
+							if (*(uint8_t *)(addr - 2) == 0x24 && *(uint8_t *)(addr - 1) == 0x04)
+							{
+								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
+								continue;
+							}
+
 						}
 						if (next_byte == 0x50)
 						{
@@ -550,6 +564,15 @@ void PatchRdtscInstructions()
 						if (next_byte == 0x01)
 						{
 							if (*(uint8_t*)(addr - 1) == 0xE8 && *(uint8_t*)(addr + 3) == 0x00)
+							{
+								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
+								continue;
+							}
+
+						}
+						if (next_byte == 0xF7)
+						{
+							if (*(uint8_t *)(addr - 1) == 0xE8 && *(uint8_t *)(addr + 3) == 0xFF)
 							{
 								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
 								continue;


### PR DESCRIPTION
This is based on the below rdtsc logs:
```
Patching rdtsc opcode at 0x001F52E8
1D 68 A0 00 00 00 56 56  68 E4 56 28 00 8B CB E8
0F 31 F7 FF 89 2B 89 1D  58 14 31 00 EB 06 89 35

Patching rdtsc opcode at 0x0021837E
CC CC 83 EC 08 8D 04 24  89 44 24 04 8B 4C 24 04
0F 31 89 01 8B 4C 24 0C  51 FF 15 0C BC 3A 00 8D

Patching rdtsc opcode at 0x00218394 
24 0C 51 FF 15 0C BC 3A  00 8D 14 24 89 54 24 0C
0F 31 8B 4C 24 0C 8B D0  2B 01 89 01 8B 14 24 E8

Patching rdtsc opcode at 0x002183BE
CC CC 83 EC 08 8D 04 24  89 44 24 04 8B 4C 24 04
0F 31 89 01 8B 4C 24 0C  51 FF 15 18 BC 3A 00 8D

Patching rdtsc opcode at 0x002183D4
24 0C 51 FF 15 18 BC 3A  00 8D 14 24 89 54 24 0C
0F 31 8B 4C 24 0C 8B D0  2B 01 89 01 8B 14 24 E8
```

The first is actually a call instruction, and the remaining four are just data and not even code.
This brings the game Oddworld: Stranger's Wrath from instantly crashing at startup to actually booting and rendering the title screens.

![Stranger's Wrath](https://user-images.githubusercontent.com/45463469/96037506-36932c80-0e66-11eb-8335-5bb3e1234c83.PNG)
