### PR TITLE
Re-enable texture stage swap hack

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
@@ -166,13 +166,12 @@ void XboxTextureStateConverter::Apply()
     // Track if we need to overwrite state 0 with 3 because of Point Sprites
     // The Xbox NV2A uses only Stage 3 for point-sprites, so we emulate this
     // by mapping Stage 3 to Stage 0, and disabling all stages > 0
+	// TODO use stage 3 when we roll our own point sprites after moving off D3D9
     bool pointSpriteOverride = false;
     bool pointSpritesEnabled = false;
-    if (g_Xbox_VertexShaderMode == VertexShaderMode::FixedFunction && g_UseFixedFunctionVertexShader) {
-        pointSpritesEnabled = pXboxRenderStates->GetXboxRenderState(xbox::X_D3DRS_POINTSPRITEENABLE);
-        if (pointSpritesEnabled) {
-            pointSpriteOverride = true;
-        }
+    pointSpritesEnabled = pXboxRenderStates->GetXboxRenderState(xbox::X_D3DRS_POINTSPRITEENABLE);
+    if (pointSpritesEnabled) {
+        pointSpriteOverride = true;
     }
 
     for (int XboxStage = 0; XboxStage < xbox::X_D3DTS_STAGECOUNT; XboxStage++) {


### PR DESCRIPTION
Fix wrong texture coordinates on particles, causing a regression in Amped and probably any other title with point sprites