### PR TITLE
ImGui: couple fixes for different cause of crashes

### DIFF
--- a/src/core/common/video/RenderBase.hpp
+++ b/src/core/common/video/RenderBase.hpp
@@ -31,7 +31,9 @@ public:
 	}
 
 	void DeviceRelease() {
-		m_device_release();
+		if (m_device_release) {
+			m_device_release();
+		}
 	}
 
 	void SetWindowRelease(const std::function<void()>& func_register) {
@@ -39,7 +41,9 @@ public:
 	}
 
 	void WindowRelease() {
-		m_window_release();
+		if (m_window_release) {
+			m_window_release();
+		}
 	}
 
 protected:

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1783,9 +1783,10 @@ void CxbxKrnlShutDown(bool is_reboot)
 	g_VMManager.Shutdown();
 
 	// Shutdown the render manager
-	g_renderbase->Shutdown();
-	g_renderbase.release();
-	g_renderbase = nullptr;
+	if (g_renderbase != nullptr) {
+		g_renderbase->Shutdown();
+		g_renderbase = nullptr;
+	}
 
 	CxbxUnlockFilePath();
 


### PR DESCRIPTION
Test cases of crash occur when titles doesn't create Direct3D9 device window through patched function:
- NASCAR Heat 2002 on boot.

The other issue is early termination by intentional testing purpose due to g_renderbase is not created.
