### PR TITLE
SetViewport & Clear improvements

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4999,12 +4999,14 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_Clear)
 
     if (pRects != nullptr) {
         // Scale the fill based on our scale factor and MSAA scale
-        D3DRECT rect;
-        rect.x1 = static_cast<LONG>(pRects->x1 * g_Xbox_MultiSampleXScale * g_RenderScaleFactor);
-        rect.x2 = static_cast<LONG>(pRects->x2 * g_Xbox_MultiSampleXScale * g_RenderScaleFactor);
-        rect.y1 = static_cast<LONG>(pRects->y1 * g_Xbox_MultiSampleYScale * g_RenderScaleFactor);
-        rect.y2 = static_cast<LONG>(pRects->y2 * g_Xbox_MultiSampleYScale * g_RenderScaleFactor);
-        hRet = g_pD3DDevice->Clear(Count, &rect, HostFlags, Color, Z, Stencil);
+        std::vector<D3DRECT> rects(Count);
+        for (DWORD i = 0; i < Count; i++) {
+            rects[i].x1 = static_cast<LONG>(pRects[i].x1 * g_Xbox_MultiSampleXScale * g_RenderScaleFactor);
+            rects[i].x2 = static_cast<LONG>(pRects[i].x2 * g_Xbox_MultiSampleXScale * g_RenderScaleFactor);
+            rects[i].y1 = static_cast<LONG>(pRects[i].y1 * g_Xbox_MultiSampleYScale * g_RenderScaleFactor);
+            rects[i].y2 = static_cast<LONG>(pRects[i].y2 * g_Xbox_MultiSampleYScale * g_RenderScaleFactor);
+		}
+        hRet = g_pD3DDevice->Clear(Count, rects.data(), HostFlags, Color, Z, Stencil);
     } else {
         hRet = g_pD3DDevice->Clear(Count, pRects, HostFlags, Color, Z, Stencil);
     }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4117,6 +4117,8 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetViewport)
 	// Apply MSAA scale and offset
 	HostViewPort.Width = static_cast<DWORD>(HostViewPort.Width * g_Xbox_MultiSampleXScale);
 	HostViewPort.Height = static_cast<DWORD>(HostViewPort.Height * g_Xbox_MultiSampleYScale);
+	HostViewPort.X = static_cast<DWORD>(HostViewPort.X * g_Xbox_MultiSampleXScale);
+	HostViewPort.Y = static_cast<DWORD>(HostViewPort.Y * g_Xbox_MultiSampleYScale);
 	// Since Width and Height are DWORD, adding GetMultiSampleOffset 0.0f or 0.5f makes no sense
 
 	HRESULT hRet = g_pD3DDevice->SetViewport(&HostViewPort);


### PR DESCRIPTION
1. Scales viewport X and Y and not only Width and Height. Cherry picked from #1894
2. Pre-emptively fixes possible issues when the game passes multiple rectangles to `Clear`.

Fixes a misplaced and broken rear view mirror in NASCAR Heat 2002.
Potentially fixes misplaced skaters in Tony Hawk's Pro Skater 2X.