### PR TITLE
Few fixes toward title mount path and prepped for chihiro work

### DIFF
--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -796,6 +796,9 @@ void Settings::SyncToEmulator()
 
 	// register data location setting
 	g_EmuShared->SetStorageLocation(GetDataLocation().c_str());
+
+	// reset title mount path
+	g_EmuShared->SetTitleMountPath("");
 }
 
 void verifyDebugFilePath(DebugMode& debug_mode, std::string& file_path)

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -44,8 +44,6 @@
 #include "devices\SMCDevice.h" // For SMC_COMMAND_SCRATCH
 #include "common/util/strConverter.hpp" // for utf16_to_ascii
 #include "core\kernel\memory-manager\VMManager.h"
-#include "common/util/cliConfig.hpp"
-#include "common/CxbxDebugger.h"
 
 #include <algorithm> // for std::replace
 #include <locale>
@@ -565,49 +563,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 				// Some titles (Xbox Dashboard and retail/demo discs) use ";" as a current directory path seperator
 				// This process is handled during initialization. No special handling here required.
 
-				cli_config::SetLoad(XbePath);
-
-				bool Debugging{ false };
-				g_EmuShared->GetDebuggingFlag(&Debugging);
-
-				if (Debugging)
-				{
-					std::string cliCommands;
-					if (!cli_config::GenCMD(cliCommands))
-					{
-						CxbxKrnlCleanup("Could not launch %s", XbePath.c_str());
-					}
-
-					CxbxDebugger::ReportNewTarget(cliCommands.c_str());
-
-					// The debugger will execute this process
-				}
-				else
-				{
-					if (!CxbxExec(false, nullptr, false))
-					{
-						CxbxKrnlCleanup("Could not launch %s", XbePath.c_str());
-					}
-				}
-
-				// This is a requirement to have shared memory buffers remain alive and transfer to new emulation process.
-				unsigned int retryAttempt = 0;
-				unsigned int curProcID = 0;
-				unsigned int oldProcID = GetCurrentProcessId();
-				while(true) {
-					std::this_thread::sleep_for(std::chrono::milliseconds(100));
-					g_EmuShared->GetKrnlProcID(&curProcID);
-					// Break when new emulation process has take over.
-					if (curProcID != oldProcID) {
-						break;
-					}
-					retryAttempt++;
-					// Terminate after 5 seconds of failure.
-					if (retryAttempt >= (5 * (1000 / 100))) {
-						PopupError(nullptr, "Could not reboot; New emulation process did not take over.");
-						break;
-					}
-				}
+				CxbxLaunchNewXbe(XbePath);
 
 			}
 		}
@@ -624,10 +580,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 
 		g_VMManager.SavePersistentMemory();
 
-		cli_config::SetLoad(szFilePath_Xbe);
-		if (!CxbxExec(false, nullptr, false)) {
-			CxbxKrnlCleanup("Could not launch %s", szFilePath_Xbe);
-		}
+		CxbxLaunchNewXbe(szFilePath_Xbe);
 		break;
 	}
 

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -539,7 +539,6 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 
 
 			std::string TitlePath = xbox::LaunchDataPage->Header.szLaunchPath;
-			char szWorkingDirectoy[xbox::max_path];
 
 			// If the title path starts with a semicolon, remove it
 			if (TitlePath.length() > 0 && TitlePath[0] == ';') {
@@ -552,12 +551,6 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 			}
 
 			std::string& XbePath = CxbxConvertXboxToHostPath(TitlePath);
