### PR TITLE
Fix Outrun 2006 performance issue

### DIFF
--- a/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
@@ -1658,7 +1658,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IDirectSoundBuffer_StopEx)
             }
         }
 		else {
-			LOG_TEST_CASE("Expected DSBSTOPEX_ENVELOPE");
+			LOG_TEST_CASE("Expected X_DSBSTOPEX_ENVELOPE");
 		}
     }
 


### PR DESCRIPTION
Outrun 2006 lags entirely due to converting large ADPCM buffers when certain sound effects occur.
This change attempts to convert the minimum range of bytes required
This is probably broken