### PR TITLE
Implement ImageDesc and fix DSStream packet vector iterator, fix Otogi 1, PGR2

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DSStream_PacketManager.cpp
@@ -308,6 +308,8 @@ bool DSStream_Packet_Process(
                         }
                         return 0;
                     }
+                    //the iterator might be invalidated, so we update it again.
+                    packetCurrent = pThis->Host_BufferPacketArray.begin();
 #if 0               // Extend debug verification
                     EmuLog(LOG_LEVEL::DEBUG, "nextBuffer: %08X; packetCurrent->bufPlayed: %08X; bufPlayed: %08X;\n",
                         packetCurrent._Ptr,

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -371,19 +371,19 @@ static inline void DSoundGenericUnlock(
 static inline HRESULT DSoundBufferCreate(LPDSBUFFERDESC pDSBufferDesc, LPDIRECTSOUNDBUFFER8 &pDSBuffer)
 {
     LPDIRECTSOUNDBUFFER pTempBuffer;
-	//Todo:shall we check the pDSBufferDesc->dwBufferBytes with legal ranges between DSBSIZE_MIN and DSBSIZE_MAX again?
+    //Todo:shall we check the pDSBufferDesc->dwBufferBytes with legal ranges between DSBSIZE_MIN and DSBSIZE_MAX again?
     HRESULT hRetDS = g_pDSound8->CreateSoundBuffer(pDSBufferDesc, &pTempBuffer, nullptr);
 
-	if (hRetDS == DS_OK) {
-		hRetDS = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&(pDSBuffer));
-		pTempBuffer->Release();
-		if (pDSBuffer == nullptr) {
-			EmuLog(LOG_LEVEL::WARNING, "CreateSoundBuffer:QueryInterface Failed!");
-		}
-	}
-	else {
-		EmuLog(LOG_LEVEL::WARNING, "CreateSoundBuffer Failed!");
-	}
+    if (hRetDS == DS_OK) {
+        hRetDS = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&(pDSBuffer));
+        pTempBuffer->Release();
+        if (pDSBuffer == nullptr) {
+            EmuLog(LOG_LEVEL::WARNING, "CreateSoundBuffer:QueryInterface Failed!");
+        }
+    }
+    else {
+        EmuLog(LOG_LEVEL::WARNING, "CreateSoundBuffer Failed!");
+    }
     return hRetDS;
 }
 
@@ -433,9 +433,9 @@ static inline void DSoundBufferTransferSettings(
     LONG lVolume, lPan;
     DS3DBUFFER ds3dBuffer;
 
-	if (pDSBufferOld == nullptr) {
-		return;
-	}
+    if (pDSBufferOld == nullptr) {
+        return;
+    }
 
     // if sync current frequency used (then use pitch only).
     uint32_t freq = converter_pitch2freq(Xb_Voice->GetPitch());
@@ -464,14 +464,14 @@ static inline void DSoundBufferReCreate(
 
 
     HRESULT hretDS = DSoundBufferCreate(&DSBufferDesc, pDSBufferNew);
-	//create new DS3DBuffer from the new DSBuffer if the new DSBuffer is created successfully.
+    //create new DS3DBuffer from the new DSBuffer if the new DSBuffer is created successfully.
     if (pDSBufferNew != nullptr) {
         DSound3DBufferCreate(pDSBufferNew, pDS3DBufferNew);
-		DSoundBufferTransferSettings(pDSBuffer, pDSBufferNew, pDS3DBuffer, pDS3DBufferNew, Xb_Voice);//Sanity checks inside.
-	}
-	else {
-		EmuLog(LOG_LEVEL::WARNING, "DSoundBufferReCreate Failed!");
-	}
+        DSoundBufferTransferSettings(pDSBuffer, pDSBufferNew, pDS3DBuffer, pDS3DBufferNew, Xb_Voice);//Sanity checks inside.
+    }
+    else {
+        EmuLog(LOG_LEVEL::WARNING, "DSoundBufferReCreate Failed!");
+    }
 
     
 }
@@ -514,12 +514,12 @@ static inline void DSoundBufferResizeSetSize(
         return;
     }
 
-	if (Host_dwByteLength< DSBSIZE_MIN) { //the min. buffer bytes must be equal or greater then DSBSIZE_MIN
-		pThis->EmuBufferDesc.dwBufferBytes = DSBSIZE_MIN;
-	}
-	else {
-		pThis->EmuBufferDesc.dwBufferBytes = Host_dwByteLength;
-	}
+    if (Host_dwByteLength< DSBSIZE_MIN) { //the min. buffer bytes must be equal or greater then DSBSIZE_MIN
+        pThis->EmuBufferDesc.dwBufferBytes = DSBSIZE_MIN;
+    }
+    else {
+        pThis->EmuBufferDesc.dwBufferBytes = Host_dwByteLength;
+    }
     // NOTE: Test case JSRF, if we allow to re-alloc without checking allocated buffer size.
     // Then it is somehow binded to IDirectSound_SetPosition control for any allocated audio afterward.
 
