### PR TITLE
Removed redundant allocation functions in VMManager

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1269,7 +1269,7 @@ int GetD3DResourceRefCount(IDirect3DResource *EmuResource)
 /*
 xbox::X_D3DSurface *EmuNewD3DSurface()
 {
-	xbox::X_D3DSurface *result = (xbox::X_D3DSurface *)g_VMManager.AllocateZeroed(sizeof(xbox::X_D3DSurface));
+	xbox::X_D3DSurface *result = (xbox::X_D3DSurface *)xbox::ExAllocatePool(sizeof(xbox::X_D3DSurface));
 	result->Common = X_D3DCOMMON_D3DCREATED | X_D3DCOMMON_TYPE_SURFACE | 1; // Set refcount to 1
 	return result;
 }

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -863,8 +863,8 @@ void CxbxImpl_End()
 	g_InlineVertexBuffer_DeclarationOverride = false;
 
 	// TODO: Should technically clean this up at some point..but on XP doesnt matter much
-	//	g_VMManager.Deallocate((VAddr)g_InlineVertexBuffer_pData);
-	//	g_VMManager.Deallocate((VAddr)g_InlineVertexBuffer_Table);
+	//	ExFreePool(g_InlineVertexBuffer_pData);
+	//	ExFreePool(g_InlineVertexBuffer_Table);
 }
 
 void CxbxImpl_SetVertexData4f(int Register, FLOAT a, FLOAT b, FLOAT c, FLOAT d)

--- a/src/core/hle/XACTENG/XactEng.cpp
+++ b/src/core/hle/XACTENG/XactEng.cpp
@@ -34,7 +34,6 @@
 #include "core\kernel\support\Emu.h"
 #include "EmuShared.h"
 #include "core\hle\XACTENG\XactEng.h"
-#include "core\kernel\memory-manager\VMManager.h"
 
 #include <mmreg.h>
 #include <msacm.h>
@@ -65,7 +64,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(XACTEngineCreate)
 
 	// TODO: Any other form of initialization?
 
-	*ppEngine = (X_XACTEngine*)g_VMManager.AllocateZeroed(sizeof( X_XACTEngine ));
+	*ppEngine = (X_XACTEngine*)ExAllocatePool(sizeof( X_XACTEngine ));
 
 		
 	
@@ -109,7 +108,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IXACTEngine_RegisterWaveBank)
 
 	// TODO: Implement
 
-	*ppWaveBank = (X_XACTWaveBank*)g_VMManager.AllocateZeroed(sizeof( X_XACTWaveBank ));
+	*ppWaveBank = (X_XACTWaveBank*)ExAllocatePool(sizeof( X_XACTWaveBank ));
 
 	RETURN(S_OK);
 }
@@ -132,7 +131,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IXACTEngine_RegisterStreamedWaveBank)
 
 	// TODO: Implement
 
-	*ppWaveBank = (X_XACTWaveBank*)g_VMManager.AllocateZeroed(sizeof( X_XACTWaveBank ));
+	*ppWaveBank = (X_XACTWaveBank*)ExAllocatePool(sizeof( X_XACTWaveBank ));
 
 	RETURN(S_OK);
 }
@@ -157,7 +156,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IXACTEngine_CreateSoundBank)
 
 	// TODO: Implement
 
-	*ppSoundBank = (X_XACTSoundBank*)g_VMManager.AllocateZeroed(sizeof( X_XACTSoundBank ));
+	*ppSoundBank = (X_XACTSoundBank*)ExAllocatePool(sizeof( X_XACTSoundBank ));
 
 	RETURN(S_OK);
 }
@@ -203,7 +202,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IXACTEngine_CreateSoundSource)
 		LOG_FUNC_ARG(ppSoundSource)
 		LOG_FUNC_END;
 
-	*ppSoundSource = (X_XACTSoundSource*)g_VMManager.AllocateZeroed(sizeof( X_XACTSoundSource ));
+	*ppSoundSource = (X_XACTSoundSource*)ExAllocatePool(sizeof( X_XACTSoundSource ));
 
 	RETURN(S_OK);
 }
@@ -500,7 +499,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IXACTEngine_UnRegisterWaveBank)
 	// to IXACTWaveBank is released.
 
 //	if(pWaveBank)
-//		g_VMManager.Deallocate((VAddr)pWaveBank);
+//		ExFreePool(pWaveBank);
 
 	RETURN(S_OK);
 }

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1398,7 +1398,7 @@ __declspec(noreturn) void CxbxKrnlInit
 
 		// Assign the running Xbe path, so it can be accessed via the kernel thunk 'XeImageFileName' :
 		xbox::XeImageFileName.MaximumLength = MAX_PATH;
-		xbox::XeImageFileName.Buffer = (PCHAR)g_VMManager.Allocate(MAX_PATH);
+		xbox::XeImageFileName.Buffer = (PCHAR)xbox::ExAllocatePool(MAX_PATH);
 		sprintf(xbox::XeImageFileName.Buffer, "%c:\\%s", CxbxDefaultXbeDriveLetter, fileName.c_str());
 		xbox::XeImageFileName.Length = (USHORT)strlen(xbox::XeImageFileName.Buffer);
 		EmuLogInit(LOG_LEVEL::INFO, "XeImageFileName = %s", xbox::XeImageFileName.Buffer);

--- a/src/core/kernel/memory-manager/VMManager.h
+++ b/src/core/kernel/memory-manager/VMManager.h
@@ -102,10 +102,6 @@ class VMManager : public PhysicalMemory
 		void Initialize(unsigned int SystemType, int BootFlags, blocks_reserved_t blocks_reserved);
 		// retrieves memory statistics
 		void MemoryStatistics(xbox::PMM_STATISTICS memory_statistics);
-		// allocates memory in the user region
-		VAddr Allocate(size_t Size);
-		// allocates memory in the user region and zeros it
-		VAddr AllocateZeroed(size_t size);
 		// allocates memory in the system region
 		VAddr AllocateSystemMemory(PageType BusyType, DWORD Perms, size_t Size, bool bAddGuardPage);
 		// allocates memory in the contiguous region
@@ -118,8 +114,6 @@ class VMManager : public PhysicalMemory
 		void DeallocateContiguousMemory(VAddr addr);
 		// unmaps device memory in the system region
 		void UnmapDeviceMemory(VAddr addr, size_t Size);
-		// deallocates memory in the user region
-		void Deallocate(VAddr addr);
 		// changes the protections of a memory region
 		void Protect(VAddr addr, size_t Size, DWORD NewPerms);
 		// checks if a VAddr is valid

--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -38,7 +38,6 @@
 #include <ntstatus.h>
 #pragma warning(default:4005)
 #include "core\kernel\init\CxbxKrnl.h"
-#include "core\kernel\memory-manager\VMManager.h"
 #include "Logging.h"
 
 #include <filesystem>
@@ -752,8 +751,9 @@ EmuNtSymbolicLinkObject* FindNtSymbolicLinkObjectByRootHandle(const HANDLE Handl
 
 void _CxbxPVOIDDeleter(PVOID *ptr)
 {
-	if (*ptr)
-		g_VMManager.Deallocate((VAddr)*ptr);
+	if (*ptr) {
+		xbox::ExFreePool(*ptr);
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -771,7 +771,7 @@ NtDll::FILE_LINK_INFORMATION * _XboxToNTLinkInfo(xbox::FILE_LINK_INFORMATION *xb
 
 	// Build the native FILE_LINK_INFORMATION struct
 	*Length = sizeof(NtDll::FILE_LINK_INFORMATION) + convertedFileName.size() * sizeof(wchar_t);
-	NtDll::FILE_LINK_INFORMATION *ntLinkInfo = (NtDll::FILE_LINK_INFORMATION *) g_VMManager.AllocateZeroed(*Length);
+	NtDll::FILE_LINK_INFORMATION *ntLinkInfo = (NtDll::FILE_LINK_INFORMATION *)xbox::ExAllocatePool(*Length);
 	ntLinkInfo->ReplaceIfExists = xboxLinkInfo->ReplaceIfExists;
 	ntLinkInfo->RootDirectory = RootDirectory;
 	ntLinkInfo->FileNameLength = convertedFileName.size() * sizeof(wchar_t);
@@ -791,7 +791,7 @@ NtDll::FILE_RENAME_INFORMATION * _XboxToNTRenameInfo(xbox::FILE_RENAME_INFORMATI
 
 	// Build the native FILE_RENAME_INFORMATION struct
 	*Length = sizeof(NtDll::FILE_RENAME_INFORMATION) + convertedFileName.size() * sizeof(wchar_t);
-	NtDll::FILE_RENAME_INFORMATION *ntRenameInfo = (NtDll::FILE_RENAME_INFORMATION *) g_VMManager.AllocateZeroed(*Length);
+	NtDll::FILE_RENAME_INFORMATION *ntRenameInfo = (NtDll::FILE_RENAME_INFORMATION *)xbox::ExAllocatePool(*Length);
 	ntRenameInfo->ReplaceIfExists = xboxRenameInfo->ReplaceIfExists;
 	ntRenameInfo->RootDirectory = RootDirectory;
 	ntRenameInfo->FileNameLength = convertedFileName.size() * sizeof(wchar_t);


### PR DESCRIPTION
Closes https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/1145. This removes the redundant functions `Allocate(Zeroed)` and `Deallocate` and replaces them with calls to `ExAllocatePool` and `ExFreePool` respectively. Other than that, this should not have any effect on any games, but testing is needed to be certain of that.