### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,7 +7,7 @@ Cxbx was initiated by Caustik. Dxbx was initiated by shadowtj.
 
 The following contributors are grouped per project and listed in alphabetical order,
 based on sources like https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/graphs/contributors ,
-http://www.caustik.com/cxbx/about.htm , http://emulation.gametechwiki.com/index.php/Cxbx ,
+http://www.caustik.com/cxbx/about.htm , https://emulation.gametechwiki.com/index.php/Cxbx ,
 and https://github.com/PatrickvL/Dxbx/graphs/contributors .
 
 
@@ -34,7 +34,7 @@ Ernegien (Mike Davis)
 ergo720
 faha223 (Fred Hallock)
 Fisherman166
-gandalfthewhite19890404 
+gandalfthewhite19890404
 gellis713
 ggKismet
 GXTX (wutno)
@@ -46,7 +46,7 @@ JayFoxRox (Jannik Vogel)
 literalmente-game 
 Luca1991 (Luca D'Amico) [Luca91]
 LukeUsher (Luke Usher) [SoullessSentinel]
-Margen67 
+Margen67
 NZJenkins
 PatrickvL (Patrick van Logchem)
 phire (Scott Mansell)
@@ -54,7 +54,7 @@ RadWolfie
 revel8n
 Silent (CookiePLMonster)
 StrikerX3 (Ivan Roberto de Oliveira)
-TotalCaesar659 
+TotalCaesar659
 Voxel9 (Voxel)
 x1nixmzeng
 
@@ -62,7 +62,7 @@ x1nixmzeng
 Cxbx-Reloaded Supporters:
 
 Cedric Wilson
-Cisco	Martinez
+Cisco Martinez
 Cody Dale Barton
 Elijah Chondropoulos
 Jacob Kelly
@@ -73,7 +73,7 @@ Kenneth Edmonds
 Kyle Lenhardt
 Manny Calavera
 Mark Knasiak
-Marko	V.
+Marko V.
 Matt Coady
 Roman Guivan
 Taylor Stock

--- a/src/common/AddressRanges.cpp
+++ b/src/common/AddressRanges.cpp
@@ -45,8 +45,8 @@ const _XboxAddressRanges XboxAddressRanges[] = {
 #else
 	#define RANGE_ENTRY(START, END, SIZE, PROT, FLAGS, COMMENT) { START, SIZE, PROT, FLAGS }
 #endif
-	// See http://xboxdevwiki.net/Memory
-	// and http://xboxdevwiki.net/Boot_Process#Paging
+	// See https://xboxdevwiki.net/Memory
+	// and https://xboxdevwiki.net/Boot_Process#Paging
 	// Entry :  Start             , End              , Size              , Protect , RangeFlags              , Comment
 	RANGE_ENTRY(USER_ADDRESS1_BASE, USER_ADDRESS1_END, USER_ADDRESS1_SIZE, PROT_XRW, SYSTEM_ALL    | MAY_FAIL, "MemLowVirtual (General Xbox type) lower 64 MiB Optional (already reserved via virtual_memory_placeholder)"),
 	RANGE_ENTRY(USER_ADDRESS2_BASE, USER_ADDRESS2_END, USER_ADDRESS2_SIZE, PROT_XRW, SYSTEM_128MB  | MAY_FAIL, "MemLowVirtual (Chihiro / DevKit)  ^ + upper 64 MiB"),

--- a/src/common/input/InputWindow.cpp
+++ b/src/common/input/InputWindow.cpp
@@ -349,7 +349,7 @@ bool InputWindow::SaveProfile(const std::string& name)
 		return false;
 	}
 	if (m_host_dev == std::string()) {
-		PopupError(m_hwnd_window, "Cannot save. No input devices detected", "Cxbx-Reloaded");
+		PopupError(m_hwnd_window, "Cannot save. No input devices detected.", "Cxbx-Reloaded");
 		return false;
 	}
 	OverwriteProfile(name);

--- a/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
@@ -81,7 +81,7 @@ float x_floor(float src)
 	return floor(src + BIAS);
 }
 
-// http://xboxdevwiki.net/NV2A/Vertex_Shader
+// https://xboxdevwiki.net/NV2A/Vertex_Shader
 // https://www.khronos.org/registry/OpenGL/extensions/NV/NV_vertex_program.txt
 // https://www.khronos.org/registry/OpenGL/extensions/NV/NV_vertex_program1_1.txt
 

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -630,7 +630,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 					retryAttempt++;
 					// Terminate after 5 seconds of failure.
 					if (retryAttempt >= (5 * (1000 / 100))) {
-						PopupError(nullptr, "Could not reboot, new emulation process did not take over.");
+						PopupError(nullptr, "Could not reboot; New emulation process did not take over.");
 						break;
 					}
 				}

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1616,7 +1616,7 @@ bool CxbxLockFilePath()
     }
 
     if (GetLastError() == ERROR_ALREADY_EXISTS) {
-        PopupError(nullptr, "Data path directory is currently in used.\nUse different data path directory or stop emulation from another process.");
+        PopupError(nullptr, "Data path directory is currently in use.\nUse a different data path directory or stop emulation from another process.");
         CloseHandle(hMapDataHash);
         return false;
     }

