### PR TITLE
fixing 3D mip-map conversion with volume texture, fix Halo

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6123,9 +6123,9 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 					if (!skipDueToNoPalette) {
 						if (!ConvertD3DTextureToARGBBuffer(
 							X_Format,
-							pSrc, pxMipWidth, pxMipHeight, dwMipRowPitch, dwMipSize,//use dwMipSize instaed of dwSrcSlicePitch here, because the mipSize changed in 3D mip map.
+							pSrc, pxMipWidth, pxMipHeight, dwMipRowPitch, dwMipSize,//use dwMipSize instead of dwSrcSlicePitch here, because the mipSize changed in 3D mip map.
 							pDst, dwDstRowPitch, dwDstSlicePitch,
-							pxMipDepth,//usd pxMipDepth here because in 3D mip map the 3rd dimension also shrinked to 1/2 at each mip level.
+							pxMipDepth,//used pxMipDepth here because in 3D mip map the 3rd dimension also shrinked to 1/2 at each mip level.
 							iTextureStage)) {
 							CxbxKrnlCleanup("Unhandled conversion!");
 						}
@@ -6218,7 +6218,7 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 				}
 
 				if (pxMipDepth > 1) {
-					pxMipDepth /= 2;//this is for 3D volumeTexture mip-map, it shrinked down to 1/2 in 3 diemesions. this variable should be used.
+					pxMipDepth /= 2;//this is for 3D volumeTexture mip-map, it shrinked down to 1/2 in 3 dimensions. this variable should be used.
 				}
 			} // for mipmap levels
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6123,9 +6123,9 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 					if (!skipDueToNoPalette) {
 						if (!ConvertD3DTextureToARGBBuffer(
 							X_Format,
-							pSrc, pxMipWidth, pxMipHeight, dwMipRowPitch, dwSrcSlicePitch,
+							pSrc, pxMipWidth, pxMipHeight, dwMipRowPitch, dwMipSize,//use dwMipSize instaed of dwSrcSlicePitch here, because the mipSize changed in 3D mip map.
 							pDst, dwDstRowPitch, dwDstSlicePitch,
-							dwDepth,
+							pxMipDepth,//usd pxMipDepth here because in 3D mip map the 3rd dimension also shrinked to 1/2 at each mip level.
 							iTextureStage)) {
 							CxbxKrnlCleanup("Unhandled conversion!");
 						}
@@ -6196,11 +6196,11 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 				}
 
 				if (face == D3DCUBEMAP_FACE_POSITIVE_X) {
-					dwCubeFaceSize += dwDepth * dwMipSize;
+					dwCubeFaceSize += pxMipDepth * dwMipSize;
 				}
 
 				// Calculate the next mipmap level dimensions
-				dwMipOffset += dwMipSize;
+				dwMipOffset += pxMipDepth * dwMipSize;//for 3D volumeTexture, the dwDepth >1 in mip_level 0, pxMipDepth must be multiplied.
 				if (pxMipWidth > 1) {
 					pxMipWidth /= 2;
 
@@ -6218,7 +6218,7 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 				}
 
 				if (pxMipDepth > 1) {
-					pxMipDepth /= 2;
+					pxMipDepth /= 2;//this is for 3D volumeTexture mip-map, it shrinked down to 1/2 in 3 diemesions. this variable should be used.
 				}
 			} // for mipmap levels
 


### PR DESCRIPTION
using correct 3D mip map dimention sizes in all 3 dimensions, and calculate correct source size.
this fix Halo, get in game.
note: the cache partition must be cleared prior to emulation, or the title would get stocked in D3DResouce_IsBusy() check. 
debug build is more stable. somehow the release build won't work, seems stocked in the  D3DResouce_IsBusy() check.

 video here https://www.youtube.com/watch?v=ARHHpgDrCts
https://youtu.be/LHXHPia4Pc0
![image](https://user-images.githubusercontent.com/16368365/121475693-58927e00-c9f8-11eb-819c-4c5c1f955e73.png)
![image](https://user-images.githubusercontent.com/16368365/121478719-e6239d00-c9fb-11eb-830a-bf3d0f7675dc.png)
