### PR TITLE
HACK: Add DSP hack for force failure to avoid access invalid pointer

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -538,7 +538,8 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IDirectSound_DownloadEffectsImage)
 
     LOG_NOT_SUPPORTED();
 
-    return S_OK;
+    // HACK: Return as failure workaround to allow titles to progress further.
+    return E_FAIL;
 }
 
 // ******************************************************************

--- a/src/core/hle/DSOUND/DirectSound/XFileMediaObject.cpp
+++ b/src/core/hle/DSOUND/DirectSound/XFileMediaObject.cpp
@@ -117,7 +117,8 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(XAudioDownloadEffectsImage)
 
 	LOG_NOT_SUPPORTED();
 
-    return S_OK;
+    // HACK: Return as failure workaround to allow titles to progress further.
+    return E_FAIL;
 }
 
 // ******************************************************************


### PR DESCRIPTION
With this hack, Otogi is able to progress further which is part of hidden bug.