### PR TITLE
Modernize DxbxUpdateActivePixelShader

### DIFF
--- a/src/core/hle/D3D8/XbD3D8Types.h
+++ b/src/core/hle/D3D8/XbD3D8Types.h
@@ -62,7 +62,6 @@
 #define D3DXAssembleShader		        D3DXAssembleShader
 #define FullScreen_PresentationInterval PresentationInterval // a field in D3DPRESENT_PARAMETERS
 #define D3DLockData                     void
-#define PixelShaderConstantType         float
 
 #define D3DADAPTER_IDENTIFIER           D3DADAPTER_IDENTIFIER9
 #define D3DCAPS                         D3DCAPS9


### PR DESCRIPTION
The biggest offender in that function was `SetPixelShaderConstantF` called redundantly - it was supposed to be called one time once all the constants were set up, but a scoping mistake applied it for every constant over and over again!

Other than this it's just cleaning up of this one specific function so it's less messy, and does not leak a pixel shader pointer returned from `GetPixelShader`. I used `WRL::ComPtr` there to save on having to explicitly test the pointer for null and releasing.