### PR TITLE
Handle D3DTTFF_PROJECTED and when the w texture coordinate component is specified

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
@@ -174,14 +174,20 @@ TextureArgs ExecuteTextureStage(
 	// Sample the texture
 	float4 t;
 	int type = TextureSampleType[i];
+	// Divide texcoords by w when sampling
+	// Which corresponds to D3DTTFF_PROJECTED behaviour
+	// The w component can be set by titles in vertex shaders
+	// without using texture transform flags
+	// Test case: DoA 3 reflections on 'Ice Stage'
+	float4 coords = TexCoords[i].xyzw / TexCoords[i].w;
 	if (type == SAMPLE_NONE)
 		t = 1; // Test case JSRF
 	else if (type == SAMPLE_2D)
-		t = tex2D(samplers[i], TexCoords[i].xy + offset.xy);
+		t = tex2D(samplers[i], coords.xy + offset.xy);
 	else if (type == SAMPLE_3D)
-		t = tex3D(samplers[i], TexCoords[i].xyz + offset.xyz);
+		t = tex3D(samplers[i], coords.xyz + offset.xyz);
 	else if (type == SAMPLE_CUBE)
-		t = texCUBE(samplers[i], TexCoords[i].xyz + offset.xyz);
+		t = texCUBE(samplers[i], coords.xyz + offset.xyz);
 
 #ifdef ENABLE_FF_ALPHAKILL
 	if (s.ALPHAKILL)

--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsl
@@ -184,11 +184,11 @@ TextureArgs ExecuteTextureStage(
 		t = texCUBE(samplers[i], TexCoords[i].xyz + offset.xyz);
 
 #ifdef ENABLE_FF_ALPHAKILL
-	if (stage.ALPHAKILL)
+	if (s.ALPHAKILL)
 		if (t.a == 0)
 			discard;
-
 #endif
+
 	// Assign the final value for TEXTURE
 	ctx.TEXTURE = t * factor;
 

--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionPixelShader.hlsli
@@ -85,13 +85,6 @@ namespace FixedFunctionPixelShader {
 		constexpr DWORD X_D3DTSS_MAXANISOTROPY = 8;
 		*/
 
-		alignas(16) float COLORKEYOP; // Unimplemented Xbox extension!
-		alignas(16) float COLORSIGN; // Unimplemented Xbox extension!
-#ifdef ENABLE_FF_ALPHAKILL
-		alignas(16) float ALPHAKILL; // Xbox extension!
-#else
-		alignas(16) float ALPHAKILL; // Unimplemented Xbox extension!
-#endif
 		// TEXTURETRANSFORMFLAGS handled by the VS
 		alignas(16) float BUMPENVMAT00;
 		alignas(16) float BUMPENVMAT01;
@@ -101,7 +94,6 @@ namespace FixedFunctionPixelShader {
 		alignas(16) float BUMPENVLOFFSET;
 		// TEXCOORDINDEX handled by the VS
 		// BORDERCOLOR set on sampler
-		alignas(16) float COLORKEYCOLOR; // Unimplemented Xbox extension!
 	};
 
 	// This state is compiled into the shader
@@ -117,6 +109,14 @@ namespace FixedFunctionPixelShader {
 		alignas(16) float ALPHAARG1;
 		alignas(16) float ALPHAARG2;
 		alignas(16) float RESULTARG;
+		alignas(16) float COLORKEYOP; // Unimplemented Xbox extension!
+		alignas(16) float4 COLORKEYCOLOR; // Unimplemented Xbox extension!
+		alignas(16) float4 COLORSIGN; // Unimplemented Xbox extension!
+#ifdef ENABLE_FF_ALPHAKILL
+		alignas(16) float ALPHAKILL; // Xbox extension!
+#else
+		alignas(16) float ALPHAKILL; // Unimplemented Xbox extension!
+#endif
 	};
 
 	struct FixedFunctionPixelShaderState {

--- a/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShader.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/FixedFunctionVertexShader.hlsl
@@ -333,7 +333,8 @@ float4 DoTexCoord(const uint stage, const VS_INPUT xIn)
     // Get texture coordinates
     // Coordinates are either from the vertex texcoord data
     // Or generated
-    float4 texCoord = float4(0, 0, 0, 0);
+    // Note w can be used in the pixel shader, init to 1
+    float4 texCoord = float4(0, 0, 0, 1);
     if (tState.TexCoordIndexGen == TCI_PASSTHRU)
     {
         // Get from vertex data
@@ -351,11 +352,9 @@ float4 DoTexCoord(const uint stage, const VS_INPUT xIn)
        // TODO move alongside the texture transformation when it stops angering the HLSL compiler
         const float componentCount = state.TexCoordComponentCount[texCoordIndex];
         if (componentCount == 1)
-            texCoord.yzw = float3(1, 0, 0);
+            texCoord.yz = float2(1, 0);
         if (componentCount == 2)
-            texCoord.zw = float2(1, 0);
-        if (componentCount == 3)
-            texCoord.w = 1;
+            texCoord.z = 1;
     }   // Generate texture coordinates
     else if (tState.TexCoordIndexGen == TCI_CAMERASPACENORMAL)
         texCoord = float4(View.Normal, 1);
@@ -385,17 +384,16 @@ float4 DoTexCoord(const uint stage, const VS_INPUT xIn)
 
     // We always send four coordinates
     // If we are supposed to send less than four
-    // then copy the last coordinate to the remaining coordinates
+    // then copy the last coordinate to w
     // For D3DTTFF_PROJECTED, the value of the *last* coordinate is important
     // Test case: ProjectedTexture sample, which uses 3 coordinates
-    // We'll need to implement the divide when D3D stops handling it for us?
     // https://docs.microsoft.com/en-us/windows/win32/direct3d9/d3dtexturetransformflags
     if (projected)
     {
         if (countFlag == 1)
-            texCoord.yzw = texCoord.x;
+            texCoord.w = texCoord.x;
         if (countFlag == 2)
-            texCoord.zw = texCoord.y;
+            texCoord.w = texCoord.y;
         if (countFlag == 3)
             texCoord.w = texCoord.z;
     }

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -839,6 +839,14 @@ IDirect3DPixelShader9* GetFixedFunctionShader()
 		states[i].ALPHAARG2 = (float)XboxTextureStates.Get(i, xbox::X_D3DTSS_ALPHAARG2);
 
 		states[i].RESULTARG = (float)XboxTextureStates.Get(i, xbox::X_D3DTSS_RESULTARG);
+
+		auto colorSign = XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORSIGN);
+		if (colorSign) LOG_TEST_CASE("FF COLORSIGN");
+		float fColorSign[4] = { colorSign & 8, colorSign & 4, colorSign & 2, colorSign & 1 };
+		states[i].COLORSIGN = fColorSign;
+		states[i].ALPHAKILL = XboxTextureStates.Get(i, xbox::X_D3DTSS_ALPHAKILL);
+		states[i].COLORKEYOP = XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORKEYOP);
+		states[i].COLORKEYCOLOR = (D3DXVECTOR4)((D3DXCOLOR)XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORKEYCOLOR));
 	}
 
 	// Create a key from the shader state
