### PR TITLE
Complete refactor of D3D8 LTCG patches calling conventions

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4475,14 +4475,18 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_Begin)
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData2f)
 (
-    int     Register,
+    int_xt     Register,
     float_xt   a,
     float_xt   b
 )
 {
-	LOG_FORWARD("D3DDevice_SetVertexData4f");
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Register)
+		LOG_FUNC_ARG(a)
+		LOG_FUNC_ARG(b)
+		LOG_FUNC_END;
 
-    EMUPATCH(D3DDevice_SetVertexData4f)(Register, a, b, 0.0f, 1.0f);
+	CxbxImpl_SetVertexData4f(Register, a, b, 0.0f, 1.0f);
 }
 
 static inline DWORD FtoDW(FLOAT f) { return *((DWORD*)&f); }
@@ -4493,33 +4497,56 @@ static inline FLOAT DWtoF(DWORD f) { return *((FLOAT*)&f); }
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData2s)
 (
-    int     Register,
-    SHORT   a,
-    SHORT   b
+    int_xt   Register,
+    short_xt a,
+    short_xt b
 )
 {
-	LOG_FORWARD("D3DDevice_SetVertexData4f");
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Register)
+		LOG_FUNC_ARG(a)
+		LOG_FUNC_ARG(b)
+		LOG_FUNC_END;
 
-	float fa, fb;
-	
 	// Test case: Halo
 	// Note : XQEMU verified that the int16_t arguments
 	// must be mapped to floats in the range [-32768.0, 32767.0]
 	// (See https://github.com/xqemu/xqemu/pull/176)
-	fa = (float)a;
-	fb = (float)b;
+	const float fa = static_cast<float>(a);
+	const float fb = static_cast<float>(b);
 
-    EMUPATCH(D3DDevice_SetVertexData4f)(Register, fa, fb, 0.0f, 1.0f);
+
+	CxbxImpl_SetVertexData4f(Register, a, b, 0.0f, 1.0f);
 }
 
 extern uint32_t HLE_read_NV2A_pgraph_register(const int reg); // Declared in PushBuffer.cpp
 
 extern NV2ADevice* g_NV2A;
 
+// Overload for logging
+static void D3DDevice_SetVertexData4f_16
+(
+    xbox::int_xt     Register,
+    xbox::float_xt   a,
+    xbox::float_xt   b,
+    xbox::float_xt   c,
+    xbox::float_xt   d
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Register)
+		LOG_FUNC_ARG(a)
+		LOG_FUNC_ARG(b)
+		LOG_FUNC_ARG(c)
+		LOG_FUNC_ARG(d)
+		LOG_FUNC_END;
+}
+
 // ******************************************************************
 // * patch: D3DDevice_SetVertexData4f_16
 // ******************************************************************
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f_16)
+// This is an LTCG specific version of SetVertexData4f where the first param is passed in EDI
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f_16)
 (
 	float_xt   a,
 	float_xt   b,
@@ -4527,15 +4554,22 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f_16)
 	float_xt   d
 )
 {
-	// This is an LTCG specific version of SetVertexData4f where the first param is passed in edi
-	int Register = 0;
-	__asm{
-		mov Register, edi
+	int_xt Register;
+
+	__asm {
+		LTCG_PROLOGUE
+		mov  Register, edi
 	}
 
-	LOG_FORWARD("D3DDevice_SetVertexData4f");
+	// Log
+	D3DDevice_SetVertexData4f_16(Register, a, b, c, d);
 
-	EMUPATCH(D3DDevice_SetVertexData4f)(Register, a, b, c, d);
+	CxbxImpl_SetVertexData4f(Register, a, b, c, d);
+
+	_asm {
+		LTCG_EPILOGUE
+		ret  10h
+	}
 }
 
 // ******************************************************************
@@ -4543,7 +4577,7 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f_16)
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f)
 (
-    int     Register,
+    int_xt     Register,
     float_xt   a,
     float_xt   b,
     float_xt   c,
@@ -4566,21 +4600,27 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4f)
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4ub)
 (
-	int_xt		Register,
+	int_xt	Register,
 	byte_xt	a,
 	byte_xt	b,
 	byte_xt	c,
 	byte_xt	d
 )
 {
-	LOG_FORWARD("D3DDevice_SetVertexData4f");
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Register)
+		LOG_FUNC_ARG(a)
+		LOG_FUNC_ARG(b)
+		LOG_FUNC_ARG(c)
+		LOG_FUNC_ARG(d)
+		LOG_FUNC_END;
 
-	float fa = a / 255.0f;
-	float fb = b / 255.0f;
-	float fc = c / 255.0f;
-	float fd = d / 255.0f;
+	const float fa = a / 255.0f;
+	const float fb = b / 255.0f;
+	const float fc = c / 255.0f;
+	const float fd = d / 255.0f;
 
