### PR TITLE
Reduce the amount of work done per draw

### DIFF
--- a/src/common/Logging.h
+++ b/src/common/Logging.h
@@ -183,24 +183,6 @@ PopupReturn PopupCustomEx(const void* hwnd, const CXBXR_MODULE cxbxr_module, con
 // For LOG_TEST_CASE
 extern inline void EmuLogOutputEx(const CXBXR_MODULE cxbxr_module, const LOG_LEVEL level, const char *szWarningMessage, ...);
 
-// The reason of having EmuLogOutputEx in LOG_TEST_CASE is to allow dump to log directly for any test cases triggered.
-// Which will make developers easier to note which applications has triggered quicker, easier, and doesn't require any individual log enabled to capture them.
-#define LOG_TEST_CASE(message) do { \
-	static bool bTestCaseLogged = false; \
-	if (bTestCaseLogged) break; \
-	bTestCaseLogged = true; \
-	if (g_CurrentLogPopupTestCase) { \
-		LOG_CHECK_ENABLED(LOG_LEVEL::INFO) { \
-			PopupInfo(nullptr, "Please report that %s shows the following message:\nLOG_TEST_CASE: %s\nIn %s (%s line %d)", \
-			CxbxKrnl_Xbe->m_szAsciiTitle, message, __func__, __FILE__, __LINE__); \
-			continue; \
-		} \
-	} \
-	EmuLogOutputEx(LOG_PREFIX, LOG_LEVEL::INFO, "Please report that %s shows the following message:\nLOG_TEST_CASE: %s\nIn %s (%s line %d)", \
-	CxbxKrnl_Xbe->m_szAsciiTitle, message, __func__, __FILE__, __LINE__); \
-} while (0)
-// was g_pCertificate->wszTitleName
-
 //
 // __FILENAME__
 //

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -2702,7 +2702,7 @@ ConvertedIndexBuffer& CxbxUpdateActiveIndexBuffer
 	}
 
 	// Poor-mans eviction policy : when exceeding treshold, clear entire cache :
-	if (g_IndexBufferCache.size() > 256) {
+	if (g_IndexBufferCache.size() > 10000) {
 		g_IndexBufferCache.clear(); // Note : ConvertedIndexBuffer destructor will release any assigned pHostIndexBuffer
 	}
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -175,6 +175,8 @@ xbox::X_D3DVIEWPORT8 g_Xbox_Viewport = { 0 };
 float g_Xbox_BackbufferScaleX = 1;
 float g_Xbox_BackbufferScaleY = 1;
 
+static constexpr size_t INDEX_BUFFER_CACHE_SIZE = 10000;
+
 /* Unused :
 static xbox::dword_xt                  *g_Xbox_D3DDevice; // TODO: This should be a D3DDevice structure
 */
@@ -2641,8 +2643,8 @@ public:
 	}
 };
 
-std::unordered_map<uint32_t, ConvertedIndexBuffer> g_IndexBufferCache;
-	
+	std::unordered_map<uint32_t, ConvertedIndexBuffer> g_IndexBufferCache;
+
 void CxbxRemoveIndexBuffer(PWORD pData)
 {
 	// HACK: Never Free
@@ -2702,7 +2704,7 @@ ConvertedIndexBuffer& CxbxUpdateActiveIndexBuffer
 	}
 
 	// Poor-mans eviction policy : when exceeding treshold, clear entire cache :
-	if (g_IndexBufferCache.size() > 10000) {
+	if (g_IndexBufferCache.size() > INDEX_BUFFER_CACHE_SIZE) {
 		g_IndexBufferCache.clear(); // Note : ConvertedIndexBuffer destructor will release any assigned pHostIndexBuffer
 	}
 

--- a/src/core/hle/D3D8/Direct3D9/TextureStates.h
+++ b/src/core/hle/D3D8/Direct3D9/TextureStates.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <array>
 #include "core\hle\D3D8\XbD3D8Types.h"
+#include <optional>
 
 #define CXBX_D3DRS_UNSUPPORTED (xbox::X_D3DRS_LAST + 1)
 
@@ -47,4 +48,6 @@ private:
     uint32_t* D3D__TextureState = nullptr;
     std::array<int, xbox::X_D3DTSS_LAST + 1> XboxTextureStateOffsets;
     XboxRenderStateConverter* pXboxRenderStates;
+    // Holds the last state that was set, so we don't set it again
+    std::optional<DWORD> PreviousStates[xbox::X_D3DTS_STAGECOUNT][xbox::X_D3DTSS_LAST + 1] = {};
 };

