### PR TITLE
Fixed a crash in Halo 2 on debug builds

### DIFF
--- a/src/core/kernel/exports/EmuKrnlKe.cpp
+++ b/src/core/kernel/exports/EmuKrnlKe.cpp
@@ -1827,8 +1827,8 @@ XBSYSAPI EXPORTNUM(150) xbox::boolean_xt NTAPI xbox::KeSetTimerEx
 	}
 
 	/* Exit the dispatcher */
-	KiUnlockDispatcherDatabase(OldIrql);
 	KiTimerUnlock();
+	KiUnlockDispatcherDatabase(OldIrql);
 
 	RETURN(Inserted);
 }


### PR DESCRIPTION
On debug builds. Halo 2 would regularly crash with a stack overflow exception when trying to execute a dpc set by `KeSetTimerEx`. At the end of the function, `KiUnlockDispatcherDatabase` is called before releasing the timer lock, which would mean that, when `KiUnlockDispatcherDatabase` tries to execute a dpc, the lock was still held and somehow, that caused the problem. Simply swapping the order of the two calls solves this.