### PR TITLE
remove 3925 fog/alpha hacks

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
@@ -278,14 +278,6 @@ void XboxRenderStateConverter::ApplySimpleRenderState(uint32_t State, uint32_t V
             Value = EmuXB2PC_D3DSTENCILOP(Value);
             break;
         case xbox::X_D3DRS_ALPHATESTENABLE:
-            if (g_LibVersion_D3D8 == 3925) {
-                // HACK: Many 3925 have missing polygons when this is true
-                // Until  we find out the true underlying cause, and carry on
-                // Test Cases: Halo, Silent Hill 2.
-                LOG_TEST_CASE("Applying 3925 alpha test disable hack");
-                Value = false;
-            }
-            break;
         case xbox::X_D3DRS_ALPHABLENDENABLE:
         case xbox::X_D3DRS_BLENDCOLOR:
         case xbox::X_D3DRS_ALPHAREF: case xbox::X_D3DRS_ZWRITEENABLE:
@@ -331,15 +323,6 @@ void XboxRenderStateConverter::ApplyDeferredRenderState(uint32_t State, uint32_t
             }
         } break;
         case xbox::X_D3DRS_FOGENABLE:
-            if (g_LibVersion_D3D8 == 3925) {
-                // HACK: Many 3925 games only show a black screen if fog is enabled
-                // Initially, this was thought to be bad offsets, but it has been verified to be correct
-                // Until we find out the true underlying cause, disable fog and carry on
-                // Test Cases: Halo, Silent Hill 2.
-                LOG_TEST_CASE("Applying 3925 fog disable hack");
-                Value = false;
-            }
-            break;
         case xbox::X_D3DRS_FOGTABLEMODE:
         case xbox::X_D3DRS_FOGDENSITY:
         case xbox::X_D3DRS_RANGEFOGENABLE:


### PR DESCRIPTION
This PR removes the Fog and Alpha disable hacks for 3925 XDK.

We don't yet understand why these hacks were needed, and while they have been present, a solution has not been investigated.

This *will* cause apparent regressions in some titles using this XDK (Silent Hill 2, perhaps Halo), however, while this hack is present, we cannot understand and fix the proper behavior.

There's also a chance that there are some 3925 games this hack hinders, rather than helps. 

I don't think it's productive to have such a massive hack in the codebase.

ergo720 EDIT:
Closes https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1900 because it removes the corresponding test case.