@@ -549,7 +549,7 @@ static inline void DSoundBufferResizeUpdate(
     DWORD                       Xb_dwByteLength) {
 
     xbox::EmuDirectSoundBuffer* pThis = pHybridThis->emuDSBuffer;
-    DSoundBufferResizeSetSize(pHybridThis, hRet, Xb_dwByteLength); 
+    DSoundBufferResizeSetSize(pHybridThis, hRet, Xb_dwByteLength);
 
     hRet = pThis->EmuDirectSoundBuffer8->Lock(0, 0, &pThis->Host_lock.pLockPtr1, &pThis->Host_lock.dwLockBytes1,
                                               nullptr, nullptr, DSBLOCK_ENTIREBUFFER);

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -371,12 +371,19 @@ static inline void DSoundGenericUnlock(
 static inline HRESULT DSoundBufferCreate(LPDSBUFFERDESC pDSBufferDesc, LPDIRECTSOUNDBUFFER8 &pDSBuffer)
 {
     LPDIRECTSOUNDBUFFER pTempBuffer;
+	//Todo:shall we check the pDSBufferDesc->dwBufferBytes with legal ranges between DSBSIZE_MIN and DSBSIZE_MAX again?
     HRESULT hRetDS = g_pDSound8->CreateSoundBuffer(pDSBufferDesc, &pTempBuffer, nullptr);
 
-    if (hRetDS == DS_OK) {
-        hRetDS = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&(pDSBuffer));
-        pTempBuffer->Release();
-    }
+	if (hRetDS == DS_OK) {
+		hRetDS = pTempBuffer->QueryInterface(IID_IDirectSoundBuffer8, (LPVOID*)&(pDSBuffer));
+		pTempBuffer->Release();
+		if (pDSBuffer == nullptr) {
+			EmuLog(LOG_LEVEL::WARNING, "CreateSoundBuffer:QueryInterface Failed!");
+		}
+	}
+	else {
+		EmuLog(LOG_LEVEL::WARNING, "CreateSoundBuffer Failed!");
+	}
     return hRetDS;
 }
 
@@ -456,13 +463,17 @@ static inline void DSoundBufferReCreate(
     xbox::CDirectSoundVoice*     Xb_Voice) {
 
 
-    DSoundBufferCreate(&DSBufferDesc, pDSBufferNew);
-
-    if (pDS3DBuffer != nullptr) {
+    HRESULT hretDS = DSoundBufferCreate(&DSBufferDesc, pDSBufferNew);
+	//create new DS3DBuffer from the new DSBuffer if the new DSBuffer is created successfully.
+    if (pDSBufferNew != nullptr) {
         DSound3DBufferCreate(pDSBufferNew, pDS3DBufferNew);
-    }
+		DSoundBufferTransferSettings(pDSBuffer, pDSBufferNew, pDS3DBuffer, pDS3DBufferNew, Xb_Voice);//Sanity checks inside.
+	}
+	else {
+		EmuLog(LOG_LEVEL::WARNING, "DSoundBufferReCreate Failed!");
+	}
 
-    DSoundBufferTransferSettings(pDSBuffer, pDSBufferNew, pDS3DBuffer, pDS3DBufferNew, Xb_Voice);
+    
 }
 
 static inline void DSoundBufferRelease(
@@ -503,8 +514,12 @@ static inline void DSoundBufferResizeSetSize(
         return;
     }
 
-    pThis->EmuBufferDesc.dwBufferBytes = Host_dwByteLength;
-
+	if (Host_dwByteLength< DSBSIZE_MIN) { //the min. buffer bytes must be equal or greater then DSBSIZE_MIN
+		pThis->EmuBufferDesc.dwBufferBytes = DSBSIZE_MIN;
+	}
+	else {
+		pThis->EmuBufferDesc.dwBufferBytes = Host_dwByteLength;
+	}
     // NOTE: Test case JSRF, if we allow to re-alloc without checking allocated buffer size.
     // Then it is somehow binded to IDirectSound_SetPosition control for any allocated audio afterward.
 
@@ -534,7 +549,7 @@ static inline void DSoundBufferResizeUpdate(
     DWORD                       Xb_dwByteLength) {
 
     xbox::EmuDirectSoundBuffer* pThis = pHybridThis->emuDSBuffer;
-    DSoundBufferResizeSetSize(pHybridThis, hRet, Xb_dwByteLength);
+    DSoundBufferResizeSetSize(pHybridThis, hRet, Xb_dwByteLength); 
 
     hRet = pThis->EmuDirectSoundBuffer8->Lock(0, 0, &pThis->Host_lock.pLockPtr1, &pThis->Host_lock.dwLockBytes1,
                                               nullptr, nullptr, DSBLOCK_ENTIREBUFFER);


### PR DESCRIPTION
Implement ImageDesc in DownloadEffectsImage call. fix Otogi 1, and first step of Otogi 2, PRG2.
vector iterator fix PGR2 in further step, get in game now.
there is further vector iterator fix which would help CrashTwinsanity to avoid crash, but the title seems to trap in another inifinite loop so I didn't put the fix here together.