### PR TITLE
Preserve original IO status block and context for ApcRoutine

### DIFF
--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -191,6 +191,14 @@ void CxbxFormatPartitionByHandle(HANDLE hFile)
 	printf("Formatted EmuDisk Partition%d\n", CxbxGetPartitionNumberFromHandle(hFile));
 }
 
+void NTAPI CxbxIoApcDispatcher(PVOID ApcContext, xbox::PIO_STATUS_BLOCK /*IoStatusBlock*/, xbox::ulong_xt Reserved)
+{
+	CxbxIoDispatcherContext* cxbxContext = reinterpret_cast<CxbxIoDispatcherContext*>(ApcContext);
+	std::get<xbox::PIO_APC_ROUTINE>(*cxbxContext)(
+		std::get<LPVOID>(*cxbxContext),std::get<xbox::PIO_STATUS_BLOCK>(*cxbxContext), Reserved);
+	delete cxbxContext;
+}
+
 const std::string MediaBoardRomFile = "Chihiro\\fpr21042_m29w160et.bin";
 const std::string DrivePrefix = "\\??\\";
 const std::string DriveSerial = DrivePrefix + "serial:";

--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -304,4 +304,15 @@ int CxbxGetPartitionNumberFromHandle(HANDLE hFile);
 std::string CxbxGetPartitionDataPathFromHandle(HANDLE hFile);
 void CxbxFormatPartitionByHandle(HANDLE hFile);
 
+// Ensures that an original IoStatusBlock gets passed to the completion callback
+// Used by NtReadFile and NtWriteFile
+using CxbxIoDispatcherContext = std::tuple<xbox::PIO_STATUS_BLOCK, xbox::PIO_APC_ROUTINE, PVOID>;
+
+void NTAPI CxbxIoApcDispatcher
+(
+	PVOID                  ApcContext,
+	xbox::PIO_STATUS_BLOCK IoStatusBlock,
+	xbox::ulong_xt         Reserved
+);
+
 #endif


### PR DESCRIPTION
Fixes cases where guest's APC routine/completion callback does not receive the original IO status block variable, but it assumed it did (it's allowed as per WinAPI docs).

In the MSDN docs for [ReadFileEx](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfileex) it is mentioned that "user data" may be stashed in the `OVERLAPPED` structure:

> The ReadFileEx function ignores the OVERLAPPED structure's hEvent member. An application is free to use that member for its own purposes in the context of a ReadFileEx call. ReadFileEx signals completion of its read operation by calling, or queuing a call to, the completion routine pointed to by lpCompletionRoutine, so it does not need an event handle.

For reasons I can't currently explain, `NtReadFile` does not always respect this and the `ApcContext` returned back to the game isn't always the same. I can only imagine that since `NtReadFile` and the APC fields in particular are **undocumented**, we are hitting some non-contractual behaviour which would not be visible if `ReadFileEx` was used directly (I poked around in the debugger and our "original" pointer was stashed 16 bytes after the one our APC routine received, so **I think** it was a stack of some worker thread).

Either way, my fix should be safe regardless of what Windows truly is doing under the hood.

Fixes **Project Gotham Racing** deadlocking after intro movies unless `silence.wma` was removed. I think it also makes it load main menu music properly, but I did not verify that for certain.