### PR TITLE
Cleanup system selection, so it's no longer abusing xbeType

### DIFF
--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -61,13 +61,14 @@ enum DebugMode { DM_NONE, DM_CONSOLE, DM_FILE };
 /*! debugger enable state */
 enum DebuggerState { debuggerOff, debuggerOn };
 
-/*! indicates emulation of an Chihiro (arcade, instead of Xbox console) executable */
+/*! indicates emulation of a Chihiro system */
 extern bool g_bIsChihiro;
 
-/*! indicates emulation of a Debug xbe executable */
-extern bool g_bIsDebug;
+/*! indicates emulation of a DevKit system */
+/* Note: Our DevKit emulation lacks the kernel debugging interface and virtual dvd-rom emulator card, so this is actually a Debug Kit */
+extern bool g_bIsDevKit;
 
-/*! indicates emulation of a Retail xbe executable*/
+/*! indicates emulation of a Retail system */
 extern bool g_bIsRetail;
 
 /*! indicates ability to save on exit (needed for settings reset) */

--- a/src/core/kernel/exports/EmuKrnlEx.cpp
+++ b/src/core/kernel/exports/EmuKrnlEx.cpp
@@ -641,7 +641,7 @@ XBSYSAPI EXPORTNUM(29) xbox::ntstatus_xt NTAPI xbox::ExSaveNonVolatileSetting
 		RETURN(X_STATUS_OBJECT_NAME_NOT_FOUND);
 
 	// handle eeprom write
-	if (g_bIsDebug || ValueIndex <= XC_MAX_OS || ValueIndex > XC_MAX_FACTORY)
+	if (g_bIsDevKit || ValueIndex <= XC_MAX_OS || ValueIndex > XC_MAX_FACTORY)
 	{
 		const EEPROMInfo* info = EmuFindEEPROMInfo((XC_VALUE_INDEX)ValueIndex);
 		if (info != nullptr) {


### PR DESCRIPTION
Rename g_bIsDebug into g_bIsDevKit for consistency with system selection
Cleaned up related comments