### PR TITLE
Misc fixes after the vertex declaration changes

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3061,6 +3061,8 @@ void Direct3D_CreateDevice_Start
 	xbox::X_D3DPRESENT_PARAMETERS     *pPresentationParameters
 )
 {
+    CxbxVertexShaderSetFlags();
+
     if (!XboxRenderStates.Init()) {
         CxbxKrnlCleanup("Failed to init XboxRenderStates");
     }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4304,8 +4304,6 @@ void CxbxImpl_SetViewPort(xbox::X_D3DVIEWPORT8* pViewport)
 	HostViewPort.Y = static_cast<DWORD>(HostViewPort.Y * g_Xbox_MultiSampleYScale);
 	HostViewPort.Width = static_cast<DWORD>(HostViewPort.Width * g_Xbox_MultiSampleXScale);
 	HostViewPort.Height = static_cast<DWORD>(HostViewPort.Height * g_Xbox_MultiSampleYScale);
-	HostViewPort.X = static_cast<DWORD>(HostViewPort.X * g_Xbox_MultiSampleXScale);
-	HostViewPort.Y = static_cast<DWORD>(HostViewPort.Y * g_Xbox_MultiSampleYScale);
 	// Since Width and Height are DWORD, adding GetMultiSampleOffset 0.0f or 0.5f makes no sense
 
 	HRESULT hRet = g_pD3DDevice->SetViewport(&HostViewPort);

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -301,6 +301,7 @@ g_EmuCDPD = {0};
     XB_MACRO(xbox::void_xt,       WINAPI,     D3DDevice_SetTexture_4__LTCG_eax_pTexture,          (xbox::dword_xt)                                                                                      );  \
     XB_MACRO(xbox::void_xt,       WINAPI,     D3DDevice_SetTexture_4,                             (xbox::X_D3DBaseTexture*)                                                                             );  \
     XB_MACRO(xbox::void_xt,       WINAPI,     D3DDevice_SetVertexShader,                          (xbox::dword_xt)                                                                                      );  \
+    XB_MACRO(xbox::void_xt,       WINAPI,     D3DDevice_SetVertexShader_0,                        ()                                                                                                    );  \
     XB_MACRO(xbox::void_xt,       WINAPI,     D3DDevice_SetVertexShaderInput,                     (xbox::dword_xt, xbox::uint_xt, xbox::X_STREAMINPUT*)                                                 );  \
     XB_MACRO(xbox::void_xt,       WINAPI,     D3DDevice_SetViewport,                              (CONST xbox::X_D3DVIEWPORT8*)                                                                         );  \
     XB_MACRO(xbox::void_xt,       WINAPI,     D3DDevice_SetTransform,                             (D3DTRANSFORMSTATETYPE, CONST D3DMATRIX*)                                                             );  \
@@ -6604,22 +6605,51 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexShader)
 {
 	LOG_FUNC_ONE_ARG(Handle);
 
-	if (XB_TRMP(D3DDevice_SetVertexShader))
-		XB_TRMP(D3DDevice_SetVertexShader)(Handle);
+	// This trampoline leads to calling D3DDevice_LoadVertexShader and D3DDevice_SelectVertexShader
+	// Please raise the alarm if this is ever not the case
+	XB_TRMP(D3DDevice_SetVertexShader)(Handle);
 
 	CxbxImpl_SetVertexShader(Handle);
 }
 
+// Overload for logging
+static void D3DDevice_SetVertexShader_0
+(
+    xbox::dword_xt Handle
+)
+{
+	LOG_FUNC_ONE_ARG(Handle);
+}
+
 // This uses a custom calling convention where Handle is passed in EBX
 // Test-case: NASCAR Heat 2002
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexShader_0)()
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexShader_0)()
 {
 	dword_xt Handle;
-	__asm mov Handle, ebx
+	__asm {
+		push ebp
+		mov  ebp, esp
+		sub  esp, __LOCAL_SIZE
+		mov  Handle, ebx
+	}
 
-	LOG_FUNC_ONE_ARG(Handle);
+	// Log
+	D3DDevice_SetVertexShader_0(Handle);
+
+	// This trampoline leads to calling D3DDevice_LoadVertexShader and D3DDevice_SelectVertexShader
+	// Please raise the alarm if this is ever not the case
+	__asm {
+		mov  ebx, Handle
+		call XB_TRMP(D3DDevice_SetVertexShader_0)
+	}
 
 	CxbxImpl_SetVertexShader(Handle);
+
+	__asm {
+		mov  esp, ebp
+		pop  ebp
+		ret
+	}
 }
 
 // TODO : Move to own file

--- a/src/core/hle/D3D8/XbD3D8Types.h
+++ b/src/core/hle/D3D8/XbD3D8Types.h
@@ -1149,13 +1149,15 @@ struct X_D3DVertexShader
 // X_D3DVertexShader.Flags values :
 #define X_VERTEXSHADER_FLAG_WRITE           (1 <<  0) // = 0x0001 // Set for Xbox ShaderType != X_VST_NORMAL 
 #define X_VERTEXSHADER_FLAG_PASSTHROUGH     (1 <<  1) // = 0x0002
-#define X_VERTEXSHADER_FLAG_UNKNOWN         (1 <<  2) // = 0x0004 // Test case: Amped
 #define X_VERTEXSHADER_FLAG_STATE           (1 <<  3) // = 0x0008 // Set for Xbox ShaderType == X_VST_STATE
