### PR TITLE
Avoid false rdtsc negative in 25 to life

### DIFF
--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -545,7 +545,7 @@ void PatchRdtscInstructions()
 						}
 						if (next_byte == 0x89)
 						{
-							if (*(uint8_t *)(addr - 2) == 0x24 && *(uint8_t *)(addr - 1) == 0x04)
+							if (*(uint8_t *)(addr + 4) == 0x8B && *(uint8_t *)(addr - 5) == 0x04)
 							{
 								EmuLogInit(LOG_LEVEL::INFO, "Skipped false positive: rdtsc pattern  0x%.2X, @ 0x%.8X", next_byte, (DWORD)addr);
 								continue;


### PR DESCRIPTION
This issue was raised by @LukeUsher, which noticed that an rdtsc instruction in 25 to life has the same pattern of Stranger's Wrath, thus resulting in a false negative. This changes the pattern used in cxbxr to still recognize the false positve in Stranger's Wrath but also avoid the false negative in 25 to life.