### PR TITLE
Ensure WM_PAINT is handled correctly

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1824,6 +1824,10 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
 			{
 				DrawUEM(hWnd);
 			}
+			else
+			{
+				DefWindowProc(hWnd, msg, wParam, lParam);
+			}
 		}
 		break;
 


### PR DESCRIPTION
Otherwise, Windows will send WM_PAINT messages non-stop and burn CPU doing nothing
This fixes an odd behaviour where moving the mouse over the window could increase FPS

Related:
https://stackoverflow.com/questions/1117511/never-ending-wm-paint-loop-with-atl-cwindowimpl