### PR TITLE
Ensure the xbox viewport is applied when Clear is called

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4836,6 +4836,9 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_Clear)
 
 	DWORD HostFlags = 0;
 
+	// Clear requires the Xbox viewport to be applied
+	CxbxUpdateNativeD3DResources();
+
     // make adjustments to parameters to make sense with windows d3d
     {
 		if (Flags & X_D3DCLEAR_TARGET) {


### PR DESCRIPTION
This fixes an issue introduced in 46ec7516faca6641255246b34423013cec5bf4a1
The xbox viewport was applied in UpdateNativeD3DResources instead of the SetViewport patch, so wouldn't be applied until a Draw call.
Crash Tag Team Racing graphics would be blacked out whenever the rear view mirror appeared on the screen.