### PR TITLE
Convert STENCILFAIL

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/RenderStates.cpp
@@ -435,11 +435,13 @@ void XboxRenderStateConverter::ApplyComplexRenderState(uint32_t State, uint32_t 
         case xbox::X_D3DRS_NORMALIZENORMALS:
         case xbox::X_D3DRS_ZENABLE:
         case xbox::X_D3DRS_STENCILENABLE:
-        case xbox::X_D3DRS_STENCILFAIL:
         case xbox::X_D3DRS_TEXTUREFACTOR:
         case xbox::X_D3DRS_EDGEANTIALIAS:
         case xbox::X_D3DRS_MULTISAMPLEANTIALIAS:
         case xbox::X_D3DRS_MULTISAMPLEMASK:
+            break;
+        case xbox::X_D3DRS_STENCILFAIL:
+            Value = EmuXB2PC_D3DSTENCILOP(Value);
             break;
         case xbox::X_D3DRS_MULTISAMPLETYPE:
             SetXboxMultiSampleType(Value);


### PR DESCRIPTION
Improves shadows in DoA3

before:
![image](https://user-images.githubusercontent.com/9897874/113479746-40c8e600-94ed-11eb-80c8-cca698307233.png)

after:
![image](https://user-images.githubusercontent.com/9897874/113479751-46263080-94ed-11eb-8c2b-759fa4b66f24.png)
