### PR TITLE
Take vertex stream offset into the account when caching VBs

### DIFF
--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -296,6 +296,7 @@ void CxbxVertexBufferConverter::ConvertStream
 			return;
 		}
 
+		pXboxVertexData += XboxStreamInput.Offset;
 		uiXboxVertexStride = XboxStreamInput.Stride;
         // Set a new (exact) vertex count
 		uiVertexCount = pDrawContext->VerticesInBuffer;


### PR DESCRIPTION
Caching vertex buffers in `CxbxVertexBufferConverter::ConvertStream` ignored the vertex stream offset parameter passed together with the vertex stream, therefore always sampling X vertices from the beginning of the buffer. Adding offset to the guest vertex data allows the cache to treat such buffers with an offset no different than separate buffers.

Basing on a quick check I don't foresee this breaking the vertex buffer cache, but **please review this with caching behaviour in mind**. I expect it to work correctly however because this change properly modifies the range of vertices the cache hashes as a key.

Fixes exploding vertices in TOCA Race Driver/Pro Race Driver. Game's UI is still invisible and the game locks up shortly after starting the race because of an unrelated issue related to DirectSound buffers, so it's **not playable**.
![image](https://user-images.githubusercontent.com/7947461/99318156-771c0680-2867-11eb-8001-e281a477a1cd.png)
![image](https://user-images.githubusercontent.com/7947461/99318167-7be0ba80-2867-11eb-9191-cd2cf4d42a08.png)
