### PR TITLE
vs: use model 2.a primarily, with 3.0 fallback

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1634,17 +1634,6 @@ void EmuD3DInit()
 		std::cout << "Host D3DCaps : " << g_D3DCaps << "\n";
 		std::cout << "----------------------------------------\n";
 	}
-
-	// AMD compatibility workaround since VS model 3.0 doesn't work as intended with Direct3D9.
-	{
-		D3DADAPTER_IDENTIFIER9 adapter_info;
-		HRESULT status = g_pDirect3D->GetAdapterIdentifier(g_EmuCDPD.Adapter, 0, &adapter_info);
-		// 1002 and 1022 are vendor ids of AMD gpus
-		if (status == D3D_OK && (adapter_info.VendorId == 0x1002 || adapter_info.VendorId == 0x1022)) {
-			g_vs_model = vs_model_2_a;
-			EmuLogInit(LOG_LEVEL::WARNING, "AMD GPU Detected, falling back to shader model 2.X to prevent missing polygons");
-		}
-	}
 }
 
 // cleanup Direct3D


### PR DESCRIPTION
Based on conversations with @CookiePLMonster: This PR defaults to shader model 2.a for Vertex Shaders, rather than 3.0. 

Using Vertex Shader Model 3.0 with fixed-function or pixel shader model < 3 is *undefined* behavior and not supposed to work, yet Cxbx-R does this.

This PR avoids that undefined behavior in the default case, removing the need for the AMD hack, while still falling back to 3.0 in case of compilation failure, to allow large shaders to use their existing (undefined, but better than crashing) behavior.

This may not have *any* impact whatsoever in most games, but it also has the potential to fix weird issues that have no obvious explanation.

I'd consider this a low-risk merge, as we know vertex shader model 2.a is functional (ALL shaders use this on AMD gpus already, with,or without dxvk).