### PR TITLE
Handle game title strings that aren't null terminated

### DIFF
--- a/src/common/xbe/Xbe.cpp
+++ b/src/common/xbe/Xbe.cpp
@@ -160,7 +160,8 @@ Xbe::Xbe(const char *x_szFilename, bool bFromGUI)
 
         setlocale( LC_ALL, "English" );
 
-        wcstombs(m_szAsciiTitle, m_Certificate.wszTitleName, 40);
+        wcstombs(m_szAsciiTitle, m_Certificate.wsTitleName, 40);
+        m_szAsciiTitle[40] = '\0'; // ensure null terminated
 
         printf("OK\n");
 

--- a/src/common/xbe/Xbe.h
+++ b/src/common/xbe/Xbe.h
@@ -150,7 +150,7 @@ class Xbe : public Error
             uint32_t  dwSize;                               // 0x0000 - size of certificate
             uint32_t  dwTimeDate;                           // 0x0004 - timedate stamp
             uint32_t  dwTitleId;                            // 0x0008 - title id
-            wchar_t wszTitleName[40];                       // 0x000C - title name (unicode)
+            wchar_t wsTitleName[40];                       // 0x000C - title name (unicode)
             uint32_t  dwAlternateTitleId[0x10];             // 0x005C - alternate title ids
             uint32_t  dwAllowedMedia;                       // 0x009C - allowed media types
             uint32_t  dwGameRegion;                         // 0x00A0 - game region
@@ -257,7 +257,7 @@ class Xbe : public Error
         char m_szPath[MAX_PATH];
 
         // Xbe ascii title, translated from certificate title
-        char m_szAsciiTitle[40];
+        char m_szAsciiTitle[41];
 
         // retrieve thread local storage data address
         uint8_t *GetTLSData() { if(m_TLS == 0) return 0; else return GetAddr(m_TLS->dwDataStartAddr); }

--- a/src/common/xbe/Xbe.h
+++ b/src/common/xbe/Xbe.h
@@ -150,7 +150,7 @@ class Xbe : public Error
             uint32_t  dwSize;                               // 0x0000 - size of certificate
             uint32_t  dwTimeDate;                           // 0x0004 - timedate stamp
             uint32_t  dwTitleId;                            // 0x0008 - title id
-            wchar_t wsTitleName[40];                       // 0x000C - title name (unicode)
+            wchar_t wsTitleName[40];                        // 0x000C - title name (unicode)
             uint32_t  dwAlternateTitleId[0x10];             // 0x005C - alternate title ids
             uint32_t  dwAllowedMedia;                       // 0x009C - allowed media types
             uint32_t  dwGameRegion;                         // 0x00A0 - game region

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -387,8 +387,8 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	std::stringstream sstream;
 	char tAsciiTitle[40] = "Unknown";
 	std::setlocale(LC_ALL, "English");
-	std::wcstombs(tAsciiTitle, CxbxKrnl_Xbe->m_Certificate.wszTitleName, sizeof(tAsciiTitle));
-	std::string szTitleName(tAsciiTitle);
+	std::wcstombs(tAsciiTitle, CxbxKrnl_Xbe->m_Certificate.wsTitleName, sizeof(tAsciiTitle));
+	std::string szTitleName(tAsciiTitle, sizeof(tAsciiTitle));
 	CxbxKrnl_Xbe->PurgeBadChar(szTitleName);
 	sstream << cachePath << szTitleName << "-" << std::hex << uiHash << ".ini";
 	std::string filename = sstream.str();

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1418,7 +1418,7 @@ __declspec(noreturn) void CxbxKrnlInit
 			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID : %s", FormatTitleId(g_pCertificate->dwTitleId).c_str());
 			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID (Hex) : 0x%s", titleIdHex.str().c_str());
 			EmuLogInit(LOG_LEVEL::INFO, "XBE Version : 1.%02d", g_pCertificate->dwVersion);
-			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleName : %ls", g_pCertificate->wsTitleName);
+			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleName : %.40ls", g_pCertificate->wsTitleName);
 			EmuLogInit(LOG_LEVEL::INFO, "XBE Region : %s", CxbxKrnl_Xbe->GameRegionToString());
 		}
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1418,7 +1418,7 @@ __declspec(noreturn) void CxbxKrnlInit
 			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID : %s", FormatTitleId(g_pCertificate->dwTitleId).c_str());
 			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID (Hex) : 0x%s", titleIdHex.str().c_str());
 			EmuLogInit(LOG_LEVEL::INFO, "XBE Version : 1.%02d", g_pCertificate->dwVersion);
-			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleName : %ls", g_pCertificate->wszTitleName);
+			EmuLogInit(LOG_LEVEL::INFO, "XBE TitleName : %ls", g_pCertificate->wsTitleName);
 			EmuLogInit(LOG_LEVEL::INFO, "XBE Region : %s", CxbxKrnl_Xbe->GameRegionToString());
 		}
 


### PR DESCRIPTION
Fixes instability in King Kong since its title name uses all 40 characters
* Rename wszTitleName to wsTitleName
* Pass length to std::string constructor
* Ensure null termination when copying to m_szAsciiTitle

In King Kong the title would be something like this:
`Peter Jackson's King Kong official Game ÌÌÌÌÌÌÌÌ_0OÌÌÌÌ-c3c4e904.ini`
which makes `std::filesystem::exists` throw due to invalid characters in the file name