--- a/src/devices/x86/EmuX86.cpp
+++ b/src/devices/x86/EmuX86.cpp
@@ -918,7 +918,7 @@ void EmuX86_Opcode_CPUID(LPEXCEPTION_POINTERS e, _DInst& info)
 	// This CPUID emulation is based on :
 	// https://github.com/docbrown/vxb/wiki/Xbox-CPUID-Information
 	// https://github.com/docbrown/vxb/wiki/Xbox-Hardware-Information and
-	// http://www.sandpile.org/x86/cpuid.htm
+	// https://www.sandpile.org/x86/cpuid.htm
 	switch (e->ContextRecord->Eax) { // simpler than EmuX86_GetRegisterValue32(e, R_EAX)
 	case 0: { // CPUID Function 0, return the maximum supported standard level and vendor ID string
 		// Maximum supported standard level

--- a/src/emulator/cxbxr-emu.cpp
+++ b/src/emulator/cxbxr-emu.cpp
@@ -130,7 +130,7 @@ DWORD WINAPI Emulate(unsigned int reserved_systems, blocks_reserved_t blocks_res
 
 	/*! Verify our host executable, cxbxr-ldr.exe, is loaded to base address 0x00010000 */
 	if (!VerifyBaseAddr()) {
-		PopupError(nullptr, "cxbx-ldr.exe was not loaded to base address 0x00010000 (which is a requirement for Xbox emulation)");
+		PopupError(nullptr, "cxbx-ldr.exe was not loaded to base address 0x00010000, which is a requirement for Xbox emulation.");
 		return EXIT_FAILURE;
 	}
 

--- a/src/gui/WinMain.cpp
+++ b/src/gui/WinMain.cpp
@@ -54,14 +54,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	// First detect if we are running on WoW64, if not, prevent Cxbx-Reloaded from starting
 	// Cxbx-Reloaded needs access to high memory, only exposed to WoW64.
 	if (!VerifyWow64()) {
-		PopupError(nullptr, "Cxbx-Reloaded can only run under WoW64\nThis means either a 64-bit version of Windows or Wine with a 64-bit prefix");
+		PopupError(nullptr, "Cxbx-Reloaded can only run under WoW64;\nThis means either a 64-bit version of Windows, or Wine with a 64-bit prefix.");
 		return EXIT_FAILURE;
 	}
 
 #ifndef CXBXR_EMU
 	/*! verify Cxbx.exe is loaded to base address 0x00010000 */
 	if (!VerifyBaseAddr()) {
-		PopupError(nullptr, "Cxbx.exe is not loaded to base address 0x00010000 (which is a requirement for Xbox emulation)");
+		PopupError(nullptr, "Cxbx.exe is not loaded to base address 0x00010000, which is a requirement for Xbox emulation.");
 		return EXIT_FAILURE;
 	}
 #endif

--- a/src/gui/WinMain.cpp
+++ b/src/gui/WinMain.cpp
@@ -54,7 +54,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	// First detect if we are running on WoW64, if not, prevent Cxbx-Reloaded from starting
 	// Cxbx-Reloaded needs access to high memory, only exposed to WoW64.
 	if (!VerifyWow64()) {
-		PopupError(nullptr, "Cxbx-Reloaded can only run under WoW64;\nThis means either a 64-bit version of Windows, or Wine with a 64-bit prefix.");
+		PopupError(nullptr, "Cxbx-Reloaded can only run under WoW64;\nThis means either a 64-bit version of Windows or Wine with a 64-bit prefix.");
 		return EXIT_FAILURE;
 	}
 

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -985,7 +985,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 				if (m_bIsStarted) {
 					// We don't allow changing the contents of the eeprom while a game is running, mostly because we lack a "pause emulation"
 					// function necessary to modify the contents safely (the game itself can modify the eeprom)
-					PopupError(hwnd, "Cannot modify eeprom file while a title is running");
+					PopupError(hwnd, "Cannot modify eeprom file while a title is running.");
 					break;
 				}
 				ShowEepromConfig(hwnd);


### PR DESCRIPTION
Remove whitespace.
Convert tabs to spaces.
Make links https where applicable.