### PR TITLE
Add support for mouse input as cursor position relative to the rendering window

### DIFF
--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -947,12 +947,9 @@ void Settings::RemoveLegacyConfigs(unsigned int CurrentRevision)
 			std::string current_section = std::string(section_input_port) + std::to_string(port_num);
 			std::string device_name = m_si.GetValue(current_section.c_str(), sect_input_port.device, "");
 
-			// NOTE: with C++20, this can be simplified by simply calling device_name.ends_with()
-			if (device_name.length() >= kb_str.length()) {
-				if (device_name.compare(device_name.length() - kb_str.length(), kb_str.length(), kb_str) == 0) {
-					device_name += "Mouse";
-					m_si.SetValue(current_section.c_str(), sect_input_port.device, device_name.c_str(), nullptr, true);
-				}
+			if (StrEndsWith(device_name, kb_str)) {
+				device_name += "Mouse";
+				m_si.SetValue(current_section.c_str(), sect_input_port.device, device_name.c_str(), nullptr, true);
 			}
 		}
 

--- a/src/common/input/Button.cpp
+++ b/src/common/input/Button.cpp
@@ -63,10 +63,16 @@ LRESULT CALLBACK ButtonDukeSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 
 	case WM_RBUTTONDOWN: {
 		Button *button = reinterpret_cast<Button *>(dwRefData);
-		button->ClearText();
-		static_cast<DukeInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_CLEAR);
-		if (button->GetId() == IDC_SET_MOTOR) {
-			static_cast<DukeInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), RUMBLE_CLEAR);
+		if (wParam & MK_SHIFT) {
+			static_cast<DukeInputWindow *>(button->GetWnd())->SwapMoCursorAxis(button);
+			static_cast<DukeInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_SWAP);
+		}
+		else if (!(wParam & ~MK_RBUTTON)) {
+			button->ClearText();
+			static_cast<DukeInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_CLEAR);
+			if (button->GetId() == IDC_SET_MOTOR) {
+				static_cast<DukeInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), RUMBLE_CLEAR);
+			}
 		}
 	}
 	break;
@@ -88,8 +94,14 @@ LRESULT CALLBACK ButtonSbcSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 
 	case WM_RBUTTONDOWN: {
 		Button *button = reinterpret_cast<Button *>(dwRefData);
-		button->ClearText();
-		static_cast<SbcInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_CLEAR);
+		if (wParam & MK_SHIFT) {
+			static_cast<SbcInputWindow *>(button->GetWnd())->SwapMoCursorAxis(button);
+			static_cast<SbcInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_SWAP);
+		}
+		else if (!(wParam & ~MK_RBUTTON)) {
+			button->ClearText();
+			static_cast<SbcInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_CLEAR);
+		}
 	}
 	break;
 

--- a/src/common/input/Button.cpp
+++ b/src/common/input/Button.cpp
@@ -51,6 +51,19 @@ void Button::GetText(char* const text, size_t size) const
 	SendMessage(m_button_hwnd, WM_GETTEXT, size, reinterpret_cast<LPARAM>(text));
 }
 
+void Button::AddTooltip(HWND hwnd, HWND tooltip_hwnd, char *text) const
+{
+	assert((hwnd != NULL) && (tooltip_hwnd != NULL));
+
+	TOOLINFO tool = { 0 };
+	tool.cbSize = sizeof(tool);
+	tool.hwnd = hwnd;
+	tool.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
+	tool.uId = reinterpret_cast<UINT_PTR>(m_button_hwnd);
+	tool.lpszText = text;
+	SendMessage(tooltip_hwnd, TTM_ADDTOOL, 0, reinterpret_cast<LPARAM>(&tool));
+}
+
 LRESULT CALLBACK ButtonDukeSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
 	switch (uMsg)

--- a/src/common/input/Button.h
+++ b/src/common/input/Button.h
@@ -50,6 +50,7 @@ public:
 	int GetId() const { return m_id; }
 	int GetIndex() const { return m_index; }
 	void *GetWnd() const { return m_wnd; }
+	void AddTooltip(HWND hwnd, HWND tooltip_hwnd, char *text) const;
 
 
 private:

--- a/src/common/input/DInputKeyboardMouse.h
+++ b/src/common/input/DInputKeyboardMouse.h
@@ -51,6 +51,7 @@ namespace DInput
 		std::string GetDeviceName() const override;
 		std::string GetAPI() const override;
 		bool UpdateInput() override;
+		void SetHwnd(HWND hwnd) { m_hwnd = hwnd; }
 
 
 	private:
@@ -78,6 +79,7 @@ namespace DInput
 			const uint8_t m_index;
 		};
 
+		// gives mouse input based on relative motion
 		class Axis : public Input
 		{
 		public:
@@ -91,14 +93,37 @@ namespace DInput
 			const uint8_t m_index;
 		};
 
