### PR TITLE
Vertex buffer cache improvements

### DIFF
--- a/src/common/util/hasher.cpp
+++ b/src/common/util/hasher.cpp
@@ -27,7 +27,7 @@ void InitHasher()
     }
 }
 
-uint64_t ComputeHash(void* data, size_t len)
+uint64_t ComputeHash(const void* data, size_t len)
 {
     if (g_HashAlgorithm == HASH_NONE) {
         InitHasher();

--- a/src/common/util/hasher.h
+++ b/src/common/util/hasher.h
@@ -29,6 +29,6 @@
 
 #include <stdint.h>
 
-uint64_t ComputeHash(void* data, size_t len);
+uint64_t ComputeHash(const void* data, size_t len);
 
 #endif

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -55,7 +55,7 @@ CxbxDrawContext;
 class CxbxPatchedStream
 {
 public:
-    CxbxPatchedStream();
+    CxbxPatchedStream() = default;
     ~CxbxPatchedStream();
     void Clear();
     void Activate(CxbxDrawContext *pDrawContext, UINT HostStreamNumber) const;
@@ -76,7 +76,7 @@ public:
 class CxbxVertexBufferConverter
 {
     public:
-        CxbxVertexBufferConverter();
+        CxbxVertexBufferConverter() = default;
         void Apply(CxbxDrawContext *pPatchDesc);
         void PrintStats();
     private:
@@ -97,25 +97,21 @@ class CxbxVertexBufferConverter
             }
         };
 
-        UINT m_uiNbrStreams;
-
         // Stack tracking
         ULONG m_TotalCacheHits = 0;
         ULONG m_TotalCacheMisses = 0;
 
-        UINT m_MaxCacheSize = 10000;                                        // Maximum number of entries in the cache
-        UINT m_CacheElasticity = 200;                                      // Cache is allowed to grow this much more than maximum before being purged to maximum
+        const UINT m_MaxCacheSize = 10000;                                        // Maximum number of entries in the cache
+        const UINT m_CacheElasticity = 200;                                      // Cache is allowed to grow this much more than maximum before being purged to maximum
         std::unordered_map<StreamKey, std::list<CxbxPatchedStream>::iterator, StreamKeyHash> m_PatchedStreams; // Stores references to patched streams for fast lookup
         std::list<CxbxPatchedStream> m_PatchedStreamUsageList;             // Linked list of vertex streams, least recently used is last in the list
         CxbxPatchedStream& GetPatchedStream(uint64_t dataKey, uint64_t streamInfoKey); // Fetches (or inserts) a patched stream associated with the given key
 
-        CxbxVertexDeclaration *m_pCxbxVertexDeclaration;
-
         // Returns the number of streams of a patch
-        UINT GetNbrStreams(CxbxDrawContext *pPatchDesc);
+        UINT GetNbrStreams(CxbxDrawContext *pPatchDesc) const;
 
         // Patches the types of the stream
-        void ConvertStream(CxbxDrawContext *pPatchDesc, UINT uiStream);
+        void ConvertStream(CxbxDrawContext *pPatchDesc, CxbxVertexDeclaration* pCxbxVertexDeclaration, UINT uiStream);
 };
 
 // Inline vertex buffer emulation


### PR DESCRIPTION
This PR improves the vertex buffer cache again to improve its performance.  Basing on **Group S Challenge** as a test case, I identified our current cache generated a lot of "false positive" matches, continuously evicting buffers and recreating new ones up to 1000 times per frame. Turns out, those cases were caused by vertex buffers with identical vertex data but different vertex declarations.

I modified the vertex buffer cache to key cached resources by a `(dataHash, vertexElementsHash)` pair of elements, which allows such "buffer views" to coexist in the cache without continuously invalidating each other. On top of that, I modified `vertexElementsHash` not to hash some of the vertex stream attributes not relevant for the final form of the vertex buffer - most notably, it wrongly hashed a stream number, effectively evicting buffers from the cache if they are being bound to different stream numbers!

This has potential to improve performance in every game, based on my testing **Group S Challenge** gets a 3x performance improvement in-race, jumping from <20FPS to 55-60FPS - essentially full speed.

Before:
![image](https://user-images.githubusercontent.com/7947461/111526061-8ef49000-875e-11eb-967f-e89f1807b6dd.png)

After:
![image](https://user-images.githubusercontent.com/7947461/111526072-9320ad80-875e-11eb-9c24-4aed150f6d26.png)
