### PR TITLE
Fix XeUnloadSection errorerously zeroing memory

### DIFF
--- a/src/common/xbe/Xbe.cpp
+++ b/src/common/xbe/Xbe.cpp
@@ -194,25 +194,18 @@ Xbe::Xbe(const char *x_szFilename, bool bFromGUI)
 
     // read Xbe section headers
     {
-        printf("Xbe::Xbe: Reading Section Headers...\n");
+        printf("Xbe::Xbe: Reading Section Headers...");
 
         fseek(XbeFile, m_Header.dwSectionHeadersAddr - m_Header.dwBaseAddr, SEEK_SET);
 
         m_SectionHeader = new SectionHeader[m_Header.dwSections];
-
-        for(uint32_t v=0;v<m_Header.dwSections;v++)
+        if (fread(m_SectionHeader, sizeof(*m_SectionHeader), m_Header.dwSections, XbeFile) != m_Header.dwSections)
         {
-            printf("Xbe::Xbe: Reading Section Header 0x%.04X...", v);
-
-            if(fread(&m_SectionHeader[v], sizeof(*m_SectionHeader), 1, XbeFile) != 1)
-            {
-                sprintf(szBuffer, "Unexpected end of file while reading Xbe Section Header %d (%Xh)", v, v);
-                SetFatalError(szBuffer);
-                goto cleanup;
-            }
-
-            printf("OK\n");
+            SetFatalError("Unexpected end of file while reading Xbe Section Headers");
+            goto cleanup;
         }
+
+        printf("OK\n");
     }
 
     // read Xbe section names
@@ -246,25 +239,18 @@ Xbe::Xbe(const char *x_szFilename, bool bFromGUI)
     // read Xbe library versions
 	if (m_Header.dwLibraryVersionsAddr != 0)
 	{
-		printf("Xbe::Xbe: Reading Library Versions...\n");
+		printf("Xbe::Xbe: Reading Library Versions...");
 
 		fseek(XbeFile, m_Header.dwLibraryVersionsAddr - m_Header.dwBaseAddr, SEEK_SET);
 
 		m_LibraryVersion = new LibraryVersion[m_Header.dwLibraryVersions];
-
-		for (uint32_t v = 0; v < m_Header.dwLibraryVersions; v++)
+		if (fread(m_LibraryVersion, sizeof(*m_LibraryVersion), m_Header.dwLibraryVersions, XbeFile) != m_Header.dwLibraryVersions)
 		{
-			printf("Xbe::Xbe: Reading Library Version 0x%.04X...", v);
-
-			if (fread(&m_LibraryVersion[v], sizeof(*m_LibraryVersion), 1, XbeFile) != 1)
-			{
-				sprintf(szBuffer, "Unexpected end of file while reading Xbe Library Version %d (%Xh)", v, v);
-				SetFatalError(szBuffer);
-				goto cleanup;
-			}
-
-			printf("OK\n");
+			SetFatalError("Unexpected end of file while reading Xbe Library Versions");
+			goto cleanup;
 		}
+
+		printf("OK\n");
 	}
 
     // read Xbe sections

--- a/src/core/kernel/exports/EmuKrnlXe.cpp
+++ b/src/core/kernel/exports/EmuKrnlXe.cpp
@@ -126,9 +126,8 @@ XBSYSAPI EXPORTNUM(328) xbox::ntstatus_xt NTAPI xbox::XeUnloadSection
 
 		// Free the section and the physical memory in use if necessary
 		if (Section->SectionReferenceCount == 0) {
-			memset(Section->VirtualAddress, 0, Section->VirtualSize);
-
 			// REMARK: the following can be tested with Broken Sword - The Sleeping Dragon, RalliSport Challenge, ...
+			// Test-case: Apex/Racing Evoluzione requires the memory NOT to be zeroed
 
 			VAddr BaseAddress = (VAddr)Section->VirtualAddress;
 			VAddr EndingAddress = (VAddr)Section->VirtualAddress + Section->VirtualSize;


### PR DESCRIPTION
In cases where `XeUnloadSection` does not decommit memory (due to the section being too small), we'd zero that section. Turns out this should not be done and some games (or to be specific, middleware) relies on those sections **not** being zeroed.

While investigating this issue I also noticed Xbe section headers and library versions are read in an odd way. I modified the code to read them in a single call, which should hopefully be faster. Technically this loses some logging information, but the loss is so minimal I don't consider this an issue.

Fixes **Apex**/**Racing Evoluzione** crashing before reaching menus. Since this crash resided in BINK code, it's possible this fixes more games with BINK version(s) relying on this edge case.

![image](https://user-images.githubusercontent.com/7947461/110175988-e7dd3380-7e02-11eb-938a-ed8bdb6b3654.png)