+		// gives mouse input based on cursor position relative to the rendering window
+		class Cursor : public Input
+		{
+		public:
+			Cursor(uint8_t index, const ControlState &cursor, const ControlState range)
+				: m_cursor(cursor), m_index(index), m_range(range) {}
+			std::string GetName() const override;
+			ControlState GetState() const override;
+			bool IsDetectable() const override { return false; }
+
+		private:
+			const ControlState &m_cursor;
+			const ControlState m_range;
+			const uint8_t m_index;
+		};
+
 		struct State
 		{
 			BYTE keyboard[256];
 			DIMOUSESTATE2 mouse;
+			struct
+			{
+				ControlState x, y;
+			} cursor;
 		};
+
+		void UpdateCursorPosition();
 
 		const LPDIRECTINPUTDEVICE8 m_kb_device;
 		const LPDIRECTINPUTDEVICE8 m_mo_device;
 		State m_state_in;
+		HWND m_hwnd;
 	};
 }

--- a/src/common/input/EmuDevice.h
+++ b/src/common/input/EmuDevice.h
@@ -46,8 +46,11 @@ public:
 
 
 private:
+	void CreateTooltipWindow();
+
 	std::vector<Button*> m_buttons;
 	HWND m_hwnd;
+	HWND m_tooltip_hwnd;
 };
 
 template void EmuDevice::BindDefault(const std::array<const char *, XBOX_CTRL_NUM_BUTTONS> &arr);

--- a/src/common/input/InputDevice.h
+++ b/src/common/input/InputDevice.h
@@ -93,6 +93,7 @@ public:
 	{
 	public:
 		virtual ControlState GetState() const = 0;
+		virtual bool IsDetectable() const { return true; };
 	};
 
 	class Output : public IoControl

--- a/src/common/input/InputManager.h
+++ b/src/common/input/InputManager.h
@@ -123,7 +123,7 @@ CXBX_CONTROLLER_HOST_BRIDGE, *PCXBX_CONTROLLER_HOST_BRIDGE;
 class InputDeviceManager
 {
 public:
-	void Initialize(bool is_gui);
+	void Initialize(bool is_gui, HWND hwnd);
 	void Shutdown();
 	// read/write the input/output from/to the device attached to the supplied xbox port
 	bool UpdateXboxPortInput(int usb_port, void* Buffer, int Direction, int xid_type);
@@ -169,6 +169,8 @@ private:
 	std::thread m_PollingThread;
 	// used to indicate that the manager is shutting down
 	bool m_bPendingShutdown;
+	// handle of the rendering or the input gui window
+	HWND m_hwnd;
 };
 
 extern InputDeviceManager g_InputDeviceManager;

