### PR TITLE
Simplify thread creation logic, remove hardcoded delays and tighten affinity changes

### DIFF
--- a/src/core/kernel/common/ps.h
+++ b/src/core/kernel/common/ps.h
@@ -25,7 +25,7 @@ namespace xbox
 XBSYSAPI EXPORTNUM(254) ntstatus_xt NTAPI PsCreateSystemThread
 (
 	OUT PHANDLE         ThreadHandle,
-	OUT PHANDLE         ThreadId OPTIONAL,
+	OUT PDWORD          ThreadId OPTIONAL,
 	IN  PKSTART_ROUTINE StartRoutine,
 	IN  PVOID           StartContext,
 	IN  boolean_xt         DebuggerThread
@@ -40,7 +40,7 @@ XBSYSAPI EXPORTNUM(255) ntstatus_xt NTAPI PsCreateSystemThreadEx
 	IN  ulong_xt           ThreadExtensionSize,
 	IN  ulong_xt           KernelStackSize,
 	IN  ulong_xt           TlsDataSize,
-	OUT PHANDLE         ThreadId OPTIONAL,
+	OUT PDWORD          ThreadId OPTIONAL,
 	IN  PKSTART_ROUTINE StartRoutine,
 	IN  PVOID           StartContext,
 	IN  boolean_xt         CreateSuspended,

--- a/src/core/kernel/exports/EmuKrnlPs.cpp
+++ b/src/core/kernel/exports/EmuKrnlPs.cpp
@@ -166,7 +166,7 @@ void PspSystemThreadStartup
 XBSYSAPI EXPORTNUM(254) xbox::ntstatus_xt NTAPI xbox::PsCreateSystemThread
 (
 	OUT PHANDLE         ThreadHandle,
-	OUT PHANDLE         ThreadId OPTIONAL,
+	OUT PDWORD          ThreadId OPTIONAL,
 	IN  PKSTART_ROUTINE StartRoutine,
 	IN  PVOID           StartContext,
 	IN  boolean_xt         DebuggerThread
@@ -210,7 +210,7 @@ XBSYSAPI EXPORTNUM(255) xbox::ntstatus_xt NTAPI xbox::PsCreateSystemThreadEx
 	IN  ulong_xt           ThreadExtensionSize,
 	IN  ulong_xt           KernelStackSize,
 	IN  ulong_xt           TlsDataSize,
-	OUT PHANDLE         ThreadId OPTIONAL,
+	OUT PDWORD          ThreadId OPTIONAL,
 	IN  PKSTART_ROUTINE StartRoutine,
 	IN  PVOID           StartContext,
 	IN  boolean_xt         CreateSuspended,
@@ -284,9 +284,9 @@ XBSYSAPI EXPORTNUM(255) xbox::ntstatus_xt NTAPI xbox::PsCreateSystemThreadEx
 			}
 		}*/
 
-        *ThreadHandle = (HANDLE)_beginthreadex(NULL, KernelStackSize, PCSTProxy, iPCSTProxyParam, NULL, (unsigned int*)&dwThreadId);
+        *ThreadHandle = reinterpret_cast<HANDLE>(_beginthreadex(NULL, KernelStackSize, PCSTProxy, iPCSTProxyParam, NULL, reinterpret_cast<unsigned int*>(&dwThreadId)));
         if (ThreadId != NULL)
-            *ThreadId = (xbox::HANDLE)dwThreadId;
+            *ThreadId = dwThreadId;
 
 		// Note : DO NOT use iPCSTProxyParam anymore, since ownership is transferred to the proxy (which frees it too)
 

--- a/src/core/kernel/exports/EmuKrnlPs.cpp
+++ b/src/core/kernel/exports/EmuKrnlPs.cpp
@@ -55,7 +55,6 @@ typedef struct _PCSTProxyParam
 	IN PVOID  StartContext;
 	IN PVOID  SystemRoutine;
 	IN BOOL   StartSuspended;
-	IN HANDLE hStartedEvent;
 }
 PCSTProxyParam;
 
@@ -69,8 +68,7 @@ void LOG_PCSTProxy
 	PVOID StartRoutine,
 	PVOID StartContext,
 	PVOID SystemRoutine,
-	BOOL   StartSuspended,
-	HANDLE hStartedEvent
+	BOOL  StartSuspended
 )
 {
 	LOG_FUNC_BEGIN
@@ -78,7 +76,6 @@ void LOG_PCSTProxy
 		LOG_FUNC_ARG(StartContext)
 		LOG_FUNC_ARG(SystemRoutine)
 		LOG_FUNC_ARG(StartSuspended)
-		LOG_FUNC_ARG(hStartedEvent)
 		LOG_FUNC_END;
 }
 
