### PR TITLE
Fix kernel type hints for READ_PORT_BUFFER and friends

### DIFF
--- a/src/core/kernel/common/hal.h
+++ b/src/core/kernel/common/hal.h
@@ -133,7 +133,7 @@ XBSYSAPI EXPORTNUM(50) ntstatus_xt NTAPI HalWriteSMBusValue
 // ******************************************************************
 XBSYSAPI EXPORTNUM(329) void_xt NTAPI READ_PORT_BUFFER_UCHAR
 (
-    IN PUCHAR Port,
+    IN word_xt Port,
     IN PUCHAR Buffer,
     IN ulong_xt  Count
 );
@@ -143,7 +143,7 @@ XBSYSAPI EXPORTNUM(329) void_xt NTAPI READ_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(330) void_xt NTAPI READ_PORT_BUFFER_USHORT
 (
-    IN PUSHORT Port,
+    IN word_xt Port,
     IN PUSHORT Buffer,
     IN ulong_xt   Count
 );
@@ -153,7 +153,7 @@ XBSYSAPI EXPORTNUM(330) void_xt NTAPI READ_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(331) void_xt NTAPI READ_PORT_BUFFER_ULONG
 (
-    IN PULONG Port,
+    IN word_xt Port,
     IN PULONG Buffer,
     IN ulong_xt  Count
 );
@@ -163,7 +163,7 @@ XBSYSAPI EXPORTNUM(331) void_xt NTAPI READ_PORT_BUFFER_ULONG
 // ******************************************************************
 XBSYSAPI EXPORTNUM(332) void_xt NTAPI WRITE_PORT_BUFFER_UCHAR
 (
-    IN PUCHAR Port,
+    IN word_xt Port,
     IN PUCHAR Buffer,
     IN ulong_xt  Count
 );
@@ -173,7 +173,7 @@ XBSYSAPI EXPORTNUM(332) void_xt NTAPI WRITE_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(333) void_xt NTAPI WRITE_PORT_BUFFER_USHORT
 (
-    IN PUSHORT Port,
+    IN word_xt Port,
     IN PUSHORT Buffer,
     IN ulong_xt   Count
 );
@@ -183,7 +183,7 @@ XBSYSAPI EXPORTNUM(333) void_xt NTAPI WRITE_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(334) void_xt NTAPI WRITE_PORT_BUFFER_ULONG
 (
-    IN PULONG Port,
+    IN word_xt Port,
     IN PULONG Buffer,
     IN ulong_xt  Count
 );

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -656,7 +656,7 @@ XBSYSAPI EXPORTNUM(50) xbox::ntstatus_xt NTAPI xbox::HalWriteSMBusValue
 // ******************************************************************
 XBSYSAPI EXPORTNUM(329) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_UCHAR
 (
-	IN PUCHAR Port,
+	IN word_xt Port,
 	IN PUCHAR Buffer,
 	IN ulong_xt  Count
 )
@@ -676,7 +676,7 @@ XBSYSAPI EXPORTNUM(329) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(330) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_USHORT
 (
-	IN PUSHORT Port,
+	IN word_xt Port,
 	IN PUSHORT Buffer,
 	IN ulong_xt   Count
 )
@@ -696,7 +696,7 @@ XBSYSAPI EXPORTNUM(330) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(331) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_ULONG
 (
-	IN PULONG Port,
+	IN word_xt Port,
 	IN PULONG Buffer,
 	IN ulong_xt  Count
 )
@@ -716,7 +716,7 @@ XBSYSAPI EXPORTNUM(331) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_ULONG
 // ******************************************************************
 XBSYSAPI EXPORTNUM(332) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_UCHAR
 (
-	IN PUCHAR Port,
+	IN word_xt Port,
 	IN PUCHAR Buffer,
 	IN ulong_xt  Count
 )
@@ -736,7 +736,7 @@ XBSYSAPI EXPORTNUM(332) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(333) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_USHORT
 (
-	IN PUSHORT Port,
+	IN word_xt Port,
 	IN PUSHORT Buffer,
 	IN ulong_xt   Count
 )
@@ -756,7 +756,7 @@ XBSYSAPI EXPORTNUM(333) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(334) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_ULONG
 (
-	IN PULONG Port,
+	IN word_xt Port,
 	IN PULONG Buffer,
 	IN ulong_xt  Count
 )


### PR DESCRIPTION
Testing this functions thanks to nxdk removing abstractions for port reading I noticed that it was crashing my Xbox, this is due to invalid type hints. Both CXBX-R and nxdk have varying problems (for example nxdk has `PULONG` for some `Count`s and not others).

This patch will fix this for CXBX-R.

Valid ports are from 0x0 - 0xFFFF so a uint16 will suffice.

