### PR TITLE
Fix UEM and LED Status

### DIFF
--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1716,6 +1716,10 @@ void CxbxKrnlPrintUEM(ULONG ErrorCode)
 	g_CxbxFatalErrorCode = ErrorCode;
 	g_CxbxPrintUEM = true; // print the UEM
 
+	// Force repaint screen in order for UEM to be visible every time.
+	InvalidateRect(g_hEmuWindow, nullptr, TRUE);
+	UpdateWindow(g_hEmuWindow);
+
 	CxbxPrintUEMInfo(ErrorCode);
 
 	// Sleep forever to prevent continuing the initialization

--- a/src/gui/WndMain.h
+++ b/src/gui/WndMain.h
@@ -188,6 +188,7 @@ class WndMain : public Wnd
         // ******************************************************************
         bool        m_bXbeChanged;
         bool        m_bIsStarted;
+        size_t      m_iIsEmulating;
 
         // ******************************************************************
         // * cached filenames


### PR DESCRIPTION
It came to our attention that UEM does not show and LED status remain black. It turns out two separate issues.
1. Emulator created a window and get called to paint once with `g_CxbxPrintUEM` value currently set to false. When reach to print UEM function, it was too late. So the screen need to be invalidate and redraw again in order to show up.
2. LED status return black when emulator have fatal error. It turns out GUI thinks emulation has stopped between reboots except it has not. Here's the current procedure of how communication between emulator and gui.
   - 1st emulator sent ID_GUI_STATUS_KRNL_IS_READY message to GUI
   - CrashMonitor is called to bind check for 1st process termination.
   - 1st emulator's window creation (WM_CREATE)
      **(reboot process)**
   - 2nd emulator sent ID_GUI_STATUS_KRNL_IS_READY message to GUI
   - CrashMonitor is called to bind check for 2nd process termination.
   - 1st emulator's window destruction (WM_DESTROY)
   - CrashMonitor resume check for 1st process termination's status.
   - 2nd emulator's window creation (WM_CREATE)
  
  First emulator's window destruction triggered to kill the timer for LED status. Instead of checking child window, we perform increment in CrashMonitorWrapper to keep thinking emulation is still running until CrashMonitor thread is done.
  
  Beside this, I also organize all of stopping emulation calls into StopEmulation to keep the code cleaner and simple.