@@ -897,6 +905,7 @@ IDirect3DPixelShader9* GetFixedFunctionShader()
 		std::string target = "stages[" + std::to_string(i) + "].";
 
 		auto s = states[i];
+		// Texture stage ops and args
 		stageSetup << target << "COLOROP = " << GetD3DTOPString(s.COLOROP) << ";\n";
 
 		stageSetup << target << "COLORARG0 = " << GetD3DTASumString(s.COLORARG0) << ";\n";
@@ -910,6 +919,23 @@ IDirect3DPixelShader9* GetFixedFunctionShader()
 		stageSetup << target << "ALPHAARG2 = " << GetD3DTASumString(s.ALPHAARG2) << ";\n";
 
 		stageSetup << target << "RESULTARG = " << GetD3DTASumString(s.RESULTARG, false) << ";\n";
+
+		// Xbox extension states
+		stageSetup << target << "COLORSIGN = " << "float4("
+			<< s.COLORSIGN[0] << ", "
+			<< s.COLORSIGN[1] << ", "
+			<< s.COLORSIGN[2] << ", "
+			<< s.COLORSIGN[3] << ");\n";
+
+		stageSetup << target << "ALPHAKILL = " << s.ALPHAKILL << ";\n";
+
+		stageSetup << target << "COLORKEYOP = " << s.COLORKEYOP << ";\n";
+		stageSetup << target << "COLORKEYCOLOR = " << "float4("
+			<< s.COLORKEYCOLOR[0] << ", "
+			<< s.COLORKEYCOLOR[1] << ", "
+			<< s.COLORKEYCOLOR[2] << ", "
+			<< s.COLORKEYCOLOR[3] << ");\n";
+
 		stageSetup << '\n';
 	}
 
@@ -960,16 +986,12 @@ void UpdateFixedFunctionPixelShaderState()
 
 		auto stage = &ffPsState.stages[i];
 
-		stage->COLORKEYOP = XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORKEYOP);
-		stage->COLORSIGN = XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORSIGN);
-		stage->ALPHAKILL = XboxTextureStates.Get(i, xbox::X_D3DTSS_ALPHAKILL);
 		stage->BUMPENVMAT00 = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVMAT00));
 		stage->BUMPENVMAT01 = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVMAT01));
 		stage->BUMPENVMAT10 = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVMAT10));
 		stage->BUMPENVMAT11 = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVMAT11));
 		stage->BUMPENVLSCALE = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVLSCALE));
 		stage->BUMPENVLOFFSET = AsFloat(XboxTextureStates.Get(i, xbox::X_D3DTSS_BUMPENVLOFFSET));
-		stage->COLORKEYCOLOR = XboxTextureStates.Get(i, xbox::X_D3DTSS_COLORKEYCOLOR);
 	}
 
 	const int size = (sizeof(FixedFunctionPixelShaderState) + 16 - 1) / 16;


### PR DESCRIPTION
Also move Xbox FF extension states to the fixed function shader so they will be easier to debug

Fixes the ProjectedTexture sample and DoA3 reflections