### PR TITLE
Fix Azurik render issue

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl
@@ -93,17 +93,6 @@ uniform const float  FRONTFACE_FACTOR : register(c27); // Note : PSH_XBOX_CONSTA
 // Second raw string :
 R"DELIMITER(
 
-// Define defaults when their inverses are not defined (handy while compiler isn't yet providing these) :
-#ifndef PS_COMBINERCOUNT_SAME_C0
-	#define PS_COMBINERCOUNT_UNIQUE_C0
-#endif
-#ifndef PS_COMBINERCOUNT_SAME_C1
-	#define PS_COMBINERCOUNT_UNIQUE_C1
-#endif
-#ifndef PS_COMBINERCOUNT_MUX_LSB
-	#define PS_COMBINERCOUNT_MUX_MSB
-#endif
-
 // PS_COMBINERCOUNT_UNIQUE_C0 steers whether for C0 to use stage-specific constants c0_0 .. c0_7, or c0_0 for all stages
 #ifdef PS_COMBINERCOUNT_UNIQUE_C0
 	#define C0 c0_[stage] // concatenate stage to form c0_0 .. c0_7


### PR DESCRIPTION
Remove #ifndef blocks that were driven by the opposite define than they should have been
Also provide the opposite flag as a comment, next to where the 'driver' define

Looks like this...
```hlsl
bool alphakill[4] = {false, false, false, false};
#define PS_COMBINERCOUNT 2
// enable PS_COMBINERCOUNT_SAME_C0
#undef PS_COMBINERCOUNT_UNIQUE_C0
// enable PS_COMBINERCOUNT_SAME_C1
#undef PS_COMBINERCOUNT_UNIQUE_C1
#define PS_COMBINERCOUNT_MUX_MSB
#define PS_COMPAREMODE_0(in) CM_LT(in.x) CM_LT(in.y) CM_LT(in.z) CM_LT(in.w)
```

### How this fixes Azurik:
Azurik intends to use the mode: `PS_COMBINERCOUNT_SAME_C0`
We do this by undefining the opposite flag e.g.
```c++
#undef PS_COMBINERCOUNT_UNIQUE_C0
```
But, later we have code that accidentally checked if `PS_COMBINERCOUNT_SAME_C0` was be undefined, rather than `PS_COMBINERCOUNT_UNIQUE_C0`
```c++
#ifndef PS_COMBINERCOUNT_SAME_C0
	#define PS_COMBINERCOUNT_UNIQUE_C0
#endif
```

This would cause `PS_COMBINERCOUNT_UNIQUE_C0` to _always_ be defined, which caused an incorrect constant to be used in Azurik shaders.

Since the code is currently only driven by whether `PS_COMBINERCOUNT_UNIQUE_C0` is defined or not, the `#ifndef` section was removed.