### PR TITLE
Move to Direct3D 9Ex

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -72,7 +72,7 @@ extern void EmuD3DInit();
 // cleanup direct3d
 extern void EmuD3DCleanup();
 
-extern IDirect3DDevice *g_pD3DDevice;
+extern IDirect3DDevice9Ex *g_pD3DDevice;
 
 extern xbox::dword_xt g_Xbox_VertexShader_Handle;
 
@@ -92,7 +92,7 @@ xbox::hresult_xt WINAPI EMUPATCH(Direct3D_CreateDevice)
     HWND                        hFocusWindow,
     dword_xt                       BehaviorFlags,
     X_D3DPRESENT_PARAMETERS    *pPresentationParameters,
-    IDirect3DDevice           **ppReturnedDeviceInterface
+    X_D3DDevice           **ppReturnedDeviceInterface
 );
 
 xbox::hresult_xt WINAPI EMUPATCH(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ebx_ppReturnedDeviceInterface)

--- a/src/core/hle/D3D8/Direct3D9/VertexShaderSource.cpp
+++ b/src/core/hle/D3D8/Direct3D9/VertexShaderSource.cpp
@@ -170,7 +170,7 @@ void VertexShaderSource::ReleaseShader(ShaderKey key)
 	}
 }
 
-void VertexShaderSource::ResetD3DDevice(IDirect3DDevice* newDevice)
+void VertexShaderSource::ResetD3DDevice(IDirect3DDevice9* newDevice)
 {
 	EmuLog(LOG_LEVEL::DEBUG, "Resetting D3D device");
 	this->pD3DDevice = newDevice;

--- a/src/core/hle/D3D8/Direct3D9/VertexShaderSource.h
+++ b/src/core/hle/D3D8/Direct3D9/VertexShaderSource.h
@@ -15,7 +15,7 @@ public:
 	IDirect3DVertexShader *GetShader(ShaderKey key);
 	void ReleaseShader(ShaderKey key);
 
-	void ResetD3DDevice(IDirect3DDevice* pD3DDevice);
+	void ResetD3DDevice(IDirect3DDevice9* pD3DDevice);
 
 	// TODO
 	// WriteCacheToDisk
@@ -35,7 +35,7 @@ private:
 		// OptimizationLevel?
 	};
 
-	IDirect3DDevice* pD3DDevice;
+	IDirect3DDevice9* pD3DDevice;
 	std::mutex cacheMutex;
 	std::map<ShaderKey, LazyVertexShader> cache;
 

--- a/src/core/hle/D3D8/XbD3D8Types.h
+++ b/src/core/hle/D3D8/XbD3D8Types.h
@@ -58,7 +58,6 @@
 // Alias all host Direct3D 9 symbols to generic symbols
 #define DXGetErrorString                DXGetErrorString9A
 #define DXGetErrorDescription           DXGetErrorDescription9A
-#define Direct3DCreate			        Direct3DCreate9
 #define D3DXAssembleShader		        D3DXAssembleShader
 #define FullScreen_PresentationInterval PresentationInterval // a field in D3DPRESENT_PARAMETERS
 #define D3DLockData                     void
@@ -68,8 +67,6 @@
 #define D3DVERTEXELEMENT                D3DVERTEXELEMENT9
 #define D3DVIEWPORT                     D3DVIEWPORT9
 
-#define IDirect3D                       IDirect3D9
-#define IDirect3DDevice                 IDirect3DDevice9
 #define IDirect3DStateBlock             IDirect3DStateBlock9 // unused
 #define IDirect3DVertexDeclaration      IDirect3DVertexDeclaration9
 #define IDirect3DVertexShader           IDirect3DVertexShader9
@@ -417,6 +414,7 @@ typedef struct _X_D3DPIXELSHADERDEF	// <- blueshogun 10/1/07
 }
 X_D3DPIXELSHADERDEF;
 
+typedef void X_D3DDevice;
 
 typedef struct _X_PixelShader
 {

--- a/src/gui/DlgVideoConfig.cpp
+++ b/src/gui/DlgVideoConfig.cpp
@@ -47,7 +47,7 @@ static void RefreshDirect3DDevice();
 static void RefreshRenderResolution();
 
 /*! direct3d instance */
-static IDirect3D *g_pDirect3D = nullptr;
+static IDirect3D9Ex *g_pDirect3D = nullptr;
 /*! video configuration */
 static Settings::s_video g_XBVideo;
 /*! changes flag */
@@ -63,8 +63,6 @@ static HWND g_hVideoResolution = NULL;
 /*! handle to scale factor window*/
 static HWND g_hRenderResolution = NULL;
 
-#pragma optimize("", off)
-
 void ShowVideoConfig(HWND hwnd)
 {
     /*! reset changes flag */
@@ -75,9 +73,7 @@ void ShowVideoConfig(HWND hwnd)
 
     /*! initialize direct3d */
     {
-        g_pDirect3D = Direct3DCreate(D3D_SDK_VERSION);
-
-        if(g_pDirect3D == 0) { goto cleanup; }
+        if(FAILED(Direct3DCreate9Ex(D3D_SDK_VERSION, &g_pDirect3D))) { goto cleanup; }
 
         g_dwAdapterCount = g_pDirect3D->GetAdapterCount();
     }


### PR DESCRIPTION
For a full list of improvements see:
https://docs.microsoft.com/en-us/windows/win32/direct3darticles/direct3d-9ex-improvements

For us the most important aspect is no more device loss, which never existed on Xbox. This allows exclusive fullscreen to work properly,

In the future might also potentially allow for resizing the backbuffer at runtime.