### PR TITLE
Improve reverse screenspace transformation precision

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
@@ -261,9 +261,13 @@ float4 reverseScreenspaceTransform(float4 oPos)
 	// mad oPos.xyz, r12, r1.x, c-37
 	// where c-37 and c-38 are reserved transform values
 
+	// oPos.w and xboxViewportScale.z might be VERY big when a D24 depth buffer is used
+	// and multiplying oPos.xyz by oPos.w may cause precision issues.
+	// Pre-divide them to help keep the values reasonably small.
+	// Test case: Burnout 3
+	float3 divisor = xboxViewportScale.xyz / oPos.w;
 	oPos.xyz -= xboxViewportOffset.xyz; // reverse offset
-	oPos.xyz *= oPos.w; // reverse perspective divide
-	oPos.xyz /= xboxViewportScale.xyz; // reverse scale
+	oPos.xyz /= divisor; // reverse scale and perspective divide
 
 	return oPos;
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4032,11 +4032,10 @@ void GetViewPortOffsetAndScale(float (&vOffset)[4], float(&vScale)[4])
 
 void UpdateViewPortOffsetAndScaleConstants()
 {
-    float vOffset[4], vScale[4];
-    GetViewPortOffsetAndScale(vOffset, vScale);
+    float vScaleOffset[2][4]; // 0 - scale 1 - offset
+    GetViewPortOffsetAndScale(vScaleOffset[1], vScaleOffset[0]);
 
-	g_pD3DDevice->SetVertexShaderConstantF(CXBX_D3DVS_VIEWPORT_SCALE_MIRROR, vScale, 1);
-    g_pD3DDevice->SetVertexShaderConstantF(CXBX_D3DVS_VIEWPORT_OFFSET_MIRROR, vOffset, 1);
+	g_pD3DDevice->SetVertexShaderConstantF(CXBX_D3DVS_VIEWPORT_SCALE_MIRROR, reinterpret_cast<float*>(vScaleOffset), 2);
 
 	// Store viewport offset and scale in constant registers 58 (c-38) and
 	// 59 (c-37) used for screen space transformation.
@@ -4044,8 +4043,7 @@ void UpdateViewPortOffsetAndScaleConstants()
 	// Treat this as a flag
 	// Test Case: GTA III, Soldier of Fortune II
 	if (!(g_Xbox_VertexShaderConstantMode & X_D3DSCM_NORESERVEDCONSTANTS)) {
-		g_pD3DDevice->SetVertexShaderConstantF(X_D3DSCM_RESERVED_CONSTANT_SCALE + X_D3DSCM_CORRECTION, vScale, 1);
-		g_pD3DDevice->SetVertexShaderConstantF(X_D3DSCM_RESERVED_CONSTANT_OFFSET + X_D3DSCM_CORRECTION, vOffset, 1);
+		g_pD3DDevice->SetVertexShaderConstantF(X_D3DSCM_RESERVED_CONSTANT_SCALE + X_D3DSCM_CORRECTION, reinterpret_cast<float*>(vScaleOffset), 2);
 	}
 }
 


### PR DESCRIPTION
**This PR needs testing with games which:**
* **Have Z fighting anywhere**
* **Have interactive menus which don't show**

When a D24 depth buffer was used, its viewport Z scale was `16777215.0f`. This number is high enough to cause precision issues in the reverse screenspace transformation calculation for some elements. In my case, it shifted the Z to slightly above 1.0f, causing it to get clipped.

Basing on some tests, pre-dividing the divisor increases the numerical stability of those calculations and allows to retain better precision. **WARN:** pre-multiplying instead of pre-dividing might seem like a better idea, but I found it did **not** resolve the precision issues!

Also adds an "unrelated" change of better batching for viewport scale/offset constant submission calls.

Makes Burnout 3 display menus properly:
![image](https://user-images.githubusercontent.com/7947461/97093294-ec226480-164a-11eb-8e2a-bf0a4e7b4f65.png)
