### PR TITLE
Tidy mip code and work around DXT crash with small textures

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5985,7 +5985,7 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 			for (unsigned int mipmap_level = 0; mipmap_level < dwMipMapLevels; mipmap_level++) {
 
 				// Calculate size of this mipmap level
-				auto numRows = pxMipHeight;
+				DWORD numRows = pxMipHeight;
 
 				if (bCompressed) {
 					// Each row contains a 4x4 pixel blocks, instead of single pixels

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5982,6 +5982,12 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
             DWORD dwMipRowPitch = dwRowPitch;
 			DWORD dwSrcSlicePitch = dwMipRowPitch * pxMipHeight; // TODO
 
+			// Block size only applies to compressed DXT formats
+			// DXT1 block size is 8 bytes
+			// Other Xbox DXT formats are 16 bytes
+			DWORD blockSize = 0;
+			blockSize = X_Format == xbox::X_D3DFMT_DXT1 ? 8 : 16;
+
 			for (unsigned int mipmap_level = 0; mipmap_level < dwMipMapLevels; mipmap_level++) {
 
 				// Calculate size of this mipmap level
@@ -5991,15 +5997,6 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 					// Each row contains a 4x4 pixel blocks, instead of single pixels
 					// So divide by 4 to get the number of rows
 					numRows = (numRows + 3) / 4;
-
-					// The row pitch can't be smaller than a single 4x4 block
-					// even if we need to store just one pixel
-					// DXT1 block size is 8 bytes
-					// Other Xbox DXT formats are 16 bytes
-					auto blockSize = X_Format == xbox::X_D3DFMT_DXT1 ? 8 : 16;
-					if (dwMipRowPitch < blockSize) {
-						dwMipRowPitch = blockSize;
-					}
 				}
 
 				DWORD dwMipSize = dwMipRowPitch * numRows;
@@ -6155,6 +6152,11 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 
 					// Update the row pitch
 					dwMipRowPitch /= 2;
+
+					// The pitch can't be less than a block
+					if (dwMipRowPitch < blockSize) {
+						dwMipRowPitch = blockSize;
+					}
 				}
 
 				if (pxMipHeight > 1) {

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5991,6 +5991,15 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 					// Each row contains a 4x4 pixel blocks, instead of single pixels
 					// So divide by 4 to get the number of rows
 					numRows = (numRows + 3) / 4;
+
+					// The row pitch can't be smaller than a single 4x4 block
+					// even if we need to store just one pixel
+					// DXT1 block size is 8 bytes
+					// Other Xbox DXT formats are 16 bytes
+					auto blockSize = X_Format == xbox::X_D3DFMT_DXT1 ? 8 : 16;
+					if (dwMipRowPitch < blockSize) {
+						dwMipRowPitch = blockSize;
+					}
 				}
 
 				DWORD dwMipSize = dwMipRowPitch * numRows;
@@ -6146,17 +6155,6 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 
 					// Update the row pitch
 					dwMipRowPitch /= 2;
-
-					if (bCompressed) {
-						// The row pitch can't be smaller than a single 4x4 block
-						// even if we need to store just one pixel
-						// DXT1 block size is 8 bytes
-						// Other supported DXT formats are 16 bytes
-						auto blockSize = X_Format == xbox::X_D3DFMT_DXT1 ? 8 : 16;
-						if (dwMipRowPitch < blockSize) {
-							dwMipRowPitch = blockSize;
-						}
-					}
 				}
 
 				if (pxMipHeight > 1) {

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5973,6 +5973,15 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 		DWORD dwCubeFaceOffset = 0;
 		DWORD dwCubeFaceSize = 0;
 		D3DCUBEMAP_FACES last_face = (bCubemap) ? D3DCUBEMAP_FACE_NEGATIVE_Z : D3DCUBEMAP_FACE_POSITIVE_X;
+
+		// Block size only applies to compressed DXT formats
+		// DXT1 block size is 8 bytes
+		// Other Xbox DXT formats are 16 bytes
+		DWORD blockSize = 0;
+		if (bCompressed) {
+			blockSize = X_Format == xbox::X_D3DFMT_DXT1 ? 8 : 16;
+		}
+
 		for (int face = D3DCUBEMAP_FACE_POSITIVE_X; face <= last_face; face++) {
 			// As we iterate through mipmap levels, we'll adjust the source resource offset
 			DWORD dwMipOffset = 0;
@@ -5981,12 +5990,6 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 			DWORD pxMipDepth = dwDepth;
             DWORD dwMipRowPitch = dwRowPitch;
 			DWORD dwSrcSlicePitch = dwMipRowPitch * pxMipHeight; // TODO
-
-			// Block size only applies to compressed DXT formats
-			// DXT1 block size is 8 bytes
-			// Other Xbox DXT formats are 16 bytes
-			DWORD blockSize = 0;
-			blockSize = X_Format == xbox::X_D3DFMT_DXT1 ? 8 : 16;
 
 			for (unsigned int mipmap_level = 0; mipmap_level < dwMipMapLevels; mipmap_level++) {
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1542,6 +1542,14 @@ bool ConvertD3DTextureToARGBBuffer(
 		AdditionalArgument = DstRowPitch;
 
 	if (EmuXBFormatIsCompressed(X_Format)) {
+		if (SrcWidth < 4 || SrcHeight < 4) {
+			// HACK: The compressed DXT conversion code currently writes more pixels than it should, which can cause a crash.
+			// This code will get hit when converting compressed texture mipmaps on hardware that somehow doesn't support DXT natively
+			// (or lied when Cxbx asked it if it does!)
+			EmuLog(LOG_LEVEL::WARNING, "Converting DXT textures smaller than a block is not currently implemented. Ignoring conversion!");
+			return true;
+		}
+
 		// All compressed formats (DXT1, DXT3 and DXT5) encode blocks of 4 pixels on 4 lines
 		SrcHeight = (SrcHeight + 3) / 4;
 		DstRowPitch *= 4;


### PR DESCRIPTION
Some cleanup work while looking at an issue with DXT conversion when textures are smaller than a 4x4 block
Added a hack to avoid crashes, but stopped short of fixing the conversion code!