-
-			// Determine Working Directory
-			{
-				strncpy_s(szWorkingDirectoy, XbePath.c_str(), MAX_PATH);
-				PathRemoveFileSpec(szWorkingDirectoy);
-			}
 
 			// Relaunch Cxbx, to load another Xbe
 			{

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1398,7 +1398,7 @@ __declspec(noreturn) void CxbxKrnlInit
 	CxbxResolveHostToFullPath(relative_path, "xbe's directory");
 
 	CxbxBasePathHandle = CreateFile(CxbxBasePath.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
-	int CxbxTitleDeviceDriveIndex = -1;
+	int CxbxCdrom0DeviceIndex = -1;
 	bool isEmuDisk = _strnicmp(relative_path.c_str(), CxbxBasePath.c_str(), CxbxBasePath.size() - 1) == 0;
 	// Check if title mounth path is already set. This may occur from early boot of Chihiro title.
 	char title_mount_path[sizeof(szFilePath_Xbe)];
@@ -1415,9 +1415,10 @@ __declspec(noreturn) void CxbxKrnlInit
 
 	// TODO: Find a place to make permanent placement for DeviceCdrom0 that does not have disc loaded.
 	if (tmp_buffer[0] != '\0') {
-		CxbxTitleDeviceDriveIndex = CxbxRegisterDeviceHostPath(DeviceCdrom0, tmp_buffer);
+		CxbxCdrom0DeviceIndex = CxbxRegisterDeviceHostPath(DeviceCdrom0, tmp_buffer);
+		// Since Chihiro also map Mbfs to the same path as Cdrom0, we'll map it the same way.
 		if (g_bIsChihiro) {
-			CxbxRegisterDeviceHostPath(DriveMbfs, tmp_buffer);
+			(void)CxbxRegisterDeviceHostPath(DriveMbfs, tmp_buffer);
 		}
 	}
 
@@ -1445,7 +1446,7 @@ __declspec(noreturn) void CxbxKrnlInit
 #else
 		// HACK: It is a hack to override XDK's default mount to CdRom0 which may not exist when launch to dashboard directly.
 		// Otherwise, titles may launch to dashboard, more specifically xbox live title, and back.
-		if (CxbxTitleDeviceDriveIndex == -1 || lastFind != std::string::npos) {
+		if (CxbxCdrom0DeviceIndex == -1 || lastFind != std::string::npos) {
 #endif
 			CxbxCreateSymbolicLink(DriveD, relative_path);
 		}

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1402,23 +1402,23 @@ __declspec(noreturn) void CxbxKrnlInit
 	bool isEmuDisk = _strnicmp(relative_path.c_str(), CxbxBasePath.c_str(), CxbxBasePath.size() - 1) == 0;
 	// Check if title mounth path is already set. This may occur from early boot of Chihiro title.
 	char title_mount_path[sizeof(szFilePath_Xbe)];
-	const char* tmp_buffer = title_mount_path;
+	const char* p_default_mount_path = title_mount_path;
 	g_EmuShared->GetTitleMountPath(title_mount_path);
 
-	if (tmp_buffer[0] == '\0' && BootFlags == BOOT_NONE) {
+	if (p_default_mount_path[0] == '\0' && BootFlags == BOOT_NONE) {
 		// Remember our first initialize mount path for CdRom0 and Mbfs.
 		if (!isEmuDisk) {
 			g_EmuShared->SetTitleMountPath(relative_path.c_str());
-			tmp_buffer = relative_path.c_str();
+			p_default_mount_path = relative_path.c_str();
 		}
 	}
 
 	// TODO: Find a place to make permanent placement for DeviceCdrom0 that does not have disc loaded.
-	if (tmp_buffer[0] != '\0') {
-		CxbxCdrom0DeviceIndex = CxbxRegisterDeviceHostPath(DeviceCdrom0, tmp_buffer);
+	if (p_default_mount_path[0] != '\0') {
+		CxbxCdrom0DeviceIndex = CxbxRegisterDeviceHostPath(DeviceCdrom0, p_default_mount_path);
 		// Since Chihiro also map Mbfs to the same path as Cdrom0, we'll map it the same way.
 		if (g_bIsChihiro) {
-			(void)CxbxRegisterDeviceHostPath(DriveMbfs, tmp_buffer);
+			(void)CxbxRegisterDeviceHostPath(DriveMbfs, p_default_mount_path);
 		}
 	}
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1448,9 +1448,6 @@ __declspec(noreturn) void CxbxKrnlInit
 		if (CxbxTitleDeviceDriveIndex == -1 || lastFind != std::string::npos) {
 #endif
 			CxbxCreateSymbolicLink(DriveD, relative_path);
-			// Arrange that the Xbe path can reside outside the partitions, and put it to g_hCurDir :
-			EmuNtSymbolicLinkObject* xbePathSymbolicLinkObject = FindNtSymbolicLinkObjectByDriveLetter(CxbxAutoMountDriveLetter);
-			g_hCurDir = xbePathSymbolicLinkObject->RootDirectoryHandle;
 		}
 	}
 

--- a/src/core/kernel/support/Emu.cpp
+++ b/src/core/kernel/support/Emu.cpp
@@ -42,8 +42,6 @@ CRITICAL_SECTION dbgCritical;
 #endif
 
 // Global Variable(s)
-HANDLE           g_hCurDir    = NULL;
-CHAR            *g_strCurDrive= NULL;
 volatile thread_local  bool    g_bEmuException = false;
 static thread_local bool bOverrideEmuException;
 volatile bool    g_bEmuSuspended = false;

--- a/src/core/kernel/support/Emu.h
+++ b/src/core/kernel/support/Emu.h
@@ -63,9 +63,6 @@ extern volatile bool g_bEmuSuspended;
 // global exception patching address
 extern void * funcExclude[2048];
 
-// partition emulation directory handles
-extern HANDLE g_hCurDir;
-extern CHAR  *g_strCurDrive;
 extern HWND   g_hEmuWindow;
 
 #define GET_FRONT_WINDOW_HANDLE ((CxbxKrnl_hEmuParent != nullptr) ? CxbxKrnl_hEmuParent : g_hEmuWindow)

--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -715,8 +715,12 @@ xbox::ntstatus_xt CxbxCreateSymbolicLink(std::string SymbolicLinkName, std::stri
 	SymbolicLinkObject = new EmuNtSymbolicLinkObject();
 	result = SymbolicLinkObject->Init(SymbolicLinkName, FullPath);
 
-	if (result != xbox::status_success)
+	if (result != xbox::status_success) {
 		SymbolicLinkObject->NtClose();
+	}
+	else if (SymbolicLinkObject->DriveLetter == CxbxAutoMountDriveLetter) {
+		g_hCurDir = SymbolicLinkObject->RootDirectoryHandle;
+	}
 
 	return result;
 }
@@ -807,6 +811,9 @@ NTSTATUS EmuNtSymbolicLinkObject::Init(std::string aSymbolicLinkName, std::strin
 	if (DriveLetter >= 'A' && DriveLetter <= 'Z') {
 		NtSymbolicLinkObjects[DriveLetter - 'A'] = NULL;
 		NtDll::NtClose(RootDirectoryHandle);
+		if (DriveLetter == CxbxAutoMountDriveLetter) {
+			g_hCurDir = NULL;
+		}
 	}
 }
 

--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -216,18 +216,24 @@ struct XboxDevice {
 	HANDLE HostRootHandle;
 };
 
+struct EmuDirPath {
+	std::string_view XboxDirPath;
+	std::string_view HostDirPath;
+	HANDLE HostDirHandle;
+};
+
 CHAR* NtStatusToString(IN NTSTATUS Status);
 
 int CxbxRegisterDeviceHostPath(std::string_view XboxFullPath, std::string HostDevicePath, bool IsFile = false);
 int CxbxDeviceIndexByDevicePath(const char *XboxDevicePath);
-XboxDevice *CxbxDeviceByDevicePath(const std::string_view XboxDevicePath);
+XboxDevice* CxbxDeviceByDevicePath(const std::string_view XboxDevicePath);
 XboxDevice* CxbxDeviceByHostPath(const std::string_view HostPath);
 std::string CxbxConvertXboxToHostPath(const std::string_view XboxDevicePath);
 
 char SymbolicLinkToDriveLetter(std::string aSymbolicLinkName);
 EmuNtSymbolicLinkObject* FindNtSymbolicLinkObjectByDriveLetter(const char DriveLetter);
 EmuNtSymbolicLinkObject* FindNtSymbolicLinkObjectByName(std::string SymbolicLinkName);
-EmuNtSymbolicLinkObject* FindNtSymbolicLinkObjectByDevice(std::string DeviceName);
+void FindEmuDirPathByDevice(std::string DeviceName, EmuDirPath& hybrid_path);
 EmuNtSymbolicLinkObject* FindNtSymbolicLinkObjectByRootHandle(HANDLE Handle);
 void CleanupSymbolicLinks();
 
@@ -321,5 +327,7 @@ void NTAPI CxbxIoApcDispatcher
 	xbox::PIO_STATUS_BLOCK IoStatusBlock,
 	xbox::ulong_xt         Reserved
 );
+
+void CxbxLaunchNewXbe(const std::string& XbePath);
 
 #endif


### PR DESCRIPTION
After feedbacks from @LukeUsher and giving me new knowledge how Chihiro work. This pull request resolve couple issues to work with Chihiro and one regression found from Grand Theft Auto 3 title.

Since Chihiro does have CdRom0 device to mount GD-ROM along with Mbfs. Correction has been made to append mount Mbfs instead of choose one or the other. While testing other titles, I found Grand Theft Auto 3 title regressed due to `g_hCurDir` is zero'd. I made a relocation into symbolic link creation to able allow titles to auto mount themselves.

We should **not** be relying on symbolic link objects 100% of the time. I made a complete replacement `FindNtSymbolicLinkObjectByDevice` to `FindEmuDirPathByDevice`. With this change, ability to support Chihiro is possible.