### PR TITLE
Implement IsEmuHandle by keeping a lookup of EmuHandle objects

### DIFF
--- a/src/core/kernel/exports/EmuKrnlNt.cpp
+++ b/src/core/kernel/exports/EmuKrnlNt.cpp
@@ -142,7 +142,7 @@ XBSYSAPI EXPORTNUM(187) xbox::ntstatus_xt NTAPI xbox::NtClose
 
 	NTSTATUS ret = xbox::status_success;
 
-	if (IsEmuHandle(Handle))
+	if (EmuHandle::IsEmuHandle(Handle))
 	{
 		// delete 'special' handles
 		EmuHandle *iEmuHandle = HandleToEmuHandle(Handle);
@@ -682,7 +682,7 @@ XBSYSAPI EXPORTNUM(197) xbox::ntstatus_xt NTAPI xbox::NtDuplicateObject
 
 	NTSTATUS ret = xbox::status_success;
 
-	if (IsEmuHandle(SourceHandle)) {
+	if (EmuHandle::IsEmuHandle(SourceHandle)) {
 		EmuHandle* iEmuHandle = HandleToEmuHandle(SourceHandle);
 		ret = iEmuHandle->NtDuplicateObject(TargetHandle, Options);
 /*
@@ -739,7 +739,7 @@ XBSYSAPI EXPORTNUM(198) xbox::ntstatus_xt NTAPI xbox::NtFlushBuffersFile
 		LOG_FUNC_END;
 	NTSTATUS ret = xbox::status_success;
 	
-	if (IsEmuHandle(FileHandle)) 
+	if (EmuHandle::IsEmuHandle(FileHandle))
 		LOG_UNIMPLEMENTED();
 	else
 		ret = NtDll::NtFlushBuffersFile(FileHandle, (NtDll::IO_STATUS_BLOCK*)IoStatusBlock);

--- a/src/core/kernel/exports/EmuKrnlNt.cpp
+++ b/src/core/kernel/exports/EmuKrnlNt.cpp
@@ -1371,11 +1371,14 @@ XBSYSAPI EXPORTNUM(215) xbox::ntstatus_xt NTAPI xbox::NtQuerySymbolicLinkObject
 		LOG_FUNC_ARG_OUT(ReturnedLength)
 		LOG_FUNC_END;
 
-	NTSTATUS ret = 0;
+	NTSTATUS ret = STATUS_INVALID_HANDLE;
 	EmuNtSymbolicLinkObject* symbolicLinkObject = NULL;
 
-	// Check that we actually got an EmuHandle :
-	ret = STATUS_INVALID_HANDLE;
+	// We expect LinkHandle to always be an EmuHandle
+	if (!EmuHandle::IsEmuHandle(LinkHandle)) {
+		LOG_UNIMPLEMENTED();
+		return ret;
+	}
 
 	auto iEmuHandle = (EmuHandle*)LinkHandle;
 	// Retrieve the NtSymbolicLinkObject and populate the output arguments :

--- a/src/core/kernel/exports/EmuKrnlNt.cpp
+++ b/src/core/kernel/exports/EmuKrnlNt.cpp
@@ -145,7 +145,7 @@ XBSYSAPI EXPORTNUM(187) xbox::ntstatus_xt NTAPI xbox::NtClose
 	if (EmuHandle::IsEmuHandle(Handle))
 	{
 		// delete 'special' handles
-		EmuHandle *iEmuHandle = HandleToEmuHandle(Handle);
+		auto iEmuHandle = (EmuHandle*)Handle;
 		ret = iEmuHandle->NtClose();
 
 		LOG_UNIMPLEMENTED(); // TODO : Base this on the Ob* functions
@@ -683,7 +683,7 @@ XBSYSAPI EXPORTNUM(197) xbox::ntstatus_xt NTAPI xbox::NtDuplicateObject
 	NTSTATUS ret = xbox::status_success;
 
 	if (EmuHandle::IsEmuHandle(SourceHandle)) {
-		EmuHandle* iEmuHandle = HandleToEmuHandle(SourceHandle);
+		auto iEmuHandle = (EmuHandle*)SourceHandle;
 		ret = iEmuHandle->NtDuplicateObject(TargetHandle, Options);
 /*
 		PVOID Object;
@@ -1377,7 +1377,7 @@ XBSYSAPI EXPORTNUM(215) xbox::ntstatus_xt NTAPI xbox::NtQuerySymbolicLinkObject
 	// Check that we actually got an EmuHandle :
 	ret = STATUS_INVALID_HANDLE;
 
-	EmuHandle* iEmuHandle = HandleToEmuHandle(LinkHandle);
+	auto iEmuHandle = (EmuHandle*)LinkHandle;
 	// Retrieve the NtSymbolicLinkObject and populate the output arguments :
 	ret = xbox::status_success;
 	symbolicLinkObject = (EmuNtSymbolicLinkObject*)iEmuHandle->NtObject;

--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -255,9 +255,50 @@ EmuHandle::EmuHandle(EmuNtObject* ntObject)
 	NtObject = ntObject;
 }
 
+std::unordered_map<HANDLE, EmuHandle*> EmuHandle::EmuHandleLookup = {};
+std::mutex EmuHandle::EmuHandleLookupLock = {};
+
+EmuHandle* EmuHandle::CreateEmuHandle(EmuNtObject* ntObject) {
+	auto emuHandle = new EmuHandle(ntObject);
+
+	// Register EmuHandle
+	EmuHandleLookupLock.lock();
+	EmuHandleLookup.emplace(EmuHandleToHandle(emuHandle), emuHandle);
+	EmuHandleLookupLock.unlock();
+
+	return emuHandle;
+}
+
 NTSTATUS EmuHandle::NtClose()
 {
-	return NtObject->NtClose();
+	auto status = NtObject->NtClose();
+
+	// Unregister the handle
+	if (status == STATUS_SUCCESS) {
+		EmuHandleLookupLock.lock();
+		EmuHandleLookup.erase(EmuHandleToHandle(this));
+		EmuHandleLookupLock.unlock();
+	}
+
+	return status;
+}
+
+bool EmuHandle::IsEmuHandle(HANDLE Handle)
+{
+	auto iter = EmuHandleLookup.find(Handle);
+	return !(iter == EmuHandleLookup.end());
+}
+
+EmuHandle* HandleToEmuHandle(HANDLE Handle)
+{
+	return (EmuHandle*)((uint32_t)Handle & 0x7FFFFFFF);
+}
+
+HANDLE EmuHandleToHandle(EmuHandle* emuHandle)
+{
+	// Set the high bit
+	// Avoids collisions with real Xbox handles..?
+	return (HANDLE)((uint32_t)emuHandle | 0x80000000);
 }
 
 NTSTATUS EmuHandle::NtDuplicateObject(PHANDLE TargetHandle, DWORD Options)
@@ -274,7 +315,7 @@ EmuNtObject::EmuNtObject()
 HANDLE EmuNtObject::NewHandle()
 {
 	RefCount++;
-	return EmuHandleToHandle(new EmuHandle(this));
+	return EmuHandle::CreateEmuHandle(this);
 }
 
 NTSTATUS EmuNtObject::NtClose()
@@ -290,21 +331,6 @@ EmuNtObject* EmuNtObject::NtDuplicateObject(DWORD Options)
 {
 	RefCount++;
 	return this;
-}
-
-bool IsEmuHandle(HANDLE Handle)
-{
-	return ((uint32_t)Handle > 0x80000000) && ((uint32_t)Handle < 0xFFFFFFFE);
-}
-
-EmuHandle* HandleToEmuHandle(HANDLE Handle)
-{
-	return (EmuHandle*)((uint32_t)Handle & 0x7FFFFFFF);
-}
-
-HANDLE EmuHandleToHandle(EmuHandle* emuHandle)
-{
-	return (HANDLE)((uint32_t)emuHandle | 0x80000000);
 }
 
 std::wstring string_to_wstring(std::string const & src)

--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -30,7 +30,7 @@
 #include <cstdio>
 #include <string>
 #include <memory>
-#include <unordered_map>
+#include <unordered_set>
 #include <shared_mutex>
 
 // ******************************************************************
@@ -175,7 +175,7 @@ private:
 	// We used to rely on the high bit to differentiatean EmuHandles
 	// But titles may attempt to operate on invalid handles with the high bit set
 	// Test case: Amped sets a handle value to 0xFDFDFDFD (coincidentally a VS debugger guard value)
-	static std::unordered_map<HANDLE, EmuHandle*> EmuHandleLookup;
+	static std::unordered_set<EmuHandle*> EmuHandleLookup;
 	static std::shared_mutex EmuHandleLookupLock;
 };
 
@@ -216,12 +216,6 @@ struct XboxDevice {
 	std::string HostDevicePath;
 	HANDLE HostRootHandle;
 };
-
-// ******************************************************************
-// * is Handle a 'special' emulated handle?
-// ******************************************************************
-EmuHandle* HandleToEmuHandle(HANDLE Handle);
-HANDLE EmuHandleToHandle(EmuHandle* emuHandle);
 
 CHAR* NtStatusToString(IN NTSTATUS Status);
 

--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -31,7 +31,7 @@
 #include <string>
 #include <memory>
 #include <unordered_map>
-#include <mutex>
+#include <shared_mutex>
 
 // ******************************************************************
 // * prevent name collisions
@@ -176,7 +176,7 @@ private:
 	// But titles may attempt to operate on invalid handles with the high bit set
 	// Test case: Amped sets a handle value to 0xFDFDFDFD (coincidentally a VS debugger guard value)
 	static std::unordered_map<HANDLE, EmuHandle*> EmuHandleLookup;
-	static std::mutex EmuHandleLookupLock;
+	static std::shared_mutex EmuHandleLookupLock;
 };
 
 // ******************************************************************


### PR DESCRIPTION
Fixes a crash in Amped on loading a map after having exited one
Amped requests an invalid handle 0xFDFDFDFD
IsEmuHandle return a false positive and we'd crash trying to call NtClose()