### PR TITLE
Add D3D9 half-pixel offset

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4197,6 +4197,12 @@ void CxbxUpdateHostViewPortOffsetAndScaleConstants()
 	GetScreenScaleFactors(screenScaleX, screenScaleY);
 	GetMultiSampleOffset(aaOffsetX, aaOffsetY);
 
+	// Add D3D9 half-pixel offset (-0.5 given this offset is subtracted)
+	// We should be able to remove this when off D3D9
+	// https://aras-p.info/blog/2016/04/08/solving-dx9-half-pixel-offset/
+	aaOffsetX -= 0.5f;
+	aaOffsetY -= 0.5f;
+
 	float xboxScreenspaceWidth = xboxRenderTargetWidth * screenScaleX;
 	float xboxScreenspaceHeight = xboxRenderTargetHeight * screenScaleY;
 


### PR DESCRIPTION
Fixes UI rendering issues especially text

before:
![image](https://user-images.githubusercontent.com/9897874/109415864-0a94d400-7a20-11eb-9318-c8e38d251885.png)
after:
![image](https://user-images.githubusercontent.com/9897874/109415872-14b6d280-7a20-11eb-80fc-bee358e6a549.png)