--- a/src/common/input/InputWindow.cpp
+++ b/src/common/input/InputWindow.cpp
@@ -121,7 +121,7 @@ InputDevice::Input* InputWindow::DetectInput(InputDevice* const Device, int ms)
 		Device->UpdateInput();
 		std::vector<bool>::iterator state = initial_states.begin();
 		for (; i != e && s == e; i++, state++) {
-			if ((*i)->GetState() > INPUT_DETECT_THRESHOLD) {
+			if ((*i)->IsDetectable() && ((*i)->GetState() > INPUT_DETECT_THRESHOLD)) {
 				if (*state == false) {
 					// input was not initially pressed or it was but released afterwards
 					s = i;
@@ -289,4 +289,66 @@ void InputWindow::UpdateCurrentDevice()
 	SendMessage(m_hwnd_device_list, WM_GETTEXT, sizeof(device_name), reinterpret_cast<LPARAM>(device_name));
 	m_host_dev = device_name;
 	EnableDefaultButton();
+}
+
+void InputWindow::SwapMoCursorAxis(Button *button)
+{
+	// Axis X+ <-> Cursor X+
+	// Axis X- <-> Cursor X-
+	// Axis Y+ <-> Cursor Y-
+	// Axis Y- <-> Cursor Y+
+	if (StrEndsWith(m_host_dev, "KeyboardMouse")) {
+		assert(button != nullptr);
+		char control_name[HOST_BUTTON_NAME_LENGTH];
+		button->GetText(control_name, sizeof(control_name));
+		if (StrStartsWith(control_name, "Axis")) {
+			switch (control_name[5])
+			{
+			case 'X':
+				if (control_name[6] == '+') {
+					button->UpdateText("Cursor X+");
+				}
+				else {
+					button->UpdateText("Cursor X-");
+				}
+				break;
+
+			case 'Y':
+				if (control_name[6] == '+') {
+					button->UpdateText("Cursor Y-");
+				}
+				else {
+					button->UpdateText("Cursor Y+");
+				}
+				break;
+
+			}
+
+			return;
+		}
+
+		if (StrStartsWith(control_name, "Cursor")) {
+			switch (control_name[7])
+			{
+			case 'X':
+				if (control_name[8] == '+') {
+					button->UpdateText("Axis X+");
+				}
+				else {
+					button->UpdateText("Axis X-");
+				}
+				break;
+
+			case 'Y':
+				if (control_name[8] == '+') {
+					button->UpdateText("Axis Y-");
+				}
+				else {
+					button->UpdateText("Axis Y+");
+				}
+				break;
+
+			}
+		}
+	}
 }

--- a/src/common/input/InputWindow.h
+++ b/src/common/input/InputWindow.h
@@ -39,6 +39,7 @@
 #define RUMBLE_TEST    6
 #define RUMBLE_CLEAR   7
 #define BUTTON_CLEAR   8
+#define BUTTON_SWAP    9
 
 #define XINPUT_DEFAULT 0
 #define DINPUT_DEFAULT 1
@@ -60,6 +61,7 @@ public:
 	virtual void UpdateProfile(const std::string& name, int command) = 0;
 	void UpdateCurrentDevice();
 	bool IsProfileSaved();
+	void SwapMoCursorAxis(Button *button);
 
 
 protected:

--- a/src/common/util/CxbxUtil.cpp
+++ b/src/common/util/CxbxUtil.cpp
@@ -280,3 +280,27 @@ std::string StripQuotes(const std::string& str)
 {
 	return StripChars(str, "\"");
 }
+
+// NOTE: with C++20, this can be replaced by simply calling full_str.ends_with()
+bool StrEndsWith(const std::string &full_str, const std::string &substr)
+{
+	if (full_str.length() >= substr.length()) {
+		if (full_str.compare(full_str.length() - substr.length(), substr.length(), substr) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// NOTE: with C++20, this can be replaced by simply calling full_str.starts_with()
+bool StrStartsWith(const std::string &full_str, const std::string &substr)
+{
+	if (!full_str.empty()) {
+		if (full_str.rfind(substr, 0) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/common/util/CxbxUtil.h
+++ b/src/common/util/CxbxUtil.h
@@ -67,6 +67,8 @@ bool Memory_RW(void* Addr, void* Buf, size_t Num, bool bIsWrite);
 void unix2dos(std::string& string);
 std::string StripSpaces(const std::string& str);
 std::string StripQuotes(const std::string& str);
+bool StrEndsWith(const std::string &full_str, const std::string &substr);
+bool StrStartsWith(const std::string &full_str, const std::string &substr);
 
 // Retrieves the underlying integer value of a scoped enumerator. It allows to avoid using static_cast every time
 template <typename E>

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1497,7 +1497,7 @@ __declspec(noreturn) void CxbxKrnlInit
 	// Read Xbox video mode from the SMC, store it in HalBootSMCVideoMode
 	xbox::HalReadSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_AV_PACK, FALSE, (xbox::PULONG)&xbox::HalBootSMCVideoMode);
 
-	g_InputDeviceManager.Initialize(false);
+	g_InputDeviceManager.Initialize(false, g_hEmuWindow);
 
 	// Now the hardware devices exist, couple the EEPROM buffer to it's device
 	g_EEPROM->SetEEPROM((uint8_t*)EEPROM);

--- a/src/gui/DlgInputConfig.cpp
+++ b/src/gui/DlgInputConfig.cpp
@@ -98,7 +98,7 @@ void UpdateInputOpt(HWND hwnd)
 
 void ShowInputConfig(HWND hwnd, HWND ChildWnd)
 {
-	g_InputDeviceManager.Initialize(true);
+	g_InputDeviceManager.Initialize(true, hwnd);
 	g_ChildWnd = ChildWnd;
 
 	// Show dialog box

--- a/src/gui/controllers/DlgDukeControllerConfig.cpp
+++ b/src/gui/controllers/DlgDukeControllerConfig.cpp
@@ -196,7 +196,8 @@ void DukeInputWindow::UpdateProfile(const std::string &name, int command)
 	}
 	break;
 
-	case BUTTON_CLEAR: {
+	case BUTTON_CLEAR:
+	case BUTTON_SWAP: {
 		m_bHasChanges = true;
 	}
 	break;

--- a/src/gui/controllers/DlgSBControllerConfig.cpp
+++ b/src/gui/controllers/DlgSBControllerConfig.cpp
@@ -100,7 +100,8 @@ void SbcInputWindow::UpdateProfile(const std::string &name, int command)
 	}
 	break;
 
-	case BUTTON_CLEAR: {
+	case BUTTON_CLEAR:
+	case BUTTON_SWAP: {
 		m_bHasChanges = true;
 	}
 	break;


### PR DESCRIPTION
This PR adds a new mouse input mode which reports its state as the cursor position relative to the rendering window, as opposed to mouse relative motion (the only mode available for the mouse right now). In the input GUI, this is represented with the "Cursor X/Y+/-" name when bound to a button, instead of the "Axis X/Y/Z+/-" name used otherwise. Users can toggle between the two modes by SHIFT - right clicking the corresponding button (will only work if the KeyboardMouse device is selected in the device list). Using this mode fixes the re-center issue of both the crosshair of Virtua Cop 3 and the sticks of Steel Battalion.