### PR TITLE
Fix Linguist Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,5 +21,5 @@
 *.unused-patches text eol=lf
 *.rc text eol=lf
 
-# All submodule imports are vendor, remove them from linguist stats chart for accurate stats.
+# All module imports are vendor, remove them from linguist stats chart for accurate stats.
 import/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,6 @@
 *.hpp text eol=lf
 *.unused-patches text eol=lf
 *.rc text eol=lf
+
+# All submodule imports are vendor, remove them from linguist stats chart for accurate stats.
+import/* linguist-vendored


### PR DESCRIPTION
I notice our repository has HTML language which is from glew's folder. With this change, it will suppress from the stats along with other source code languages that are not submodule.