@@ -105,40 +102,32 @@ static unsigned int WINAPI PCSTProxy
 {
 	CxbxSetThreadName("PsCreateSystemThread Proxy");
 
-	PCSTProxyParam *iPCSTProxyParam = (PCSTProxyParam*)Parameter;
+	PCSTProxyParam *iPCSTProxyParam = static_cast<PCSTProxyParam*>(Parameter);
 
-	PVOID StartRoutine = iPCSTProxyParam->StartRoutine;
-	PVOID StartContext = iPCSTProxyParam->StartContext;
-	PVOID SystemRoutine = iPCSTProxyParam->SystemRoutine;
-	BOOL StartSuspended = iPCSTProxyParam->StartSuspended;
-	HANDLE hStartedEvent = iPCSTProxyParam->hStartedEvent;
-
-	// Once deleted, unable to directly access iPCSTProxyParam in remainder of function.
-	free(iPCSTProxyParam);
+	// Copy params to the stack so they can be freed
+	PCSTProxyParam params = *iPCSTProxyParam;
+	delete iPCSTProxyParam;
 
 	LOG_PCSTProxy(
-		StartRoutine,
-		StartContext,
-		SystemRoutine,
-		StartSuspended,
-		hStartedEvent);
+		params.StartRoutine,
+		params.StartContext,
+		params.SystemRoutine,
+		params.StartSuspended);
 
 
 	// Do minimal thread initialization
 	InitXboxThread(g_CPUXbox);
 
