### PR TITLE
Removed unnecessary calls to SetWindowText

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5492,16 +5492,7 @@ xbox::dword_xt WINAPI xbox::EMUPATCH(D3DDevice_Swap)
 
 	if (Flags == CXBX_SWAP_PRESENT_FORWARD) // Only do this when forwarded from Present
 	{
-		// Put primitives per frame in the title
-		/*{
-			char szString[64];
-
-			sprintf( szString, "Cxbx: PPF(%d)", g_dwPrimPerFrame );
-
-			SetWindowText( CxbxKrnl_hEmuParent, szString );
-
-			g_dwPrimPerFrame = 0;
-		}*/
+		// TODO: print the primitives per frame with ImGui
 
 		// TODO : Check if this should be done at Swap-not-Present-time too :
 		// not really accurate because you definately dont always present on every vblank

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1801,18 +1801,6 @@ void CxbxKrnlSuspend()
         }
     }
 
-    // append 'paused' to rendering window caption text
-    {
-        char szBuffer[256];
-
-        HWND hWnd = GET_FRONT_WINDOW_HANDLE;
-
-        GetWindowText(hWnd, szBuffer, 255 - 10);
-
-        strcat(szBuffer, " (paused)");
-        SetWindowText(hWnd, szBuffer);
-    }
-
     g_bEmuSuspended = true;
 }
 
@@ -1820,19 +1808,6 @@ void CxbxKrnlResume()
 {
     if(!g_bEmuSuspended)
         return;
-
-    // remove 'paused' from rendering window caption text
-    {
-        char szBuffer[256];
-
-        HWND hWnd = GET_FRONT_WINDOW_HANDLE;
-
-        GetWindowText(hWnd, szBuffer, 255);
-
-        szBuffer[strlen(szBuffer)-9] = '\0';
-
-        SetWindowText(hWnd, szBuffer);
-    }
 
 	for (auto it = g_hThreads.begin(); it != g_hThreads.end(); ++it)
 	{


### PR DESCRIPTION
Closes https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/863. This removes all calls to `SetWindowText` but the one in `WndMain::UpdateCaption()`, which becomes the only one used to change the title bar. The previous locations that were calling it were these:
1.  In `D3DDevice_Swap`. However, it was disabled by a comment and it was meant to print the `g_dwPrimPerFrame`  variable. In my opinion, we should use ImGui instead of the title bar to print such stats.
2.  In `CxbxKrnlSuspend`. This is only called in `Direct3D9.cpp`, when the emu process receives `WM_SIZE` with a `wParam` of `SIZE_MINIMIZED`, which means the cxbxr window has been minimized. However, I debugged the code and this message is never received, even when I minimize the window (I'm not sure whether or not this is a bug).
3. In `CxbxKrnlResume`. This is called in `Direct3D9.cpp`, when the emu process receives `WM_SIZE` with a `wParam` of `SIZE_MAXIMIZED` or `SIZE_RESTORED`, and also from `CxbxKrnlCleanupEx`. The first two cases are triggered when the cxbxr window is first created, and never afterwards (because it's not possible for the user to maximize the cxbxr window). However, the call only happens when `bAutoPaused` is true, which is never the case because it's a global variable initialized to false, and only becomes true when `SIZE_MINIMIZED` is received, and that never happens like I explained above. This, in turns, means that `CxbxKrnlSuspend` is never called, which is the only function that would set `g_bEmuSuspended` to true, and thus the call in `CxbxKrnlCleanupEx` is also useless as well.

Finally, I think that `CxbxKrnlSuspend` and `CxbxKrnlResume` were originally designed to suspend/resume threads in the old cxbx, where it was possible to do so from the GUI, but since we have removed that ability, they are effectively obsolete now and could probably be removed entirely, unless we decide to use them to implement `KeSuspendThread` and `KeResumeThread`.