### PR TITLE
Fix incorrect flags in NtDuplicateObject

### DIFF
--- a/src/core/kernel/exports/EmuKrnlNt.cpp
+++ b/src/core/kernel/exports/EmuKrnlNt.cpp
@@ -702,7 +702,10 @@ XBSYSAPI EXPORTNUM(197) xbox::ntstatus_xt NTAPI xbox::NtDuplicateObject
 	}
 	else
 	{
-		// On the xbox, the duplicated handle always has the same access rights of the source handle
+		// On the xbox, the duplicated handle always has the same access rigths of the source handle
+		const ACCESS_MASK DesiredAccess = 0;
+		const ULONG Attributes = 0;
+		Options |= (DUPLICATE_SAME_ATTRIBUTES | DUPLICATE_SAME_ACCESS);
 
 		// redirect to Win2k/XP
 		ret = NtDll::NtDuplicateObject(
@@ -710,9 +713,9 @@ XBSYSAPI EXPORTNUM(197) xbox::ntstatus_xt NTAPI xbox::NtDuplicateObject
 			SourceHandle,
 			/*TargetProcessHandle=*/g_CurrentProcessHandle,
 			TargetHandle,
-			0,
-			0,
-			(Options | DUPLICATE_SAME_ATTRIBUTES | DUPLICATE_SAME_ACCESS));
+			DesiredAccess,
+			Attributes,
+			Options);
 	}
 
 	if (ret != xbox::status_success)

--- a/src/core/kernel/exports/EmuKrnlNt.cpp
+++ b/src/core/kernel/exports/EmuKrnlNt.cpp
@@ -702,9 +702,7 @@ XBSYSAPI EXPORTNUM(197) xbox::ntstatus_xt NTAPI xbox::NtDuplicateObject
 	}
 	else
 	{
-		// TODO : What arguments should we use?
-		const ACCESS_MASK DesiredAccess = 0;
-		const ULONG Attributes = 0;
+		// On the xbox, the duplicated handle always has the same access rights of the source handle
 
 		// redirect to Win2k/XP
 		ret = NtDll::NtDuplicateObject(
@@ -712,9 +710,9 @@ XBSYSAPI EXPORTNUM(197) xbox::ntstatus_xt NTAPI xbox::NtDuplicateObject
 			SourceHandle,
 			/*TargetProcessHandle=*/g_CurrentProcessHandle,
 			TargetHandle,
-			DesiredAccess,
-			Attributes,
-			Options);
+			0,
+			0,
+			(Options | DUPLICATE_SAME_ATTRIBUTES | DUPLICATE_SAME_ACCESS));
 	}
 
 	if (ret != xbox::status_success)


### PR DESCRIPTION
Closes https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1718. The problem was that we were passing an access mask of zero to `NtDuplicateObject`, which meant that the duplicated handle would have no access rights at all, which explains why all subsequent file access operations on it would inevitably fail. With this change, both Project Zero 1 and 2 successfully reach the title screens.

![ff1](https://user-images.githubusercontent.com/45463469/101400973-f5e9e980-38d1-11eb-9390-af2030c4d4c0.PNG)

![ff2](https://user-images.githubusercontent.com/45463469/101400988-fb473400-38d1-11eb-9ee2-89e51c8fe724.PNG)
