### PR TITLE
Removed unnecessary info from the cxbxr title string

### DIFF
--- a/src/CxbxVersion.cpp
+++ b/src/CxbxVersion.cpp
@@ -7,8 +7,10 @@
 /*! version string dependent on trace flag */
 #ifndef _DEBUG_TRACE
 const char* CxbxVersionStr = _GIT_VERSION " (" __DATE__  ")";
+const char *CxbxrHashBuild = _GIT_VERSION;
 #else
 const char* CxbxVersionStr = _GIT_VERSION "-Trace (" __DATE__  ")";
+const char *CxbxrHashBuild = _GIT_VERSION "-Trace";
 #endif
 
 static constexpr const char *GitVersionStr = _GIT_VERSION;

--- a/src/CxbxVersion.h
+++ b/src/CxbxVersion.h
@@ -1,6 +1,7 @@
 #pragma once
 
 extern const char* CxbxVersionStr;
+extern const char *CxbxrHashBuild;
 
 // Note: GitVersionMaxLength should be large enough to accomodate the longest git version string we can practically expect to have. This is necessary
 // to avoid possible mismatches in the string length which can happen if the user mixes different cxbxr versions

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -205,7 +205,7 @@ WndMain::WndMain(HINSTANCE x_hInstance) :
 	// initialize members
 	{
 		m_classname = "WndMain";
-		m_wndname   = "Cxbx-Reloaded " + std::string(CxbxVersionStr);
+		m_wndname   = "Cxbx-Reloaded " + std::string(CxbxrHashBuild);
 	}
 
 	// load configuration from settings file
@@ -1868,16 +1868,9 @@ void WndMain::UpdateCaption()
 {
 	char AsciiTitle[MAX_PATH];
 
-	int i = sprintf(AsciiTitle, "Cxbx-Reloaded %s", CxbxVersionStr);
+	int i = sprintf(AsciiTitle, "Cxbx-Reloaded %s", CxbxrHashBuild);
 	if (m_Xbe != nullptr) {
-		if (m_bIsStarted) {
-			i += sprintf(AsciiTitle + i, " : Emulating ");
-		}
-		else {
-			i += sprintf(AsciiTitle + i, " : Loaded ");
-		}
-
-		i += sprintf(AsciiTitle + i, "%s v1.%02d (%s)", FormatTitleId(m_Xbe->m_Certificate.dwTitleId).c_str(), m_Xbe->m_Certificate.dwVersion, m_Xbe->m_szAsciiTitle);
+		i += sprintf(AsciiTitle + i, " : %s v1.%02d (%s)", FormatTitleId(m_Xbe->m_Certificate.dwTitleId).c_str(), m_Xbe->m_Certificate.dwVersion, m_Xbe->m_szAsciiTitle);
 
 		UpdateFpsStatus();
 		UpdateLogStatus();


### PR DESCRIPTION
This removes from the title string the date of the build and the strings "Loaded" and "Emulating". This, because the latter are just useless, and the former because the build is already uniquely identified by the hash and it's not reliable because we can have multiple builds on the same day. Very often, this led to excessively long title strings, and you could not read the name of the game because of this.