### PR TITLE
hle: detect when patches fail to apply

### DIFF
--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -438,8 +438,14 @@ inline void EmuInstallPatch(const std::string FunctionName, const xbox::addr_xt 
         return;
     }
 
-	g_FunctionHooks[FunctionName].Install((void*)(FunctionAddr), (void*)patch.patchFunc);
-	printf("HLE: %s Patched\n", FunctionName.c_str());
+	auto result = g_FunctionHooks[FunctionName].Install((void*)(FunctionAddr), (void*)patch.patchFunc);
+	if (!result) {
+		printf("HLE: %s Patch Failed\n", FunctionName.c_str());
+	}
+	else {
+		printf("HLE: %s Patched\n", FunctionName.c_str());
+	}
+	
 }
 
 void EmuInstallPatches()

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -438,12 +438,12 @@ inline void EmuInstallPatch(const std::string FunctionName, const xbox::addr_xt 
         return;
     }
 
-	auto result = g_FunctionHooks[FunctionName].Install((void*)(FunctionAddr), (void*)patch.patchFunc);
-	if (!result) {
-		printf("HLE: %s Patch Failed\n", FunctionName.c_str());
+	auto success = g_FunctionHooks[FunctionName].Install((void*)(FunctionAddr), (void*)patch.patchFunc);
+	if (success) {
+		printf("HLE: %s Patched\n", FunctionName.c_str());
 	}
 	else {
-		printf("HLE: %s Patched\n", FunctionName.c_str());
+		printf("HLE: %s Patch Failed\n", FunctionName.c_str());
 	}
 	
 }


### PR DESCRIPTION
Although steps could be taken to make this more obvious, I don't want to make a developer feature harm user experience, which is why this is logged rather than quitting emulation.

Previously, failed patches would be totally ignored and we would have no way to detect this,