-    EMUPATCH(D3DDevice_SetVertexData4f)(Register, fa, fb, fc, fd);
+    CxbxImpl_SetVertexData4f(Register, fa, fb, fc, fd);
 }
 
 // ******************************************************************
@@ -4588,27 +4628,31 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4ub)
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4s)
 (
-	int_xt		Register,
-	SHORT	a,
-	SHORT	b,
-	SHORT	c,
-	SHORT	d
+	int_xt	 Register,
+	short_xt a,
+	short_xt b,
+	short_xt c,
+	short_xt d
 )
 {
-	LOG_FORWARD("D3DDevice_SetVertexData4f");
-
-	float fa, fb, fc, fd;
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Register)
+		LOG_FUNC_ARG(a)
+		LOG_FUNC_ARG(b)
+		LOG_FUNC_ARG(c)
+		LOG_FUNC_ARG(d)
+		LOG_FUNC_END;
 
 	// Test case: Halo
 	// Note : XQEMU verified that the int16_t arguments
 	// must be mapped to floats in the range [-32768.0, 32767.0]
 	// (See https://github.com/xqemu/xqemu/pull/176)
-	fa = (float)a;
-	fb = (float)b;
-	fc = (float)c;
-	fd = (float)d;
+	const float fa = static_cast<float>(a);
+	const float fb = static_cast<float>(b);
+	const float fc = static_cast<float>(c);
+	const float fd = static_cast<float>(d);
 
-    EMUPATCH(D3DDevice_SetVertexData4f)(Register, fa, fb, fc, fd);
+    CxbxImpl_SetVertexData4f(Register, fa, fb, fc, fd);
 }
 
 // ******************************************************************
@@ -4616,15 +4660,18 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexData4s)
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexDataColor)
 (
-    int         Register,
+    int_xt      Register,
     D3DCOLOR    Color
 )
 {
-	LOG_FORWARD("D3DDevice_SetVertexData4f");
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(Register)
+		LOG_FUNC_ARG(Color)
+		LOG_FUNC_END;
 
-    D3DXCOLOR XColor = Color;
+    const D3DXCOLOR XColor = Color;
 
-    EMUPATCH(D3DDevice_SetVertexData4f)(Register, XColor.r, XColor.g, XColor.b, XColor.a);
+    CxbxImpl_SetVertexData4f(Register, XColor.r, XColor.g, XColor.b, XColor.a);
 }
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4255,16 +4255,22 @@ void CxbxImpl_SetViewport(xbox::X_D3DVIEWPORT8* pViewport)
 
 // LTCG specific D3DDevice_SetShaderConstantMode function...
 // This uses a custom calling convention where parameter is passed in EAX
-xbox::void_xt __stdcall xbox::EMUPATCH(D3DDevice_SetShaderConstantMode_0)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetShaderConstantMode_0)
 (
 )
 {
-	xbox::X_VERTEXSHADERCONSTANTMODE param;
-	__asm {
-		mov param, eax;
-	}
+    X_VERTEXSHADERCONSTANTMODE Mode;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Mode, eax
+    }
 
-	return EMUPATCH(D3DDevice_SetShaderConstantMode)(param);
+    EMUPATCH(D3DDevice_SetShaderConstantMode)(Mode);
+
+    __asm {
+        LTCG_EPILOGUE
+        ret
+    }
 }
 
 // ******************************************************************
@@ -4272,7 +4278,7 @@ xbox::void_xt __stdcall xbox::EMUPATCH(D3DDevice_SetShaderConstantMode_0)
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetShaderConstantMode)
 (
-    xbox::X_VERTEXSHADERCONSTANTMODE Mode
+    X_VERTEXSHADERCONSTANTMODE Mode
 )
 {
 	LOG_FUNC_ONE_ARG(Mode);
@@ -4412,58 +4418,94 @@ xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInli
 	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - X_D3DSCM_CORRECTION, pConstantData, ConstantCount / 4);
 }
 
