### PR TITLE
Action: Fix CI Release Job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,8 @@ jobs:
     env:
       artifact_1: CxbxReloaded-Release-VS2019
       artifact_2: CxbxReloaded-Release-VS2017
-    runs-on: windows-latest
+    # Use the Ubuntu image to make releases quicker.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download artifacts (1)
@@ -87,8 +88,8 @@ jobs:
       - name: Prepare artifacts for release
         run: | # download-artifact doesn't download a zip, so rezip it
           echo "short_commit_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          7z a -mx1 "$env:artifact_1.zip" ".\$env:artifact_1\*"
-          7z a -mx1 "$env:artifact_2.zip" ".\$env:artifact_2\*"
+          7z a -mx1 "${{ env.artifact_1 }}.zip" "./${{ env.artifact_1 }}/*"
+          7z a -mx1 "${{ env.artifact_2 }}.zip" "./${{ env.artifact_2 }}/*"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.1.1


### PR DESCRIPTION
After informed release step isn't working. I found out windows image doesn't support `echo "short_commit_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV` method unless using bash shell.

As an alternative, I choose to use Ubuntu image instead since workload is a lot less than using windows image. So, I change the image preference, fix powershell parameter toward universal environment parameter, and finally use forward slash.

I have personally verified this change is working for release job.