### PR TITLE
rework texturestate mapping to be more sane + fix unmapped get

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
@@ -295,7 +295,7 @@ void XboxTextureStateConverter::Apply()
         // Make sure we only do this once
         if (pointSpriteOverride && XboxStage == 3) {
             pointSpriteOverride = false;
-            XboxStage--; ng C` to XDK Textu
+            XboxStage--;
         }
     }
 


### PR DESCRIPTION
This reworks the TextureState mapping table indexing to be a little saner/easier to grasp what's happening.

It also fixes an oversight where TextureState reads were not taking mapping into account.