### PR TITLE
Removed stdcall from EmuLog functions

### DIFF
--- a/src/common/Logging.cpp
+++ b/src/common/Logging.cpp
@@ -159,7 +159,7 @@ inline void EmuLogOutputEx(const CXBXR_MODULE cxbxr_module, const LOG_LEVEL leve
 }
 
 // print out a custom message to the console or kernel debug log file
-void NTAPI EmuLogEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, const char *szWarningMessage, ...)
+void EmuLogEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, const char *szWarningMessage, ...)
 {
 	if (szWarningMessage == NULL) {
 		return;
@@ -180,7 +180,7 @@ void NTAPI EmuLogEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, const char *szWa
 	}
 }
 
-void NTAPI EmuLogInit(LOG_LEVEL level, const char *szWarningMessage, ...)
+void EmuLogInit(LOG_LEVEL level, const char *szWarningMessage, ...)
 {
 	if (szWarningMessage == NULL) {
 		return;

--- a/src/common/Logging.h
+++ b/src/common/Logging.h
@@ -121,8 +121,8 @@ extern std::atomic_int g_CurrentLogLevel;
 extern std::atomic_bool g_CurrentLogPopupTestCase;
 
 // print out a log message to the console or kernel debug log file if level is high enough
-void NTAPI EmuLogEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, const char *szWarningMessage, ...);
-void NTAPI EmuLogInit(LOG_LEVEL level, const char *szWarningMessage, ...);
+void EmuLogEx(CXBXR_MODULE cxbxr_module, LOG_LEVEL level, const char *szWarningMessage, ...);
+void EmuLogInit(LOG_LEVEL level, const char *szWarningMessage, ...);
 
 #define EmuLog(level, fmt, ...) EmuLogEx(LOG_PREFIX, level, fmt, ##__VA_ARGS__)
 


### PR DESCRIPTION
`EmuLogEx` and `EmuLogInit` are variadic functions, and thus using stdcall on them is an error and probably caused undefined behavior. This switches them to use cdecl instead.