### PR TITLE
Fix Halo fog issue

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
@@ -288,14 +288,6 @@ float4 reverseScreenspaceTransform(float4 oPos)
 
 VS_OUTPUT main(const VS_INPUT xIn)
 {
-	// Output variables
-	float4 oPos, oD0, oD1, oB0, oB1, oT0, oT1, oT2, oT3;
-	oPos = oD0 = oD1 = oB0 = oB1 = oT0 = oT1 = oT2 = oT3 = float4(0, 0, 0, 1); // Pre-initialize w component of outputs to 1
-
-	// Single component outputs
-	float4 oFog, oPts; // x is write-only on Xbox. Use float4 as some games use incorrect masks
-	oFog = oPts = 0;
-
 	// Address (index) register
 	int1 a0 = 0;
 
@@ -318,6 +310,22 @@ VS_OUTPUT main(const VS_INPUT xIn)
 	init_v( 4); init_v( 5); init_v( 6); init_v( 7);
 	init_v( 8); init_v( 9); init_v(10); init_v(11);
 	init_v(12); init_v(13); init_v(14); init_v(15);
+
+    // Output variables
+    // Initialize to vertex attribute values
+    // Note only the x component matters for oFog and oPts
+    // but we still use float4 as some games use incorrect masks
+    float4 oPos = v0;
+    float4 oD0 = v3;
+    float4 oD1 = v4;
+    float4 oFog = v5;
+    float4 oPts = v6;
+    float4 oB0 = v7;
+    float4 oB1 = v8;
+    float4 oT0 = v9;
+    float4 oT1 = v10;
+    float4 oT2 = v11;
+    float4 oT3 = v12;
 
 	// Xbox shader program)DELIMITER", /* This terminates the header raw string" // */
 

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -709,6 +709,18 @@ void CxbxSetVertexAttribute(int Register, FLOAT a, FLOAT b, FLOAT c, FLOAT d)
 	// not present in the vertex declaration.
 	// We use range 193 and up to store these values, as Xbox shaders stop at c192!
 	g_pD3DDevice->SetVertexShaderConstantF(CXBX_D3DVS_CONSTREG_VREGDEFAULTS_BASE + Register, attribute_floats, 1);
+
+	// Some early titles have fog issues
+	// In fixed-function mode, the fog factor is stored in specular alpha
+	// Halo sets the specular alpha to 1 (which if treated as the fog value, fixes geometry visibility)
+	// We may need to copy specular alpha to the fog register in some specific circumstances
+	// Do it all the time for now
+	// Test cases: Halo, Silent Hill 2
+	if (Register == xbox::X_D3DVSDE_SPECULAR) {
+		auto fogFloats = HLE_get_NV2A_vertex_attribute_value_pointer(xbox::X_D3DVSDE_FOG);
+		fogFloats[0] = d;
+		g_pD3DDevice->SetVertexShaderConstantF(CXBX_D3DVS_CONSTREG_VREGDEFAULTS_BASE + xbox::X_D3DVSDE_FOG, fogFloats, 1);
+	}
 }
 
 DWORD Float4ToDWORD(float* floats)


### PR DESCRIPTION
Halo sets the specular alpha via the `SetVertexData` API - in the fixed-function world this corresponds to the fog factor
This PR copies the specular alpha value to the fog register
With Halo's fog renderstate configuration this essentially disables fog
Not sure if the solution is 100% correct but hopefully a step in the right direction

May fix fog issues for other titles mentioned in https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1685

Tested in Halo v1.01 (PAL XDK 3948)