### PR TITLE
Remove hacks skipping guest resource removal if they are bound

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -8749,20 +8749,34 @@ void WINAPI xbox::EMUPATCH(D3D_DestroyResource)(X_D3DResource* pResource)
 // ******************************************************************
 // * patch: D3D_DestroyResource_LTCG
 // ******************************************************************
-void WINAPI xbox::EMUPATCH(D3D_DestroyResource__LTCG)()
+static void D3D_DestroyResource__LTCG(xbox::X_D3DResource* pResource)
+{
+	LOG_FUNC_ONE_ARG(pResource);
+}
+
+__declspec(naked) void WINAPI xbox::EMUPATCH(D3D_DestroyResource__LTCG)()
 {
     X_D3DResource* pResource;
     __asm {
-        mov pResource, edi
+        push ebp
+        mov  ebp, esp
+        sub  esp, __LOCAL_SIZE
+        mov  pResource, edi
     }
+
+    // Log
+    D3D_DestroyResource__LTCG(pResource);
 
     // Release the host copy (if it exists!)
     FreeHostResource(GetHostResourceKey(pResource));
 
     // Call the Xbox version of DestroyResource
     __asm {
-        mov edi, pResource
+        mov  edi, pResource
         call XB_TRMP(D3D_DestroyResource__LTCG)
+        mov  esp, ebp
+        pop  ebp
+        ret
     }
 }
 


### PR DESCRIPTION
This PR removes special cases in patched `DestroyResource` methods, skipping removal of currently bound resources. It may have been required in the past to avoid crashes, but nowadays it is not only unneeded, but also causes host and guest memory leaks. Because our special case skipped the guest trampoline, games literally ran out of memory as far as they are concerned.

As a "bonus", I modified the `D3D_DestroyResource__LTCG` patch to follow the current style of writing usercall-style functions. This allows to ensure that `edi` register isn't trashed (was more than unlikely, though) and allows to log the function properly, just like its non-LTCG sibling.

Fixes **Outrun 2** running out of memory and crashing several seconds after entering the race.
Fixes **Monster Garage** running out of memory and crashing as soon as the mission was started.
Fixes possibly many more games showing `Skipping Release of...` test cases **and** crashing at some point.

Removes `Skipping Release of active [X]` test cases (#1779).
![image](https://user-images.githubusercontent.com/7947461/99440244-902fc080-2916-11eb-94bc-d71adee5b39d.png)
![image](https://user-images.githubusercontent.com/7947461/99440256-958d0b00-2916-11eb-8a62-0a073c2aa0ff.png)

