### PR TITLE
Improve scaling of depth buffer texture coordinates

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4096,7 +4096,7 @@ void ValidateRenderTargetDimensions(DWORD HostRenderTarget_Width, DWORD HostRend
     }
 }
 
-float GetZScaleForSurface(xbox::X_D3DSurface* pSurface)
+float GetZScaleForPixelContainer(xbox::X_D3DPixelContainer* pSurface)
 {
     // If no surface was present, fallback to 1
     if (pSurface == xbox::zeroptr) {
@@ -7398,9 +7398,21 @@ void CxbxUpdateHostTextureScaling()
 			*texCoordScale = {
 				width,
 				height,
-				(float)CxbxGetPixelContainerDepth(pXboxBaseTexture),
+				1.0f, // TODO should this be mip levels for volume textures?
 				1.0f
 			};
+		}
+
+		// When a depth buffer is used as a texture
+		// We do 'Native Shadow Mapping'
+		// https://aras-p.info/texts/D3D9GPUHacks.html
+		// The z texture coordinate component holds a depth value, which needs to be normalized
+		// TODO implement handling for
+		// - X_D3DRS_SHADOWFUNC
+		// - X_D3DRS_POLYGONOFFSETZSLOPESCALE
+		// - X_D3DRS_POLYGONOFFSETZOFFSET
+		if (EmuXBFormatIsDepthBuffer(XboxFormat)) {
+			(*texCoordScale)[2] = (float)GetZScaleForPixelContainer(pXboxBaseTexture);
 		}
 	}
 	// Pass above determined texture scaling factors to our HLSL shader.
@@ -8228,7 +8240,7 @@ static void CxbxImpl_SetRenderTarget
 
 	// The currenct depth stencil is always replaced by whats passed in here (even a null)
 	g_pXbox_DepthStencil = pNewZStencil;
-	g_ZScale = GetZScaleForSurface(g_pXbox_DepthStencil); // TODO : Discern between Xbox and host and do this in UpdateDepthStencilFlags?
+	g_ZScale = GetZScaleForPixelContainer(g_pXbox_DepthStencil); // TODO : Discern between Xbox and host and do this in UpdateDepthStencilFlags?
     pHostDepthStencil = GetHostSurface(g_pXbox_DepthStencil, D3DUSAGE_DEPTHSTENCIL);
 
 	HRESULT hRet;


### PR DESCRIPTION
- GetZScale accepts a PixelContainer rather than a surface
- Fix accidental call to CxbxGetPixelContainerDepth instead of GetZScale
- Assume we should scale the z component for all depth buffers, not just linear ones

Before (hlsl_ps) the shadow casts in both directions
![image](https://user-images.githubusercontent.com/9897874/111022085-7c641900-8435-11eb-96e1-00a045a8b83f.png)

After (master)
Currently this will cause horrible shadow acne in some games
![image](https://user-images.githubusercontent.com/9897874/111020649-63a33580-842c-11eb-9e39-5afe63dc8db5.png)