+// Overload for logging
+static void D3DDevice_SetTexture_4__LTCG_eax_pTexture
+(
+    xbox::dword_xt           Stage,
+    xbox::X_D3DBaseTexture  *pTexture
+)
+{
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(Stage)
+        LOG_FUNC_ARG(pTexture)
+        LOG_FUNC_END;
+}
+
 // LTCG specific D3DDevice_SetTexture function...
 // This uses a custom calling convention where pTexture is passed in EAX
 // Test-case: NASCAR Heat 2002
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4__LTCG_eax_pTexture)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4__LTCG_eax_pTexture)
 (
-	dword_xt           Stage
+    dword_xt           Stage
 )
 {
-	X_D3DBaseTexture  *pTexture;
-	__asm mov pTexture, eax;
+    X_D3DBaseTexture *pTexture;
+    __asm {
+        LTCG_PROLOGUE
+        mov  pTexture, eax
+    }
 
-	//LOG_FUNC_BEGIN
-	//	LOG_FUNC_ARG(Stage)
-	//	LOG_FUNC_ARG(pTexture)
-	//	LOG_FUNC_END;
-	EmuLog(LOG_LEVEL::DEBUG, "D3DDevice_SetTexture_4__LTCG_eax_pTexture(Stage : %d pTexture : %08x);", Stage, pTexture);
+    // Log
+    D3DDevice_SetTexture_4__LTCG_eax_pTexture(Stage, pTexture);
 
-	// Call the Xbox implementation of this function, to properly handle reference counting for us
-	__asm {
-		mov eax, pTexture
-		push Stage
-		call XB_TRMP(D3DDevice_SetTexture_4__LTCG_eax_pTexture)
-	}
+    // Call the Xbox implementation of this function, to properly handle reference counting for us
+    __asm {
+        mov eax, pTexture
+        push Stage
+        call XB_TRMP(D3DDevice_SetTexture_4__LTCG_eax_pTexture)
+    }
 
-	g_pXbox_SetTexture[Stage] = pTexture;
+    g_pXbox_SetTexture[Stage] = pTexture;
+
+    __asm {
+        LTCG_EPILOGUE
+        ret  4
+    }
+}
+
+// Overload for logging
+static void D3DDevice_SetTexture_4
+(
+    xbox::dword_xt           Stage,
+    xbox::X_D3DBaseTexture  *pTexture
+)
+{
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(Stage)
+        LOG_FUNC_ARG(pTexture)
+        LOG_FUNC_END;
 }
 
 // LTCG specific D3DDevice_SetTexture function...
 // This uses a custom calling convention where Stage is passed in EAX
 // Test-case: Metal Wolf Chaos
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetTexture_4)
 (
-	X_D3DBaseTexture  *pTexture
+    X_D3DBaseTexture  *pTexture
 )
 {
-	dword_xt           Stage;
-	__asm mov Stage, eax;
+    dword_xt Stage;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Stage, eax
+    }
 
-	//LOG_FUNC_BEGIN
-	//	LOG_FUNC_ARG(Stage)
-	//	LOG_FUNC_ARG(pTexture)
-	//	LOG_FUNC_END;
-	EmuLog(LOG_LEVEL::DEBUG, "D3DDevice_SetTexture_4(Stage : %d pTexture : %08x);", Stage, pTexture);
+    // Log
+    D3DDevice_SetTexture_4(Stage, pTexture);
 
-	// Call the Xbox implementation of this function, to properly handle reference counting for us
-	__asm {
-		mov eax, Stage
-		push pTexture
-		call XB_TRMP(D3DDevice_SetTexture_4)
-	}
+    // Call the Xbox implementation of this function, to properly handle reference counting for us
+    __asm {
+        mov eax, Stage
+        push pTexture
+        call XB_TRMP(D3DDevice_SetTexture_4)
+    }
 
-	g_pXbox_SetTexture[Stage] = pTexture;
+    g_pXbox_SetTexture[Stage] = pTexture;
+
+    __asm {
+        LTCG_EPILOGUE
+        ret  4
+    }
 }
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3242,30 +3242,50 @@ __declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(Direct3D_CreateDevice_1
 	}
 }
 
+// Overload for logging
+static void D3DDevice_SetIndices_4
+(
+    xbox::X_D3DIndexBuffer   *pIndexData,
+    xbox::uint_xt             BaseVertexIndex
+)
+{
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pIndexData)
+        LOG_FUNC_ARG(BaseVertexIndex)
+        LOG_FUNC_END;
+}
+
 // ******************************************************************
 // * patch: D3DDevice_SetIndices_4
 // LTCG specific D3DDevice_SetIndices function...
 // This uses a custom calling convention where parameter is passed in EBX and Stack
 // Test Case: Conker
 // ******************************************************************
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetIndices_4)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetIndices_4)
 (
     uint_xt                BaseVertexIndex
 )
 {
     X_D3DIndexBuffer   *pIndexData;
-
     __asm {
-        mov pIndexData, ebx
+        LTCG_PROLOGUE
+        mov  pIndexData, ebx
     }
+
+    // Log
+    D3DDevice_SetIndices_4(pIndexData, BaseVertexIndex);
+
     // Cache the base vertex index
     g_Xbox_BaseVertexIndex = BaseVertexIndex;
 
     // Call LTCG-specific trampoline
     __asm {
-        mov ebx, pIndexData
+        mov  ebx, pIndexData
         push BaseVertexIndex
         call XB_TRMP(D3DDevice_SetIndices_4);
+
+        LTCG_EPILOGUE
+        ret  4
     }
 }
 
@@ -3497,17 +3517,24 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(D3DDevice_BeginVisibilityTest)()
 // LTCG specific D3DDevice_EndVisibilityTest function...
 // This uses a custom calling convention where parameter is passed in EAX
 // Test-case: Test Drive: Eve of Destruction
