### PR TITLE
Fix Missing ResCxbx.h File from the List

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,6 @@ file (GLOB CXBXR_HEADER_GUIv1
  "${CXBXR_ROOT_DIR}/src/gui/DlgLoggingConfig.h"
  "${CXBXR_ROOT_DIR}/src/gui/DlgNetworkConfig.h"
  "${CXBXR_ROOT_DIR}/src/gui/DlgVideoConfig.h"
- "${CXBXR_ROOT_DIR}/src/gui/ResCxbx.h"
  "${CXBXR_ROOT_DIR}/src/gui/Wnd.h"
  "${CXBXR_ROOT_DIR}/src/gui/WndMain.h"
 )

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -73,6 +73,7 @@ file (GLOB RESOURCES
  "${CXBXR_ROOT_DIR}/src/gui/resource/Cxbx-R.ico"
  "${CXBXR_ROOT_DIR}/src/gui/resource/Logo.bmp"
  "${CXBXR_ROOT_DIR}/src/gui/resource/Logo-License-CC4.bmp"
+ "${CXBXR_ROOT_DIR}/src/gui/resource/ResCxbx.h"
  "${CXBXR_ROOT_DIR}/src/.editorconfig"
 )
 


### PR DESCRIPTION
Since `ResCxbx.h` file is located in resource folder. IDE couldn't find it then result not listed.

***Oops***