### PR TITLE
Reworded fatal error message popup

### DIFF
--- a/src/core/kernel/support/Emu.cpp
+++ b/src/core/kernel/support/Emu.cpp
@@ -191,15 +191,15 @@ void EmuExceptionNonBreakpointUnhandledShow(LPEXCEPTION_POINTERS e)
 {
 	EmuExceptionPrintDebugInformation(e, /*IsBreakpointException=*/false);
 
-	char buffer[256];
-	sprintf(buffer,
-		"Received Exception Code 0x%.08X @ EIP := %s\n"
+	std::printf("Received Exception Code 0x%.08X @ EIP := %s\n",
+		e->ExceptionRecord->ExceptionCode, EIPToString(e->ContextRecord->Eip).c_str());
+	std::fflush(stdout);
+
+	if (PopupFatalEx(nullptr, PopupButtons::OkCancel, PopupReturn::Ok,
+		"  The running xbe has encountered an unrecoverable error.\n"
 		"\n"
 		"  Press \"OK\" to terminate emulation.\n"
-		"  Press \"Cancel\" to debug.",
-		e->ExceptionRecord->ExceptionCode, EIPToString(e->ContextRecord->Eip).c_str());
-
-	if (PopupFatalEx(nullptr, PopupButtons::OkCancel, PopupReturn::Ok, buffer) == PopupReturn::Ok)
+		"  Press \"Cancel\" to debug.") == PopupReturn::Ok)
 	{
 		EmuExceptionExitProcess();
 	}

--- a/src/core/kernel/support/Emu.cpp
+++ b/src/core/kernel/support/Emu.cpp
@@ -191,10 +191,6 @@ void EmuExceptionNonBreakpointUnhandledShow(LPEXCEPTION_POINTERS e)
 {
 	EmuExceptionPrintDebugInformation(e, /*IsBreakpointException=*/false);
 
-	std::printf("Received Exception Code 0x%.08X @ EIP := %s\n",
-		e->ExceptionRecord->ExceptionCode, EIPToString(e->ContextRecord->Eip).c_str());
-	std::fflush(stdout);
-
 	if (PopupFatalEx(nullptr, PopupButtons::OkCancel, PopupReturn::Ok,
 		"  The running xbe has encountered an unhandled exception (Code := 0x%.8X) at address 0x%.08X.\n"
 		"\n"

--- a/src/core/kernel/support/Emu.cpp
+++ b/src/core/kernel/support/Emu.cpp
@@ -196,10 +196,11 @@ void EmuExceptionNonBreakpointUnhandledShow(LPEXCEPTION_POINTERS e)
 	std::fflush(stdout);
 
 	if (PopupFatalEx(nullptr, PopupButtons::OkCancel, PopupReturn::Ok,
-		"  The running xbe has encountered an unrecoverable error.\n"
+		"  The running xbe has encountered an unhandled exception (Code := 0x%.8X) at address 0x%.08X.\n"
 		"\n"
 		"  Press \"OK\" to terminate emulation.\n"
-		"  Press \"Cancel\" to debug.") == PopupReturn::Ok)
+		"  Press \"Cancel\" to debug.",
+		e->ExceptionRecord->ExceptionCode, e->ContextRecord->Eip) == PopupReturn::Ok)
 	{
 		EmuExceptionExitProcess();
 	}


### PR DESCRIPTION
This is to avoid people assuming the crash is caused by the function mentioned in message, which is almost never the case. ~The original message is still printed in the kernel log.~