### PR TITLE
Fix free up address range's system allocated

### DIFF
--- a/src/common/AddressRanges.cpp
+++ b/src/common/AddressRanges.cpp
@@ -72,17 +72,17 @@ const _XboxAddressRanges XboxAddressRanges[] = {
 
 const size_t XboxAddressRanges_size = ARRAY_SIZE(XboxAddressRanges);
 
-bool AddressRangeMatchesFlags(const int index, const unsigned int flags)
+bool AddressRangeMatchesFlags(const size_t index, const unsigned int flags)
 {
 	return XboxAddressRanges[index].RangeFlags & flags;
 }
 
-bool IsOptionalAddressRange(const int index)
+bool IsOptionalAddressRange(const size_t index)
 {
 	return AddressRangeMatchesFlags(index, MAY_FAIL);
 }
 
-int AddressRangeGetSystemFlags(const int index)
+unsigned int AddressRangeGetSystemFlags(const size_t index)
 {
 	return XboxAddressRanges[index].RangeFlags & SYSTEM_ALL;
 }

--- a/src/common/AddressRanges.h
+++ b/src/common/AddressRanges.h
@@ -196,8 +196,8 @@ extern const struct _XboxAddressRanges {
 
 extern const size_t XboxAddressRanges_size;
 
-extern bool AddressRangeMatchesFlags(const int index, const unsigned int flags);
-extern bool IsOptionalAddressRange(const int index);
-extern int AddressRangeGetSystemFlags(const int index);
+extern bool AddressRangeMatchesFlags(const size_t index, const unsigned int flags);
+extern bool IsOptionalAddressRange(const size_t index);
+extern unsigned int AddressRangeGetSystemFlags(const size_t index);
 
 extern bool VerifyWow64();

--- a/src/common/ReserveAddressRanges.cpp
+++ b/src/common/ReserveAddressRanges.cpp
@@ -302,9 +302,9 @@ bool AttemptReserveAddressRanges(unsigned int* p_reserved_systems, blocks_reserv
 			// Some ranges are allowed to fail reserving
 			if (!IsOptionalAddressRange(i)) {
 				// If not, then let's free them and downgrade host's limitation.
+				clear_systems = AddressRangeGetSystemFlags(i);
 				iLast = i;
 				i = -1; // Reset index back to zero after for statement's increment.
-				clear_systems = AddressRangeGetSystemFlags(i);
 				continue;
 			}
 		}


### PR DESCRIPTION
Since we have found the cause of address range for wine issue, which of course has been solve in pull request #2037.

Base on @ergo720 and @LukeUsher inputs, I am able to reproduce the issue on Windows side. The cause was index is set to negative one which then try to obtain value outside of address ranges' list. With this fix, it is no longer cause loophole on both linux with wine and Windows. Aka `clear_systems` not being set other than zero.