-xbox::hresult_xt __stdcall xbox::EMUPATCH(D3DDevice_EndVisibilityTest_0)
+__declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(D3DDevice_EndVisibilityTest_0)
 (
 )
 {
-	dword_xt                       Index;
+    dword_xt Index;
+	xbox::hresult_xt result;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Index, eax
+    }
 
-	__asm {
-		mov Index, eax
-	}
+    result = EMUPATCH(D3DDevice_EndVisibilityTest)(Index);
 
-	return EMUPATCH(D3DDevice_EndVisibilityTest)(Index);
+    __asm {
+        mov  eax, result
+        LTCG_EPILOGUE
+        ret
+    }
 }
 
 // ******************************************************************
@@ -3608,50 +3635,80 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(D3DDevice_GetVisibilityTestResult)
     return D3D_OK;
 }
 
+// Overload for logging
+static void D3DDevice_LoadVertexShader_0
+(
+    xbox::dword_xt                 Handle,
+    xbox::dword_xt                 Address
+)
+{
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(Handle)
+        LOG_FUNC_ARG(Address)
+    LOG_FUNC_END;
+}
+
 // LTCG specific D3DDevice_LoadVertexShader function...
 // This uses a custom calling convention where parameter is passed in EAX, ECX
 // Test-case: Aggressive Inline
-xbox::void_xt __stdcall xbox::EMUPATCH(D3DDevice_LoadVertexShader_0)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_LoadVertexShader_0)
 (
 )
 {
-    dword_xt                       Handle;
-    dword_xt                       Address;
+    dword_xt Handle;
+    dword_xt Address;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Address, eax
+        mov  Handle, ecx
+    }
 
-	__asm {
-		mov Address, eax
-		mov Handle, ecx
-	}
+    // Log
+    D3DDevice_LoadVertexShader_0(Handle, Address);
 
-	return EMUPATCH(D3DDevice_LoadVertexShader)(Handle, Address);
+    CxbxImpl_LoadVertexShader(Handle, Address);
+
+    __asm {
+        LTCG_EPILOGUE
+        ret
+    }
+}
+
+// Overload for logging
+static void D3DDevice_LoadVertexShader_4
+(
+    xbox::dword_xt                 Handle,
+    xbox::dword_xt                 Address
+)
+{
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(Handle)
+        LOG_FUNC_ARG(Address)
+    LOG_FUNC_END;
 }
 
 // This uses a custom calling convention where parameter is passed in EAX
 // Test-case: Ninja Gaiden
-__declspec(naked) VOID xbox::EMUPATCH(D3DDevice_LoadVertexShader_4)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_LoadVertexShader_4)
 (
     dword_xt                       Address
 )
 {
-	dword_xt Handle;
+    dword_xt Handle;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Handle, eax
+    }
 
-	// prologue
-	__asm
-	{
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
-		mov  Handle, eax // get parameter from eax
-	}
+    // Log
+    D3DDevice_LoadVertexShader_4(Handle, Address);
 
-	CxbxImpl_LoadVertexShader(Handle, Address);
+    CxbxImpl_LoadVertexShader(Handle, Address);
 
-	// epilogue
-	__asm {
-		mov  esp, ebp
-		pop  ebp
-		ret  4
-	}
+    __asm {
+        LTCG_EPILOGUE
+        ret  4
+    }
 }
 
 // ******************************************************************
@@ -3671,36 +3728,81 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_LoadVertexShader)
 	CxbxImpl_LoadVertexShader(Handle, Address);
 }
 
+// Overload for logging
+static void D3DDevice_SelectVertexShader_0
+(
+    xbox::dword_xt                 Handle,
+    xbox::dword_xt                 Address
+)
+{
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(Handle)
+        LOG_FUNC_ARG(Address)
+        LOG_FUNC_END;
+}
+
 // LTCG specific D3DDevice_SelectVertexShader function...
 // This uses a custom calling convention where parameter is passed in EAX, EBX
 // Test-case: Star Wars - Battlefront
-xbox::void_xt __stdcall xbox::EMUPATCH(D3DDevice_SelectVertexShader_0)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SelectVertexShader_0)
 (
 )
 {
-    dword_xt                       Handle;
-    dword_xt                       Address;
+    dword_xt Handle;
+    dword_xt Address;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Handle, eax
+        mov  Address, ebx
+    }
 
-	__asm {
-		mov Handle, eax
-		mov Address, ebx
-	}
+    // Log
+    D3DDevice_SelectVertexShader_0(Handle, Address);
 
