### PR TITLE
Dsstream pause fixes

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.cpp
@@ -372,7 +372,7 @@ bool DSStream_Packet_Flush(
     }
     // Clear flags and set status to zero.
     DSStream_Packet_FlushEx_Reset(pThis);
-    pThis->EmuFlags &= ~DSE_FLAG_PAUSE;
+    pThis->EmuFlags |= DSE_FLAG_PAUSE;
     pThis->Xb_Status = 0;
     return false;
 }

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -854,10 +854,10 @@ static inline HRESULT HybridDirectSoundBuffer_Pause(
          // TODO: NOTE: If stream is playing, it perform same behavior as pause flag. If it is not played, it act as a queue until trigger to play it.
         case X_DSSPAUSE_PAUSENOACTIVATE:
             if ((dwEmuFlags & DSE_FLAG_PAUSE) != 0) {
-                // TODO: Start queueing
+                // TODO: Start queueing, might need the use of a DSE_FLAG_IS_ACTIVATED flag
                 break;
             }
-            // Intentional fallthrough
+            [[fallthrough]];
         case X_DSSPAUSE_PAUSE:
             pDSBuffer->Stop();
             DSoundBufferSynchPlaybackFlagRemove(dwEmuFlags);

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -851,6 +851,13 @@ static inline HRESULT HybridDirectSoundBuffer_Pause(
             dwEmuFlags &= ~DSE_FLAG_PAUSE;
             Xb_rtTimeStamp = 0;
             break;
+         // TODO: NOTE: If stream is playing, it perform same behavior as pause flag. If it is not played, it act as a queue until trigger to play it.
+        case X_DSSPAUSE_PAUSENOACTIVATE:
+            if ((dwEmuFlags & DSE_FLAG_PAUSE) != 0) {
+                // TODO: Start queueing
+                break;
+            }
+            // Intentional fallthrough
         case X_DSSPAUSE_PAUSE:
             pDSBuffer->Stop();
             DSoundBufferSynchPlaybackFlagRemove(dwEmuFlags);
@@ -865,9 +872,6 @@ static inline HRESULT HybridDirectSoundBuffer_Pause(
             if (hRet == DS_OK) {
                 pDSBuffer->Stop();
             }
-            break;
-        // TODO: NOTE: If stream is playing, it perform same behavior as pause flag. If it is not played, it act as a queue until trigger to play it.
-        case X_DSSPAUSE_PAUSENOACTIVATE:
             break;
     }
 


### PR DESCRIPTION
This PR fixes a bug potentially introduced by #1853. It changes two things:

1. Partially implements `X_DSSPAUSE_PAUSENOACTIVATE` because it's identical to `X_DSSPAUSE_PAUSE` in the case where the stream is not playing yet. The other case is still unimplemented.
2. Marks flushed sound streams as paused, as flushing is intended to stop the stream. Removing the pause flag made games keep pushing data packets to the stream after flushing, resulting in them not stopping.

**Needs testing with Obscure,  since fixes from #1853 targetted it!**
**Needs testing with Manhunt - it reportedly had the same bug as The Warriors (shared codebase) but I did not verify that.**
**Needs testing with games which would not pause/stop sounds and/or music as intended.**

Fixes cutscene audio not stopping when skipping cutscenes in The Warriors.
Fixes EA Trax playing in the background when launching Burnout 3. Main menu theme loops after a few seconds, but this was also the case before this PR and is an unrelated bug.