### PR TITLE
Add support to load dsp images from xbe sections

### DIFF
--- a/src/common/xbe/Xbe.cpp
+++ b/src/common/xbe/Xbe.cpp
@@ -698,19 +698,6 @@ uint8_t *Xbe::GetLogoBitmap(uint32_t x_dwSize)
     return 0;
 }
 
-void *Xbe::FindSection(char *zsSectionName)
-{
-	for (uint32_t v = 0; v < m_Header.dwSections; v++) {
-		if (strcmp(m_szSectionName[v], zsSectionName) == 0) {
-			if (m_SectionHeader[v].dwVirtualAddr > 0 && m_SectionHeader[v].dwVirtualSize > 0) {
-				return m_bzSection[v];
-			}
-		}
-	}
-
-	return nullptr;
-}
-
 void* Xbe::FindSection(xbox::PXBEIMAGE_SECTION section)
 {
 	for (uint32_t v = 0; v < m_Header.dwSections; v++) {
@@ -827,3 +814,6 @@ XbeType Xbe::GetXbeType()
 	// Otherwise, the XBE is a Retail build :
 	return XbeType::xtRetail;
 }
+
+template auto Xbe::FindSection<true>(const char *zsSectionName);
+template auto Xbe::FindSection<false>(const char *zsSectionName);

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -1489,9 +1489,9 @@ typedef struct {
 void WndMain::LoadGameLogo()
 {
 	// Export Game Logo bitmap (XTIMAG or XSIMAG)
-	uint8_t *pSection = (uint8_t *)m_Xbe->FindSection("$$XTIMAGE"); // Check for XTIMAGE
+	uint8_t *pSection = (uint8_t *)m_Xbe->FindSection<false>("$$XTIMAGE"); // Check for XTIMAGE
 	if (!pSection) {
-		pSection = (uint8_t *)m_Xbe->FindSection("$$XSIMAGE"); // if XTIMAGE isn't present, check for XSIMAGE (smaller)
+		pSection = (uint8_t *)m_Xbe->FindSection<false>("$$XSIMAGE"); // if XTIMAGE isn't present, check for XSIMAGE (smaller)
 		if (!pSection) {
 			return;
 		}


### PR DESCRIPTION
Halo 2 tries to load a dsp image with `XAudioDownloadEffectsImage` from an xbe section called "DSPImage", and it was crashing when it attempted to read the nullptr that we were returning from the function. Unfortunately, it still crashes later before showing anything when it tries to execute a dpc set by `KeSetTimer`.