### PR TITLE
Fix Release Title Default

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,4 +79,4 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }} # https://github.com/cli/cli/issues/3556
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ steps.git.outputs.tag_name }} artifacts/*.zip -p --target $GITHUB_SHA
+        run: gh release create ${{ steps.git.outputs.tag_name }} artifacts/*.zip -p --target $GITHUB_SHA --title '${{ steps.git.outputs.tag_name }}'


### PR DESCRIPTION
@LukeUsher found a bug caused by #2242 for release creation to return empty name in GitHub API. I recongize recent merged pull request output unintentional default title name on release page. This pull request will fix the issue.

Doc: https://cli.github.com/manual/gh_release_create