### PR TITLE
Fix cubemap faces all being the same face

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6102,7 +6102,7 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 					dwDstSlicePitch = 0;
 				}
 
-				uint8_t *pSrc = (uint8_t *)VirtualAddr + dwMipOffset;
+				uint8_t *pSrc = (uint8_t *)VirtualAddr + dwCubeFaceOffset + dwMipOffset;
 
 				// Do we need to convert to ARGB?
 				if (bConvertToARGB) {


### PR DESCRIPTION
And clarification of the texture/mipmap copy code

Cubemap fix fixes PerPixelLighting samples and some lights in Halo

Before:
![image](https://user-images.githubusercontent.com/9897874/123940653-7d718400-d9ed-11eb-91a3-a36e77345422.png)

After:
![image](https://user-images.githubusercontent.com/9897874/123940375-3a171580-d9ed-11eb-9fd4-bd6779178f2d.png)