### PR TITLE
Allow cxbxr to work again with wine under Linux

### DIFF
--- a/src/common/AddressRanges.cpp
+++ b/src/common/AddressRanges.cpp
@@ -65,7 +65,7 @@ const _XboxAddressRanges XboxAddressRanges[] = {
 	RANGE_ENTRY(NVNET_DEVICE_BASE , NVNET_DEVICE_END , NVNET_DEVICE_SIZE , PROT_NAC, SYSTEM_ALL              , "DeviceNVNet"),
 	RANGE_ENTRY(FLASH_DEVICE1_BASE, FLASH_DEVICE1_END, FLASH_DEVICEN_SIZE, PROT_NAC, SYSTEM_ALL              , "DeviceFlash_a (Flash mirror 1)"),
 	RANGE_ENTRY(FLASH_DEVICE2_BASE, FLASH_DEVICE2_END, FLASH_DEVICEN_SIZE, PROT_NAC, SYSTEM_ALL              , "DeviceFlash_b (Flash mirror 2)"),
-	RANGE_ENTRY(FLASH_DEVICE3_BASE, FLASH_DEVICE3_END, FLASH_DEVICEN_SIZE, PROT_NAC, SYSTEM_ALL              , "DeviceFlash_c (Flash mirror 3)"),
+	RANGE_ENTRY(FLASH_DEVICE3_BASE, FLASH_DEVICE3_END, FLASH_DEVICEN_SIZE, PROT_NAC, SYSTEM_ALL    | MAY_FAIL, "DeviceFlash_c (Flash mirror 3)"), // this region fails reservation when running under Ubuntu with wine, so it must be allowed to fail
 	RANGE_ENTRY(FLASH_DEVICE4_BASE, FLASH_DEVICE4_END, FLASH_DEVICEN_SIZE, PROT_NAC, SYSTEM_ALL    | MAY_FAIL, "DeviceFlash_d (Flash mirror 4) Optional (will probably fail reservation, which is acceptable - the 3 other mirrors work just fine"),
 	#undef RANGE_ENTRY
 };


### PR DESCRIPTION
Closes https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1937. The flash region number 3 fails reservation when running under wine, which causes the emulation to fail. Since it's still acceptable for this region to fail, we workaround the problem by simply allowing it to fail reservation by adding the `MAY_FAIL` flag. With this, the loader works again under wine. I tested this by running it in Ubuntu 20.04.1 LTS with wine-5.0.3 and building with VS2019, which incidentally also works again now after installing vcrun2019 with winetricks. @RadWolfie also confirmed that this fix also works good for the 2017 version.