### PR TITLE
Fix some HLSL issues

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
@@ -121,7 +121,11 @@ float4 ExecuteTextureOp(float op, float4 arg1, float4 arg2, float4 arg0, Texture
 	else if (op == X_D3DTOP_MODULATEINVCOLOR_ADDALPHA)
 		return float4((1 - arg1.rgb) * arg2.rgb + arg1.a, 1);
 	else if (op == X_D3DTOP_DOTPRODUCT3)
-		return dot(arg1.rgb, arg2.rgb).rrrr;
+		// Test case: PerPixelLighting
+		return saturate(dot(
+			(arg1.rgb - 0.5) * 2,
+			(arg2.rgb - 0.5) * 2
+		));
 	// Note arg0 below is arg1 in D3D docs
 	// since it becomes the first argument for operations supporting 3 arguments...
 	else if (op == X_D3DTOP_MULTIPLYADD)


### PR DESCRIPTION
Improves some (still broken) samples

<details>
<summary>PerPixelLighting Before/After</summary>

![image](https://user-images.githubusercontent.com/9897874/114538264-4a014200-9ca7-11eb-9118-67133f159017.png)

Now matches D3D9 fixed function
![image](https://user-images.githubusercontent.com/9897874/114538098-158d8600-9ca7-11eb-9fd0-e81434cd32ea.png)
</details>

<details>
<summary>BumpDemo Before/After</summary>

![image](https://user-images.githubusercontent.com/9897874/114538799-ddd30e00-9ca7-11eb-8542-bb357478cb82.png)

Reflects the (broken) cubemap - unfortunately the reflection rotates!
![image](https://user-images.githubusercontent.com/9897874/114537911-e2e38d80-9ca6-11eb-86c5-fbc8c10d1ce2.png)
</details>