### PR TITLE
check for null device

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -3028,6 +3028,11 @@ void Direct3D_CreateDevice_Start
 
 	// create default device *before* calling Xbox Direct3D_CreateDevice trampoline
 	// to avoid hitting EMUPATCH'es that need a valid g_pD3DDevice
+
+	if (g_pD3DDevice != nullptr) { // Check to make sure device is null, otherwise no need to create it
+		return;
+	}
+
 	CreateDefaultD3D9Device(pPresentationParameters);
 }
 


### PR DESCRIPTION
Check to make sure device is null before creating it, avoids losing device due to unneeded recreation
IE
Indiana jones and buffy menus