-	return EMUPATCH(D3DDevice_SelectVertexShader)(Handle, Address);
+    CxbxImpl_SelectVertexShader(Handle, Address);
+
+    __asm {
+        LTCG_EPILOGUE
+        ret
+    }
+}
+
+// Overload for logging
+static void D3DDevice_SelectVertexShader_4
+(
+    xbox::dword_xt                 Handle,
+    xbox::dword_xt                 Address
+)
+{
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(Handle)
+        LOG_FUNC_ARG(Address)
+        LOG_FUNC_END;
 }
 
 // LTCG specific D3DDevice_SelectVertexShader function...
 // This uses a custom calling convention where parameter is passed in EAX
 // Test-case: Aggressive Inline
-xbox::void_xt __stdcall xbox::EMUPATCH(D3DDevice_SelectVertexShader_4)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SelectVertexShader_4)
 (
     dword_xt                       Address
 )
 {
-	dword_xt           Handle;
-	__asm mov Handle, eax;
+    dword_xt Handle;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Handle, eax
+    }
 
-	return EMUPATCH(D3DDevice_SelectVertexShader)(Handle, Address);
+    // Log
+    D3DDevice_SelectVertexShader_4(Handle, Address);
+
+    CxbxImpl_SelectVertexShader(Handle, Address);
+
+    __asm {
+        LTCG_EPILOGUE
+        ret  4
+    }
 }
 
 // ******************************************************************
@@ -3712,12 +3814,12 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SelectVertexShader)
     dword_xt                       Address
 )
 {
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(Handle)
-		LOG_FUNC_ARG(Address)
-		LOG_FUNC_END;
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(Handle)
+        LOG_FUNC_ARG(Address)
+        LOG_FUNC_END;
 
-	CxbxImpl_SelectVertexShader(Handle, Address);
+    CxbxImpl_SelectVertexShader(Handle, Address);
 }
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -7462,10 +7462,10 @@ xbox::void_xt CxbxImpl_SetPixelShader(xbox::dword_xt Handle)
 // Overload for logging
 static void D3DDevice_SetPixelShader_0
 (
-	xbox::dword_xt      Handle
+    xbox::dword_xt      Handle
 )
 {
-	LOG_FUNC_ONE_ARG(Handle);
+    LOG_FUNC_ONE_ARG(Handle);
 }
 
 // LTCG specific D3DDevice_SetPixelShader function...
@@ -7475,31 +7475,26 @@ static void D3DDevice_SetPixelShader_0
 // Test-case: Midtown Madness 3
 __declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetPixelShader_0)()
 {
-	dword_xt Handle;
-	// prologue
-	__asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
-		mov  Handle, eax
-	}
+    dword_xt Handle;
+    __asm {
+        LTCG_PROLOGUE
+        mov  Handle, eax
+    }
 
-	// Log
-	D3DDevice_SetPixelShader_0(Handle);
+    // Log
+    D3DDevice_SetPixelShader_0(Handle);
 
-	__asm {
-		mov  eax, Handle
-		call XB_TRMP(D3DDevice_SetPixelShader_0)
-	}
+    __asm {
+        mov  eax, Handle
+        call XB_TRMP(D3DDevice_SetPixelShader_0)
+    }
 
-	CxbxImpl_SetPixelShader(Handle);
+    CxbxImpl_SetPixelShader(Handle);
 
-	// epilogue
-	__asm {
-		mov  esp, ebp
-		pop  ebp
-		ret
-	}
+    __asm {
+        LTCG_EPILOGUE
+        ret
+    }
 }
 
 // ******************************************************************
