### PR TITLE
Add Basic ImGui Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,7 @@
 	url = https://github.com/Cyan4973/xxHash.git
 	branch = release
 	shallow = true
+[submodule "import/imgui"]
+	path = import/imgui
+	url = https://github.com/ocornut/imgui.git
+	shadow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ file (GLOB CXBXR_HEADER_GUIv1
 # Emulator (module)
 file (GLOB CXBXR_HEADER_EMU_IMPORT
  "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_dx9.h"
+ "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_opengl3.h"
  "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_win32.h"
 )
 file (GLOB CXBXR_HEADER_EMU
@@ -124,6 +125,11 @@ file (GLOB CXBXR_HEADER_EMU
  "${CXBXR_ROOT_DIR}/src/common/util/gloffscreen/gloffscreen.h"
  "${CXBXR_ROOT_DIR}/src/common/audio/XADPCM.h"
  "${CXBXR_ROOT_DIR}/src/common/xbox/Logging.hpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/imgui/audio.hpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/imgui/ui.hpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/imgui/settings.h"
+ "${CXBXR_ROOT_DIR}/src/core/common/imgui/video.hpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/video/RenderBase.hpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/Direct3D9.h"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShader.hlsl"
@@ -270,6 +276,7 @@ file (GLOB CXBXR_KRNL_CPP
 )
 file (GLOB CXBXR_SOURCE_EMU_IMPORT
  "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_dx9.cpp"
+ "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_opengl3.cpp"
  "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_win32.cpp"
 )
 file (GLOB CXBXR_SOURCE_EMU
@@ -280,6 +287,10 @@ file (GLOB CXBXR_SOURCE_EMU
  "${CXBXR_ROOT_DIR}/src/common/util/gloffscreen/gloffscreen_common.cpp"
  "${CXBXR_ROOT_DIR}/src/common/util/gloffscreen/gloffscreen_wgl.cpp"
  "${CXBXR_ROOT_DIR}/src/common/xbox/Logging.cpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/imgui/audio.cpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/imgui/ui.cpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/imgui/video.cpp"
+ "${CXBXR_ROOT_DIR}/src/core/common/video/RenderBase.cpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/RenderStates.cpp"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/TextureStates.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,11 @@ add_custom_target(misc-batch
   WORKING_DIRECTORY ${CXBXR_ROOT_DIR}
 )
 
+# Custom CMake projects since some import libraries doesn't have it.
+
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/libtom")
+
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/imgui")
 
 # Split the files into group for which project is likely
 # going to be used for both header and source files.
@@ -109,6 +113,10 @@ file (GLOB CXBXR_HEADER_GUIv1
 )
 
 # Emulator (module)
+file (GLOB CXBXR_HEADER_EMU_IMPORT
+ "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_dx9.h"
+ "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_win32.h"
+)
 file (GLOB CXBXR_HEADER_EMU
  "${CXBXR_ROOT_DIR}/src/common/AddressRanges.h"
  "${CXBXR_ROOT_DIR}/src/common/audio/converter.hpp"
@@ -260,6 +268,10 @@ file (GLOB CXBXR_SOURCE_GUIv1
 file (GLOB CXBXR_KRNL_CPP
  "${CXBXR_ROOT_DIR}/src/core/kernel/init/CxbxKrnl.cpp"
 )
+file (GLOB CXBXR_SOURCE_EMU_IMPORT
+ "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_dx9.cpp"
+ "${CXBXR_ROOT_DIR}/import/imgui/backends/imgui_impl_win32.cpp"
+)
 file (GLOB CXBXR_SOURCE_EMU
  "${CXBXR_KRNL_CPP}"
  "${CXBXR_ROOT_DIR}/src/common/AddressRanges.cpp"
@@ -385,7 +397,7 @@ add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/cxbxr-emu")
 set(cxbxr_INSTALL_files "COPYING" "README.md")
 
 # Cxbx-Reloaded project with third-party libraries
-set_target_properties(cxbx cxbxr-ldr cxbxr-emu misc-batch subhook libXbSymbolDatabase libtommath libtomcrypt
+set_target_properties(cxbx cxbxr-ldr cxbxr-emu misc-batch subhook libXbSymbolDatabase libtommath libtomcrypt imgui
  PROPERTIES FOLDER Cxbx-Reloaded
 )
 

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -77,10 +77,18 @@ file (GLOB RESOURCES
  "${CXBXR_ROOT_DIR}/src/.editorconfig"
 )
 
+source_group(TREE ${CXBXR_ROOT_DIR}/import PREFIX import FILES
+ ${CXBXR_HEADER_EMU_IMPORT}
+)
+
 source_group(TREE ${CXBXR_ROOT_DIR}/src PREFIX header FILES
  ${CXBXR_HEADER_GUIv1}
  ${CXBXR_HEADER_COMMON}
  ${CXBXR_HEADER_EMU}
+)
+
+source_group(TREE ${CXBXR_ROOT_DIR}/import PREFIX import FILES
+ ${CXBXR_SOURCE_EMU_IMPORT}
 )
 
 source_group(TREE ${CXBXR_ROOT_DIR}/src PREFIX source FILES 
@@ -94,9 +102,11 @@ source_group(TREE ${CXBXR_ROOT_DIR} FILES ${RESOURCES})
 add_executable(cxbx WIN32 ${RESOURCES}
  ${CXBXR_HEADER_GUIv1}
  ${CXBXR_HEADER_COMMON}
+ ${CXBXR_HEADER_EMU_IMPORT}
  ${CXBXR_HEADER_EMU}
  ${CXBXR_SOURCE_GUIv1}
  ${CXBXR_SOURCE_COMMON}
+ ${CXBXR_SOURCE_EMU_IMPORT}
  ${CXBXR_SOURCE_EMU}
  ${CXBXR_GIT_VERSION_H}
 )
@@ -181,6 +191,7 @@ target_link_libraries(cxbx
  subhook
  libtomcrypt
  SDL2
+ imgui
 
  ${WINS_LIB}
 )

--- a/projects/cxbxr-emu/CMakeLists.txt
+++ b/projects/cxbxr-emu/CMakeLists.txt
@@ -68,6 +68,10 @@ file (GLOB RESOURCES
  "${CXBXR_ROOT_DIR}/README.md"
 )
 
+source_group(TREE ${CXBXR_ROOT_DIR}/import PREFIX import FILES
+ ${CXBXR_HEADER_EMU_IMPORT}
+)
+
 source_group(TREE ${CXBXR_ROOT_DIR}/src PREFIX header FILES
  ${CXBXR_HEADER_GUIv1}
  ${CXBXR_HEADER_COMMON}
@@ -75,7 +79,11 @@ source_group(TREE ${CXBXR_ROOT_DIR}/src PREFIX header FILES
  "${CXBXR_ROOT_DIR}/src/emulator/targetver.h"
 )
 
-source_group(TREE ${CXBXR_ROOT_DIR}/src PREFIX source FILES 
+source_group(TREE ${CXBXR_ROOT_DIR}/import PREFIX import FILES
+ ${CXBXR_SOURCE_EMU_IMPORT}
+)
+
+source_group(TREE ${CXBXR_ROOT_DIR}/src PREFIX source FILES
  ${CXBXR_SOURCE_GUIv1}
  ${CXBXR_SOURCE_COMMON}
  ${CXBXR_SOURCE_EMU}
@@ -87,9 +95,11 @@ source_group(TREE ${CXBXR_ROOT_DIR} FILES ${RESOURCES})
 
 add_library(cxbxr-emu SHARED ${RESOURCES}
  ${CXBXR_HEADER_COMMON}
+ ${CXBXR_HEADER_EMU_IMPORT}
  ${CXBXR_HEADER_EMU}
  "${CXBXR_ROOT_DIR}/src/emulator/targetver.h"
  ${CXBXR_SOURCE_COMMON}
+ ${CXBXR_SOURCE_EMU_IMPORT}
  ${CXBXR_SOURCE_EMU}
  ${CXBXR_GIT_VERSION_H}
  "${CXBXR_ROOT_DIR}/src/emulator/cxbxr-emu.cpp"
@@ -157,6 +167,7 @@ target_link_libraries(cxbxr-emu
  subhook
  libtomcrypt
  SDL2
+ imgui
 
  ${WINS_LIB}
 )

--- a/projects/imgui/CMakeLists.txt
+++ b/projects/imgui/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required (VERSION 3.8)
+project(imgui LANGUAGES CXX)
+# Since imgui doesn't have CMake, we'll make an interface project here.
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+ add_compile_definitions(
+ _CRT_SECURE_NO_WARNINGS
+ _CRT_NONSTDC_NO_DEPRECATE
+ )
+endif()
+
+file (GLOB HEADERS
+ "${CXBXR_ROOT_DIR}/import/imgui/imconfig.h"
+ "${CXBXR_ROOT_DIR}/import/imgui/imgui.h"
+ "${CXBXR_ROOT_DIR}/import/imgui/imgui_internal.h"
+ "${CXBXR_ROOT_DIR}/import/imgui/imstb_rectpack.h"
+ "${CXBXR_ROOT_DIR}/import/imgui/imstb_textedit.h"
+ "${CXBXR_ROOT_DIR}/import/imgui/imstb_truetype.h"
+)
+
+file (GLOB SOURCES
+ "${CXBXR_ROOT_DIR}/import/imgui/imgui.cpp"
+ "${CXBXR_ROOT_DIR}/import/imgui/imgui_draw.cpp"
+ "${CXBXR_ROOT_DIR}/import/imgui/imgui_tables.cpp"
+ "${CXBXR_ROOT_DIR}/import/imgui/imgui_widgets.cpp"
+)
+
+source_group(TREE ${CXBXR_ROOT_DIR}/import/imgui PREFIX header FILES ${HEADERS})
+
+source_group(TREE ${CXBXR_ROOT_DIR}/import/imgui PREFIX source FILES ${SOURCES})
+
+add_library(${PROJECT_NAME} ${HEADERS} ${SOURCES})
+
+target_include_directories(${PROJECT_NAME}
+ PUBLIC "${CXBXR_ROOT_DIR}/import/imgui"
+)

--- a/projects/imgui/CMakeLists.txt
+++ b/projects/imgui/CMakeLists.txt
@@ -9,6 +9,12 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
  )
 endif()
 
+# Add any defines from imconfig.h file in here without need to use import file directly.
+add_compile_definitions(
+ IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS
+ IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS
+)
+
 file (GLOB HEADERS
  "${CXBXR_ROOT_DIR}/import/imgui/imconfig.h"
  "${CXBXR_ROOT_DIR}/import/imgui/imgui.h"

--- a/projects/imgui/CMakeLists.txt
+++ b/projects/imgui/CMakeLists.txt
@@ -9,7 +9,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
  )
 endif()
 
-# Add any defines from imconfig.h file in here without need to use import file directly.
+# Add any defines from imconfig.h file in here without need to edit import file directly.
 add_compile_definitions(
  IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS
  IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS

--- a/src/common/IPCHybrid.hpp
+++ b/src/common/IPCHybrid.hpp
@@ -38,6 +38,7 @@ typedef enum class _IPC_UPDATE_GUI {
 	, XBOX_LED_COLOUR
 	, LOG_ENABLED
 	, KRNL_IS_READY
+	, OVERLAY
 } IPC_UPDATE_GUI;
 
 void ipc_send_gui_update(IPC_UPDATE_GUI command, const unsigned int value);

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -458,7 +458,7 @@ bool Settings::LoadConfig()
 
 	m_input_general.MoAxisRange = m_si.GetLongValue(section_input_general, sect_input_general.mo_axis_range, MO_AXIS_DEFAULT_RANGE);
 	m_input_general.MoWheelRange = m_si.GetLongValue(section_input_general, sect_input_general.mo_wheel_range, MO_WHEEL_DEFAULT_RANGE);
-	m_input_general.IgnoreKbMoUnfocus = m_si.GetLongValue(section_input_general, sect_input_general.ignore_kbmo_unfocus, 1);
+	m_input_general.IgnoreKbMoUnfocus = m_si.GetBoolValue(section_input_general, sect_input_general.ignore_kbmo_unfocus, true);
 
 	// ==== Input General End ==============
 
@@ -631,7 +631,7 @@ bool Settings::Save(std::string file_path)
 
 	m_si.SetLongValue(section_input_general, sect_input_general.mo_axis_range, m_input_general.MoAxisRange, nullptr, false, true);
 	m_si.SetLongValue(section_input_general, sect_input_general.mo_wheel_range, m_input_general.MoWheelRange, nullptr, false, true);
-	m_si.SetLongValue(section_input_general, sect_input_general.ignore_kbmo_unfocus, m_input_general.IgnoreKbMoUnfocus, nullptr, false, true);
+	m_si.SetBoolValue(section_input_general, sect_input_general.ignore_kbmo_unfocus, m_input_general.IgnoreKbMoUnfocus, nullptr, true);
 
 	// ==== Input General End =========
 

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -112,6 +112,12 @@ static struct {
 	const char* RenderResolution = "RenderResolution";
 } sect_video_keys;
 
+static const char* section_overlay = "overlay";
+static struct {
+	const char* FPS = "FPS";
+	const char* hle_lle_stats = "HLE/LLE Stats";
+} sect_overlay_keys;
+
 static const char* section_audio = "audio";
 static struct {
 	const char* adapter = "adapter";
@@ -523,6 +529,13 @@ bool Settings::LoadConfig()
 
 	// ==== Input Profile End ======
 
+	// ==== Overlay Begin =========
+
+	m_overlay.fps = m_si.GetBoolValue(section_overlay, sect_overlay_keys.FPS, true);
+	m_overlay.hle_lle_stats = m_si.SetBoolValue(section_overlay, sect_overlay_keys.hle_lle_stats, true);
+
+	// ==== Overlay End ===========
+
 	return true;
 }
 
@@ -588,6 +601,7 @@ bool Settings::Save(std::string file_path)
 	m_si.SetBoolValue(section_video, sect_video_keys.FullScreen, m_video.bFullScreen, nullptr, true);
 	m_si.SetBoolValue(section_video, sect_video_keys.MaintainAspect, m_video.bMaintainAspect, nullptr, true);
 	m_si.SetLongValue(section_video, sect_video_keys.RenderResolution, m_video.renderScaleFactor, nullptr, false, true);
+
 	// ==== Video End ===========
 
 	// ==== Audio Begin =========
@@ -700,6 +714,13 @@ bool Settings::Save(std::string file_path)
 
 	// ==== Input Profile End ======
 
+	// ==== Overlay Begin =======
+
+	m_si.SetBoolValue(section_overlay, sect_overlay_keys.FPS, m_overlay.fps, nullptr, true);
+	m_si.SetBoolValue(section_overlay, sect_overlay_keys.hle_lle_stats, m_overlay.hle_lle_stats, nullptr, true);
+
+	// ==== Overlay End =========
+
 	// ==== Hack Begin ==========
 
 	m_si.SetBoolValue(section_hack, sect_hack_keys.DisablePixelShaders, m_hacks.DisablePixelShaders, nullptr, true);
@@ -737,6 +758,7 @@ void Settings::SyncToEmulator()
 
 	// register Video settings
 	g_EmuShared->SetVideoSettings(&m_video);
+	g_EmuShared->SetOverlaySettings(&m_overlay);
 
 	// register Audio settings
 	g_EmuShared->SetAudioSettings(&m_audio);

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -744,7 +744,7 @@ void Settings::SyncToEmulator()
 	// register Network settings
 	g_EmuShared->SetNetworkSettings(&m_network);
 
-	// register Input settings
+	// register Input gamepad settings
 	for (int i = 0; i < 4; i++) {
 		g_EmuShared->SetInputDevTypeSettings(&m_input_port[i].Type, i);
 		if (m_input_port[i].Type != to_underlying(XBOX_INPUT_DEVICE::DEVICE_INVALID)) {
@@ -766,9 +766,8 @@ void Settings::SyncToEmulator()
 		}
 	}
 
-	g_EmuShared->SetInputMoAxisSettings(m_input_general.MoAxisRange);
-	g_EmuShared->SetInputMoWheelSettings(m_input_general.MoWheelRange);
-	g_EmuShared->SetInputKbMoUnfocusSettings(m_input_general.IgnoreKbMoUnfocus);
+	// register Input general settings
+	g_EmuShared->SetInputGeneralSettings(&m_input_general);
 
 	// register Hacks settings
 	g_EmuShared->SetHackSettings(&m_hacks);

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -766,7 +766,7 @@ void Settings::SyncToEmulator()
 	// register Network settings
 	g_EmuShared->SetNetworkSettings(&m_network);
 
-	// register Input gamepad settings
+	// register xbox device input settings
 	for (int i = 0; i < 4; i++) {
 		g_EmuShared->SetInputDevTypeSettings(&m_input_port[i].Type, i);
 		if (m_input_port[i].Type != to_underlying(XBOX_INPUT_DEVICE::DEVICE_INVALID)) {

--- a/src/common/Settings.hpp
+++ b/src/common/Settings.hpp
@@ -34,6 +34,8 @@
 #include <string>
 #include <array>
 
+#include "core/common/imgui/settings.h"
+
 extern std::string g_exec_filepath;
 
 // Individual library version
@@ -180,6 +182,8 @@ public:
 		int  Reserved99[8] = { 0 };
 	} m_hacks;
 	static_assert(sizeof(s_hack) == 0x28, assert_check_shared_memory(s_hack));
+
+	overlay_settings m_overlay;
 
 private:
 	void RemoveLegacyConfigs(unsigned int CurrentRevision);

--- a/src/common/Settings.hpp
+++ b/src/common/Settings.hpp
@@ -134,12 +134,14 @@ public:
 	} m_audio;
 	static_assert(sizeof(s_audio) == 0x4C, assert_check_shared_memory(s_audio));
 
+	// Input general settings
 	struct s_input_general {
 		long MoAxisRange;
 		long MoWheelRange;
 		bool IgnoreKbMoUnfocus;
-	};
-	s_input_general m_input_general;
+		bool Reserved1[3];
+	} m_input_general;
+	static_assert(sizeof(s_input_general) == 0xC, assert_check_shared_memory(s_input_general));
 
 	struct s_input_port {
 		int Type;

--- a/src/common/input/InputManager.cpp
+++ b/src/common/input/InputManager.cpp
@@ -706,16 +706,13 @@ std::shared_ptr<InputDevice> InputDeviceManager::FindDevice(int usb_port, int du
 void InputDeviceManager::UpdateOpt(bool is_gui)
 {
 	if (!is_gui) {
-		long axis_range, wheel_range;
-		bool ignore_kbmo;
-		g_EmuShared->GetInputMoAxisSettings(&axis_range);
-		g_EmuShared->GetInputMoWheelSettings(&wheel_range);
-		g_EmuShared->GetInputKbMoUnfocusSettings(&ignore_kbmo);
-		DInput::mo_axis_range_pos = axis_range;
-		DInput::mo_wheel_range_pos = wheel_range;
-		DInput::mo_axis_range_neg = -(axis_range);
-		DInput::mo_wheel_range_neg = -(wheel_range);
-		DInput::IgnoreKbMoUnfocus = ignore_kbmo;
+		Settings::s_input_general input_general;
+		g_EmuShared->GetInputGeneralSettings(&input_general);
+		DInput::mo_axis_range_pos = input_general.MoAxisRange;
+		DInput::mo_wheel_range_pos = input_general.MoWheelRange;
+		DInput::mo_axis_range_neg = -(input_general.MoAxisRange);
+		DInput::mo_wheel_range_neg = -(input_general.MoWheelRange);
+		DInput::IgnoreKbMoUnfocus = input_general.IgnoreKbMoUnfocus;
 	}
 	else {
 		DInput::mo_axis_range_pos = g_Settings->m_input_general.MoAxisRange;

--- a/src/common/input/InputManager.cpp
+++ b/src/common/input/InputManager.cpp
@@ -363,7 +363,7 @@ bool InputDeviceManager::UpdateXboxPortInput(int usb_port, void* Buffer, int Dir
 
 	// First check if ImGui is focus, then ignore any input update occur.
 	// If somebody else is currently holding the lock, we won't wait and instead report no input changes
-	if (!g_renderbase->IsImGuiFocus() && m_Mtx.try_lock()) {
+	if (static_cast<uint8_t>(!g_renderbase->IsImGuiFocus()) & static_cast<uint8_t>(m_Mtx.try_lock())) {
 		for (auto &dev_ptr : m_Devices) {
 			if (dev_ptr->GetPort(usb_port)) {
 				switch (xid_type)

--- a/src/common/input/InputManager.cpp
+++ b/src/common/input/InputManager.cpp
@@ -45,6 +45,7 @@
 #include "core\kernel\exports\EmuKrnl.h" // For EmuLog
 #include "EmuShared.h"
 #include "devices\usb\OHCI.h"
+#include "core/common/video/RenderBase.hpp"
 
 // hle input specific
 #include "core\hle\XAPI\Xapi.h"
@@ -360,8 +361,9 @@ bool InputDeviceManager::UpdateXboxPortInput(int usb_port, void* Buffer, int Dir
 		xid_type < to_underlying(XBOX_INPUT_DEVICE::DEVICE_MAX));
 	bool has_changed = false;
 
+	// First check if ImGui is focus, then ignore any input update occur.
 	// If somebody else is currently holding the lock, we won't wait and instead report no input changes
-	if (m_Mtx.try_lock()) {
+	if (!g_renderbase->IsImGuiFocus() && m_Mtx.try_lock()) {
 		for (auto &dev_ptr : m_Devices) {
 			if (dev_ptr->GetPort(usb_port)) {
 				switch (xid_type)

--- a/src/common/win32/EmuShared.cpp
+++ b/src/common/win32/EmuShared.cpp
@@ -152,7 +152,6 @@ EmuShared::EmuShared()
 	m_bEmulating_status = false;
 	m_bFirstLaunch = false;
 	m_bClipCursor = false;
-	m_bIgnoreKbMoUnfocus = true;
 
 	// Reserve space (default to 0)
 	m_bReserved4 = false;

--- a/src/common/win32/EmuShared.cpp
+++ b/src/common/win32/EmuShared.cpp
@@ -161,6 +161,10 @@ EmuShared::EmuShared()
 	std::memset(m_Reserved99, 0, sizeof(m_Reserved99));
 	std::memset(m_DeviceControlNames, '\0', sizeof(m_DeviceControlNames));
 	std::memset(m_DeviceName, '\0', sizeof(m_DeviceName));
+	m_imgui_general.ini_size = IMGUI_INI_SIZE_MAX;
+	std::memset(&m_imgui_general.ini_settings, 0, sizeof(m_imgui_general.ini_settings));
+	std::memset(&m_imgui_audio_windows, 0, sizeof(m_imgui_audio_windows));
+	std::memset(&m_imgui_video_windows, 0, sizeof(m_imgui_video_windows));
 	for (auto& i : m_DeviceType) {
 		i = to_underlying(XBOX_INPUT_DEVICE::DEVICE_INVALID);
 	}

--- a/src/common/win32/EmuShared.h
+++ b/src/common/win32/EmuShared.h
@@ -30,6 +30,7 @@
 #include "Mutex.h"
 #include "common\IPCHybrid.hpp"
 #include "common\input\Button.h"
+#include "core/common/imgui/settings.h"
 
 #include <memory.h>
 
@@ -249,6 +250,43 @@ class EmuShared : public Mutex
 		void SetClipCursorFlag(const bool value) { Lock(); m_bClipCursor = value; Unlock(); }
 
 		// ******************************************************************
+		// * ImGui Accessors
+		// ******************************************************************
+		void GetImGuiFocusFlag(bool *value) { Lock(); *value = m_imgui_general.is_focus; Unlock(); }
+		void SetImGuiFocusFlag(const bool value) { Lock(); m_imgui_general.is_focus = value; Unlock(); }
+
+		void GetImGuiIniSettings(char value[IMGUI_INI_SIZE_MAX]) {
+			Lock();
+			if (m_imgui_general.ini_size < IMGUI_INI_SIZE_MAX) {
+				value = '\0';
+				return;
+			}
+			strcpy_s(value, IMGUI_INI_SIZE_MAX, m_imgui_general.ini_settings);
+			Unlock();
+		}
+		void SetImGuiIniSettings(const char value[IMGUI_INI_SIZE_MAX]) {
+			Lock();
+			// Do not save if external size is less than internal limit
+			if (m_imgui_general.ini_size < IMGUI_INI_SIZE_MAX) {
+				return;
+			}
+			strcpy_s(m_imgui_general.ini_settings, IMGUI_INI_SIZE_MAX, value);
+			Unlock();
+		}
+
+		void GetImGuiAudioWindows(imgui_audio_windows *value) { Lock(); *value = m_imgui_audio_windows; Unlock(); }
+		void SetImGuiAudioWindows(const imgui_audio_windows* value) { Lock(); m_imgui_audio_windows = *value; Unlock(); }
+		void GetImGuiVideoWindows(imgui_video_windows*value) { Lock(); *value = m_imgui_video_windows; Unlock(); }
+		void SetImGuiVideoWindows(const imgui_video_windows* value) { Lock(); m_imgui_video_windows = *value; Unlock(); }
+
+
+		// ******************************************************************
+		// * Overlay Accessors
+		// ******************************************************************
+		void GetOverlaySettings(overlay_settings *value) { Lock(); *value = m_imgui_overlay_settings; Unlock(); }
+		void SetOverlaySettings(const overlay_settings* value) { Lock(); m_imgui_overlay_settings = *value; Unlock(); }
+
+		// ******************************************************************
 		// * Reset specific variables to default for kernel mode.
 		// ******************************************************************
 		void ResetKrnl()
@@ -313,6 +351,10 @@ class EmuShared : public Mutex
 		Settings::s_network m_network;
 		Settings::s_input_general m_input_general;
 		Settings::s_hack m_hacks;
+		imgui_general m_imgui_general;
+		overlay_settings m_imgui_overlay_settings;
+		imgui_audio_windows m_imgui_audio_windows;
+		imgui_video_windows m_imgui_video_windows;
 };
 
 // ******************************************************************

--- a/src/common/win32/EmuShared.h
+++ b/src/common/win32/EmuShared.h
@@ -152,12 +152,8 @@ class EmuShared : public Mutex
 		// ******************************************************************
 		// * Input option Accessors
 		// ******************************************************************
-		void GetInputMoAxisSettings(long *axis) { Lock(); *axis = m_MoAxisRange; Unlock(); }
-		void SetInputMoAxisSettings(const long axis) { Lock(); m_MoAxisRange = axis; Unlock(); }
-		void GetInputMoWheelSettings(long *wheel) { Lock(); *wheel = m_MoWheelRange; Unlock(); }
-		void SetInputMoWheelSettings(const long wheel) { Lock(); m_MoWheelRange = wheel; Unlock(); }
-		void GetInputKbMoUnfocusSettings(bool *flag) { Lock(); *flag = m_bIgnoreKbMoUnfocus; Unlock(); }
-		void SetInputKbMoUnfocusSettings(const bool flag) { Lock(); m_bIgnoreKbMoUnfocus = flag; Unlock(); }
+		void GetInputGeneralSettings(Settings::s_input_general *input_general) { Lock(); *input_general = m_input_general; Unlock(); }
+		void SetInputGeneralSettings(const Settings::s_input_general *input_general) { Lock(); m_input_general = *input_general; Unlock(); }
 
 		// ******************************************************************
 		// * LLE Flags Accessors
@@ -301,15 +297,13 @@ class EmuShared : public Mutex
 #endif
 		bool         m_bFirstLaunch;
 		bool         m_bClipCursor;
-		bool         m_bIgnoreKbMoUnfocus;
+		bool         m_bReserved3;
 		bool         m_bReserved4;
 		unsigned int m_dwKrnlProcID; // Only used for kernel mode level.
 		int          m_DeviceType[4];
 		char         m_DeviceControlNames[4][HIGHEST_NUM_BUTTONS][HOST_BUTTON_NAME_LENGTH];
 		char         m_DeviceName[4][50];
-		long         m_MoAxisRange;
-		long         m_MoWheelRange;
-		int          m_Reserved99[26]; // Reserve space
+		int          m_Reserved99[28]; // Reserve space
 
 		// Settings class in memory should not be tampered by third-party.
 		// Third-party program should only be allow to edit settings.ini file.
@@ -317,6 +311,7 @@ class EmuShared : public Mutex
 		Settings::s_video m_video;
 		Settings::s_audio m_audio;
 		Settings::s_network m_network;
+		Settings::s_input_general m_input_general;
 		Settings::s_hack m_hacks;
 };
 

--- a/src/common/win32/EmuShared.h
+++ b/src/common/win32/EmuShared.h
@@ -196,7 +196,7 @@ class EmuShared : public Mutex
 		// * Debugging flag Accessors
 		// ******************************************************************
 		void GetDebuggingFlag(bool *value) { Lock(); *value = m_bDebugging; Unlock(); }
-		void SetDebuggingFlag(const bool *value) { Lock(); m_bDebugging = *value; Unlock(); }
+		void SetDebuggingFlag(const bool value) { Lock(); m_bDebugging = value; Unlock(); }
 #ifndef CXBX_LOADER // Temporary usage for cxbx.exe's emu
 		// ******************************************************************
 		// * Previous Memory Layout value Accessors
@@ -246,7 +246,7 @@ class EmuShared : public Mutex
 		// * ClipCursor flag Accessors
 		// ******************************************************************
 		void GetClipCursorFlag(bool *value) { Lock(); *value = m_bClipCursor; Unlock(); }
-		void SetClipCursorFlag(const bool *value) { Lock(); m_bClipCursor = *value; Unlock(); }
+		void SetClipCursorFlag(const bool value) { Lock(); m_bClipCursor = value; Unlock(); }
 
 		// ******************************************************************
 		// * Reset specific variables to default for kernel mode.

--- a/src/common/win32/IPCWindows.cpp
+++ b/src/common/win32/IPCWindows.cpp
@@ -65,6 +65,10 @@ void ipc_send_gui_update(IPC_UPDATE_GUI command, const unsigned int value)
 			cmdParam = ID_GUI_STATUS_KRNL_IS_READY;
 			break;
 
+		case IPC_UPDATE_GUI::OVERLAY:
+			cmdParam = ID_GUI_STATUS_OVERLAY;
+			break;
+
 		default:
 			cmdParam = 0;
 			break;

--- a/src/core/common/imgui/audio.cpp
+++ b/src/core/common/imgui/audio.cpp
@@ -1,0 +1,37 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+
+#define LOG_PREFIX CXBXR_MODULE::GUI
+
+#include <thread>
+
+#include "audio.hpp"
+
+#include "EmuShared.h"
+
+bool ImGuiAudio::Initialize()
+{
+	g_EmuShared->GetImGuiAudioWindows(&m_windows);
+	return true;
+}
+
+void ImGuiAudio::Shutdown()
+{
+	g_EmuShared->SetImGuiAudioWindows(&m_windows);
+}
+
+void ImGuiAudio::DrawMenu()
+{
+	if (ImGui::BeginMenu("Audio")) {
+		ImGui::MenuItem("Debug General Cache Stats", NULL, &m_windows.cache_stats_general);
+		ImGui::EndMenu();
+	}
+}
+
+void ImGuiAudio::DrawWidgets(bool is_focus, ImGuiWindowFlags input_handler)
+{
+	//TODO: In need of make interface class to return generic info in some way.
+	extern void DSound_PrintStats(bool, ImGuiWindowFlags, bool m_show_audio_stats); 
+	DSound_PrintStats(is_focus, input_handler, m_windows.cache_stats_general);
+}

--- a/src/core/common/imgui/audio.hpp
+++ b/src/core/common/imgui/audio.hpp
@@ -1,0 +1,24 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+#pragma once
+
+#include <imgui.h>
+#include "settings.h"
+
+class ImGuiAudio
+{
+public:
+	ImGuiAudio() = default;
+	virtual ~ImGuiAudio() = default;
+
+	bool Initialize();
+	void Shutdown();
+
+	void DrawMenu();
+	void DrawWidgets(bool is_focus, ImGuiWindowFlags input_handler);
+
+protected:
+
+	imgui_audio_windows m_windows;
+};

--- a/src/core/common/imgui/settings.h
+++ b/src/core/common/imgui/settings.h
@@ -1,0 +1,53 @@
+// ******************************************************************
+// *
+// *  This file is part of the Cxbx-Reloaded project.
+// *
+// *  Cxbx and Cxbe are free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2021 RadWolfie
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+#pragma once
+
+// Intended to store as permanent settings
+
+typedef struct {
+	bool fps;
+	bool hle_lle_stats;
+} overlay_settings;
+
+// Intended for EmuShared only below
+
+const int IMGUI_INI_SIZE_MAX = 1024;
+
+typedef struct {
+	bool is_focus;
+	bool Reserved[3];
+	int  ini_size; // Cannot be touch anywhere except EmuShared's constructor.
+	char ini_settings[IMGUI_INI_SIZE_MAX];
+} imgui_general;
+
+typedef struct {
+	bool cache_stats_general;
+	bool Reserved[3];
+} imgui_audio_windows;
+
+typedef struct {
+	bool cache_stats_vertex;
+	bool Reserved[3];
+} imgui_video_windows;

--- a/src/core/common/imgui/ui.cpp
+++ b/src/core/common/imgui/ui.cpp
@@ -62,7 +62,6 @@ void ImGuiUI::Shutdown()
 	g_EmuShared->SetOverlaySettings(&m_settings);
 	m_audio.Shutdown();
 	m_video.Shutdown();
-	ImGui::EndFrame();
 	ImGui::DestroyContext(m_imgui_context);
 }
 

--- a/src/core/common/imgui/ui.cpp
+++ b/src/core/common/imgui/ui.cpp
@@ -1,0 +1,161 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+//
+// Copyright 2010 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+
+#define LOG_PREFIX CXBXR_MODULE::GUI
+
+#include <thread>
+
+#include "ui.hpp"
+#include "EmuShared.h"
+
+#include "core/kernel/init/CxbxKrnl.h"
+
+bool ImGuiUI::Initialize()
+{
+	IMGUI_CHECKVERSION();
+	m_imgui_context = ImGui::CreateContext();
+	if (!m_imgui_context) {
+		CxbxKrnlCleanup("Unable to create ImGui context!");
+		return false;
+	}
+
+	ImGuiIO& io = ImGui::GetIO();
+#if 0 // TODO: Currently most voted for memory, so this block of code is disabled. And may will add an option between file vs memory.
+	// May be best ideal to do manual update call than ImGui's internal auto update.
+	g_EmuShared->GetStorageLocation(m_file_path);
+	if (m_file_path[0] == '\0') {
+		return false;
+	}
+	strcat_s(m_file_path, "/imgui.ini");
+	io.IniFilename = m_file_path;
+#else
+	io.IniFilename = nullptr;
+	char temp_ini_settings[IMGUI_INI_SIZE_MAX];
+	g_EmuShared->GetImGuiIniSettings(temp_ini_settings);
+	ImGui::LoadIniSettingsFromMemory(temp_ini_settings, IMGUI_INI_SIZE_MAX);
+#endif
+
+	ImGui::StyleColorsDark();
+	g_EmuShared->GetImGuiFocusFlag(&m_is_focus);
+
+	g_EmuShared->GetOverlaySettings(&m_settings);
+	g_EmuShared->GetFlagsLLE(&m_lle_flags);
+	m_audio.Initialize();
+	m_video.Initialize();
+
+	return true;
+}
+
+void ImGuiUI::Shutdown()
+{
+	size_t ini_size = IMGUI_INI_SIZE_MAX;
+	const char* temp_ini_settings = ImGui::SaveIniSettingsToMemory(&ini_size);
+	if (ini_size > IMGUI_INI_SIZE_MAX) {
+		CxbxKrnlCleanup("ImGui ini settings is too large: %d > %d (IMGUI_INI_SIZE_MAX)", ini_size, IMGUI_INI_SIZE_MAX);
+	}
+	g_EmuShared->SetImGuiIniSettings(temp_ini_settings);
+	g_EmuShared->SetOverlaySettings(&m_settings);
+	m_audio.Shutdown();
+	m_video.Shutdown();
+	ImGui::EndFrame();
+	ImGui::DestroyContext(m_imgui_context);
+}
+
+bool ImGuiUI::IsImGuiFocus()
+{
+	return m_is_focus;
+}
+
+void ImGuiUI::ToggleImGui()
+{
+	m_is_focus = !m_is_focus;
+	g_EmuShared->SetImGuiFocusFlag(m_is_focus);
+}
+
+void ImGuiUI::DrawMenu()
+{
+	if (!m_is_focus) {
+		return;
+	}
+	if (ImGui::BeginMainMenuBar()) {
+		if (ImGui::BeginMenu("Settings")) {
+			if (ImGui::BeginMenu("Overlay")) {
+				bool bChanged = false;
+				bChanged |= ImGui::MenuItem("Show FPS", NULL, &m_settings.fps);
+				bChanged |= ImGui::MenuItem("Show HLE/LLE Stats", NULL, &m_settings.hle_lle_stats);
+				if (bChanged) {
+					g_EmuShared->SetOverlaySettings(&m_settings);
+					ipc_send_gui_update(IPC_UPDATE_GUI::OVERLAY, 1);
+				}
+				ImGui::EndMenu();
+			}
+			ImGui::EndMenu();
+		}
+
+		m_video.DrawMenu();
+		m_audio.DrawMenu();
+		ImGui::EndMainMenuBar();
+	}
+}
+
+void ImGuiUI::DrawWidgets()
+{
+	if (m_settings.fps || m_settings.hle_lle_stats) {
+
+		ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - (IMGUI_MIN_DIST_SIDE/* * m_backbuffer_scale*/),
+			IMGUI_MIN_DIST_TOP/* * m_backbuffer_scale*/), ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+
+		ImGui::SetNextWindowSize(ImVec2(200.0f/* * m_backbuffer_scale*/, 0.0f));
+		ImGui::SetNextWindowBgAlpha(0.5f);
+		if (ImGui::Begin("overlay_stats", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoNav |
+			ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar |
+			ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing)) {
+
+			if (m_settings.fps) {
+
+				float fps_counter;
+				g_EmuShared->GetCurrentFPS(&fps_counter);
+				ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "FPS: %.2f  MS / F : %.2f", fps_counter, (float)(1000.0 / fps_counter));
+			}
+
+			if (m_settings.hle_lle_stats) {
+				std::string flagString = "LLE-";
+
+				// TODO: Need improvement in upstream for all of bLLE_xxx globals
+				// Set LLE flags string based on selected LLE flags
+				if (m_lle_flags & LLE_APU) {
+					flagString.append("A");
+				}
+				if (m_lle_flags & LLE_GPU) {
+					flagString.append("G");
+				}
+				if (m_lle_flags & LLE_USB) {
+					flagString.append("U");
+				}
+				if (m_lle_flags & LLE_JIT) {
+					flagString.append("J");
+				}
+				if (m_lle_flags == 0) {
+					flagString = "HLE";
+				}
+
+				// Align text to the right
+				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetWindowWidth() - ImGui::CalcTextSize(flagString.c_str()).x
+					- ImGui::GetScrollX() - 2 * ImGui::GetStyle().ItemSpacing.x);
+				ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), flagString.c_str());
+			}
+			ImGui::End();
+		}
+	}
+
+	ImGuiWindowFlags input_handler = m_is_focus ? ImGuiWindowFlags_None : ImGuiWindowFlags_NoInputs;
+
+	m_video.DrawWidgets(m_is_focus, input_handler);
+
+	m_audio.DrawWidgets(m_is_focus, input_handler);
+}

--- a/src/core/common/imgui/ui.hpp
+++ b/src/core/common/imgui/ui.hpp
@@ -1,0 +1,67 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+//
+// Copyright 2010 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+
+#pragma once
+
+#include <imgui.h>
+
+#include <mutex>
+#include <functional>
+
+#include "settings.h"
+#include "audio.hpp"
+#include "video.hpp"
+
+constexpr float IMGUI_MIN_DIST_TOP = 20.0f;
+constexpr float IMGUI_MIN_DIST_SIDE = 1.0f;
+
+class ImGuiUI
+{
+public:
+	ImGuiUI() = default;
+	virtual ~ImGuiUI() = default;
+
+	void ToggleImGui();
+	bool IsImGuiFocus();
+
+	void DrawMenu();
+	void DrawWidgets();
+
+protected:
+
+	bool Initialize();
+	void Shutdown();
+
+	template<class C, class T>
+	void Render(C callback, T arg)
+	{
+		// Some games seem to call Swap concurrently, so we need to ensure only one thread
+		// at a time can render ImGui
+		std::unique_lock lock(m_imgui_mutex, std::try_to_lock);
+		if (!lock) return;
+
+		callback(this, arg);
+	}
+
+	std::mutex m_imgui_mutex;
+	ImGuiContext* m_imgui_context;
+	char m_file_path[FILENAME_MAX+1];
+	bool m_is_focus;
+	// Using as their own member than integrate may be helpful to bind different plugin at latter change?
+	ImGuiAudio m_audio;
+	ImGuiVideo m_video;
+	overlay_settings m_settings;
+	unsigned int m_lle_flags;
+	// Make them as settings storage.
+	/*bool m_show_fps;
+	bool m_show_LLE_stats;
+	// Make them as memory storage.
+	bool m_show_vertex_stats;
+	bool m_show_audio_stats;
+	*/
+};

--- a/src/core/common/imgui/video.cpp
+++ b/src/core/common/imgui/video.cpp
@@ -12,6 +12,7 @@
 #include "EmuShared.h"
 
 #include "core/kernel/init/CxbxKrnl.h"
+#include "core/hle/D3D8/XbVertexBuffer.h"
 
 bool ImGuiVideo::Initialize()
 {
@@ -27,14 +28,22 @@ void ImGuiVideo::Shutdown()
 void ImGuiVideo::DrawMenu()
 {
 	if (ImGui::BeginMenu("Video")) {
-		ImGui::MenuItem("Show Vertex Stats", NULL, &m_windows.cache_stats_vertex);
+		ImGui::MenuItem("Debug Vertex Buffer Cache Stats", NULL, &m_windows.cache_stats_vertex);
 		ImGui::EndMenu();
 	}
 }
 
 void ImGuiVideo::DrawWidgets(bool is_focus, ImGuiWindowFlags input_handler)
 {
-	//TODO: move into plugin class usage.
-	extern void CxbxImGui_Video_DrawWidgets(bool, ImGuiWindowFlags, bool);
-	CxbxImGui_Video_DrawWidgets(is_focus, input_handler, m_windows.cache_stats_vertex);
+	// Render vertex buffer cache stats
+	if (m_windows.cache_stats_vertex) {
+		ImGui::SetNextWindowPos(ImVec2(IMGUI_MIN_DIST_SIDE, IMGUI_MIN_DIST_TOP), ImGuiCond_FirstUseEver, ImVec2(0.0f, 0.0f));
+		ImGui::SetNextWindowSize(ImVec2(200, 275), ImGuiCond_FirstUseEver);
+		if (ImGui::Begin("Debugging stats", nullptr, input_handler | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysVerticalScrollbar)) {
+			if (ImGui::CollapsingHeader("Vertex Buffer Cache", ImGuiTreeNodeFlags_DefaultOpen)) {
+				VertexBufferConverter.DrawCacheStats();
+			}
+			ImGui::End();
+		}
+	}
 }

--- a/src/core/common/imgui/video.cpp
+++ b/src/core/common/imgui/video.cpp
@@ -1,0 +1,40 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+
+#define LOG_PREFIX CXBXR_MODULE::GUI
+
+#include <thread>
+
+#include "video.hpp"
+#include "ui.hpp"
+
+#include "EmuShared.h"
+
+#include "core/kernel/init/CxbxKrnl.h"
+
+bool ImGuiVideo::Initialize()
+{
+	g_EmuShared->GetImGuiVideoWindows(&m_windows);
+	return true;
+}
+
+void ImGuiVideo::Shutdown()
+{
+	g_EmuShared->SetImGuiVideoWindows(&m_windows);
+}
+
+void ImGuiVideo::DrawMenu()
+{
+	if (ImGui::BeginMenu("Video")) {
+		ImGui::MenuItem("Show Vertex Stats", NULL, &m_windows.cache_stats_vertex);
+		ImGui::EndMenu();
+	}
+}
+
+void ImGuiVideo::DrawWidgets(bool is_focus, ImGuiWindowFlags input_handler)
+{
+	//TODO: move into plugin class usage.
+	extern void CxbxImGui_Video_DrawWidgets(bool, ImGuiWindowFlags, bool);
+	CxbxImGui_Video_DrawWidgets(is_focus, input_handler, m_windows.cache_stats_vertex);
+}

--- a/src/core/common/imgui/video.hpp
+++ b/src/core/common/imgui/video.hpp
@@ -1,0 +1,23 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+#pragma once
+
+#include <imgui.h>
+#include "settings.h"
+
+class ImGuiVideo
+{
+public:
+	ImGuiVideo() = default;
+	virtual ~ImGuiVideo() = default;
+
+	bool Initialize();
+	void Shutdown();
+
+	void DrawMenu();
+	void DrawWidgets(bool is_focus, ImGuiWindowFlags input_handler);
+
+protected:
+	imgui_video_windows m_windows;
+};

--- a/src/core/common/video/RenderBase.cpp
+++ b/src/core/common/video/RenderBase.cpp
@@ -1,0 +1,31 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+//
+// Copyright 2010 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+
+//#define LOG_PREFIX CXBXR_MODULE::GUI
+
+#include <thread>
+
+#include "RenderBase.hpp"
+
+//#include "core/kernel/init/CxbxKrnl.h"
+
+std::unique_ptr<RenderBase> g_renderbase;
+
+bool RenderBase::Initialize()
+{
+	if (!ImGuiUI::Initialize()) {
+		return false;
+	}
+
+	return true;
+}
+
+void RenderBase::Shutdown()
+{
+	ImGuiUI::Shutdown();
+}

--- a/src/core/common/video/RenderBase.cpp
+++ b/src/core/common/video/RenderBase.cpp
@@ -27,5 +27,9 @@ bool RenderBase::Initialize()
 
 void RenderBase::Shutdown()
 {
+	DeviceRelease();
+	m_device_release = std::function<void()>{};
+	WindowRelease();
+	m_window_release = std::function<void()>{};
 	ImGuiUI::Shutdown();
 }

--- a/src/core/common/video/RenderBase.hpp
+++ b/src/core/common/video/RenderBase.hpp
@@ -24,6 +24,28 @@ public:
 	{
 		ImGuiUI::Render(callback, arg);
 	}
+
+	// When video backends has its own class, make DeviceRelease call as virtual requirement for parent class usage.
+	void SetDeviceRelease(const std::function<void()>& func_register) {
+		m_device_release = func_register;
+	}
+
+	void DeviceRelease() {
+		m_device_release();
+	}
+
+	void SetWindowRelease(const std::function<void()>& func_register) {
+		m_window_release = func_register;
+	}
+
+	void WindowRelease() {
+		m_window_release();
+	}
+
+protected:
+
+	std::function<void()> m_device_release;
+	std::function<void()> m_window_release;
 };
 
 extern std::unique_ptr<RenderBase> g_renderbase;

--- a/src/core/common/video/RenderBase.hpp
+++ b/src/core/common/video/RenderBase.hpp
@@ -1,0 +1,29 @@
+// Copyright 2021 Cxbx-Reloaded Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+//
+// Copyright 2010 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the COPYING file included.
+
+#pragma once
+
+#include "../imgui/ui.hpp"
+
+class RenderBase : public ImGuiUI
+{
+public:
+	RenderBase() = default;
+	virtual ~RenderBase() = default;
+
+	virtual bool Initialize();
+	virtual void Shutdown();
+
+	template<class C, class T>
+	void Render(std::function<void(C, T)> callback, T arg)
+	{
+		ImGuiUI::Render(callback, arg);
+	}
+};
+
+extern std::unique_ptr<RenderBase> g_renderbase;

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1966,7 +1966,7 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
             else if (wParam == VK_F3)
             {
                 g_bClipCursor = !g_bClipCursor;
-                g_EmuShared->SetClipCursorFlag(&g_bClipCursor);
+                g_EmuShared->SetClipCursorFlag(g_bClipCursor);
 
                 if (g_bClipCursor) {
                     CxbxClipCursor(hWnd);

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -128,8 +128,6 @@ static size_t                       g_QuadToTriangleHostIndexBuffer_Size = 0; //
 static INDEX16                     *g_pQuadToTriangleIndexData = nullptr;
 static size_t                       g_QuadToTriangleIndexData_Size = 0; // = NrOfQuadIndices
 
-static CxbxVertexBufferConverter VertexBufferConverter = {};
-
 struct {
 	xbox::X_D3DSurface Surface;
 	RECT SrcRect;
@@ -185,21 +183,6 @@ float g_Xbox_BackbufferScaleX = 1;
 float g_Xbox_BackbufferScaleY = 1;
 
 static constexpr size_t INDEX_BUFFER_CACHE_SIZE = 10000;
-
-// ImGui
-void CxbxImGui_Video_DrawWidgets(bool is_focus, ImGuiWindowFlags input_handler, bool show_vertex_stats)
-{
-	if (show_vertex_stats) {
-		ImGui::SetNextWindowPos(ImVec2(IMGUI_MIN_DIST_SIDE, IMGUI_MIN_DIST_TOP), ImGuiCond_FirstUseEver, ImVec2(0.0f, 0.0f));
-		ImGui::SetNextWindowSize(ImVec2(200, 275), ImGuiCond_FirstUseEver);
-		if (ImGui::Begin("Debugging stats", nullptr, input_handler | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysVerticalScrollbar)) {
-			if (ImGui::CollapsingHeader("Vertex Buffers", ImGuiTreeNodeFlags_DefaultOpen)) {
-				VertexBufferConverter.ShowImGuiStats();
-			}
-			ImGui::End();
-		}
-	}
-}
 
 static void CxbxImGui_RenderD3D9(ImGuiUI* m_imgui, IDirect3DSurface9* renderTarget)
 {

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -186,11 +186,22 @@ float g_Xbox_BackbufferScaleY = 1;
 static constexpr size_t INDEX_BUFFER_CACHE_SIZE = 10000;
 
 // ImGui
+static bool imGuiShown = false;
 static void CxbxImGui_DrawWidgets()
 {
+	if (!imGuiShown) return;
+
 	// Put all ImGui drawing here
 
-	ImGui::ShowDemoWindow();
+	constexpr float DIST_FROM_CORNER = 10.0f;
+	ImGui::SetNextWindowPos(ImVec2(DIST_FROM_CORNER, DIST_FROM_CORNER), ImGuiCond_Once, ImVec2(0.0f, 0.0f));
+	ImGui::SetNextWindowSize(ImVec2(200, 275), ImGuiCond_Once);
+	if (ImGui::Begin("Debugging stats", &imGuiShown, ImGuiWindowFlags_NoCollapse|ImGuiWindowFlags_AlwaysVerticalScrollbar)) {
+		if (ImGui::CollapsingHeader("Vertex Buffers", ImGuiTreeNodeFlags_DefaultOpen)) {
+			VertexBufferConverter.ShowImGuiStats();
+		}
+		ImGui::End();
+	}
 }
 
 static std::mutex imGuiMutex;
@@ -1946,10 +1957,7 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
             }
             else if (wParam == VK_F1)
             {
-                VertexBufferConverter.PrintStats();
-
-                extern void DSound_PrintStats(); //TODO: move into plugin class usage.
-                DSound_PrintStats();
+                imGuiShown = !imGuiShown;
             }
 			else if (wParam == VK_F2)
 			{
@@ -1967,6 +1975,11 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
                     CxbxReleaseCursor();
                 }
             }
+			else if (wParam == VK_F4)
+			{
+                extern void DSound_PrintStats(); //TODO: move into plugin class usage.
+                DSound_PrintStats();
+			}
             else if (wParam == VK_F6)
             {
                 // For some unknown reason, F6 isn't handled in WndMain::WndProc

--- a/src/core/hle/D3D8/Direct3D9/WalkIndexBuffer.h
+++ b/src/core/hle/D3D8/Direct3D9/WalkIndexBuffer.h
@@ -1,7 +1,7 @@
 #ifndef WALKINDEXBUFFER_H
 #define WALKINDEXBUFFER_H
 
-#include "core\kernel\support\Emu.h"
+#include "core/hle/D3D8/XbD3D8Types.h"
 
 extern void(*WalkIndexBuffer)
 (

--- a/src/core/hle/D3D8/XbD3D8Types.h
+++ b/src/core/hle/D3D8/XbD3D8Types.h
@@ -83,6 +83,8 @@
 #define IDirect3DSwapChain              IDirect3DSwapChain9
 #define IDirect3DQuery                  IDirect3DQuery9
 
+typedef xbox::word_xt INDEX16; // TODO: Move INDEX16 into xbox namespace
+
 namespace xbox {
 
 // TODO : Declare these aliasses as Xbox type

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -38,6 +38,8 @@
 #include "core\hle\D3D8\XbVertexBuffer.h"
 #include "core\hle\D3D8\XbConvert.h"
 
+#include <imgui.h>
+
 #include <ctime>
 #include <chrono>
 #include <algorithm>
@@ -215,12 +217,11 @@ CxbxPatchedStream& CxbxVertexBufferConverter::GetPatchedStream(uint64_t dataKey,
     return stream;
 }
 
-void CxbxVertexBufferConverter::PrintStats()
+void CxbxVertexBufferConverter::ShowImGuiStats()
 {
-    printf("Vertex Buffer Cache Status: \n");
-    printf("- Cache Size: %d\n", m_PatchedStreams.size());
-    printf("- Hits: %d\n", m_TotalCacheHits);
-    printf("- Misses: %d\n", m_TotalCacheMisses);
+	ImGui::Text("Cache Size: %u", m_PatchedStreams.size());
+	ImGui::Text("Hits: %u", std::exchange(m_TotalCacheHits, 0));
+	ImGui::Text("Misses: %u", std::exchange(m_TotalCacheMisses, 0));
 }
 
 void CxbxVertexBufferConverter::ConvertStream

--- a/src/core/hle/D3D8/XbVertexBuffer.cpp
+++ b/src/core/hle/D3D8/XbVertexBuffer.cpp
@@ -46,6 +46,8 @@
 
 #define MAX_STREAM_NOT_USED_TIME (2 * CLOCKS_PER_SEC) // TODO: Trim the not used time
 
+CxbxVertexBufferConverter VertexBufferConverter = {};
+
 // Inline vertex buffer emulation
 xbox::X_D3DPRIMITIVETYPE      g_InlineVertexBuffer_PrimitiveType = xbox::X_D3DPT_INVALID;
 uint32_t                      g_InlineVertexBuffer_WrittenRegisters = 0; // A bitmask, indicating which registers have been set in g_InlineVertexBuffer_Table
@@ -218,7 +220,7 @@ CxbxPatchedStream& CxbxVertexBufferConverter::GetPatchedStream(uint64_t dataKey,
     return stream;
 }
 
-void CxbxVertexBufferConverter::ShowImGuiStats()
+void CxbxVertexBufferConverter::DrawCacheStats()
 {
 	const ULONG falsePositives = std::exchange(m_TotalLookupSuccesses, 0) - m_TotalCacheHits;
 	const ULONG totalMisses = m_VertexStreamHashMisses + m_DataNotInCacheMisses;

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -78,7 +78,7 @@ class CxbxVertexBufferConverter
     public:
         CxbxVertexBufferConverter() = default;
         void Apply(CxbxDrawContext *pPatchDesc);
-        void PrintStats();
+        void ShowImGuiStats();
     private:
         struct StreamKey
         {

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -78,7 +78,7 @@ class CxbxVertexBufferConverter
     public:
         CxbxVertexBufferConverter() = default;
         void Apply(CxbxDrawContext *pPatchDesc);
-        void ShowImGuiStats();
+        void DrawCacheStats();
     private:
         struct StreamKey
         {
@@ -115,6 +115,8 @@ class CxbxVertexBufferConverter
         // Patches the types of the stream
         void ConvertStream(CxbxDrawContext *pPatchDesc, CxbxVertexDeclaration* pCxbxVertexDeclaration, UINT uiStream);
 };
+
+extern CxbxVertexBufferConverter VertexBufferConverter;
 
 // Inline vertex buffer emulation
 extern xbox::X_D3DPRIMITIVETYPE      g_InlineVertexBuffer_PrimitiveType;

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -99,7 +99,9 @@ class CxbxVertexBufferConverter
 
         // Stack tracking
         ULONG m_TotalCacheHits = 0;
-        ULONG m_TotalCacheMisses = 0;
+        ULONG m_TotalLookupSuccesses = 0;
+        ULONG m_VertexStreamHashMisses = 0;
+        ULONG m_DataNotInCacheMisses = 0;
 
         const UINT m_MaxCacheSize = 10000;                                        // Maximum number of entries in the cache
         const UINT m_CacheElasticity = 200;                                      // Cache is allowed to grow this much more than maximum before being purged to maximum

--- a/src/core/hle/D3D8/XbVertexBuffer.h
+++ b/src/core/hle/D3D8/XbVertexBuffer.h
@@ -40,7 +40,7 @@ typedef struct _CxbxDrawContext
     IN     DWORD                 dwStartVertex; // Only D3DDevice_DrawVertices sets this (potentially higher than default 0)
 	IN	   PWORD				 pXboxIndexData; // Set by D3DDevice_DrawIndexedVertices, D3DDevice_DrawIndexedVerticesUP and HLE_draw_inline_elements
 	IN	   DWORD				 dwBaseVertexIndex; // Set to g_Xbox_BaseVertexIndex in D3DDevice_DrawIndexedVertices
-	IN	   INDEX16				 LowIndex, HighIndex; // Set when pXboxIndexData is set
+	IN	   INDEX16               LowIndex, HighIndex; // Set when pXboxIndexData is set
 	IN	   UINT 				 NumVerticesToUse; // Set by CxbxVertexBufferConverter::Apply
     // Data if Draw...UP call
     IN PVOID                     pXboxVertexStreamZeroData;

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -495,6 +495,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 
 	case ReturnFirmwareReboot:
 		LOG_UNIMPLEMENTED(); // fall through
+		[[fallthrough]];
 	case ReturnFirmwareQuickReboot:
 	{
 		if (xbox::LaunchDataPage == NULL)

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -496,8 +496,9 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 		break;
 
 	case ReturnFirmwareReboot:
-		LOG_UNIMPLEMENTED(); // fall through
+		LOG_UNIMPLEMENTED();
 		[[fallthrough]];
+
 	case ReturnFirmwareQuickReboot:
 	{
 		if (xbox::LaunchDataPage == NULL)

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -488,6 +488,8 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 {
 	LOG_FUNC_ONE_ARG(Routine);
 
+	bool is_reboot = false;
+
 	switch (Routine) {
 	case ReturnFirmwareHalt:
 		CxbxKrnlCleanup("Emulated Xbox is halted");
@@ -586,6 +588,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 				g_EmuShared->GetBootFlags(&QuickReboot);
 				QuickReboot |= BOOT_QUICK_REBOOT;
 				g_EmuShared->SetBootFlags(&QuickReboot);
+				is_reboot = true;
 
 				g_VMManager.SavePersistentMemory();
 
@@ -666,7 +669,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 		LOG_UNIMPLEMENTED();
 	}
 
-	EmuShared::Cleanup();
+	CxbxKrnlShutDown(is_reboot);
 	TerminateProcess(GetCurrentProcess(), EXIT_SUCCESS);
 }
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -53,6 +53,7 @@
 #include "common/ReserveAddressRanges.h"
 #include "common/xbox/Types.hpp"
 #include "common/win32/WineEnv.h"
+#include <imgui.h>
 
 #include <clocale>
 #include <process.h>
@@ -1156,6 +1157,17 @@ void CxbxKrnlEmulate(unsigned int reserved_systems, blocks_reserved_t blocks_res
 	}
 
 	g_ExceptionManager = new ExceptionManager(); // If in need to add VEHs, move this line earlier. (just in case)
+
+	// Initialize ImGui
+	{
+		IMGUI_CHECKVERSION();
+        ImGui::CreateContext();
+
+        ImGuiIO& io = ImGui::GetIO();
+        io.IniFilename = nullptr;
+
+        ImGui::StyleColorsDark();
+	}
 
 	// Launch the XBE :
 	{

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1158,17 +1158,6 @@ void CxbxKrnlEmulate(unsigned int reserved_systems, blocks_reserved_t blocks_res
 
 	g_ExceptionManager = new ExceptionManager(); // If in need to add VEHs, move this line earlier. (just in case)
 
-	// Initialize ImGui
-	{
-		IMGUI_CHECKVERSION();
-        ImGui::CreateContext();
-
-        ImGuiIO& io = ImGui::GetIO();
-        io.IniFilename = nullptr;
-
-        ImGui::StyleColorsDark();
-	}
-
 	// Launch the XBE :
 	{
 		// Load TLS

--- a/src/core/kernel/init/CxbxKrnl.h
+++ b/src/core/kernel/init/CxbxKrnl.h
@@ -166,7 +166,7 @@ void CxbxKrnlSuspend();
 void CxbxKrnlResume();
 
 /*! terminate gracefully the emulation */
-void CxbxKrnlShutDown();
+void CxbxKrnlShutDown(bool is_reboot = false);
 
 /*! display the fatal error message*/
 void CxbxKrnlPrintUEM(ULONG ErrorCode);

--- a/src/core/kernel/support/Emu.h
+++ b/src/core/kernel/support/Emu.h
@@ -87,8 +87,6 @@ typedef struct DUMMY_KERNEL
 	IMAGE_SECTION_HEADER SectionHeader;
 } *PDUMMY_KERNEL;
 
-typedef WORD INDEX16;
-
 extern bool g_DisablePixelShaders;
 extern bool g_UseAllCores;
 extern bool g_SkipRdtscPatching;

--- a/src/devices/video/EmuNV2A_PGRAPH.cpp
+++ b/src/devices/video/EmuNV2A_PGRAPH.cpp
@@ -705,6 +705,23 @@ void OpenGL_draw_inline_elements(NV2AState *d)
 	OpenGL_draw_end(d);
 }
 
+static void CxbxImGui_RenderOpenGL(ImGuiUI* m_imgui, std::nullptr_t unused)
+{
+	ImGui_ImplOpenGL3_NewFrame();
+	ImGui_ImplWin32_NewFrame();
+	ImGui::NewFrame();
+
+	m_imgui->DrawMenu();
+	m_imgui->DrawWidgets();
+
+	ImGui::Render();
+
+	ImDrawData* drawData = ImGui::GetDrawData();
+	if (drawData->TotalVtxCount > 0) {
+		ImGui_ImplOpenGL3_RenderDrawData(drawData);
+	}
+}
+
 void OpenGL_draw_state_update(NV2AState *d)
 {
 	PGRAPHState *pg = &d->pgraph;
@@ -893,6 +910,10 @@ void OpenGL_draw_state_update(NV2AState *d)
 			pg->gl_zpass_pixel_count_query_count - 1] = gl_query;
 		glBeginQuery(GL_SAMPLES_PASSED, gl_query);
 	}
+
+	// Render ImGui
+	static std::function<void(ImGuiUI*, std::nullptr_t)> internal_render = &CxbxImGui_RenderOpenGL;
+	g_renderbase->Render(internal_render, nullptr);
 }
 
 void OpenGL_draw_end(NV2AState *d)
@@ -2988,6 +3009,10 @@ void pgraph_init(NV2AState *d)
 #endif
 
     glextensions_init();
+
+	// ImGui
+	//ImGui_ImplSDL2_InitForOpenGL(window, pg->gl_context);
+	ImGui_ImplOpenGL3_Init();
 
     /* DXT textures */
     assert(glo_check_extension("GL_EXT_texture_compression_s3tc"));

--- a/src/devices/video/EmuNV2A_PGRAPH.cpp
+++ b/src/devices/video/EmuNV2A_PGRAPH.cpp
@@ -3010,9 +3010,12 @@ void pgraph_init(NV2AState *d)
 
     glextensions_init();
 
-	// ImGui
+	// Set up ImGui's render backend
 	//ImGui_ImplSDL2_InitForOpenGL(window, pg->gl_context);
 	ImGui_ImplOpenGL3_Init();
+	g_renderbase->SetDeviceRelease([] {
+		ImGui_ImplOpenGL3_Shutdown();
+	});
 
     /* DXT textures */
     assert(glo_check_extension("GL_EXT_texture_compression_s3tc"));

--- a/src/devices/video/nv2a.cpp
+++ b/src/devices/video/nv2a.cpp
@@ -37,7 +37,6 @@
 
 #define LOG_PREFIX CXBXR_MODULE::NV2A
 
-
 #include <core/kernel/exports/xboxkrnl.h> // For PKINTERRUPT, etc.
 
 #ifdef _MSC_VER                         // Check if MS Visual C compiler
@@ -53,6 +52,9 @@
 #include "core\kernel\init\CxbxKrnl.h" // For XBOX_MEMORY_SIZE, DWORD, etc
 #include "core\kernel\support\Emu.h"
 #include "core\kernel\exports\EmuKrnl.h"
+#include <backends/imgui_impl_win32.h>
+#include <backends/imgui_impl_opengl3.h>
+#include "core/common/video/RenderBase.hpp"
 #include "core\hle\Intercept.hpp"
 #include "common/win32/Threads.h"
 #include "Logging.h"
@@ -1157,6 +1159,11 @@ NV2ADevice::NV2ADevice()
 NV2ADevice::~NV2ADevice()
 {
 	Reset(); // TODO : Review this
+
+	ImGui_ImplOpenGL3_Shutdown();
+	ImGui_ImplWin32_Shutdown();
+	g_renderbase->Shutdown();
+
 	delete m_nv2a_state;
 }
 

--- a/src/devices/video/nv2a.cpp
+++ b/src/devices/video/nv2a.cpp
@@ -1160,9 +1160,7 @@ NV2ADevice::~NV2ADevice()
 {
 	Reset(); // TODO : Review this
 
-	ImGui_ImplOpenGL3_Shutdown();
-	ImGui_ImplWin32_Shutdown();
-	g_renderbase->Shutdown();
+	g_renderbase->DeviceRelease();
 
 	delete m_nv2a_state;
 }

--- a/src/gui/DlgInputConfig.cpp
+++ b/src/gui/DlgInputConfig.cpp
@@ -74,9 +74,7 @@ void SyncInputSettings(int port_num, int dev_type, bool is_opt)
 			}
 		}
 		else {
-			g_EmuShared->SetInputMoAxisSettings(g_Settings->m_input_general.MoAxisRange);
-			g_EmuShared->SetInputMoWheelSettings(g_Settings->m_input_general.MoWheelRange);
-			g_EmuShared->SetInputKbMoUnfocusSettings(g_Settings->m_input_general.IgnoreKbMoUnfocus);
+			g_EmuShared->SetInputGeneralSettings(&g_Settings->m_input_general);
 			port_num = PORT_INVALID;
 		}
 #if 0 // lle usb

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -2330,7 +2330,7 @@ void WndMain::StartEmulation(HWND hwndParent, DebuggerState LocalDebuggerState /
 		}
 
 		bool AttachLocalDebugger = (LocalDebuggerState == debuggerOn);
-		g_EmuShared->SetDebuggingFlag(&AttachLocalDebugger);
+		g_EmuShared->SetDebuggingFlag(AttachLocalDebugger);
 
         /* Main process to generate emulation command line begin. */
         // If we are adding more arguments, this is the place to do so.

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -360,6 +360,8 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 						DrawLedBitmap(hwnd, true);
 					}
 				}
+				break;
+
 				case WM_COMMAND:
 				{
 					switch (HIWORD(wParam)) {

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -387,6 +387,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 							g_EmuShared->SetIsReady(true);
 						}
 						break;
+
 						case ID_GUI_STATUS_OVERLAY:
 							g_EmuShared->GetOverlaySettings(&g_Settings->m_overlay);
 							break;

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -387,6 +387,9 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 							g_EmuShared->SetIsReady(true);
 						}
 						break;
+						case ID_GUI_STATUS_OVERLAY:
+							g_EmuShared->GetOverlaySettings(&g_Settings->m_overlay);
+							break;
 					}
 				}
 				break;

--- a/src/gui/resource/ResCxbx.h
+++ b/src/gui/resource/ResCxbx.h
@@ -196,6 +196,7 @@
 #define ID_GUI_STATUS_LOG_ENABLED       1099
 #define IDC_AC_MUTE_WHEN_UNFOCUS        1100
 #define IDC_IGNORE_KBMO_UNFOCUS         1101
+#define ID_GUI_STATUS_OVERLAY           1102
 #define IDC_XBOX_PORT_0                 1158
 #define IDC_XBOX_PORT_1                 1166
 #define IDC_XBOX_PORT_2                 1174


### PR DESCRIPTION
**NOTICE: Any new features will be require put into later pull request.**

Currently open for review remarks at the moment.

---

Basic ImGui introduction support into Cxbx-Reloaded.
close #767

The code is partially obtained from Dolphin emulator's source code.

Following features has been implemented:
* Render backends:
  * Direct3D9
  * OpenGL
* Overlay:
  * Main menu bar
  * FPS
  * HLE/LLE stats
  * Vertex Buffer (was from console prints)
  * Audio Buffer Cache (was from console prints)
* Ability to remember windows last position in memory and file (currently disabled) on start and restart of emulation.
*  F1 permanent hotkey to toggle overlay view, any opened windows will remain open.
   * Also will be remembered to keep ImGui focus as well.

With F1 hotkey toggle to show our ImGui overlay, all inputs into the title are ignored.

It also contain few minor bugfixes from inputs' side.

While working on imgui tasks, I found several issues with rendering ImGui which will be create as separate ticket.
