### PR TITLE
Add a fallback to CopyRects for cases which StretchRect can't handle

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5118,7 +5118,11 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_CopyRects)
 
         HRESULT hRet = g_pD3DDevice->StretchRect(pHostSourceSurface, &SourceRect, pHostDestSurface, &DestRect, D3DTEXF_LINEAR);
         if (FAILED(hRet)) {
-            LOG_TEST_CASE("D3DDevice_CopyRects: Failed to copy surface");
+			// Fallback for cases which StretchRect cannot handle (such as copying from texture to texture)
+			hRet = D3DXLoadSurfaceFromSurface(pHostDestSurface, nullptr, &DestRect, pHostSourceSurface, nullptr, &SourceRect, D3DTEXF_LINEAR, 0);
+			if (FAILED(hRet)) {
+				LOG_TEST_CASE("D3DDevice_CopyRects: Failed to copy surface");
+			}
         }
     }
 }


### PR DESCRIPTION
Fixes menus in World Racing 2 because CopyRects tries to copy a texture to texture.

![image](https://user-images.githubusercontent.com/7947461/96623969-692ca180-130c-11eb-927d-5dbbef9af4fb.png)
