### PR TITLE
Fix incorrect type in port io kernel functions

### DIFF
--- a/src/core/kernel/common/hal.h
+++ b/src/core/kernel/common/hal.h
@@ -133,7 +133,7 @@ XBSYSAPI EXPORTNUM(50) ntstatus_xt NTAPI HalWriteSMBusValue
 // ******************************************************************
 XBSYSAPI EXPORTNUM(329) void_xt NTAPI READ_PORT_BUFFER_UCHAR
 (
-    IN word_xt Port,
+    IN dword_xt Port,
     IN PUCHAR Buffer,
     IN ulong_xt  Count
 );
@@ -143,7 +143,7 @@ XBSYSAPI EXPORTNUM(329) void_xt NTAPI READ_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(330) void_xt NTAPI READ_PORT_BUFFER_USHORT
 (
-    IN word_xt Port,
+    IN dword_xt Port,
     IN PUSHORT Buffer,
     IN ulong_xt   Count
 );
@@ -153,7 +153,7 @@ XBSYSAPI EXPORTNUM(330) void_xt NTAPI READ_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(331) void_xt NTAPI READ_PORT_BUFFER_ULONG
 (
-    IN word_xt Port,
+    IN dword_xt Port,
     IN PULONG Buffer,
     IN ulong_xt  Count
 );
@@ -163,7 +163,7 @@ XBSYSAPI EXPORTNUM(331) void_xt NTAPI READ_PORT_BUFFER_ULONG
 // ******************************************************************
 XBSYSAPI EXPORTNUM(332) void_xt NTAPI WRITE_PORT_BUFFER_UCHAR
 (
-    IN word_xt Port,
+    IN dword_xt Port,
     IN PUCHAR Buffer,
     IN ulong_xt  Count
 );
@@ -173,7 +173,7 @@ XBSYSAPI EXPORTNUM(332) void_xt NTAPI WRITE_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(333) void_xt NTAPI WRITE_PORT_BUFFER_USHORT
 (
-    IN word_xt Port,
+    IN dword_xt Port,
     IN PUSHORT Buffer,
     IN ulong_xt   Count
 );
@@ -183,7 +183,7 @@ XBSYSAPI EXPORTNUM(333) void_xt NTAPI WRITE_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(334) void_xt NTAPI WRITE_PORT_BUFFER_ULONG
 (
-    IN word_xt Port,
+    IN dword_xt Port,
     IN PULONG Buffer,
     IN ulong_xt  Count
 );

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -656,7 +656,7 @@ XBSYSAPI EXPORTNUM(50) xbox::ntstatus_xt NTAPI xbox::HalWriteSMBusValue
 // ******************************************************************
 XBSYSAPI EXPORTNUM(329) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_UCHAR
 (
-	IN word_xt Port,
+	IN dword_xt Port,
 	IN PUCHAR Buffer,
 	IN ulong_xt  Count
 )
@@ -676,7 +676,7 @@ XBSYSAPI EXPORTNUM(329) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(330) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_USHORT
 (
-	IN word_xt Port,
+	IN dword_xt Port,
 	IN PUSHORT Buffer,
 	IN ulong_xt   Count
 )
@@ -696,7 +696,7 @@ XBSYSAPI EXPORTNUM(330) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(331) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_ULONG
 (
-	IN word_xt Port,
+	IN dword_xt Port,
 	IN PULONG Buffer,
 	IN ulong_xt  Count
 )
@@ -716,7 +716,7 @@ XBSYSAPI EXPORTNUM(331) xbox::void_xt NTAPI xbox::READ_PORT_BUFFER_ULONG
 // ******************************************************************
 XBSYSAPI EXPORTNUM(332) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_UCHAR
 (
-	IN word_xt Port,
+	IN dword_xt Port,
 	IN PUCHAR Buffer,
 	IN ulong_xt  Count
 )
@@ -736,7 +736,7 @@ XBSYSAPI EXPORTNUM(332) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_UCHAR
 // ******************************************************************
 XBSYSAPI EXPORTNUM(333) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_USHORT
 (
-	IN word_xt Port,
+	IN dword_xt Port,
 	IN PUSHORT Buffer,
 	IN ulong_xt   Count
 )
@@ -756,7 +756,7 @@ XBSYSAPI EXPORTNUM(333) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_USHORT
 // ******************************************************************
 XBSYSAPI EXPORTNUM(334) xbox::void_xt NTAPI xbox::WRITE_PORT_BUFFER_ULONG
 (
-	IN word_xt Port,
+	IN dword_xt Port,
 	IN PULONG Buffer,
 	IN ulong_xt  Count
 )


### PR DESCRIPTION
https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/2318 was merged too hastily, and it actually introduces a bug. The port argument of the kernel io port functions is a pointer, which has a 4 bytes size. This means that the xbe code will pass a 32 bit argument, while our implementation will now expect a 16 bit value, and this size mismatch might/will cause issues. So, if we don't want to keep using the pointer type, we should at least use `dword_xt` instead, a 4 byte type.