### PR TITLE
Removed unused dwBytesRead variable and unused argument from XB_InitalizeObjectAttributes macro

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/XFileMediaObject.cpp
+++ b/src/core/hle/DSOUND/DirectSound/XFileMediaObject.cpp
@@ -152,7 +152,6 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(XAudioDownloadEffectsImage)
         else { // load from file
             LPDIRECTSOUND8  pThis_tmp = zeroptr;
             HANDLE hFile;
-            DWORD dwBytesRead;
 
             // using xbox::NtCreateFile() directly instead of Host CreateFile();
             OBJECT_ATTRIBUTES obj;

--- a/src/core/kernel/common/ob.h
+++ b/src/core/kernel/common/ob.h
@@ -75,7 +75,7 @@ ntstatus_xt ObpReferenceObjectByName(
 	OUT PVOID *ReturnedObject
 );
 
-#define XB_InitializeObjectAttributes(p, n, a, r, s){\
+#define XB_InitializeObjectAttributes(p, n, a, r){\
 	(p)->RootDirectory = r;   \
 	(p)->Attributes = a;      \
 	(p)->ObjectName = n;      \

--- a/src/core/kernel/exports/EmuKrnlOb.cpp
+++ b/src/core/kernel/exports/EmuKrnlOb.cpp
@@ -82,7 +82,7 @@ xbox::boolean_xt xbox::ObpCreatePermanentDirectoryObject(
 		LOG_FUNC_END;
 
 	OBJECT_ATTRIBUTES ObjectAttributes;
-	XB_InitializeObjectAttributes(&ObjectAttributes, DirectoryName, OBJ_PERMANENT, NULL, NULL);
+	XB_InitializeObjectAttributes(&ObjectAttributes, DirectoryName, OBJ_PERMANENT, NULL);
 
 	HANDLE Handle;
 	NTSTATUS status = NtCreateDirectoryObject(&Handle, &ObjectAttributes);


### PR DESCRIPTION
Spotted by @PatrickvL in the dx11 branch.