### PR TITLE
Fixed booting games from write-protected drives

### DIFF
--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -553,8 +553,6 @@ XboxDevice *CxbxDeviceByDevicePath(const std::string XboxDevicePath)
 
 int CxbxRegisterDeviceHostPath(std::string XboxDevicePath, std::string HostDevicePath, bool IsFile)
 {
-	int result = -1;
-
 	XboxDevice newDevice;
 	newDevice.XboxDevicePath = XboxDevicePath;
 	newDevice.HostDevicePath = HostDevicePath;
@@ -573,24 +571,17 @@ int CxbxRegisterDeviceHostPath(std::string XboxDevicePath, std::string HostDevic
 
 	// If this path is not a raw file partition, create the directory for it
 	if (!IsFile) {
-
-		if (std::filesystem::exists(HostDevicePath))
-		{
-			succeeded = true;
-		}
-		else
-		{
-			succeeded = std::filesystem::create_directory(HostDevicePath);
-		}
+		succeeded = std::filesystem::exists(HostDevicePath) || std::filesystem::create_directory(HostDevicePath);
 	}
 
-	if (succeeded)
-	{
-		Devices.emplace_back(newDevice);
-		result = Devices.size() - 1;
+	if (succeeded) {
+		Devices.push_back(newDevice);
+		return static_cast<int>(Devices.size()) - 1;
 	}
 
-	return result;
+	EmuLog(LOG_LEVEL::FATAL, "Failed to register host device (%s)\n", HostDevicePath.c_str());
+
+	return -1;
 }
 
 


### PR DESCRIPTION
This fixes a bug that abused `SHCreateDirectoryEx` to use the return value **`ERROR_ALREADY_EXISTS`** to check if the directory already exists. The device `\Device\CdRom0` is used for registering the XBE file path and will usually exist. I have switched to check this using `std::filesystem` instead.

On write-protected drives `SHCreateDirectoryEx` was returning **`ERROR_WRITE_PROTECT`** which caused the device to not register, and would stop games from booting.

Note "write-protected drives" are not the same as file permissions - on Windows, read-only folder permissions are ignored