-#define X_VERTEXSHADER_FLAG_PROGRAM         (1 <<  4) // = 0x0010 // Set when X_D3DVertexShader was created with assigned function data
+#define X_VERTEXSHADER_FLAG_PROGRAM         (1 <<  4) // = 0x0010 // Set when X_D3DVertexShader was created with assigned function data; introduced after XDK 3948; don't use directly, use g_X_VERTEXSHADER_FLAG_PROGRAM instead
 #define X_VERTEXSHADER_FLAG_HASDIFFUSE      (1 << 10) // = 0x0400 Corresponds to X_D3DUSAGE_PERSISTENTDIFFUSE
 #define X_VERTEXSHADER_FLAG_HASSPECULAR     (1 << 11) // = 0x0800 Corresponds to X_D3DUSAGE_PERSISTENTSPECULAR
 #define X_VERTEXSHADER_FLAG_HASBACKDIFFUSE  (1 << 12) // = 0x1000 Corresponds to X_D3DUSAGE_PERSISTENTBACKDIFFUSE
 #define X_VERTEXSHADER_FLAG_HASBACKSPECULAR (1 << 13) // = 0x2000 Corresponds to X_D3DUSAGE_PERSISTENTBACKSPECULAR
+
+// X_D3DVertexShader3948.Flags values, only those which differ from the above :
+#define X_VERTEXSHADER3948_FLAG_PROGRAM     (1 <<  2) // = 0x0004 // Test case: Amped, NASCAR Heat 2002; don't use directly, use g_X_VERTEXSHADER_FLAG_PROGRAM instead
 
 // vertex shader input registers for fixed function vertex shader
 

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -289,7 +289,7 @@ xbox::X_D3DVertexShader* GetXboxVertexShader()
 	return pXboxVertexShader;
 }
 
-static bool UseXboxD3DVertexShaderTypeForVersion3948(xbox::X_D3DVertexShader* pXboxVertexShader)
+static bool UseXboxD3DVertexShaderTypeForVersion3948(const xbox::X_D3DVertexShader* pXboxVertexShader)
 {
 	// Don't check XDK version for our internal FVF vertex shader
 	// because g_Xbox_VertexShader_ForFVF is an internal variable
@@ -304,7 +304,7 @@ static bool UseXboxD3DVertexShaderTypeForVersion3948(xbox::X_D3DVertexShader* pX
 static xbox::X_VERTEXATTRIBUTEFORMAT* CxbxGetVertexShaderAttributes(xbox::X_D3DVertexShader* pXboxVertexShader)
 {
 	if (UseXboxD3DVertexShaderTypeForVersion3948(pXboxVertexShader)) {
-		auto pXboxVertexShader3948 = (xbox::X_D3DVertexShader3948*)pXboxVertexShader;
+		auto pXboxVertexShader3948 = reinterpret_cast<xbox::X_D3DVertexShader3948*>(pXboxVertexShader);
 		return &(pXboxVertexShader3948->VertexAttribute);
 	}
 
@@ -314,7 +314,7 @@ static xbox::X_VERTEXATTRIBUTEFORMAT* CxbxGetVertexShaderAttributes(xbox::X_D3DV
 static DWORD* CxbxGetVertexShaderTokens(xbox::X_D3DVertexShader* pXboxVertexShader, DWORD* pNrTokens)
 {
 	if (UseXboxD3DVertexShaderTypeForVersion3948(pXboxVertexShader)) {
-		auto pXboxVertexShader3948 = (xbox::X_D3DVertexShader3948*)pXboxVertexShader;
+		auto pXboxVertexShader3948 = reinterpret_cast<xbox::X_D3DVertexShader3948*>(pXboxVertexShader);
 		*pNrTokens = pXboxVertexShader3948->ProgramAndConstantsDwords;
 		return &pXboxVertexShader3948->ProgramAndConstants[0];
 	}

--- a/src/core/hle/D3D8/XbVertexShader.h
+++ b/src/core/hle/D3D8/XbVertexShader.h
@@ -213,5 +213,6 @@ extern void CxbxImpl_SelectVertexShader(DWORD Handle, DWORD Address);
 extern void CxbxImpl_SetVertexShaderInput(DWORD Handle, UINT StreamCount, xbox::X_STREAMINPUT* pStreamInputs);
 extern void CxbxImpl_SetVertexShaderConstant(INT Register, PVOID pConstantData, DWORD ConstantCount);
 extern void CxbxImpl_DeleteVertexShader(DWORD Handle);
+extern void CxbxVertexShaderSetFlags();
 
 #endif


### PR DESCRIPTION
This PR fixes a few regressions after the vertex declaration changes have been merged:

* Fixes `D3DDevice_SetVertexShader_0` not calling to a trampoline - after recent changes calling to guest code here became instrumental for correct rendering but only the non-LTCG variation had a trampoline.
* Fixes `X_VERTEXSHADER_FLAG_PROGRAM` flag for xdk-3948. In this XDK version the flag appears to have a value of 4, not 16. Adjusted the code accordingly and added test cases to verify that assumption, also removed the previous test case (with a xdk-3948 game as a case), because now we have a more specific test case added instead.
* Fixes a merge error in `CxbxImpl_SetViewPort` - causing `X`/`Y` values to be multiplied by MSAA scaling twice.

Fixes regressions in **NASCAR Heat 2002**, revealing that the vertex declaration changes helped this game a lot, fixing shadowing issues and making self-shadowing work correctly!
![image](https://user-images.githubusercontent.com/7947461/99196242-7746d400-278b-11eb-8c99-72f4c5e77614.png)
