### PR TITLE
Fixed function pixel shader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ file (GLOB CXBXR_HEADER_EMU
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/Direct3D9.h"
+ "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl"
+ "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShader.hlsl"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShaderState.hlsli"
  "${CXBXR_ROOT_DIR}/src/core/hle/D3D8/Direct3D9/PixelShader.h"
@@ -446,6 +448,8 @@ install(FILES ${cxbxr_INSTALL_files}
 
 install(FILES
  "${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl"
+ "${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl"
+ "${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli"
  "${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShaderState.hlsli"
  "${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShader.hlsl"
  DESTINATION bin/hlsl

--- a/projects/misc/batch.cmake
+++ b/projects/misc/batch.cmake
@@ -32,6 +32,8 @@ file(COPY ${CXBXR_GLEW_DLL} DESTINATION  ${TargetRunTimeDir})
 set(CXBXR_HLSL_FILES
 "${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShaderState.hlsli"
 "${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShader.hlsl"
+"${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli"
+"${CMAKE_SOURCE_DIR}/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl"
 )
 set(HlslOutputDir ${TargetRunTimeDir}/hlsl)
 file(MAKE_DIRECTORY ${HlslOutputDir})

--- a/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxVertexShaderTemplate.hlsl
@@ -28,9 +28,6 @@ struct VS_OUTPUT // Declared identical to pixel shader input (see PS_INPUT)
 // Xbox constant registers
 uniform float4 C[X_D3DVS_CONSTREG_COUNT] : register(c0);
 
-// Parameters for mapping the shader's fog output value to a fog factor
-uniform float4  CxbxFogInfo: register(c218); // = CXBX_D3DVS_CONSTREG_FOGINFO
-
 // Default values for vertex registers, and whether to use them
 uniform float4 vRegisterDefaultValues[16]  : register(c192);
 uniform float4 vRegisterDefaultFlagsPacked[4]  : register(c208);
@@ -39,6 +36,9 @@ uniform float4 xboxScreenspaceScale : register(c212);
 uniform float4 xboxScreenspaceOffset : register(c213);
 
 uniform float4 xboxTextureScale[4] : register(c214);
+
+// Parameters for mapping the shader's fog output value to a fog factor
+uniform float4  CxbxFogInfo: register(c218); // = CXBX_D3DVS_CONSTREG_FOGINFO
 
 // Overloaded casts, assuring all inputs are treated as float4
 float4 _tof4(float  src) { return float4(src, src, src, src); }
@@ -329,6 +329,8 @@ R"DELIMITER(
 	// Copy variables to output struct
     VS_OUTPUT xOut;
 
+	// Fogging
+	// TODO deduplicate
 	const float fogDepth      =   abs(oFog.x); 
 	const float fogTableMode  =   CxbxFogInfo.x;
 	const float fogDensity    =   CxbxFogInfo.y;
@@ -348,7 +350,7 @@ R"DELIMITER(
     if(fogTableMode == FOG_TABLE_EXP2) 
        fogFactor = 1 / exp(pow(fogDepth * fogDensity, 2)); /* / 1 / e^((d * density)^2)*/
     if(fogTableMode == FOG_TABLE_LINEAR) 
-       fogFactor = (fogEnd - fogDepth) / (fogEnd - fogStart) ;
+       fogFactor = (fogEnd - fogDepth) / (fogEnd - fogStart);
        
 	xOut.oPos = reverseScreenspaceTransform(oPos);
 	xOut.oD0 = saturate(oD0);

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -1966,7 +1966,7 @@ static LRESULT WINAPI EmuMsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
             }
 			else if (wParam == VK_F2)
 			{
-				g_UseFixedFunctionVertexShader = !g_UseFixedFunctionVertexShader;
+				g_UseFixedFunctionPixelShader = !g_UseFixedFunctionPixelShader;
 			}
             else if (wParam == VK_F3)
             {
@@ -6414,11 +6414,6 @@ void UpdateFixedFunctionShaderLight(int d3dLightIndex, Light* pShaderLight, D3DX
 	pShaderLight->SpotIntensityDivisor = cos(d3dLight->Theta / 2) - cos(d3dLight->Phi / 2);
 }
 
-float AsFloat(uint32_t value) {
-	auto v = value;
-	return *(float*)&v;
-}
-
 void UpdateFixedFunctionVertexShaderState()
 {
 	extern xbox::X_VERTEXATTRIBUTEFORMAT* GetXboxVertexAttributeFormat(); // TMP glue
@@ -6506,8 +6501,7 @@ void UpdateFixedFunctionVertexShaderState()
 	// FIXME remove when fixed function PS is implemented
 	// Note if we are using the fixed function pixel shader
 	// We only want to produce the fog depth value in the VS, not the fog factor
-	auto psIsFixedFunction = g_pXbox_PixelShader == nullptr;
-	ffShaderState.Fog.TableMode = psIsFixedFunction ? D3DFOG_NONE : fogTableMode;
+	ffShaderState.Fog.TableMode = !g_UseFixedFunctionPixelShader ? D3DFOG_NONE : fogTableMode;
 
 	// Determine how fog depth is calculated
 	if (fogEnable && fogTableMode != D3DFOG_NONE) {

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6456,7 +6456,11 @@ void UpdateFixedFunctionVertexShaderState()
 	}
 
 	// Lighting
-	ffShaderState.Modes.Lighting = (float)XboxRenderStates.GetXboxRenderState(X_D3DRS_LIGHTING);
+	// Point sprites aren't lit - 'each point is always rendered with constant colors.'
+	// https://docs.microsoft.com/en-us/windows/win32/direct3d9/point-sprites
+	bool PointSpriteEnable = XboxRenderStates.GetXboxRenderState(X_D3DRS_POINTSPRITEENABLE);
+	bool LightingEnable = XboxRenderStates.GetXboxRenderState(X_D3DRS_LIGHTING);
+	ffShaderState.Modes.Lighting = LightingEnable && !PointSpriteEnable;
 	ffShaderState.Modes.TwoSidedLighting = (float)XboxRenderStates.GetXboxRenderState(X_D3DRS_TWOSIDEDLIGHTING);
 	ffShaderState.Modes.LocalViewer = (float)XboxRenderStates.GetXboxRenderState(X_D3DRS_LOCALVIEWER);
 
@@ -6472,7 +6476,6 @@ void UpdateFixedFunctionVertexShaderState()
 	ffShaderState.Modes.BackEmissiveMaterialSource = (float)(ColorVertex ? XboxRenderStates.GetXboxRenderState(X_D3DRS_BACKEMISSIVEMATERIALSOURCE) : D3DMCS_MATERIAL);
 
 	// Point sprites; Fetch required variables
-	bool PointSpriteEnable = XboxRenderStates.GetXboxRenderState(X_D3DRS_POINTSPRITEENABLE);
 	float pointSize = XboxRenderStates.GetXboxRenderStateAsFloat(X_D3DRS_POINTSIZE);
 	float pointSize_Min = XboxRenderStates.GetXboxRenderStateAsFloat(X_D3DRS_POINTSIZE_MIN);
 	float pointSize_Max = XboxRenderStates.GetXboxRenderStateAsFloat(X_D3DRS_POINTSIZE_MAX);

--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
@@ -174,16 +174,16 @@ TextureArgs ExecuteTextureStage(
 	}
 
 	// Sample the texture
-	float4 t = float4(1, 1, 1, 1);
-	if (stage.IsTextureSet) {
-		int type = TextureSampleType[i];
-		if (type == SAMPLE_2D)
-			t = tex2D(samplers[i], TexCoords[i].xy + offset.xy);
-		else if (type == SAMPLE_3D)
-			t = tex3D(samplers[i], TexCoords[i].xyz + offset.xyz);
-		else if (type == SAMPLE_CUBE)
-			t = texCUBE(samplers[i], TexCoords[i].xyz + offset.xyz);
-	}
+	float4 t;
+	int type = TextureSampleType[i];
+	if (type == SAMPLE_NONE)
+		t = 1; // Test case JSRF
+	else if (type == SAMPLE_2D)
+		t = tex2D(samplers[i], TexCoords[i].xy + offset.xy);
+	else if (type == SAMPLE_3D)
+		t = tex3D(samplers[i], TexCoords[i].xyz + offset.xyz);
+	else if (type == SAMPLE_CUBE)
+		t = texCUBE(samplers[i], TexCoords[i].xyz + offset.xyz);
 
 	// Assign the final value for TEXTURE
 	ctx.TEXTURE = t * factor;

--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
@@ -1,0 +1,288 @@
+#include "FixedFunctionPixelShader.hlsli"
+
+uniform FixedFunctionPixelShaderState state : register(c0);
+sampler samplers[4] : register(s0);
+
+struct PS_INPUT // Declared identical to vertex shader output (see VS_OUTPUT)
+{
+	float2 iPos : VPOS;   // Screen space x,y pixel location
+	float4 iD0  : COLOR0; // Front-facing primary (diffuse) vertex color (clamped to 0..1)
+	float4 iD1  : COLOR1; // Front-facing secondary (specular) vertex color (clamped to 0..1)
+	float  iFog : FOG;
+	float  iPts : PSIZE;
+	float4 iB0  : TEXCOORD4; // Back-facing primary (diffuse) vertex color (clamped to 0..1)
+	float4 iB1  : TEXCOORD5; // Back-facing secondary (specular) vertex color (clamped to 0..1)
+	float4 iT[4]  : TEXCOORD0; // Texture Coord 0
+	float  iFF : VFACE; // Front facing if > 0
+};
+
+// These 'D3DTA' texture argument values
+// may be used during each texture stage
+struct TextureArgs {
+	float4 CURRENT;
+	float4 TEXTURE;
+	float4 DIFFUSE;
+	float4 SPECULAR;
+	float4 TEMP;
+	float4 TFACTOR;
+};
+
+static float4 TexCoords[4];
+
+// When creating an instance of the fixed function shader
+// we string-replace the assignment below with a value
+// The define keeps the shader compilable without the replacement
+#define TEXTURE_SAMPLE_TYPE {SAMPLE_2D, SAMPLE_2D, SAMPLE_2D, SAMPLE_2D};
+static int TextureSampleType[4] = TEXTURE_SAMPLE_TYPE;
+
+bool HasFlag(float value, float flag) {
+	// http://theinstructionlimit.com/encoding-boolean-flags-into-a-float-in-hlsl
+	return fmod(value, flag) >= flag / 2;
+}
+
+float4 GetArg(float arg, TextureArgs ctx) {
+	// https://docs.microsoft.com/en-us/windows/win32/direct3d9/d3dta
+	bool alphaReplicate = HasFlag(arg, X_D3DTA_ALPHAREPLICATE);
+	bool complement = HasFlag(arg, X_D3DTA_COMPLEMENT);
+	arg = arg % 16;
+
+	float4 o;
+
+	if (arg == X_D3DTA_DIFFUSE)
+		o = ctx.DIFFUSE;
+	if (arg == X_D3DTA_CURRENT)
+		o = ctx.CURRENT;
+	if (arg == X_D3DTA_TEXTURE)
+		o = ctx.TEXTURE;
+	if (arg == X_D3DTA_TFACTOR)
+		o = ctx.TFACTOR;
+	if (arg == X_D3DTA_SPECULAR)
+		o = ctx.SPECULAR;
+	if (arg == X_D3DTA_TEMP)
+		o = ctx.TEMP;
+
+	if (alphaReplicate)
+		return o.aaaa;
+	else if (complement)
+		return 1 - o;
+	else
+		return o;
+}
+
+float4 ExecuteTextureOp(float op, float4 arg1, float4 arg2, float4 arg0, TextureArgs ctx, PsTextureStageState stage) {
+	// https://docs.microsoft.com/en-us/windows/win32/direct3d9/d3dtextureop
+
+	// Note if we use ifs here instead of else if
+	// D3DCompile may stackoverflow at runtime
+
+	// X_D3DTOP_DISABLE can only be reached by ALPHAOP
+	// It's documented as undefined behaviour
+	// Test case: DoA:Xtreme menu
+	if (op == X_D3DTOP_DISABLE)
+		return ctx.CURRENT;
+	else if (op == X_D3DTOP_SELECTARG1)
+		return arg1;
+	else if (op == X_D3DTOP_SELECTARG2)
+		return arg2;
+	else if (op == X_D3DTOP_MODULATE)
+		return arg1 * arg2;
+	else if (op == X_D3DTOP_MODULATE2X)
+		return 2 * (arg1 * arg2);
+	else if (op == X_D3DTOP_MODULATE4X)
+		return 4 * (arg1 * arg2);
+	else if (op == X_D3DTOP_ADD)
+		return arg1 + arg2;
+	else if (op == X_D3DTOP_ADDSIGNED)
+		return arg1 + arg2 - 0.5;
+	else if (op == X_D3DTOP_ADDSIGNED2X)
+		return 2 * (arg1 + arg2 - 0.5);
+	else if (op == X_D3DTOP_SUBTRACT)
+		return arg1 - arg2;
+	else if (op == X_D3DTOP_ADDSMOOTH)
+		return arg1 + arg2 * (1 - arg1);
+	else if (op == X_D3DTOP_BLENDDIFFUSEALPHA)
+		return arg1 * ctx.DIFFUSE.a + arg2 * (1 - ctx.DIFFUSE.a);
+	else if (op == X_D3DTOP_BLENDCURRENTALPHA)
+		return arg1 * ctx.CURRENT.a + arg2 * (1 - ctx.CURRENT.a);
+	else if (op == X_D3DTOP_BLENDTEXTUREALPHA)
+		return arg1 * ctx.TEXTURE.a + arg2 * (1 - ctx.TEXTURE.a);
+	else if (op == X_D3DTOP_BLENDFACTORALPHA)
+		return arg1 * ctx.TFACTOR.a + arg2 * (1 - ctx.TFACTOR.a);
+	else if (op == X_D3DTOP_BLENDTEXTUREALPHAPM)
+		return arg1 + arg2 * (1 - ctx.TEXTURE.a);
+	else if (op == X_D3DTOP_PREMODULATE)
+		return arg1; // Note this also multiplies the next stage's CURRENT by its texture
+	else if (op == X_D3DTOP_MODULATEALPHA_ADDCOLOR)
+		return float4(arg1.rgb + arg1.a * arg2.rgb, 1);
+	else if (op == X_D3DTOP_MODULATECOLOR_ADDALPHA)
+		return float4(arg1.rgb * arg2.rgb + arg1.a, 1);
+	else if (op == X_D3DTOP_MODULATEINVALPHA_ADDCOLOR)
+		return float4((1 - arg1.a) * arg2.rgb + arg1.rgb, 1);
+	else if (op == X_D3DTOP_MODULATEINVCOLOR_ADDALPHA)
+		return float4((1 - arg1.rgb) * arg2.rgb + arg1.a, 1);
+	else if (op == X_D3DTOP_DOTPRODUCT3)
+		return dot(arg1.rgb, arg2.rgb).rrrr;
+	// Note arg0 below is arg1 in D3D docs
+	// since it becomes the first argument for operations supporting 3 arguments...
+	else if (op == X_D3DTOP_MULTIPLYADD)
+		return arg0 + arg1 * arg2;
+	else if (op == X_D3DTOP_LERP)
+		return arg0 * arg1 + (1 - arg0) * arg2;
+	else if (op == X_D3DTOP_BUMPENVMAP)
+		return float4(
+			arg1.x * stage.BUMPENVMAT00 + arg1.y * stage.BUMPENVMAT10,
+			arg1.x * stage.BUMPENVMAT01 + arg1.y * stage.BUMPENVMAT11,
+			1, 1);
+	else if (op == X_D3DTOP_BUMPENVMAPLUMINANCE)
+		return float4(
+			arg1.x * stage.BUMPENVMAT00 + arg1.y * stage.BUMPENVMAT10,
+			arg1.x * stage.BUMPENVMAT01 + arg1.y * stage.BUMPENVMAT11,
+			arg1.z * stage.BUMPENVLSCALE + stage.BUMPENVLOFFSET,
+			1);
+
+	// Something is amiss... we should have returned by now!
+	// Return a bright colour
+	return float4(0, 1, 1, 1);
+}
+
+TextureArgs ExecuteTextureStage(
+	int i,
+	TextureArgs ctx,
+	PsTextureHardcodedState s,
+	int previousOp
+)
+{
+	// Early exit if this stage is disabled (and therefore all further stages are too)
+	if (s.COLOROP == X_D3DTOP_DISABLE)
+		return ctx;
+
+	PsTextureStageState stage = state.stages[i];
+
+	// Determine the texture for this stage
+	float3 offset = float3(0, 0, 0);
+	float4 factor = float4(1, 1, 1, 1);
+
+	// Bumpmap special case
+	if (previousOp == X_D3DTOP_BUMPENVMAP ||
+		previousOp == X_D3DTOP_BUMPENVMAPLUMINANCE) {
+		// Assume U, V, L is in CURRENT
+		// Add U', V', to the texture coordinates
+		// And multiply by L'
+		// https://docs.microsoft.com/en-us/windows/win32/direct3d9/bump-mapping-formulas
+		offset.xy = ctx.CURRENT.xy;
+		factor.rgb = ctx.CURRENT.z;
+	}
+
+	// Sample the texture
+	float4 t = float4(1, 1, 1, 1);
+	if (stage.IsTextureSet) {
+		int type = TextureSampleType[i];
+		if (type == SAMPLE_2D)
+			t = tex2D(samplers[i], TexCoords[i].xy + offset.xy);
+		else if (type == SAMPLE_3D)
+			t = tex3D(samplers[i], TexCoords[i].xyz + offset.xyz);
+		else if (type == SAMPLE_CUBE)
+			t = texCUBE(samplers[i], TexCoords[i].xyz + offset.xyz);
+	}
+
+	// Assign the final value for TEXTURE
+	ctx.TEXTURE = t * factor;
+
+	// Premodulate special case
+	if (previousOp == X_D3DTOP_PREMODULATE) {
+		ctx.CURRENT *= ctx.TEXTURE;
+	}
+
+	// Get arguments for the texture operation
+	// Almost all operate on 2 arguments, Arg1 and Arg2
+	// Arg0 is a third argument that seems to have been tacked on
+	// for MULTIPLYADD and LERP
+
+	// Colour operation arguments
+	float4 cArg1 = GetArg(s.COLORARG1, ctx);
+	float4 cArg2 = GetArg(s.COLORARG2, ctx);
+	float4 cArg0 = GetArg(s.COLORARG0, ctx);
+
+	// Alpha operation arguments
+	float4 aArg1 = GetArg(s.ALPHAARG1, ctx);
+	float4 aArg2 = GetArg(s.ALPHAARG2, ctx);
+	float4 aArg0 = GetArg(s.ALPHAARG0, ctx);
+
+	// Execute texture operation
+	float4 value;
+	value.rgb = ExecuteTextureOp(s.COLOROP, cArg1, cArg2, cArg0, ctx, stage).rgb;
+	value.a = ExecuteTextureOp(s.ALPHAOP, aArg1, aArg2, aArg0, ctx, stage).a;
+
+	// Save the result
+	// Note RESULTARG should either be CURRENT or TEMP
+	// But some titles seem to set it to DIFFUSE
+	// Use CURRENT for anything other than TEMP
+	// Test case: DoA 3
+	if (s.RESULTARG == X_D3DTA_TEMP)
+		ctx.TEMP = value;
+	else
+		ctx.CURRENT = value;
+
+	return ctx;
+}
+
+float4 main(const PS_INPUT input) : COLOR {
+
+	TexCoords = input.iT;
+
+	// Each stage is passed and returns
+	// a set of texture arguments
+	// And will usually update the CURRENT value
+	TextureArgs ctx;
+
+	// The CURRENT register
+	// Default to the diffuse value
+	// TODO determine whether to use the front or back colours
+	// and set them here
+	ctx.CURRENT = input.iD0;
+	ctx.DIFFUSE = input.iD0;
+	ctx.SPECULAR = input.iD1;
+	// The TEMP register
+	// Default to 0
+	ctx.TEMP = float4(0, 0, 0, 0);
+	ctx.TFACTOR = state.TextureFactor;
+
+	PsTextureHardcodedState stages[4];
+	stages[0].COLOROP = X_D3DTOP_DISABLE;
+	stages[1].COLOROP = X_D3DTOP_DISABLE;
+	stages[2].COLOROP = X_D3DTOP_DISABLE;
+	stages[3].COLOROP = X_D3DTOP_DISABLE;
+
+	// Define stages
+	// https://docs.microsoft.com/en-us/windows/win32/direct3d9/d3dtexturestagestatetype
+	// We'll find comment below and insert the definitions after it
+	// STAGE DEFINITIONS
+	// END STAGE DEFINITIONS
+
+	// Run each stage
+	int previousOp = -1;
+	for (int i = 0; i < 4; i++) {
+
+		ctx = ExecuteTextureStage(
+			i,
+			ctx,
+			stages[i],
+			previousOp
+		);
+
+		previousOp = stages[i].COLOROP;
+	}
+
+	// Add fog if enabled
+	if (state.FogEnable) {
+		ctx.CURRENT.rgb = lerp(state.FogColor.rgb, ctx.CURRENT.rgb, saturate(input.iFog));
+	}
+
+	// Add specular if enabled
+	if (state.SpecularEnable) {
+		ctx.CURRENT.rgb += ctx.SPECULAR.rgb;
+	}
+
+	// Output whatever is in current at the end
+	return ctx.CURRENT;
+}

--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli
@@ -63,9 +63,10 @@ namespace FixedFunctionPixelShader {
 	const float X_D3DTA_COMPLEMENT = 0x00000010;  // take 1.0 - x (read modifier)
 	const float X_D3DTA_ALPHAREPLICATE = 0x00000020;  // replicate alpha to color components (read modifier)
 
-	const int SAMPLE_2D = 0;
-	const int SAMPLE_3D = 1;
-	const int SAMPLE_CUBE = 2;
+	const int SAMPLE_NONE = 0;
+	const int SAMPLE_2D = 1;
+	const int SAMPLE_3D = 2;
+	const int SAMPLE_CUBE = 3;
 
 	// This state is passed to the shader
 	struct PsTextureStageState {
@@ -97,9 +98,6 @@ namespace FixedFunctionPixelShader {
 		// TEXCOORDINDEX handled by the VS
 		// BORDERCOLOR set on sampler
 		alignas(16) float COLORKEYCOLOR; // Unimplemented Xbox extension!
-
-		// Misc properties
-		alignas(16) float IsTextureSet;
 	};
 
 	// This state is compiled into the shader

--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli
@@ -1,0 +1,141 @@
+// C++ / HLSL shared state block for fixed function support
+#ifdef  __cplusplus
+#pragma once
+
+#include <d3d9.h>
+#include <d3d9types.h> // for D3DFORMAT, D3DLIGHT9, etc
+#include <d3dx9math.h> // for D3DXVECTOR4, etc
+#include <array>
+
+#define float4x4 D3DMATRIX
+#define float4 D3DXVECTOR4
+#define float3 D3DVECTOR
+#define float2 D3DXVECTOR2
+#define arr(name, type, length) std::array<type, length> name
+
+#else
+// HLSL
+#define arr(name, type, length) type name[length]
+#define alignas(x)
+#define const static
+#endif //  __cplusplus
+
+#ifdef  __cplusplus
+namespace FixedFunctionPixelShader {
+#endif
+	// From X_D3DTOP
+	const float X_D3DTOP_DISABLE = 1;
+	const float X_D3DTOP_SELECTARG1 = 2;
+	const float X_D3DTOP_SELECTARG2 = 3;
+	const float X_D3DTOP_MODULATE = 4;
+	const float X_D3DTOP_MODULATE2X = 5;
+	const float X_D3DTOP_MODULATE4X = 6;
+	const float X_D3DTOP_ADD = 7;
+	const float X_D3DTOP_ADDSIGNED = 8;
+	const float X_D3DTOP_ADDSIGNED2X = 9;
+	const float X_D3DTOP_SUBTRACT = 10;
+	const float X_D3DTOP_ADDSMOOTH = 11;
+	const float X_D3DTOP_BLENDDIFFUSEALPHA = 12;
+	const float X_D3DTOP_BLENDCURRENTALPHA = 13;
+	const float X_D3DTOP_BLENDTEXTUREALPHA = 14;
+	const float X_D3DTOP_BLENDFACTORALPHA = 15;
+	const float X_D3DTOP_BLENDTEXTUREALPHAPM = 16;
+	const float X_D3DTOP_PREMODULATE = 17;
+	const float X_D3DTOP_MODULATEALPHA_ADDCOLOR = 18;
+	const float X_D3DTOP_MODULATECOLOR_ADDALPHA = 19;
+	const float X_D3DTOP_MODULATEINVALPHA_ADDCOLOR = 20;
+	const float X_D3DTOP_MODULATEINVCOLOR_ADDALPHA = 21;
+	const float X_D3DTOP_DOTPRODUCT3 = 22;
+	const float X_D3DTOP_MULTIPLYADD = 23;
+	const float X_D3DTOP_LERP = 24;
+	const float X_D3DTOP_BUMPENVMAP = 25;
+	const float X_D3DTOP_BUMPENVMAPLUMINANCE = 26;
+
+	// D3DTA taken from D3D9 - we don't have Xbox definitions
+	// for these so I guess they're the same?
+	const float X_D3DTA_DIFFUSE = 0x00000000;  // select diffuse color (read only)
+	const float X_D3DTA_CURRENT = 0x00000001;  // select stage destination register (read/write)
+	const float X_D3DTA_TEXTURE = 0x00000002;  // select texture color (read only)
+	const float X_D3DTA_TFACTOR = 0x00000003;  // select D3DRS_TEXTUREFACTOR (read only)
+	const float X_D3DTA_SPECULAR = 0x00000004;  // select specular color (read only)
+	const float X_D3DTA_TEMP = 0x00000005;  // select temporary register color (read/write)
+	const float X_D3DTA_CONSTANT = 0x00000006;  // select texture stage constant
+	const float X_D3DTA_COMPLEMENT = 0x00000010;  // take 1.0 - x (read modifier)
+	const float X_D3DTA_ALPHAREPLICATE = 0x00000020;  // replicate alpha to color components (read modifier)
+
+	const int SAMPLE_2D = 0;
+	const int SAMPLE_3D = 1;
+	const int SAMPLE_CUBE = 2;
+
+	// This state is passed to the shader
+	struct PsTextureStageState {
+		// Values correspond to XD3D8 version of D3DTEXTURESTAGESTATETYPE
+		// https://docs.microsoft.com/en-us/windows/win32/direct3d9/d3dtexturestagestatetype
+
+		/* Samplers for now are configured elsewhere already
+		constexpr DWORD X_D3DTSS_ADDRESSU = 0;
+		constexpr DWORD X_D3DTSS_ADDRESSV = 1;
+		constexpr DWORD X_D3DTSS_ADDRESSW = 2;
+		constexpr DWORD X_D3DTSS_MAGFILTER = 3;
+		constexpr DWORD X_D3DTSS_MINFILTER = 4;
+		constexpr DWORD X_D3DTSS_MIPFILTER = 5;
+		constexpr DWORD X_D3DTSS_MIPMAPLODBIAS = 6;
+		constexpr DWORD X_D3DTSS_MAXMIPLEVEL = 7;
+		constexpr DWORD X_D3DTSS_MAXANISOTROPY = 8;
+		*/
+
+		alignas(16) float COLORKEYOP; // Unimplemented Xbox extension!
+		alignas(16) float COLORSIGN; // Unimplemented Xbox extension!
+		alignas(16) float ALPHAKILL; // Unimplemented Xbox extension!
+		// TEXTURETRANSFORMFLAGS handled by the VS
+		alignas(16) float BUMPENVMAT00;
+		alignas(16) float BUMPENVMAT01;
+		alignas(16) float BUMPENVMAT11;
+		alignas(16) float BUMPENVMAT10;
+		alignas(16) float BUMPENVLSCALE;
+		alignas(16) float BUMPENVLOFFSET;
+		// TEXCOORDINDEX handled by the VS
+		// BORDERCOLOR set on sampler
+		alignas(16) float COLORKEYCOLOR; // Unimplemented Xbox extension!
+
+		// Misc properties
+		alignas(16) float IsTextureSet;
+	};
+
+	// This state is compiled into the shader
+	// Values correspond to XD3D8 version of D3DTEXTURESTAGESTATETYPE
+	// https://docs.microsoft.com/en-us/windows/win32/direct3d9/d3dtexturestagestatetype
+	struct PsTextureHardcodedState {
+		alignas(16) float COLOROP;
+		alignas(16) float COLORARG0;
+		alignas(16) float COLORARG1;
+		alignas(16) float COLORARG2;
+		alignas(16) float ALPHAOP;
+		alignas(16) float ALPHAARG0;
+		alignas(16) float ALPHAARG1;
+		alignas(16) float ALPHAARG2;
+		alignas(16) float RESULTARG;
+	};
+
+	struct FixedFunctionPixelShaderState {
+		alignas(16) arr(stages, PsTextureStageState, 4);
+		alignas(16) float4 TextureFactor;
+		alignas(16) float SpecularEnable;
+		alignas(16) float FogEnable;
+		alignas(16) float3 FogColor;
+	};
+#ifdef  __cplusplus
+} // FixedFunctionPixelShader namespace
+#endif
+
+#ifdef  __cplusplus
+#undef float4x4
+#undef float4
+#undef float3
+#undef float2
+#undef arr
+#else // HLSL
+#undef arr
+#undef alignas
+#undef const
+#endif //  __cplusplus

--- a/src/core/hle/D3D8/Direct3D9/PixelShader.cpp
+++ b/src/core/hle/D3D8/Direct3D9/PixelShader.cpp
@@ -289,7 +289,7 @@ void BuildShader(DecodedRegisterCombiner* pShader, std::stringstream& hlsl)
 
 	hlsl << hlsl_template[0]; // Start with the HLSL template header
 
-	hlsl << "\nbool alphakill[4] = {"
+	hlsl << "\nstatic bool alphakill[4] = {"
 		<< (pShader->AlphaKill[0] ? "true, " : "false, ")
 		<< (pShader->AlphaKill[1] ? "true, " : "false, ")
 		<< (pShader->AlphaKill[2] ? "true, " : "false, ")

--- a/src/core/hle/D3D8/Direct3D9/TextureStates.h
+++ b/src/core/hle/D3D8/Direct3D9/TextureStates.h
@@ -45,6 +45,8 @@ private:
     void BuildTextureStateMappingTable();
     DWORD GetHostTextureOpValue(DWORD XboxTextureOp);
 
+    // Pointer to Xbox texture states
+    // Note mappings may change between XDK versions
     uint32_t* D3D__TextureState = nullptr;
     std::array<int, xbox::X_D3DTSS_LAST + 1> XboxTextureStateOffsets;
     XboxRenderStateConverter* pXboxRenderStates;

--- a/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
+++ b/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
@@ -259,6 +259,9 @@ uniform float4 xboxScreenspaceOffset : register(c213);
 
 uniform float4 xboxTextureScale[4] : register(c214);
 
+// Parameters for mapping the shader's fog output value to a fog factor
+uniform float4  CxbxFogInfo: register(c218); // = CXBX_D3DVS_CONSTREG_FOGINFO
+
 struct VS_INPUT
 {
 	float4 v[16] : TEXCOORD;
@@ -337,10 +340,33 @@ VS_OUTPUT main(const VS_INPUT xIn)
 	// Copy variables to output struct
 	VS_OUTPUT xOut;
 
+	// Fogging
+	// TODO deduplicate
+	const float fogDepth      =   abs(oFog.x); 
+	const float fogTableMode  =   CxbxFogInfo.x;
+	const float fogDensity    =   CxbxFogInfo.y;
+	const float fogStart      =   CxbxFogInfo.z;
+	const float fogEnd        =   CxbxFogInfo.w;  
+
+	const float FOG_TABLE_NONE    = 0;
+	const float FOG_TABLE_EXP     = 1;
+	const float FOG_TABLE_EXP2    = 2;
+	const float FOG_TABLE_LINEAR  = 3;
+ 
+    float fogFactor;
+    if(fogTableMode == FOG_TABLE_NONE) 
+       fogFactor = fogDepth;
+    if(fogTableMode == FOG_TABLE_EXP) 
+       fogFactor = 1 / exp(fogDepth * fogDensity); /* / 1 / e^(d * density)*/
+    if(fogTableMode == FOG_TABLE_EXP2) 
+       fogFactor = 1 / exp(pow(fogDepth * fogDensity, 2)); /* / 1 / e^((d * density)^2)*/
+    if(fogTableMode == FOG_TABLE_LINEAR) 
+       fogFactor = (fogEnd - fogDepth) / (fogEnd - fogStart);
+
 	xOut.oPos = reverseScreenspaceTransform(oPos);
 	xOut.oD0 = saturate(oD0);
 	xOut.oD1 = saturate(oD1);
-	xOut.oFog = oFog.x; // Note : Xbox clamps fog in pixel shader
+	xOut.oFog = fogFactor; // Note : Xbox clamps fog in pixel shader
 	xOut.oPts = oPts.x;
 	xOut.oB0 = saturate(oB0);
 	xOut.oB1 = saturate(oB1);

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -763,7 +763,7 @@ IDirect3DPixelShader9* GetFixedFunctionShader()
 
 	// Create a key from state that will be baked in to the shader
 	PsTextureHardcodedState states[4] = {};
-	int sampleType[4] = { SAMPLE_2D, SAMPLE_2D, SAMPLE_2D, SAMPLE_2D };
+	int sampleType[4] = { SAMPLE_NONE, SAMPLE_NONE, SAMPLE_NONE, SAMPLE_NONE };
 	bool pointSpriteEnable = XboxRenderStates.GetXboxRenderState(xbox::X_D3DRS_POINTSPRITEENABLE);
 
 	bool previousStageDisabled = false;
@@ -788,11 +788,12 @@ IDirect3DPixelShader9* GetFixedFunctionShader()
 		// TODO move XD3D8 resource query functions out of Direct3D9.cpp so we can use them here
 		if (g_pXbox_SetTexture[i]) {
 			auto format = g_pXbox_SetTexture[i]->Format;
-			// SampleType is initialized to SAMPLE_2D
 			if (format & X_D3DFORMAT_CUBEMAP)
 				sampleType[i] = SAMPLE_CUBE;
 			else if (((format & X_D3DFORMAT_DIMENSION_MASK) >> X_D3DFORMAT_DIMENSION_SHIFT) > 2)
 				sampleType[i] = SAMPLE_3D;
+			else
+				sampleType[i] = SAMPLE_2D;
 		}
 
 		states[i].COLORARG0 = (float)XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORARG0);
@@ -826,6 +827,7 @@ IDirect3DPixelShader9* GetFixedFunctionShader()
 	auto sampleTypeReplace = hlslTemplate.find(sampleTypePattern);
 
 	static constexpr std::string_view typeToString[] = {
+		"SAMPLE_NONE",
 		"SAMPLE_2D",
 		"SAMPLE_3D",
 		"SAMPLE_CUBE"
@@ -933,8 +935,6 @@ void UpdateFixedFunctionPixelShaderState()
 		stage->BUMPENVLSCALE = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVLSCALE));
 		stage->BUMPENVLOFFSET = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVLOFFSET));
 		stage->COLORKEYCOLOR = XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORKEYCOLOR);
-
-		stage->IsTextureSet = g_pXbox_SetTexture[i] != nullptr;
 	}
 
 	const int size = (sizeof(FixedFunctionPixelShaderState) + 16 - 1) / 16;

--- a/src/core/hle/D3D8/XbPixelShader.h
+++ b/src/core/hle/D3D8/XbPixelShader.h
@@ -507,6 +507,7 @@ struct DecodedRegisterCombiner {
 	void Decode(xbox::X_D3DPIXELSHADERDEF *pPSDef);
 };
 
+extern bool g_UseFixedFunctionPixelShader;
 
 // PatrickvL's Dxbx pixel shader translation
 void DxbxUpdateActivePixelShader(); // NOPATCH


### PR DESCRIPTION
Placeholder shader until we are able to directly load the pixel shader program used on the Xbox
A shader is generated for each texture op and argument combination

This does not implement any Xbox extensions, so should behave more or less the same as D3D9
F2 toggles the pixel shader - though fogging for D3D9 fixed function is no longer supported

Includes some other graphics-related fixes

~~Needs testing with AMD~~