--- a/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
+++ b/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
@@ -194,32 +194,6 @@ std::string DebugPrependLineNumbers(std::string shaderString) {
 	return debugShader.str();
 }
 
-
-extern ShaderType EmuGetShaderInfo(IntermediateVertexShader* pIntermediateShader) {
-
-	if (pIntermediateShader->Instructions.size() == 0) {
-		// Do not attempt to compile empty shaders
-		// This is a declaration only shader, so there is no function to compile
-		return ShaderType::Empty;
-	}
-
-	switch (pIntermediateShader->Header.Version) {
-		case VERSION_XVS:
-			break;
-		case VERSION_XVSS:
-			LOG_TEST_CASE("Might not support vertex state shaders?");
-			break;
-		case VERSION_XVSW:
-			EmuLog(LOG_LEVEL::WARNING, "Might not support vertex read/write shaders?");
-			return ShaderType::Unsupported;
-		default:
-			EmuLog(LOG_LEVEL::WARNING, "Unknown vertex shader version 0x%02X", pIntermediateShader->Header.Version);
-			return ShaderType::Unsupported;
-	}
-
-	return ShaderType::Compilable;
-}
-
 HRESULT CompileHlsl(const std::string& hlsl, ID3DBlob** ppHostShader, const char* pSourceName)
 {
 	// TODO include header in vertex shader

--- a/src/core/hle/D3D8/Direct3D9/VertexShader.h
+++ b/src/core/hle/D3D8/Direct3D9/VertexShader.h
@@ -14,8 +14,6 @@ static const char* vs_model_2_a = "vs_2_a";
 static const char* vs_model_3_0 = "vs_3_0";
 extern const char* g_vs_model;
 
-extern ShaderType EmuGetShaderInfo(IntermediateVertexShader* pIntermediateShader);
-
 extern HRESULT EmuCompileShader
 (
     IntermediateVertexShader* pIntermediateShader,

--- a/src/core/hle/D3D8/Direct3D9/VertexShaderSource.cpp
+++ b/src/core/hle/D3D8/Direct3D9/VertexShaderSource.cpp
@@ -2,7 +2,7 @@
 
 #include "VertexShaderSource.h"
 
-#include "Logging.h"
+#include "core/kernel/init/CxbxKrnl.h"
 #include "util/hasher.h"
 #include "core/kernel/support/Emu.h"
 
@@ -78,7 +78,7 @@ ShaderKey VertexShaderSource::CreateShader(const xbox::dword_xt* pXboxFunction, 
 	else {
 		// We can't do anything with this shader
 		// Test case: ???
-		EmuLog(LOG_LEVEL::WARNING, "Empty vertex shader");
+		LOG_TEST_CASE("Empty vertex shader");
 		newShader.isReady = true;
 		newShader.pHostVertexShader = nullptr;
 	}

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -85,7 +85,7 @@ class CxbxVertexBufferConverter
         ULONG m_TotalCacheHits = 0;
         ULONG m_TotalCacheMisses = 0;
 
-        UINT m_MaxCacheSize = 2000;                                        // Maximum number of entries in the cache
+        UINT m_MaxCacheSize = 10000;                                        // Maximum number of entries in the cache
         UINT m_CacheElasticity = 200;                                      // Cache is allowed to grow this much more than maximum before being purged to maximum
         std::unordered_map<uint64_t, std::list<CxbxPatchedStream>::iterator> m_PatchedStreams;  // Stores references to patched streams for fast lookup
         std::list<CxbxPatchedStream> m_PatchedStreamUsageList;             // Linked list of vertex streams, least recently used is last in the list

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -371,9 +371,8 @@ xbox::X_STREAMINPUT& GetXboxVertexStreamInput(unsigned XboxStreamNumber)
 // * Vertex shader function recompiler
 // ****************************************************************************
 
-class XboxVertexShaderDecoder
+namespace XboxVertexShaderDecoder
 {
-private:
 	// Xbox Vertex SHader microcode types
 
 	enum VSH_OUTPUT_TYPE {
@@ -539,7 +538,7 @@ private:
 		Param.Swizzle[3] = (VSH_SWIZZLE)VshGetField(pShaderToken, (VSH_FIELD_NAME)(d + FLD_A_SWZ_W));
 	}
 
-	void VshAddIntermediateInstruction(
+	static void VshAddIntermediateInstruction(
 		uint32_t* pShaderToken,
 		IntermediateVertexShader* pShader,
 		VSH_MAC MAC,
@@ -592,8 +591,7 @@ private:
 		pShader->Instructions.push_back(intermediate);
 	}
 
-public:
-	bool VshConvertToIntermediate(uint32_t* pShaderToken, IntermediateVertexShader* pShader)
+	static bool VshConvertToIntermediate(uint32_t* pShaderToken, IntermediateVertexShader* pShader)
 	{
 		// First get the instruction(s).
 		VSH_ILU ILU = (VSH_ILU)VshGetField(pShaderToken, FLD_ILU);
@@ -648,8 +646,20 @@ public:
 
 		return VshGetField(pShaderToken, FLD_FINAL) == 0;
 	}
-
 };
+
+// Get the function size excluding the final field
+size_t GetVshFunctionSize(const xbox::dword_xt* pXboxFunction) {
+	auto curToken = (uint32_t*)pXboxFunction;
+
+	while (!XboxVertexShaderDecoder::VshGetField(curToken, XboxVertexShaderDecoder::FLD_FINAL)) {
+		curToken += X_VSH_INSTRUCTION_SIZE; // TODO use a struct to represent these instructions
+	}
+
+	curToken += X_VSH_INSTRUCTION_SIZE; // For the final instruction
+
+	return (curToken - pXboxFunction) * sizeof(xbox::dword_xt);
+}
 
 // ****************************************************************************
 // * Vertex shader declaration recompiler
@@ -1547,54 +1557,18 @@ void CxbxImpl_SetVertexShaderConstant(INT Register, PVOID pConstantData, DWORD C
 // parse xbox vertex shader function into an intermediate format
 extern void EmuParseVshFunction
 (
+	// Pointer to raw Xbox vertex shader instruction slots
 	DWORD* pXboxFunction,
-	DWORD* pXboxFunctionSize,
 	IntermediateVertexShader* pShader
 )
 {
-	auto VshDecoder = XboxVertexShaderDecoder();
-
-	*pXboxFunctionSize = 0;
-
-	// FIXME tidy handling of the header vs headerless cases
-	// Normally, pXboxFunction has a shader header before the shader tokens
-	// But we can also load shader tokens directly from the Xbox vertex shader slots too
-
-	bool headerless = pXboxFunction[0] == 0; // if its a token instead of a header, first DWORD is unused
-	auto headerSize = headerless ? 0 : sizeof(xbox::X_VSH_SHADER_HEADER);
-
 	// Decode the vertex shader program tokens into an intermediate representation
-	uint32_t* pCurToken = (uint32_t*)((uintptr_t)pXboxFunction + headerSize);
+	uint32_t* pCurToken = (uint32_t*)((uintptr_t)pXboxFunction);
 
-	if (headerless) {
-		// We've been fed shader slots. Make up a header...
-		pShader->Header.Version = VERSION_XVS;
-		pShader->Header.NumInst = (uint16_t)pShader->Instructions.size();
-
-		// Decode until we hit a token marked final
-		// Note : CxbxSetVertexShaderSlots makes sure this always stops
-		// after X_VSH_MAX_INSTRUCTION_COUNT, by setting FLD_FINAL in there.
-		while (VshDecoder.VshConvertToIntermediate(pCurToken, pShader)) {
-			pCurToken += X_VSH_INSTRUCTION_SIZE;
-		}
+	// Decode until we hit a token marked final
+	// Note : CxbxSetVertexShaderSlots makes sure this always stops
+	// after X_VSH_MAX_INSTRUCTION_COUNT, by setting FLD_FINAL in there.
+	while (XboxVertexShaderDecoder::VshConvertToIntermediate(pCurToken, pShader)) {
+		pCurToken += X_VSH_INSTRUCTION_SIZE;
 	}
-	else {
-		pShader->Header = *(xbox::X_VSH_SHADER_HEADER*)pXboxFunction;
-		// Decode only up to the number of instructions in the header
-		// The last instruction may not be marked final:
-		// Test case: Multiple Vertex Shaders sample
-		for (int i = 0; i < pShader->Header.NumInst; i++) {
-			if (!VshDecoder.VshConvertToIntermediate(pCurToken, pShader)) {
-				if (i < pShader->Header.NumInst - 1) {
-					LOG_TEST_CASE("Shader instructions after final instruction");
-				}
-				break;
-			}
-			pCurToken += X_VSH_INSTRUCTION_SIZE;
-		}
-	}
-
-	// The size of the shader is
-	pCurToken += X_VSH_INSTRUCTION_SIZE; // always at least one token
-	*pXboxFunctionSize = (intptr_t)pCurToken - (intptr_t)pXboxFunction;
 }

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -1563,7 +1563,7 @@ extern void EmuParseVshFunction
 )
 {
 	// Decode the vertex shader program tokens into an intermediate representation
-	uint32_t* pCurToken = (uint32_t*)((uintptr_t)pXboxFunction);
+	auto pCurToken = (uint32_t*)pXboxFunction;
 
 	// Decode until we hit a token marked final
 	// Note : CxbxSetVertexShaderSlots makes sure this always stops

--- a/src/core/hle/D3D8/XbVertexShader.h
+++ b/src/core/hle/D3D8/XbVertexShader.h
@@ -185,7 +185,6 @@ typedef struct _VSH_INTERMEDIATE_FORMAT {
 } VSH_INTERMEDIATE_FORMAT;
 
 typedef struct _IntermediateVertexShader {
-	xbox::X_VSH_SHADER_HEADER Header;
 	std::vector<VSH_INTERMEDIATE_FORMAT> Instructions;
 } IntermediateVertexShader;
 
@@ -193,9 +192,10 @@ typedef struct _IntermediateVertexShader {
 extern void EmuParseVshFunction
 (
 	DWORD* pXboxFunction,
-	DWORD* pXboxFunctionSize,
 	IntermediateVertexShader* pShader
 );
+
+extern size_t GetVshFunctionSize(const xbox::dword_xt* pXboxFunction);
 
 inline boolean VshHandleIsVertexShader(DWORD Handle) { return (Handle & X_D3DFVF_RESERVED0) ? TRUE : FALSE; }
 inline xbox::X_D3DVertexShader *VshHandleToXboxVertexShader(DWORD Handle) { return (xbox::X_D3DVertexShader *)(Handle & ~X_D3DFVF_RESERVED0);}
@@ -214,5 +214,4 @@ extern void CxbxImpl_SetVertexShaderInput(DWORD Handle, UINT StreamCount, xbox::
 extern void CxbxImpl_SetVertexShaderConstant(INT Register, PVOID pConstantData, DWORD ConstantCount);
 extern void CxbxImpl_DeleteVertexShader(DWORD Handle);
 extern void CxbxVertexShaderSetFlags();
-
 #endif

--- a/src/core/kernel/init/CxbxKrnl.h
+++ b/src/core/kernel/init/CxbxKrnl.h
@@ -235,4 +235,22 @@ extern char szFilePath_Xbe[MAX_PATH*2];
 // Returns the last Win32 error, in string format. Returns an empty string if there is no error.
 extern std::string CxbxGetLastErrorString(char * lpszFunction);
 
+// The reason of having EmuLogOutputEx in LOG_TEST_CASE is to allow dump to log directly for any test cases triggered.
+// Which will make developers easier to note which applications has triggered quicker, easier, and doesn't require any individual log enabled to capture them.
+#define LOG_TEST_CASE(message) do { \
+	static bool bTestCaseLogged = false; \
+	if (bTestCaseLogged) break; \
+	bTestCaseLogged = true; \
+	if (g_CurrentLogPopupTestCase) { \
+		LOG_CHECK_ENABLED(LOG_LEVEL::INFO) { \
+			PopupInfo(nullptr, "Please report that %s shows the following message:\nLOG_TEST_CASE: %s\nIn %s (%s line %d)", \
+			CxbxKrnl_Xbe->m_szAsciiTitle, message, __func__, __FILE__, __LINE__); \
+			continue; \
+		} \
+	} \
+	EmuLogOutputEx(LOG_PREFIX, LOG_LEVEL::INFO, "Please report that %s shows the following message:\nLOG_TEST_CASE: %s\nIn %s (%s line %d)", \
+	CxbxKrnl_Xbe->m_szAsciiTitle, message, __func__, __FILE__, __LINE__); \
+} while (0)
+// was g_pCertificate->wszTitleName
+
 #endif

--- a/src/core/kernel/init/CxbxKrnl.h
+++ b/src/core/kernel/init/CxbxKrnl.h
@@ -237,6 +237,7 @@ extern std::string CxbxGetLastErrorString(char * lpszFunction);
 
 // The reason of having EmuLogOutputEx in LOG_TEST_CASE is to allow dump to log directly for any test cases triggered.
 // Which will make developers easier to note which applications has triggered quicker, easier, and doesn't require any individual log enabled to capture them.
+// NOTE: This #define is here rather than Logging.h, because it has a dependency on CxbxKrnl_Xbe
 #define LOG_TEST_CASE(message) do { \
 	static bool bTestCaseLogged = false; \
 	if (bTestCaseLogged) break; \


### PR DESCRIPTION
Certain titles split geometry into many small sections, and do a huge number of draws per frame
These are some optimizations and tweaks to code that runs per-draw

Significantly increases performance in Crash Nitro Kart