-	SetEvent(hStartedEvent);
-
-	if (StartSuspended == TRUE) {
+	if (params.StartSuspended == TRUE) {
 		SuspendThread(GetCurrentThread());
 	}
 
-	auto routine = (xbox::PKSYSTEM_ROUTINE)SystemRoutine;
+	auto routine = (xbox::PKSYSTEM_ROUTINE)params.SystemRoutine;
 	// Debugging notice : When the below line shows up with an Exception dialog and a
 	// message like: "Exception thrown at 0x00026190 in cxbx.exe: 0xC0000005: Access
 	// violation reading location 0xFD001804.", then this is AS-DESIGNED behaviour!
 	// (To avoid repetitions, uncheck "Break when this exception type is thrown").
-	routine(xbox::PKSTART_ROUTINE(StartRoutine), StartContext);
+	routine(xbox::PKSTART_ROUTINE(params.StartRoutine), params.StartContext);
 
 	// This will also handle thread notification :
 	LOG_TEST_CASE("Thread returned from SystemRoutine");
@@ -245,22 +234,15 @@ XBSYSAPI EXPORTNUM(255) xbox::ntstatus_xt NTAPI xbox::PsCreateSystemThreadEx
 
     // create thread, using our special proxy technique
     {
-        DWORD dwThreadId = 0, dwThreadWait;
-        bool bWait = true;
-		HANDLE hStartedEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
-		if (hStartedEvent == NULL) {
-			std::string errorMessage = CxbxGetLastErrorString("PsCreateSystemThreadEx could not create PCSTProxyEvent");
-			CxbxKrnlCleanup(errorMessage.c_str());
-		}
+        DWORD dwThreadId = 0;
 
         // PCSTProxy is responsible for cleaning up this pointer
-		PCSTProxyParam *iPCSTProxyParam = (PCSTProxyParam*)malloc(sizeof(PCSTProxyParam));
+		PCSTProxyParam *iPCSTProxyParam = new PCSTProxyParam;
 
         iPCSTProxyParam->StartRoutine = (PVOID)StartRoutine;
         iPCSTProxyParam->StartContext = StartContext;
         iPCSTProxyParam->SystemRoutine = (PVOID)SystemRoutine; // NULL, XapiThreadStartup or unknown?
         iPCSTProxyParam->StartSuspended = CreateSuspended;
-	    iPCSTProxyParam->hStartedEvent = hStartedEvent;
 
 		/*
 		// call thread notification routine(s)
@@ -289,37 +271,6 @@ XBSYSAPI EXPORTNUM(255) xbox::ntstatus_xt NTAPI xbox::PsCreateSystemThreadEx
             *ThreadId = dwThreadId;
 
 		// Note : DO NOT use iPCSTProxyParam anymore, since ownership is transferred to the proxy (which frees it too)
-
-		EmuLog(LOG_LEVEL::DEBUG, "Waiting for Xbox proxy thread to start...");
-
-        while (bWait) {
-            dwThreadWait = WaitForSingleObject(hStartedEvent, INFINITE);
-            switch (dwThreadWait) {
-                case WAIT_TIMEOUT: { // The time-out interval elapsed, and the object's state is nonsignaled.
-					EmuLog(LOG_LEVEL::WARNING, "Timeout while waiting for Xbox proxy thread to start...\n");
-                    bWait = false;
-                    break;
-                }
-                case WAIT_OBJECT_0: { // The state of the specified object is signaled.
-					EmuLog(LOG_LEVEL::DEBUG, "Xbox proxy thread is started.");
-                    bWait = false;
-                    break;
-                }
-                default: {
-					if (dwThreadWait == WAIT_FAILED) // The function has failed
-						bWait = false;
-
-					std::string ErrorStr = CxbxGetLastErrorString("While waiting for Xbox proxy thread to start");
-					EmuLog(LOG_LEVEL::WARNING, "%s\n", ErrorStr.c_str());
-					break;
-                }
-            }
-        }
-
-
-		// Release the event
-		CloseHandle(hStartedEvent);
-		hStartedEvent = NULL;
 
 		// Log ThreadID identical to how GetCurrentThreadID() is rendered :
 		EmuLog(LOG_LEVEL::DEBUG, "Created Xbox proxy thread. Handle : 0x%X, ThreadId : [0x%.4X]", *ThreadHandle, dwThreadId);


### PR DESCRIPTION
**This PR needs extensive testing. It touches one of the areas of emulation which frequently had regressions resulting in games freezing (notably, #1511 and #857). Below I have collected a list of games which were mentioned in such issues in the past. Please verify those games for regressions or improvements:**

- ❔ Blood Wake (known past regression, later fixed)
- ❔ [Call of Duty: Finest Hour](https://github.com/Cxbx-Reloaded/game-compatibility/issues/542) (known past regression, later fixed)
- ➖ [Far Cry Instincts](https://github.com/Cxbx-Reloaded/game-compatibility/issues/62) (known past regression, later fixed) **- no change**
- ❔ Grand Theft Auto III (froze during intro movies - fixed for me, but please verify)
- ❔ Red Faction 2 (known past regression, later fixed)
- ❔ The Simpsons: Road Rage (known past regression, later fixed)
- ❔ The Warriors (crashed on startup - fixed for me, but please verify)



This PR simplifies the thread creation logic and removes hardcoded "magic" sleeps in favour of tighter affinity changes. Those "magic" sleeps were introduced to work around games hanging due to timing issues, but it appears those hangs would happen, because child threads would initially execute on any core before changing their own affinity.

Changes introduced in this PR:
* Changed `ThreadId` parameter type to `PWORD`.
* Removed `hStartedEvent` since it doesn't seem to protect anything meaningful anymore, and only messed with thread scheduling.
* Starts child threads suspended and finalize their initialization before resuming - this closes a possible race condition where a child thread uses `ThreadHandle` or `dwThreadId` and starts before `_beginthreadex` even returns. It also allowed me to remove "magic" sleeps by ensuring that the child thread really never starts on a wrong CPU core.


Gets The Warriors in-game. Before this PR, a race condition in the original game code was hit - the game spawns a thread which waits on the event. However, the event in question is created **after** spawning that thread. Previous thread creation timings always caused the child thread to try and wait on the event before it was created.
![image](https://user-images.githubusercontent.com/7947461/96350806-d267a700-10b7-11eb-8088-9479f0045c3d.png)

**Previous PR description below, not valid anymore - the hack was now replaced with a proper change.**

~~This PR adds a similar hack to the one found in Xenia: https://github.com/xenia-project/xenia/blob/8123978c498257ad9d65353bc59af3e544b4fc27/src/xenia/kernel/xthread.cc#L502~~

~~Delay the thread startup a bit to "simulate" slow startup and to encourage the scheduler not to switch to the newly created thread right away. This **is** a hack, but it's also the only way to accommodate for buggy games which initialize resources after spawning a thread which uses them.~~

~~Gets The Warriors in-game. It needs such a delay because it spawns a thread which waits on the event. However, the event in question is created **after** spawning the thread, so context switching to that thread right after creating it resulted in a spurious wakeup and in consequence a crash.~~
