### PR TITLE
Changes to D3D patches

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -8608,6 +8608,33 @@ void WINAPI xbox::EMUPATCH(D3D_BlockOnTime)( dword_xt Unknown1, int Unknown2 )
 	LOG_UNIMPLEMENTED();
 }
 
+// LTCG specific D3D_BlockOnTime function
+// This uses a custom calling convention where parameter is passed in EAX
+// Test case: Burnout 3
+__declspec(naked) void WINAPI xbox::EMUPATCH(D3D_BlockOnTime_4)( dword_xt Unknown1 )
+{
+	int Unknown2;
+
+	// prologue
+	__asm {
+		push ebp
+		mov  ebp, esp
+		sub  esp, __LOCAL_SIZE
+		mov  Unknown2, eax // get parameter from eax
+	}
+
+	// LOG_FORWARD requires unwinding, so carry on without it
+	EMUPATCH(D3D_BlockOnTime)(Unknown1, Unknown2);
+
+	// epilogue
+	__asm {
+		mov  esp, ebp
+		pop  ebp
+		ret  4
+	}
+}
+
+
 bool DestroyResource_Common(xbox::X_D3DResource* pResource)
 {
     if (pResource == g_pXbox_RenderTarget) {

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp.unused-patches
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp.unused-patches
@@ -4135,3 +4135,23 @@ HRESULT WINAPI XTL::EMUPATCH(D3DDevice_GetVertexShaderFunction)
     
     return hRet;
 }
+
+// ******************************************************************
+// * patch: D3DDevice_GetTransform
+// ******************************************************************
+xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_GetTransform)
+(
+    D3DTRANSFORMSTATETYPE State,
+    D3DMATRIX            *pMatrix
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(State)
+		LOG_FUNC_ARG(pMatrix)
+		LOG_FUNC_END;
+
+    State = EmuXB2PC_D3DTS(State);
+
+    HRESULT hRet = g_pD3DDevice->GetTransform(State, pMatrix);
+	DEBUG_D3DRESULT(hRet, "g_pD3DDevice->GetTransform");    
+}

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1313,7 +1313,7 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetTransform)
     CONST D3DMATRIX      *pMatrix
 );
 
-xbox::void_xt __stdcall EMUPATCH(D3DDevice_SetTransform_0)();
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetTransform_0)();
 
 // ******************************************************************
 // * patch: D3DDevice_MultiplyTransform

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -2069,6 +2069,12 @@ void WINAPI EMUPATCH(D3D_SetCommonDebugRegisters)();
 void WINAPI EMUPATCH(D3D_BlockOnTime)( dword_xt Unknown1, int Unknown2 );
 
 // ******************************************************************
+// * patch: D3D_BlockOnTime_4
+//   One of the parameters (unknown which) passed in EAX
+// ******************************************************************
+void WINAPI EMUPATCH(D3D_BlockOnTime_4)( dword_xt Unknown1 );
+
+// ******************************************************************
 // * patch: D3D_BlockOnResource
 // ******************************************************************
 void WINAPI EMUPATCH(D3D_BlockOnResource)( X_D3DResource* pResource );

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -90,7 +90,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_GetOverlayUpdateStatus", xbox::EMUPATCH(D3DDevice_GetOverlayUpdateStatus), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetProjectionViewportMatrix", xbox::EMUPATCH(D3DDevice_GetProjectionViewportMatrix), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetShaderConstantMode", xbox::EMUPATCH(D3DDevice_GetShaderConstantMode), PATCH_HLE_D3D),
-	PATCH_ENTRY("D3DDevice_GetTransform", xbox::EMUPATCH(D3DDevice_GetTransform), PATCH_HLE_D3D),
+	//PATCH_ENTRY("D3DDevice_GetTransform", xbox::EMUPATCH(D3DDevice_GetTransform), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetVertexShader", xbox::EMUPATCH(D3DDevice_GetVertexShader), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetVertexShaderConstant", xbox::EMUPATCH(D3DDevice_GetVertexShaderConstant), PATCH_HLE_D3D),
 	//PATCH_ENTRY("D3DDevice_GetVertexShaderDeclaration", xbox::EMUPATCH(D3DDevice_GetVertexShaderDeclaration), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -181,6 +181,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_UpdateOverlay", xbox::EMUPATCH(D3DDevice_UpdateOverlay), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DResource_BlockUntilNotBusy", xbox::EMUPATCH(D3DResource_BlockUntilNotBusy), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3D_BlockOnTime", xbox::EMUPATCH(D3D_BlockOnTime), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3D_BlockOnTime_4", xbox::EMUPATCH(D3D_BlockOnTime_4), PATCH_HLE_D3D),
     PATCH_ENTRY("D3D_DestroyResource", xbox::EMUPATCH(D3D_DestroyResource), PATCH_HLE_D3D),
     PATCH_ENTRY("D3D_DestroyResource__LTCG", xbox::EMUPATCH(D3D_DestroyResource__LTCG), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3D_LazySetPointParams", xbox::EMUPATCH(D3D_LazySetPointParams), PATCH_HLE_D3D),


### PR DESCRIPTION
* Patches `D3D_BlockOnTime_4` just like its non-LTCG equivalent.
* Unpatches `D3DDevice_GetTransform` and trampolines `SetTransform`/`MultiplyTransform` to the guest code. This fixes cases where games tried to use a potentially unpatched or inlined `GetTransform` and/or read the D3D state directly.

Fixes Burnout 3 freezing past the car selection screen and makes it render geometry properly. Currently this is not yet visible because of an unhandled "binding surface as a texture" case, but rendering now **does** happen.

![image](https://user-images.githubusercontent.com/7947461/97114973-1419d280-16f4-11eb-9d78-d692b29e86a6.png)
