### PR TITLE
HOTFIX: remove optimization due to AND bit operator does not keep in order

### DIFF
--- a/src/common/input/InputManager.cpp
+++ b/src/common/input/InputManager.cpp
@@ -363,7 +363,7 @@ bool InputDeviceManager::UpdateXboxPortInput(int usb_port, void* Buffer, int Dir
 
 	// First check if ImGui is focus, then ignore any input update occur.
 	// If somebody else is currently holding the lock, we won't wait and instead report no input changes
-	if (static_cast<uint8_t>(!g_renderbase->IsImGuiFocus()) & static_cast<uint8_t>(m_Mtx.try_lock())) {
+	if (!g_renderbase->IsImGuiFocus() && m_Mtx.try_lock()) {
 		for (auto &dev_ptr : m_Devices) {
 			if (dev_ptr->GetPort(usb_port)) {
 				switch (xid_type)


### PR DESCRIPTION


From optimized code for with AND bit operator in assembly is:
```asm
7B833B6C 32 DB                xor         bl,bl  
7B833B6E 68 A4 B4 CE 7B       push        7BCEB4A4h  
7B833B73 88 5D F3             mov         byte ptr [ebp-0Dh],bl  
7B833B76 FF 15 44 15 BA 7B    call        dword ptr [__imp___Mtx_trylock (7BBA1544h)]  
7B833B7C 83 C4 04             add         esp,4  
7B833B7F 85 C0                test        eax,eax  
7B833B81 74 10                je          InputDeviceManager::UpdateXboxPortInput+43h (7B833B93h)  
7B833B83 83 F8 03             cmp         eax,3  
7B833B86 0F 84 13 01 00 00    je          InputDeviceManager::UpdateXboxPortInput+14Fh (7B833C9Fh)  
7B833B8C 50                   push        eax  
7B833B8D FF 15 28 15 BA 7B    call        dword ptr [__imp_std::_Throw_C_error (7BBA1528h)]  
7B833B93 A1 4C B4 D5 7B       mov         eax,dword ptr [g_renderbase (7BD5B44Ch)]  
7B833B98 38 98 3D 01 00 00    cmp         byte ptr [eax+13Dh],bl  
7B833B9E 0F 85 FB 00 00 00    jne         InputDeviceManager::UpdateXboxPortInput+14Fh (7B833C9Fh) 
```
Which you can see trylock is called first before check ImGui is focus or not. When it should check ImGui is focus first. This pull request resolve the issue from #2174.