### PR TITLE
Change Memory/buffer release order. delete X_CDirectSoundStream*   when ref. count decrease to 0

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DirectSoundStream.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundStream.cpp
@@ -176,48 +176,43 @@ xbox::ulong_xt WINAPI xbox::EMUPATCH(CDirectSoundStream_Release)
     LOG_FUNC_ONE_ARG(pThis);
 
     ULONG uRet = 0;
-    if (pThis != 0 && (pThis->EmuDirectSoundBuffer8 != 0)) {
+    if (pThis != nullptr && (pThis->EmuDirectSoundBuffer8 != 0)) {
 
-        //if (uRet == 0) {
-
-            // 1. remove packet/vector/iterator
-            for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
-                //CrashTwinsanity crashed here when interrupt cut scene. the vector iterator is still valid, but the buffer->xmp_data is no longer valid. so we have to free the buffer->xmp_data after we delete the packet.
-                DSStream_Packet_Clear(buffer, XMP_STATUS_FLUSHED, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis);
-            }
-            // 2. remove the EmuBufferDesc
-            if (pThis->EmuBufferDesc.lpwfxFormat != nullptr) {
-                free(pThis->EmuBufferDesc.lpwfxFormat);
-                pThis->EmuBufferDesc.lpwfxFormat = nullptr;
-            }
-            // NOTE: Do not release X_BufferCache! X_BufferCache is using xbox buffer.
-
-            // 3. remove cache entry
-            vector_ds_stream::iterator ppDSStream = std::find(g_pDSoundStreamCache.begin(), g_pDSoundStreamCache.end(), pThis);
-            if (ppDSStream != g_pDSoundStreamCache.end()) {
-                g_pDSoundStreamCache.erase(ppDSStream);
-            }
-
-            // 4. remove direct sound 3D buffer
-            if (pThis->EmuDirectSound3DBuffer8 != nullptr) {
-                pThis->EmuDirectSound3DBuffer8->Release();
-                pThis->EmuDirectSound3DBuffer8 = nullptr;
-            }
-
-            //}
-            // 5. release the direct sound buffer
-            if (pThis->EmuDirectSoundBuffer8 != nullptr) {
-                uRet = pThis->EmuDirectSoundBuffer8->Release();
-                pThis->EmuDirectSoundBuffer8 = nullptr;
-            }
-
-            // 6. remove X_CDirectSoundStream. pThis must be delete in the last. once it's been deleted, all it's members will be unaccessible.
-            //delete pThis;
-        
-
-    }
-    else if (pThis != 0) {
-        delete pThis;
+        // 1. remove packet/vector/iterator
+        for (auto buffer = pThis->Host_BufferPacketArray.begin(); buffer != pThis->Host_BufferPacketArray.end();) {
+            //CrashTwinsanity crashed here when interrupt cut scene. the vector iterator is still valid, but the buffer->xmp_data is no longer valid. so we have to free the buffer->xmp_data after we delete the packet.
+            DSStream_Packet_Clear(buffer, XMP_STATUS_FLUSHED, pThis->Xb_lpfnCallback, pThis->Xb_lpvContext, pThis);
+        }
+        // NOTE: Do not release X_BufferCache! X_BufferCache is using xbox buffer.
+        // 2. remove cache entry
+        vector_ds_stream::iterator ppDSStream = std::find(g_pDSoundStreamCache.begin(), g_pDSoundStreamCache.end(), pThis);
+        if (ppDSStream != g_pDSoundStreamCache.end()) {
+            g_pDSoundStreamCache.erase(ppDSStream);
+        }
+        // 3. remove direct sound 3D buffer
+        if (pThis->EmuDirectSound3DBuffer8 != nullptr) {
+			if (pThis->EmuDirectSound3DBuffer8->Release() == 0) {
+				pThis->EmuDirectSound3DBuffer8 = nullptr;
+			}
+        }
+        //}
+        // 4. release the direct sound buffer
+        if (pThis->EmuDirectSoundBuffer8 != nullptr) {
+            uRet = pThis->EmuDirectSoundBuffer8->Release();
+			//check the reference count. only delete pThis when reference count decrease to 0.
+			//CrashTwinsanity will call CDirectSoundStream_Release twic with the same  X_CDirectSoundStream*   pThis, so we need to check reference count.
+			if (uRet == 0) {
+				// 5.remove the EmuBufferDesc
+				if (pThis->EmuBufferDesc.lpwfxFormat != nullptr) {
+					free(pThis->EmuBufferDesc.lpwfxFormat);
+					pThis->EmuBufferDesc.lpwfxFormat = nullptr;//this should be redundant since we're going to delete pThis.
+				}
+				pThis->EmuDirectSoundBuffer8 = nullptr; //this should be redundant since we're going to delete pThis.
+				//6. remove pThis
+				delete pThis;
+			}
+            
+        }
     }
 
     RETURN(uRet);


### PR DESCRIPTION
Change Memory/buffer release order to the reverse order of creation. 
delete X_CDirectSoundStream*   pThis in the 2nd call to CDirectSoundStream_Release(). 
this makes CrashTwinsanity happily ingame. 
somehow CrashTwinsanity calls CDirectSoundStream_Release twice with the same X_CDirectSoundStream*, and it only null out it's internal X_CDirectSoundStream* after the 2nd call of release. this modification makes it happy. so far no regressions with other titles. need further test.