### PR TITLE
Fix partition formatting

### DIFF
--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -175,17 +175,12 @@ void CxbxFormatPartitionByHandle(HANDLE hFile)
 
 	// Format the partition, by iterating through the contents and removing all files/folders within
 	// Previously, we deleted and re-created the folder, but that caused permission issues for some users
-	try
-	{
-		for (auto& directoryEntry : std::filesystem::directory_iterator(partitionPath)) {
-			std::filesystem::remove_all(directoryEntry);
+	std::error_code er;
+	for (const auto& directoryEntry : std::filesystem::directory_iterator(partitionPath, er)) {
+		if (!er) {
+			std::filesystem::remove_all(directoryEntry, er);
 		}
 	}
-	catch (std::filesystem::filesystem_error fsException)
-	{
-		printf("std::filesystem failed with message: %s\n", fsException.what());
-	}
-
 
 	printf("Formatted EmuDisk Partition%d\n", CxbxGetPartitionNumberFromHandle(hFile));
 }

--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -177,7 +177,7 @@ void CxbxFormatPartitionByHandle(HANDLE hFile)
 	// Previously, we deleted and re-created the folder, but that caused permission issues for some users
 	try
 	{
-		for (auto& directoryEntry : std::filesystem::recursive_directory_iterator(partitionPath)) {
+		for (auto& directoryEntry : std::filesystem::directory_iterator(partitionPath)) {
 			std::filesystem::remove_all(directoryEntry);
 		}
 	}

--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -307,7 +307,7 @@ typedef struct _FATX_SUPERBLOCK
 XboxPartitionTable CxbxGetPartitionTable();
 FATX_SUPERBLOCK CxbxGetFatXSuperBlock(int partitionNumber);
 int CxbxGetPartitionNumberFromHandle(HANDLE hFile);
-std::string CxbxGetPartitionDataPathFromHandle(HANDLE hFile);
+std::wstring CxbxGetPartitionDataPathFromHandle(HANDLE hFile);
 void CxbxFormatPartitionByHandle(HANDLE hFile);
 
 // Ensures that an original IoStatusBlock gets passed to the completion callback


### PR DESCRIPTION
1. Fixes a long standing bug introduced by #944 where partition formatting occassionally failed, resulting either in errors printed to the log or in a game crash. In my case, I often had to re-run the game multiple times to get partitions to format properly.
2. Modernizes `CxbxGetPartitionNumberFromHandle` and `CxbxGetPartitionDataPathFromHandle` to use Unicode and support long paths properly. This saves on internal Unicode -> ANSI -> Unicode conversions which could potentially also be lossy.