### PR TITLE
Pixel shader fix XFC SUM 

### DIFF
--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -3925,8 +3925,8 @@ void PSH_XBOX_SHADER::ConvertXFCToNative(int i)
 
   if (NeedsSum)
   {
-    // Add a new opcode that calculates r0*v1 :
-    Ins.Initialize(PO_MUL);
+    // Add a new opcode that calculates r0+v1 :
+    Ins.Initialize(PO_ADD);
     Ins.Output[0].SetRegister(PARAM_T, FakeRegNr_Sum, MASK_RGBA); // 'r2'
 
     Ins.Parameters[0].SetRegister(PARAM_R, 0, MASK_RGB);


### PR DESCRIPTION
Fix how our current pixel shader conversion calculates the final combiner special purpose register 'sum' : it was accidentally multiplying instead of adding it's arguments!

Pixel shaders that use this 'sum' register will show more accurate output because of this change.

This is a low-risk, possibly high-impact change. 