### PR TITLE
Further improve partition path functions

### DIFF
--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -307,7 +307,7 @@ typedef struct _FATX_SUPERBLOCK
 XboxPartitionTable CxbxGetPartitionTable();
 FATX_SUPERBLOCK CxbxGetFatXSuperBlock(int partitionNumber);
 int CxbxGetPartitionNumberFromHandle(HANDLE hFile);
-std::wstring CxbxGetPartitionDataPathFromHandle(HANDLE hFile);
+std::filesystem::path CxbxGetPartitionDataPathFromHandle(HANDLE hFile);
 void CxbxFormatPartitionByHandle(HANDLE hFile);
 
 // Ensures that an original IoStatusBlock gets passed to the completion callback


### PR DESCRIPTION
* Close a possible edge case of "\\Partition" being present in the path
* Close a possible edge case of an invalid path being shorter than the string "\\Partition"
* Allow for partition formatting to work fine when EmuDisk has been relocated
* Allow for partition formatting to work fine when symlinks are in place (now the "safeguard" is aware of symlinks)