### PR TITLE
Z fixes

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4862,12 +4862,14 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_Clear)
         // Scale the fill based on our scale factor and MSAA scale
 		float aaX, aaY;
 		GetMultiSampleScaleRaw(aaX, aaY);
+		auto rtUpscale = GetRenderTargetUpscaleFactor();
+
         std::vector<D3DRECT> rects(Count);
         for (DWORD i = 0; i < Count; i++) {
-            rects[i].x1 = static_cast<LONG>(pRects[i].x1 * aaX * GetRenderTargetUpscaleFactor());
-            rects[i].x2 = static_cast<LONG>(pRects[i].x2 * aaX * GetRenderTargetUpscaleFactor());
-            rects[i].y1 = static_cast<LONG>(pRects[i].y1 * aaY * GetRenderTargetUpscaleFactor());
-            rects[i].y2 = static_cast<LONG>(pRects[i].y2 * aaY * GetRenderTargetUpscaleFactor());
+            rects[i].x1 = static_cast<LONG>(pRects[i].x1 * aaX * rtUpscale);
+            rects[i].x2 = static_cast<LONG>(pRects[i].x2 * aaX * rtUpscale);
+            rects[i].y1 = static_cast<LONG>(pRects[i].y1 * aaY * rtUpscale);
+            rects[i].y2 = static_cast<LONG>(pRects[i].y2 * aaY * rtUpscale);
 		}
         hRet = g_pD3DDevice->Clear(Count, rects.data(), HostFlags, Color, Z, Stencil);
     } else {

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -58,10 +58,6 @@ UINT                          g_InlineVertexBuffer_DataSize = 0;
 // Copy of active Xbox D3D Vertex Streams (and strides), set by [D3DDevice|CxbxImpl]_SetStreamSource*
 xbox::X_STREAMINPUT g_Xbox_SetStreamSource[X_VSH_MAX_STREAMS] = { 0 }; // Note : .Offset member is never set (so always 0)
 
-extern xbox::X_D3DSurface* g_pXbox_RenderTarget;
-extern xbox::X_D3DSurface* g_pXbox_BackBufferSurface;
-extern xbox::X_D3DMULTISAMPLE_TYPE g_Xbox_MultiSampleType;
-
 extern float *HLE_get_NV2A_vertex_attribute_value_pointer(unsigned VertexSlot); // Declared in PushBuffer.cpp
 
 void *GetDataFromXboxResource(xbox::X_D3DResource *pXboxResource);

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -1193,9 +1193,6 @@ static void CxbxSetVertexShaderPassthroughProgram()
 
 	CxbxSetVertexShaderSlots(&XboxShaderBinaryPassthrough[0], 0, sizeof(XboxShaderBinaryPassthrough) / X_VSH_INSTRUCTION_SIZE_BYTES);
 
-	extern float g_ZScale; // TMP glue
-	extern float GetMultiSampleOffsetDelta(); // TMP glue
-
 	// Passthrough programs require scale and offset to be set in constants zero and one (both minus 96)
 	// (Note, these are different from GetMultiSampleOffsetAndScale / GetViewPortOffsetAndScale)
 	float scale[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
@@ -1208,6 +1205,8 @@ static void CxbxSetVertexShaderPassthroughProgram()
 
 	float MultiSampleBias = 0.0f;
 	if (XboxRenderStates.GetXboxRenderState(xbox::X_D3DRS_MULTISAMPLEANTIALIAS) > 0) {
+		extern float GetMultiSampleOffsetDelta(); // TMP glue
+
 		MultiSampleBias = GetMultiSampleOffsetDelta();
 	}
 

--- a/src/core/kernel/support/Emu.cpp
+++ b/src/core/kernel/support/Emu.cpp
@@ -51,7 +51,6 @@ volatile bool    g_bPrintfOn = true;
 bool g_DisablePixelShaders = false;
 bool g_UseAllCores = false;
 bool g_SkipRdtscPatching = false;
-int g_RenderUpscaleFactor = 1;
 
 // Delta added to host SystemTime, used in KiClockIsr and KeSetSystemTime
 // This shouldn't need to be atomic, but because raising the IRQL to high lv in KeSetSystemTime doesn't really stop KiClockIsr from running,

--- a/src/core/kernel/support/Emu.cpp
+++ b/src/core/kernel/support/Emu.cpp
@@ -51,7 +51,7 @@ volatile bool    g_bPrintfOn = true;
 bool g_DisablePixelShaders = false;
 bool g_UseAllCores = false;
 bool g_SkipRdtscPatching = false;
-int g_RenderScaleFactor = 1;
+int g_RenderUpscaleFactor = 1;
 
 // Delta added to host SystemTime, used in KiClockIsr and KeSetSystemTime
 // This shouldn't need to be atomic, but because raising the IRQL to high lv in KeSetSystemTime doesn't really stop KiClockIsr from running,

--- a/src/core/kernel/support/Emu.h
+++ b/src/core/kernel/support/Emu.h
@@ -95,5 +95,4 @@ typedef WORD INDEX16;
 extern bool g_DisablePixelShaders;
 extern bool g_UseAllCores;
 extern bool g_SkipRdtscPatching;
-extern int g_RenderUpscaleFactor;
 #endif

--- a/src/core/kernel/support/Emu.h
+++ b/src/core/kernel/support/Emu.h
@@ -95,5 +95,5 @@ typedef WORD INDEX16;
 extern bool g_DisablePixelShaders;
 extern bool g_UseAllCores;
 extern bool g_SkipRdtscPatching;
-extern int g_RenderScaleFactor;
+extern int g_RenderUpscaleFactor;
 #endif


### PR DESCRIPTION
- Calculate Z matching D3D9 docs (combined with Xbox depth scaling)
- Normalize Z from either (0, 1) or (0, zbuffer depth)

~~Haven't found any test case for this yet...~~
> The Rendertarget commit corrected aboth JSRF test cases, as well as the GunValkyrie one.