### PR TITLE
Fix array index out-of-range crash

### DIFF
--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -565,9 +565,10 @@ typedef struct s_CxbxPSDef {
 		//   EFPROD = E * F
 		// ( Or in shorthand : sum=r0+v1, prod=s4*s5, r0.rgb=s0*s1+{1-s0}*s2+s3, r0.a=s6.b )
 		RC.FinalCombiner.Input[0/*A*/].Channel = PS_CHANNEL_ALPHA;
-		RC.FinalCombiner.Input[0/*A*/].Reg = RenderStateFogEnable ? PS_REGISTER_FOG : PS_REGISTER_ONE;
+		RC.FinalCombiner.Input[0/*A*/].Reg = PS_REGISTER_FOG;
 		RC.FinalCombiner.Input[1/*B*/].Reg = PS_REGISTER_R0;
-		RC.FinalCombiner.Input[2/*C*/].Reg = PS_REGISTER_FOG;
+		// If fog is disabled, blend R0 with itself
+		RC.FinalCombiner.Input[2/*C*/].Reg = RenderStateFogEnable ? PS_REGISTER_FOG : PS_REGISTER_R0;
 		RC.FinalCombiner.Input[3/*D*/].Reg = RenderStateSpecularEnable ? PS_REGISTER_V1 : PS_REGISTER_ZERO;
 		RC.FinalCombiner.Input[4/*E*/].Reg = PS_REGISTER_ZERO; // Note : Not really needed, should be 0 already
 		RC.FinalCombiner.Input[5/*F*/].Reg = PS_REGISTER_ZERO; // Note : Not really needed, should be 0 already

--- a/src/core/hle/D3D8/XbPixelShader.h
+++ b/src/core/hle/D3D8/XbPixelShader.h
@@ -304,10 +304,12 @@ enum PS_REGISTER
     PS_REGISTER_V1R0_SUM=          0x0eL, // r    A.k.a. _REG_SPECLIT
     PS_REGISTER_EF_PROD=           0x0fL, // r    A.k.a. _REG_EF_PROD
 
-    PS_REGISTER_ONE=               PS_REGISTER_ZERO | PS_INPUTMAPPING_UNSIGNED_INVERT, // 0x20 r OK for final combiner
-    PS_REGISTER_NEGATIVE_ONE=      PS_REGISTER_ZERO | PS_INPUTMAPPING_EXPAND_NORMAL,   // 0x40 r invalid for final combiner
-    PS_REGISTER_ONE_HALF=          PS_REGISTER_ZERO | PS_INPUTMAPPING_HALFBIAS_NEGATE, // 0xa0 r invalid for final combiner
-    PS_REGISTER_NEGATIVE_ONE_HALF= PS_REGISTER_ZERO | PS_INPUTMAPPING_HALFBIAS_NORMAL, // 0x80 r invalid for final combiner
+    // These constant values can be represented as a combination of 0, and an input modifier
+    // But they're not registers
+    // PS_REGISTER_ONE=               PS_REGISTER_ZERO | PS_INPUTMAPPING_UNSIGNED_INVERT, // 0x20 r OK for final combiner
+    // PS_REGISTER_NEGATIVE_ONE=      PS_REGISTER_ZERO | PS_INPUTMAPPING_EXPAND_NORMAL,   // 0x40 r invalid for final combiner
+    // PS_REGISTER_ONE_HALF=          PS_REGISTER_ZERO | PS_INPUTMAPPING_HALFBIAS_NEGATE, // 0xa0 r invalid for final combiner
+    // PS_REGISTER_NEGATIVE_ONE_HALF= PS_REGISTER_ZERO | PS_INPUTMAPPING_HALFBIAS_NORMAL, // 0x80 r invalid for final combiner
 
     // Cxbx extension; Separate final combiner constant registers  (values not encoded on NV2A, as outside of available bits range) :
     PS_REGISTER_FC0=              0x10,


### PR DESCRIPTION
Remove PS_REGISTER_ONE usage since its not a register, but a combination of PS_REGISTER_ZERO and an INPUT_MAPPING