@@ -7524,20 +7519,25 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetPixelShader)
 // This uses a custom calling convention where parameter is passed in ECX, EAX and Stack
 // Test Case: Conker
 // ******************************************************************
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVertices_4)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVertices_4)
 (
-    X_D3DPRIMITIVETYPE  PrimitiveType
+    X_D3DPRIMITIVETYPE PrimitiveType
 )
 {
-    UINT VertexCount;
-    UINT StartVertex;
-    
-    _asm {
-        mov VertexCount, eax
-        mov StartVertex, ecx
+    uint_xt VertexCount;
+    uint_xt StartVertex;
+    __asm {
+        LTCG_PROLOGUE
+        mov  VertexCount, eax
+        mov  StartVertex, ecx
     }
 
     EMUPATCH(D3DDevice_DrawVertices)(PrimitiveType, StartVertex, VertexCount);
+
+    __asm {
+        LTCG_EPILOGUE
+        ret  4
+    }
 }
 
 // ******************************************************************
@@ -7546,8 +7546,8 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVertices_4)
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVertices)
 (
     X_D3DPRIMITIVETYPE PrimitiveType,
-    uint_xt               StartVertex,
-    uint_xt               VertexCount
+    uint_xt            StartVertex,
+    uint_xt            VertexCount
 )
 {
 	LOG_FUNC_BEGIN
@@ -7665,9 +7665,9 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVertices)
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVerticesUP)
 (
     X_D3DPRIMITIVETYPE  PrimitiveType,
-    uint_xt                VertexCount,
+    uint_xt             VertexCount,
     CONST PVOID         pVertexStreamZeroData,
-    uint_xt                VertexStreamZeroStride
+    uint_xt             VertexStreamZeroStride
 )
 {
 	LOG_FUNC_BEGIN
@@ -7701,19 +7701,25 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVerticesUP)
 // LTCG specific D3DDevice_DrawVerticesUP function...
 // This uses a custom calling convention where pVertexStreamZeroData is passed in EBX
 // Test-case: NASCAR Heat 20002
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVerticesUP_12)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVerticesUP_12)
 (
     X_D3DPRIMITIVETYPE  PrimitiveType,
-    uint_xt                VertexCount,
-    uint_xt                VertexStreamZeroStride
+    uint_xt             VertexCount,
+    uint_xt             VertexStreamZeroStride
 )
 {
-	PVOID         pVertexStreamZeroData;
-	__asm mov pVertexStreamZeroData, ebx
+    PVOID pVertexStreamZeroData;
+    __asm {
+        LTCG_PROLOGUE
+        mov  pVertexStreamZeroData, ebx
+    }
 
-	LOG_FORWARD("D3DDevice_DrawVerticesUP");
+    EMUPATCH(D3DDevice_DrawVerticesUP)(PrimitiveType, VertexCount, pVertexStreamZeroData, VertexStreamZeroStride);
 
-	EMUPATCH(D3DDevice_DrawVerticesUP)(PrimitiveType, VertexCount, pVertexStreamZeroData, VertexStreamZeroStride);
+    __asm {
+        LTCG_EPILOGUE
+        ret  0Ch
+    }
 }
 
 // ******************************************************************
@@ -7722,7 +7728,7 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawVerticesUP_12)
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DrawIndexedVertices)
 (
     X_D3DPRIMITIVETYPE  PrimitiveType,
-    uint_xt                VertexCount,
+    uint_xt             VertexCount,
     CONST PWORD         pIndexData
 )
 {
@@ -8065,12 +8071,8 @@ __declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetRenderTarget_
 {
 	X_D3DSurface *pRenderTarget;
     X_D3DSurface *pNewZStencil;
-
-	// prologue
 	__asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
+		LTCG_PROLOGUE
 		mov  pRenderTarget, ecx
 		mov  pNewZStencil, eax
 	}
@@ -8078,10 +8080,8 @@ __declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetRenderTarget_
 	// Actual function body
 	D3DDevice_SetRenderTarget_0(pRenderTarget, pNewZStencil);
 
-	// epilogue
 	__asm {
-		mov  esp, ebp
-		pop  ebp
+		LTCG_EPILOGUE
 		ret
 	}
 }
@@ -8149,12 +8149,9 @@ __declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetPalette_4)
 	X_D3DPalette *pPalette
 )
 {
-	dword_xt      Stage;
-
+	dword_xt Stage;
 	__asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
+		LTCG_PROLOGUE
 		mov  Stage, eax
 	}
 
@@ -8171,8 +8168,7 @@ __declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetPalette_4)
 	CxbxImpl_SetPalette(Stage, pPalette);
 
 	__asm {
-		mov  esp, ebp
-		pop  ebp
+		LTCG_EPILOGUE
 		ret  4
 	}
 }
@@ -8200,17 +8196,22 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetPalette)
 // LTCG specific D3DDevice_SetFlickerFilter function...
 // This uses a custom calling convention where parameter is passed in ESI
 // Test-case: Metal Wolf Chaos
-xbox::void_xt __stdcall xbox::EMUPATCH(D3DDevice_SetFlickerFilter_0)
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetFlickerFilter_0)
 (
 )
 {
-	dword_xt         Filter;
-
+	dword_xt Filter;
 	__asm {
-		mov Filter, esi
+		LTCG_PROLOGUE
+		mov  Filter, esi
 	}
 
-	return EMUPATCH(D3DDevice_SetFlickerFilter)(Filter);
+	EMUPATCH(D3DDevice_SetFlickerFilter)(Filter);
+
+	__asm {
+		LTCG_EPILOGUE
+		ret
+	}
 }
 
 // ******************************************************************
@@ -8256,11 +8257,8 @@ __declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DeleteVertexShad
 )
 {
 	dword_xt Handle;
-
 	__asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
+		LTCG_PROLOGUE
 		mov  Handle, eax
 	}
 
@@ -8274,8 +8272,8 @@ __declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_DeleteVertexShad
 	__asm {
 		mov  eax, Handle
 		call XB_TRMP(D3DDevice_DeleteVertexShader_0)
-		mov  esp, ebp
-		pop  ebp
+
+		LTCG_EPILOGUE
 		ret
 	}
 }
