### PR TITLE
Fixed invalid handle exception in freopen

### DIFF
--- a/src/common/win32/InlineFunc.cpp
+++ b/src/common/win32/InlineFunc.cpp
@@ -68,6 +68,9 @@ std::optional<std::string> CxbxExec(bool useDebugger, HANDLE* hProcess, bool req
 		Using ShellExecute has proper implement. Unfortunately, we need created process handle for Debugger monitor.
 		Plus ShellExecute is high level whilst CreateProcess is low level. We want to use official low level functions as possible to reduce
 		cpu load cycles to get the task done.
+
+		Without the DETACHED_PROCESS flag, the default behavior would be for the new process to inherit the console of the parent process,
+		which is wrong since we want the emulation process to have its own console allocated with AllocConsole instead.
 	*/
 	if (CreateProcess(nullptr, const_cast<LPSTR>(szProcArgsBuffer.c_str()), nullptr, nullptr, false, DETACHED_PROCESS, nullptr, nullptr, &startupInfo, &processInfo) == 0) {
 		return std::make_optional<std::string>("Failed to create the new emulation process. CreateProcess failed because: " + WinError2Str());

--- a/src/common/win32/InlineFunc.cpp
+++ b/src/common/win32/InlineFunc.cpp
@@ -69,7 +69,7 @@ std::optional<std::string> CxbxExec(bool useDebugger, HANDLE* hProcess, bool req
 		Plus ShellExecute is high level whilst CreateProcess is low level. We want to use official low level functions as possible to reduce
 		cpu load cycles to get the task done.
 	*/
-	if (CreateProcess(nullptr, const_cast<LPSTR>(szProcArgsBuffer.c_str()), nullptr, nullptr, false, 0, nullptr, nullptr, &startupInfo, &processInfo) == 0) {
+	if (CreateProcess(nullptr, const_cast<LPSTR>(szProcArgsBuffer.c_str()), nullptr, nullptr, false, DETACHED_PROCESS, nullptr, nullptr, &startupInfo, &processInfo) == 0) {
 		return std::make_optional<std::string>("Failed to create the new emulation process. CreateProcess failed because: " + WinError2Str());
 	}
 	CloseHandle(processInfo.hThread);


### PR DESCRIPTION
This uses `DETACHED_PROCESS` as the `dwCreationFlags` argument of `CreateProcess`, which cxbxr uses when launching a new emulation process. Without this flag, the default behavior would be for the new process to inherit the console of the parent process, which is wrong since we want the emulation process to have its own console allocated with `AllocConsole` instead. This apparently fixes the invalid handle exception that used to always happen in `freopen` during initialization in this [line](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/blob/ac68fd481cf6c4640f6986ce15174b413329fb2c/src/core/kernel/init/CxbxKrnl.cpp#L529).