### PR TITLE
emux86: fix bad bios rom mapping

### DIFF
--- a/src/common/AddressRanges.h
+++ b/src/common/AddressRanges.h
@@ -115,10 +115,6 @@ inline constexpr uint32_t NVNET_DEVICE_BASE =      0xFEF00000;
 inline constexpr uint32_t NVNET_DEVICE_SIZE =      (KiB(1)); // = 0x00000400
 inline constexpr uint32_t NVNET_DEVICE_END  =      (NVNET_DEVICE_BASE + NVNET_DEVICE_SIZE - 1); // 0xFEF003FF
 
-#define XBOX_FLASH_ROM_BASE                 0xFFF00000
-#define XBOX_FLASH_ROM_SIZE                 (MiB(1)) // = 0x00100000
-#define XBOX_FLASH_ROM_END                  (XBOX_FLASH_ROM_BASE + XBOX_FLASH_ROM_SIZE - 1) // - 0xFFFFFFF
-
 inline constexpr uint32_t FLASH_DEVICEN_SIZE =     (MiB(4)); // = 0x00400000
 inline constexpr uint32_t FLASH_DEVICE1_BASE =     0xFF000000;
 inline constexpr uint32_t FLASH_DEVICE1_END  =     (FLASH_DEVICE1_BASE + FLASH_DEVICEN_SIZE - 1); // 0xFF3FFFFF

--- a/src/devices/x86/EmuX86.cpp
+++ b/src/devices/x86/EmuX86.cpp
@@ -149,6 +149,10 @@ uint32_t EmuFlash_Read32(xbox::addr_xt addr) // TODO : Move to EmuFlash.cpp
 {
 	uint32_t r;
 
+    // Some games attempt to read from the BIOS ROM directly, for purposes of hardware-version detection
+    // And other (currently unknown) reasons. We can't include the entire bios, and we don't want to require it
+    // So we specifiy the specific values that games rely on.
+
 	switch (addr) {
     case 0x08: // ? Test Case - Shenmue II attempts to read this address but never uses the resulting value? 
         r = 0x2B16D065;
@@ -179,7 +183,7 @@ uint32_t EmuX86_Read(xbox::addr_xt addr, int size)
 
 	uint32_t value;
 
-	if (addr >= FLASH_DEVICE1_BASE) { // 0xFFF00000 - 0xFFFFFFF
+	if (addr >= FLASH_DEVICE1_BASE) { // 0xFF000000 - 0xFFFFFFF
 		return EmuFlash_Read32((addr - FLASH_DEVICE1_BASE) % KiB(256)); // NOTE: Bios is a 256kb rom, mirrored through the address space
 	}
 

--- a/src/devices/x86/EmuX86.cpp
+++ b/src/devices/x86/EmuX86.cpp
@@ -150,6 +150,9 @@ uint32_t EmuFlash_Read32(xbox::addr_xt addr) // TODO : Move to EmuFlash.cpp
 	uint32_t r;
 
 	switch (addr) {
+    case 0x08: // ? Test Case - Shenmue II attempts to read this address but never uses the resulting value? 
+        r = 0x2B16D065;
+        break;
 	case 0x78: // ROM_VERSION
 		r = 0x90; // Luke's hardware revision 1.6 Xbox returns this (also since XboxKrnlVersion is set to 5838)
 		break;
@@ -176,8 +179,8 @@ uint32_t EmuX86_Read(xbox::addr_xt addr, int size)
 
 	uint32_t value;
 
-	if (addr >= XBOX_FLASH_ROM_BASE) { // 0xFFF00000 - 0xFFFFFFF
-		return EmuFlash_Read32(addr - XBOX_FLASH_ROM_BASE); // TODO : Make flash access size-aware
+	if (addr >= FLASH_DEVICE1_BASE) { // 0xFFF00000 - 0xFFFFFFF
+		return EmuFlash_Read32((addr - FLASH_DEVICE1_BASE) % KiB(256)); // NOTE: Bios is a 256kb rom, mirrored through the address space
 	}
 
 	// TODO: Remove this once we have an LLE APU Device
@@ -206,7 +209,7 @@ void EmuX86_Write(xbox::addr_xt addr, uint32_t value, int size)
 		return;
 	}
 
-	if (addr >= XBOX_FLASH_ROM_BASE) { // 0xFFF00000 - 0xFFFFFFF
+	if (addr >= FLASH_DEVICE1_BASE) { // 0xFF000000 - 0xFFFFFFF
 		EmuLog(LOG_LEVEL::WARNING, "EmuX86_Write(0x%08X, 0x%08X) [FLASH_ROM]", addr, value);
 		return;
 	}


### PR DESCRIPTION
Bios ROM region reads were incorrectly based at 0xFFF00000 instead of 0xFF000000

Prevents a crash in Shenmue II