@@ -8913,22 +8911,16 @@ void WINAPI xbox::EMUPATCH(D3D_BlockOnTime)( dword_xt Unknown1, int Unknown2 )
 __declspec(naked) void WINAPI xbox::EMUPATCH(D3D_BlockOnTime_4)( dword_xt Unknown1 )
 {
 	int Unknown2;
-
-	// prologue
 	__asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
-		mov  Unknown2, eax // get parameter from eax
+		LTCG_PROLOGUE
+		mov  Unknown2, eax
 	}
 
 	// LOG_FORWARD requires unwinding, so carry on without it
 	EMUPATCH(D3D_BlockOnTime)(Unknown1, Unknown2);
 
-	// epilogue
 	__asm {
-		mov  esp, ebp
-		pop  ebp
+		LTCG_EPILOGUE
 		ret  4
 	}
 }
@@ -8959,9 +8951,7 @@ __declspec(naked) void WINAPI xbox::EMUPATCH(D3D_DestroyResource__LTCG)()
 {
     X_D3DResource* pResource;
     __asm {
-        push ebp
-        mov  ebp, esp
-        sub  esp, __LOCAL_SIZE
+        LTCG_PROLOGUE
         mov  pResource, edi
     }
 
@@ -8975,8 +8965,8 @@ __declspec(naked) void WINAPI xbox::EMUPATCH(D3D_DestroyResource__LTCG)()
     __asm {
         mov  edi, pResource
         call XB_TRMP(D3D_DestroyResource__LTCG)
-        mov  esp, ebp
-        pop  ebp
+
+        LTCG_EPILOGUE
         ret
     }
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -199,6 +199,24 @@ extern void UpdateFPSCounter();
 
 #define CXBX_D3DCOMMON_IDENTIFYING_MASK (X_D3DCOMMON_TYPE_MASK | X_D3DCOMMON_D3DCREATED)
 
+
+// Those should be used with LTCG patches which use __declspec(naked)
+#define LTCG_PROLOGUE \
+		__asm push ebp \
+		__asm mov  ebp, esp \
+		__asm sub  esp, __LOCAL_SIZE \
+		__asm push esi \
+		__asm push edi \
+		__asm push ebx
+
+#define LTCG_EPILOGUE \
+		__asm pop  ebx \
+		__asm pop  edi \
+		__asm pop  esi \
+		__asm mov  esp, ebp \
+		__asm pop  ebp
+
+
 typedef struct resource_key_hash {
 	// All Xbox X_D3DResource structs have these fields :
 	DWORD Common; // We set this to the CXBX_D3DCOMMON_IDENTIFYING_MASK bits of the source Common field
@@ -3060,11 +3078,8 @@ __declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(Direct3D_CreateDevice_4
 {
     DWORD BehaviorFlags;
     xbox::X_D3DDevice **ppReturnedDeviceInterface;
-
     __asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
+		LTCG_PROLOGUE
 		mov  BehaviorFlags, eax
 		mov  ppReturnedDeviceInterface, ecx
 	}
@@ -3088,8 +3103,7 @@ __declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(Direct3D_CreateDevice_4
 
 	__asm {
 		mov  eax, hRet
-		mov  esp, ebp
-		pop  ebp
+		LTCG_EPILOGUE
 		ret  4
 	}
 }
@@ -3128,11 +3142,8 @@ __declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(Direct3D_CreateDevice_1
 {
 	dword_xt BehaviorFlags;
 	xbox::X_D3DDevice **ppReturnedDeviceInterface;
-
 	__asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
+		LTCG_PROLOGUE
 		mov  BehaviorFlags, eax
 		mov  ppReturnedDeviceInterface, ecx
 	}
@@ -3159,8 +3170,7 @@ __declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(Direct3D_CreateDevice_1
 
 	__asm {
 		mov  eax, hRet
-		mov  esp, ebp
-		pop  ebp
+		LTCG_EPILOGUE
 		ret  10h
 	}
 }
@@ -3199,11 +3209,8 @@ __declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(Direct3D_CreateDevice_1
 {
 	dword_xt BehaviorFlags;
 	xbox::X_D3DDevice **ppReturnedDeviceInterface;
-
 	__asm {
-		push ebp
-		mov  ebp, esp
-		sub  esp, __LOCAL_SIZE
+		LTCG_PROLOGUE
 		mov  BehaviorFlags, eax
 		mov  ppReturnedDeviceInterface, ebx
 	}
@@ -3230,8 +3237,7 @@ __declspec(naked) xbox::hresult_xt WINAPI xbox::EMUPATCH(Direct3D_CreateDevice_1
 
 	__asm {
 		mov  eax, hRet
-		mov  esp, ebp
-		pop  ebp
+		LTCG_EPILOGUE
 		ret  10h
 	}
 }

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -663,7 +663,7 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_Begin)
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData2f)
 (
-    int     Register,
+    int_xt     Register,
     float_xt   a,
     float_xt   b
 );
@@ -673,7 +673,7 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData2f)
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData2s)
 (
-    int     Register,
+    int_xt     Register,
     short_xt   a,
     short_xt   b
 );
@@ -683,7 +683,7 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData2s)
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData4f)
 (
-    int     Register,
+    int_xt     Register,
     float_xt   a,
     float_xt   b,
     float_xt   c,
@@ -706,7 +706,7 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData4f_16)
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData4ub)
 (
-	int_xt		Register,
+	int_xt	Register,
 	byte_xt	a,
 	byte_xt	b,
 	byte_xt	c,
@@ -730,7 +730,7 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexData4s)
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexDataColor)
 (
-    int         Register,
+    int_xt      Register,
     D3DCOLOR    Color
 );
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1555,17 +1555,17 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetPalette_4)
 // ******************************************************************
 // * patch: D3DDevice_SetFlickerFilter
 // ******************************************************************
