### PR TITLE
Free thread resources upon termination

### DIFF
--- a/src/core/kernel/exports/EmuKrnlPs.cpp
+++ b/src/core/kernel/exports/EmuKrnlPs.cpp
@@ -264,6 +264,10 @@ XBSYSAPI EXPORTNUM(255) xbox::ntstatus_xt NTAPI xbox::PsCreateSystemThreadEx
 		}*/
 
         HANDLE handle = reinterpret_cast<HANDLE>(_beginthreadex(NULL, KernelStackSize, PCSTProxy, iPCSTProxyParam, CREATE_SUSPENDED, reinterpret_cast<unsigned int*>(&dwThreadId)));
+		if (handle == NULL) {
+			delete iPCSTProxyParam;
+			RETURN(xbox::status_insufficient_resources);
+		}
 		*ThreadHandle = handle;
         if (ThreadId != NULL)
             *ThreadId = dwThreadId;
@@ -378,6 +382,7 @@ XBSYSAPI EXPORTNUM(258) xbox::void_xt NTAPI xbox::PsTerminateSystemThread
 		}
 	}*/
 
+	EmuKeFreePcr();
 	_endthreadex(ExitStatus);
 	// ExitThread(ExitStatus);
 	// CxbxKrnlTerminateThread();

--- a/src/core/kernel/support/EmuFS.h
+++ b/src/core/kernel/support/EmuFS.h
@@ -34,6 +34,8 @@ extern void EmuInitFS();
 
 // generate fs segment selector
 extern void EmuGenerateFS(Xbe::TLS *pTLS, void *pTLSData);
+// free resources allocated for the thread
+void EmuKeFreePcr();
 
 typedef struct
 {


### PR DESCRIPTION
Closes https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/2166. In addition to free those resources, I also changed the allocation function for those from `ExAllocatePool` to `NtAllocateVirtualMemory`. This, because the former breaks the 16 byte alignment requirement for the TLS and also because it apparently breaks the Intel Graphics Performance Analyzer for some unknown reason.