### PR TITLE
Change listing to target specific type than default order

### DIFF
--- a/src/common/input/InputManager.h
+++ b/src/common/input/InputManager.h
@@ -39,6 +39,17 @@
 
 extern int dev_num_buttons[to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX)];
 
+typedef struct _input_controller {
+	XBOX_INPUT_DEVICE type;
+	const char* name;
+} input_controller;
+
+static input_controller input_support_list[] = {
+	{ XBOX_INPUT_DEVICE::DEVICE_INVALID, "None" },
+	{ XBOX_INPUT_DEVICE::MS_CONTROLLER_DUKE, "MS Controller Duke" },
+	{ XBOX_INPUT_DEVICE::MS_CONTROLLER_S, "MS Controller S" },
+};
+
 #pragma pack(1)
 
 // xpad in/out buffers stripped of the first two bytes

--- a/src/gui/DlgInputConfig.cpp
+++ b/src/gui/DlgInputConfig.cpp
@@ -114,11 +114,11 @@ INT_PTR CALLBACK DlgInputConfigProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPAR
 
 		for (int i = 0, j = 0; i != 4; i++) {
 			HWND hHandle = GetDlgItem(hWndDlg, IDC_DEVICE_PORT1 + i);
-			for (auto str : { "None", "MS Controller Duke", "MS Controller S" }) {
-				LRESULT index = SendMessage(hHandle, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(str));
+			for (auto input : input_support_list) {
+				LRESULT index = SendMessage(hHandle, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(input.name));
 				SendMessage(hHandle, CB_SETITEMDATA, index,
-					to_underlying(XBOX_INPUT_DEVICE::DEVICE_INVALID) + j);
-				if (g_Settings->m_input_port[i].Type == to_underlying(XBOX_INPUT_DEVICE::DEVICE_INVALID) + j) {
+					to_underlying(input.type));
+				if (g_Settings->m_input_port[i].Type == to_underlying(input.type)) {
 					SendMessage(hHandle, CB_SETCURSEL, index, 0);
 					if (g_Settings->m_input_port[i].Type == to_underlying(XBOX_INPUT_DEVICE::DEVICE_INVALID)) {
 						EnableWindow(GetDlgItem(hWndDlg, IDC_CONFIGURE_PORT1 + i), FALSE);


### PR DESCRIPTION
@LanHikariDS accidentally found a bug when a type is not implemented outside of default order did not get trigger unless rearrange `XBOX_INPUT_DEVICE` listing in `InputDevice.h` file. With this fix, we can safely add new controller type without modify `XBOX_INPUT_DEVICE` listing or add new type before max enum value.

Plus it avoid confusion and mistakes on the way too.

Low risk merge, I can confirm it works outside of default order.