### PR TITLE
Fix APU timer ticking at wrong frequency

### DIFF
--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -29,6 +29,7 @@
 #define TIMER_H
 
 #include <atomic>
+#include <mutex>
 
 #define SCALE_S_IN_NS  1000000000
 #define SCALE_MS_IN_NS 1000000
@@ -62,5 +63,24 @@ void Timer_Exit(TimerObject* Timer);
 void Timer_ChangeExpireTime(TimerObject* Timer, uint64_t Expire_ms);
 uint64_t GetTime_NS(TimerObject* Timer);
 void Timer_Init();
+
+// A stateful replacement for QueryPerformanceCounter, ticking at an arbitrary frequency
+// Thread-safe and designed to avoid overflows at all cost
+class ScaledPerformanceCounter
+{
+public:
+	ScaledPerformanceCounter() = default;
+	void Reset(uint32_t frequency);
+	uint64_t Tick();
+
+private:
+	std::mutex m_mutex;
+
+	uint64_t m_frequencyFactor;
+	int64_t m_lastQPC;
+
+	uint64_t m_currentCount;
+	uint64_t m_currentRemainder;
+};
 
 #endif


### PR DESCRIPTION
When looking for a different issue I spotted this abomination in the APU timer code:

```cpp
// Measure current host performance counter and frequency
QueryPerformanceCounter(&APUInitialPerformanceCounter);
NativeToXboxAPU_FactorForPerformanceFrequency = (double)APU_TIMER_FREQUENCY / APUInitialPerformanceCounter.QuadPart;
```

This is obviously wrong and probably pretty inaccurate due to the usage of floating point variables, so I replaced this code with an adaptation of RDTSC ticking code I wrote for #1985

No known improvements, but might improve the accuracy of whatever is relying on the APU timer for some sound timings.