### PR TITLE
Guard against nested SetTransform/MultiplyTransform calls

### DIFF
--- a/src/core/hle/Intercept.hpp
+++ b/src/core/hle/Intercept.hpp
@@ -56,4 +56,26 @@ void* GetXboxFunctionPointer(std::string functionName);
 void VerifyHLEDataBase();
 #endif
 
+// A helper class to allow code patches to detect nested calls (patches called from patches)
+class NestedPatchCounter
+{
+public:
+	explicit NestedPatchCounter(uint32_t& counter) noexcept
+		: m_counter(counter), m_level(counter)
+	{
+		m_counter++;
+	}
+
+	~NestedPatchCounter() noexcept
+	{
+		m_counter--;
+	}
+
+	uint32_t GetLevel() const noexcept { return m_level; }
+
+public:
+	uint32_t& m_counter;
+	const uint32_t m_level;
+};
+
 #endif


### PR DESCRIPTION
`MultiplyTransform` can be implemented in means of doing the multiplication internally and `SetTransform` which corrupted the host's internal state (host `SetTransform` called with a multiplied state, followed by a host `MultiplyTransform` resulting in a double multiplication).

This PR introduces a guard variable to ensure we call to host only once per the patch chain and keep the internal state pristine. I facilitated this by introducing a `NestedPatchCounter` class which acts as a scoped counter - when used on a variable shared between potentially conflicting/nested patches, this class allows functions to skip parts of the host set-up if it is either redundant or harmful (like in this case).

Fixes a regression in 25 to Life introduced by #2007

![image](https://user-images.githubusercontent.com/7947461/97209986-43e0dd00-17bd-11eb-89fe-ccc4c1e379f2.png)
