### PR TITLE
Optimize vertex stream cache for partial buffer access

### DIFF
--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -40,7 +40,7 @@ typedef struct _CxbxDrawContext
 	IN	   PWORD				 pXboxIndexData; // Set by D3DDevice_DrawIndexedVertices, D3DDevice_DrawIndexedVerticesUP and HLE_draw_inline_elements
 	IN	   DWORD				 dwBaseVertexIndex; // Set to g_Xbox_BaseVertexIndex in D3DDevice_DrawIndexedVertices
 	IN	   INDEX16				 LowIndex, HighIndex; // Set when pXboxIndexData is set
-	IN	   size_t				 VerticesInBuffer; // Set by CxbxVertexBufferConverter::Apply
+	IN	   UINT 				 NumVerticesToUse; // Set by CxbxVertexBufferConverter::Apply
     // Data if Draw...UP call
     IN PVOID                     pXboxVertexStreamZeroData;
     IN UINT                      uiXboxVertexStreamZeroStride;


### PR DESCRIPTION
**IMPORTANT NOTE: This PR has potentially huge implications. I only tested it with a handful of games and spotted no regressions, only performance improvements. These changes WILL affect most of the games and on paper they can all see performance improvements, although some of the improvements may not be measurable. Test with ALL your games if possible.**

Drastically reduces the amount of copied and converted data in cases where any of the following apply:
* `BaseVertexIndex` is not 0
* `LowIndex` is not 0
* `dwStartVertex` is not 0

Also potentially fixes an issue where data past an indexed vertex buffer was hashed and converted, leading to potential false positives on dirty checks, maybe more.

Improves in-race performance in **Group S Challenge** by over 10 times (3 FPS -> ~40 FPS), and makes the emulator not run out of memory after a few seconds into the race. The same is still too slow and buggy to be playable.
![image](https://user-images.githubusercontent.com/7947461/100385180-39b33800-3022-11eb-8105-2a847491c71e.png)
