### PR TITLE
Implement HalEnableSecureTrayEject xbox kernel function.

### DIFF
--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -828,6 +828,7 @@ XBSYSAPI EXPORTNUM(365) xbox::void_xt NTAPI xbox::HalEnableSecureTrayEject
 		xbox::ulong_xt disable_reset_on_eject = 0;
 		NTSTATUS retcode;
 		do {
+            // TODO: Implement SMC_COMMAND_RESET_ON_EJECT in the SMC.
 			retcode = HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_RESET_ON_EJECT, write_word, disable_reset_on_eject);
 		} while (retcode != xbox::status_success);
 	}

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -805,6 +805,9 @@ XBSYSAPI EXPORTNUM(360) xbox::ntstatus_xt NTAPI xbox::HalInitiateShutdown
 	RETURN(S_OK);
 }
 
+// Something else in the kernel sets this flag. Not sure what.
+static xbox::boolean_xt g_SecureTrayEjectAllowed = false;
+
 // ******************************************************************
 // * 0x016D - HalEnableSecureTrayEject()
 // ******************************************************************
@@ -819,7 +822,15 @@ XBSYSAPI EXPORTNUM(365) xbox::void_xt NTAPI xbox::HalEnableSecureTrayEject
 {
 	LOG_FUNC();
 
-	LOG_UNIMPLEMENTED();
+	if (g_SecureTrayEjectAllowed) {
+		g_SecureTrayEjectAllowed = false;
+		xbox::boolean_xt write_word = false;
+		xbox::ulong_xt disable_reset_on_eject = 0;
+		NTSTATUS retcode;
+		do {
+			retcode = HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_RESET_ON_EJECT, write_word, disable_reset_on_eject);
+		} while (retcode != xbox::status_success);
+	}
 }
 
 // ******************************************************************

--- a/src/devices/SMCDevice.h
+++ b/src/devices/SMCDevice.h
@@ -70,7 +70,7 @@
 #define SMC_COMMAND_LED_SEQUENCE 0x08	// LED flashing sequence
 //0x0C	tray eject(0 = eject; 1 = load)
 //0x0E	another scratch register ? seems like an error code.
-//0x19	reset on eject(0 = enable; 1 = disable)
+#define SMC_COMMAND_RESET_ON_EJECT 0x19	// Reset on eject (0 = disable, 1 = enable)
 //0x1A	interrupt enable(write 0x01 to enable; can't disable once enabled)
 #define SMC_COMMAND_SCRATCH 0x1B	//0x1B	scratch register for the original kernel
 //0x20	response to PIC challenge(written first)


### PR DESCRIPTION
I found this old branch on my hard drive. The function is fully implemented but I never was able to figure out how the flag variable works. I figure something is better than nothing.