-void WINAPI EMUPATCH(D3DDevice_SetFlickerFilter)
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetFlickerFilter)
 (
     dword_xt         Filter
 );
 
-xbox::void_xt __stdcall EMUPATCH(D3DDevice_SetFlickerFilter_0)();
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetFlickerFilter_0)();
 
 // ******************************************************************
 // * patch: D3DDevice_SetSoftDisplayFilter
 // ******************************************************************
-void WINAPI EMUPATCH(D3DDevice_SetSoftDisplayFilter)
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetSoftDisplayFilter)
 (
     bool_xt Enable
 );

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -190,7 +190,7 @@ xbox::hresult_xt WINAPI EMUPATCH(D3DDevice_EndVisibilityTest)
     dword_xt                       Index
 );
 
-xbox::hresult_xt __stdcall EMUPATCH(D3DDevice_EndVisibilityTest_0)();
+xbox::hresult_xt WINAPI EMUPATCH(D3DDevice_EndVisibilityTest_0)();
 
 // ******************************************************************
 // * patch: D3DDevice_GetVisibilityTestResult
@@ -216,8 +216,8 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_LoadVertexShader)
     dword_xt                       Address
 );
 
-xbox::void_xt __stdcall EMUPATCH(D3DDevice_LoadVertexShader_0)();
-xbox::void_xt EMUPATCH(D3DDevice_LoadVertexShader_4)
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_LoadVertexShader_0)();
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_LoadVertexShader_4)
 (
     dword_xt                       Address
 );
@@ -231,8 +231,8 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_SelectVertexShader)
     dword_xt                       Address
 );
 
-xbox::void_xt __stdcall EMUPATCH(D3DDevice_SelectVertexShader_0)();
-xbox::void_xt __stdcall EMUPATCH(D3DDevice_SelectVertexShader_4)
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SelectVertexShader_0)();
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SelectVertexShader_4)
 (
     dword_xt                       Address
 );

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -362,10 +362,10 @@ xbox::void_xt __stdcall EMUPATCH(D3DDevice_GetViewportOffsetAndScale_0)();
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetShaderConstantMode)
 (
-    xbox::X_VERTEXSHADERCONSTANTMODE Mode
+    X_VERTEXSHADERCONSTANTMODE Mode
 );
 
-xbox::void_xt __stdcall EMUPATCH(D3DDevice_SetShaderConstantMode_0)();
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetShaderConstantMode_0)();
 
 // ******************************************************************
 // * patch: D3DDevice_Reset

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -780,7 +780,7 @@ dword_xt WINAPI EMUPATCH(D3DDevice_Swap)
     dword_xt Flags
 );
 
-dword_xt EMUPATCH(D3DDevice_Swap_0)();
+dword_xt WINAPI EMUPATCH(D3DDevice_Swap_0)();
 
 // ******************************************************************
 // * patch: IDirect3DResource8_Register


### PR DESCRIPTION
This PR modifies **all** LTCG patches for correctness of the implementation. If any of our patches used incorrect calling conventions, it has **not** been changed, I only fixed the current code to properly implement the calling conventions we think are needed.

To put it simply, both styles of LTCG patches we've used have been wrong:
* Old style patches (without `__declspec(naked)`) could not ensure that the registers holding parameters were kept intact by the time we attempted to get their value. This could potentially lead to register poisoning **inside** the patch function, especially in Debug builds.
* New style patches (with `__declspec(naked)`) did not ensure that the persistent registers (in x86 calling convention, those are `ESI`, `EDI`, `EBP` and `EBX`) were correctly preserved. This could potentially lead to register poisoning **outside** the patch function, possibly resulting in weird, hard to debug "random" crashes in the game code.

To fix this, I introduced `LTCG_PROLOGUE` and `LTCG_EPILOGUE` macros which set up stack frames for naked functions and preserve persistent registers, then I went through every LTCG patch and adapted them to use a proper calling convention.

This PR can improve numerous LTCG games in unexpected ways, but most notably it should improve consistency between Debug and Release builds as now we have complete control over custom calling conventions.