### PR TITLE
DirectSoundBuffer streaming

### DIFF
--- a/src/core/common/imgui/audio.cpp
+++ b/src/core/common/imgui/audio.cpp
@@ -25,6 +25,7 @@ void ImGuiAudio::DrawMenu()
 {
 	if (ImGui::BeginMenu("Audio")) {
 		ImGui::MenuItem("Debug General Cache Stats", NULL, &m_windows.cache_stats_general);
+		ImGui::MenuItem("SoundBuffer Visualization", NULL, &m_windows.cache_visualization);
 		ImGui::EndMenu();
 	}
 }
@@ -32,6 +33,9 @@ void ImGuiAudio::DrawMenu()
 void ImGuiAudio::DrawWidgets(bool is_focus, ImGuiWindowFlags input_handler)
 {
 	//TODO: In need of make interface class to return generic info in some way.
-	extern void DSound_PrintStats(bool, ImGuiWindowFlags, bool m_show_audio_stats); 
+	extern void DSound_PrintStats(bool, ImGuiWindowFlags, bool m_show_audio_stats);
 	DSound_PrintStats(is_focus, input_handler, m_windows.cache_stats_general);
+
+	extern void DSound_DrawBufferVisualization(bool, bool *p_show, ImGuiWindowFlags);
+	DSound_DrawBufferVisualization(is_focus, &m_windows.cache_visualization, input_handler);
 }

--- a/src/core/common/imgui/settings.h
+++ b/src/core/common/imgui/settings.h
@@ -44,6 +44,7 @@ typedef struct {
 
 typedef struct {
 	bool cache_stats_general;
+	bool cache_visualization;
 	bool Reserved[3];
 } imgui_audio_windows;
 

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -474,7 +474,7 @@ static void dsound_thread_worker(LPVOID nullPtr)
         {
             DSoundMutexGuardLock;
 
-			if (waitCounter > g_dsBufferStreaming.streamInterval) {
+			if (waitCounter > dsStreamInterval) {
 				waitCounter = 0;
 
 				// For Async process purpose only

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.cpp
@@ -365,22 +365,134 @@ xbox::void_xt WINAPI xbox::EMUPATCH(DirectSoundDoWork)()
 
     return;
 }
-// For Async process purpose only
+
+void StreamBufferAudio(xbox::XbHybridDSBuffer* pHybridBuffer, float msToCopy) {
+	auto pThis = pHybridBuffer->emuDSBuffer;
+	auto dsb = pThis->EmuDirectSoundBuffer8;
+	bool isAdpcm = pThis->EmuFlags & DSE_FLAG_XADPCM;
+
+	DWORD xBufferRangeStart;
+	DWORD xBufferRangeSize;
+	DSoundBufferRegionCurrentLocation(pHybridBuffer, pThis->EmuPlayFlags, xBufferRangeStart, xBufferRangeSize);
+
+	DWORD hostBufferSize = pThis->EmuBufferDesc.dwBufferBytes;
+
+	DWORD playCursor;
+	DWORD writeCursor;
+	dsb->GetCurrentPosition(&playCursor, &writeCursor);
+
+	DWORD cursorGap = writeCursor >= playCursor
+		? (writeCursor - playCursor)
+		: hostBufferSize - playCursor + writeCursor;
+
+	// Determine where to copy data from.
+	// Note: The DirectSound write cursor can sit quite far ahead of the play cursor,
+	// but copying closer to the play cursor can introduce weird looping or
+	// latency issues
+	// Test case: NBA Live 2005 (writes to a very small buffer expecting low latency, can crackle at > 1ms stream interval)
+	// Test case: Halo (intro video delay when writing from play cursor)
+	DWORD writeOffset = writeCursor + cursorGap * g_dsBufferStreaming.tweakCopyOffset;
+	DWORD writeSize = std::min(
+		(DWORD)(pThis->EmuBufferDesc.lpwfxFormat->nAvgBytesPerSec * msToCopy / 1000),
+		hostBufferSize
+	);
+
+	DWORD blockSize = isAdpcm
+		? XBOX_ADPCM_DSTSIZE * pThis->EmuBufferDesc.lpwfxFormat->nChannels
+		: pThis->EmuBufferDesc.lpwfxFormat->nBlockAlign;
+
+	// ADPCM block alignment
+	writeOffset = ((writeOffset + blockSize / 2) / blockSize) * blockSize;
+	writeSize = ((writeSize + blockSize / 2) / blockSize) * blockSize;
+	writeOffset %= hostBufferSize;
+
+	DWORD xWriteOffset = DSoundBufferGetXboxBufferSize(pThis->EmuFlags, writeOffset);
+
+	assert(xBufferRangeStart + xBufferRangeSize > xWriteOffset);
+	if (isAdpcm) {
+		assert(writeOffset % XBOX_ADPCM_DSTSIZE == 0);
+		assert(xWriteOffset % XBOX_ADPCM_SRCSIZE == 0);
+	}
+
+	LPVOID lplpvAudioPtr1, lplpvAudioPtr2;
+	DWORD lplpvAudioBytes1, lplpvAudioBytes2;
+	HRESULT hRet = pThis->EmuDirectSoundBuffer8->Lock(writeOffset, writeSize,
+		&lplpvAudioPtr1, &lplpvAudioBytes1,
+		&lplpvAudioPtr2, &lplpvAudioBytes2,
+		0);
+
+	if (hRet != 0) {
+		CxbxrKrnlAbort("DirectSoundBuffer Lock Failed!");
+	}
+
+	if (lplpvAudioPtr1 && pThis->X_BufferCache != nullptr) {
+		DSoundBufferOutputXBtoHost(
+			pThis->EmuFlags,
+			pThis->EmuBufferDesc,
+			((PBYTE)pThis->X_BufferCache + xBufferRangeStart + xWriteOffset),
+			DSoundBufferGetXboxBufferSize(pThis->EmuFlags, lplpvAudioBytes1),
+			lplpvAudioPtr1,
+			lplpvAudioBytes1
+		);
+
+		if (lplpvAudioPtr2) {
+			DSoundBufferOutputXBtoHost(
+				pThis->EmuFlags,
+				pThis->EmuBufferDesc,
+				((PBYTE)pThis->X_BufferCache + xBufferRangeStart + 0),
+				DSoundBufferGetXboxBufferSize(pThis->EmuFlags, lplpvAudioBytes2),
+				lplpvAudioPtr2,
+				lplpvAudioBytes2
+			);
+		}
+
+		HRESULT hRet = dsb->Unlock(lplpvAudioPtr1, lplpvAudioBytes1, lplpvAudioPtr2, lplpvAudioBytes2);
+
+		if (hRet != DS_OK) {
+			CxbxrKrnlAbort("DirectSoundBuffer Unlock Failed!");
+		}
+	}
+}
+
 static void dsound_thread_worker(LPVOID nullPtr)
 {
     g_AffinityPolicy->SetAffinityOther();
 
+	const int dsStreamInterval = 300;
+	int waitCounter = 0;
+
     while (true) {
+		// FIXME time this loop more accurately
+		// and account for variation in the length of Sleep calls
+
         // Testcase: Gauntlet Dark Legacy, if Sleep(1) then intro videos start to starved often
         // unless console is open with logging enabled. This is the cause of stopping intro videos often.
-        Sleep(300);
+        Sleep(g_dsBufferStreaming.streamInterval);
+		waitCounter += g_dsBufferStreaming.streamInterval;
+
         // Enforce mutex guard lock only occur inside below bracket for proper compile build.
         {
             DSoundMutexGuardLock;
 
-            xbox::LARGE_INTEGER getTime;
-            xbox::KeQuerySystemTime(&getTime);
-            DirectSoundDoWork_Stream(getTime);
+			if (waitCounter > g_dsBufferStreaming.streamInterval) {
+				waitCounter = 0;
+
+				// For Async process purpose only
+				xbox::LARGE_INTEGER getTime;
+				xbox::KeQuerySystemTime(&getTime);
+				DirectSoundDoWork_Stream(getTime);
+			}
+
+			// Stream sound buffer audio
+			// because the title may change the content of sound buffers at any time
+			for (auto& pBuffer : g_pDSoundBufferCache) {
+				DWORD status;
+				HRESULT hRet = pBuffer->emuDSBuffer->EmuDirectSoundBuffer8->GetStatus(&status);
+				if (hRet == 0 && status & DSBSTATUS_PLAYING) {
+					auto streamMs = g_dsBufferStreaming.streamInterval + g_dsBufferStreaming.streamAhead;
+					StreamBufferAudio(pBuffer, streamMs);
+				}
+			}
         }
     }
 }

--- a/src/core/hle/DSOUND/DirectSound/DirectSound.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSound.hpp
@@ -110,6 +110,10 @@ struct EmuDirectSoundBuffer
     X_DSENVOLOPEDESC        Xb_EnvolopeDesc;
     X_DSVOICEPROPS          Xb_VoiceProperties;
     DWORD                   Xb_Flags;
+	struct {
+		// True if the buffer has been played, and should be considered for streaming
+		bool playRequested = false;
+	} EmuStreamingInfo;
 };
 
 struct XbHybridDSBuffer : DSBUFFER_S::DSBUFFER_I {

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
@@ -80,6 +80,7 @@ void DirectSoundDoWork_Buffer(xbox::LARGE_INTEGER &time)
             pThis->Xb_rtPauseEx = 0LL;
             pThis->EmuFlags &= ~DSE_FLAG_PAUSE;
             pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
+			pThis->EmuStreamingInfo.playRequested = true;
         }
 
         if (pThis->Xb_rtStopEx != 0LL && pThis->Xb_rtStopEx <= time.QuadPart) {
@@ -601,6 +602,7 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IDirectSoundBuffer_Play)
         }
         if ((pThis->EmuFlags & DSE_FLAG_SYNCHPLAYBACK_CONTROL) == 0) {
             hRet = pThis->EmuDirectSoundBuffer8->Play(0, 0, pThis->EmuPlayFlags);
+			pThis->EmuStreamingInfo.playRequested = true;
         }
     }
 

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundBuffer.cpp
@@ -481,6 +481,16 @@ xbox::hresult_xt WINAPI xbox::EMUPATCH(IDirectSoundBuffer_Unlock)
     dword_xt                   pdwAudioBytes2
     )
 {
+    // DSoundMutexGuardLock;
+
+    LOG_FUNC_BEGIN
+        LOG_FUNC_ARG(pHybridThis)
+        LOG_FUNC_ARG(ppvAudioPtr1)
+        LOG_FUNC_ARG(pdwAudioBytes1)
+        LOG_FUNC_ARG(ppvAudioPtr2)
+        LOG_FUNC_ARG(pdwAudioBytes2)
+        LOG_FUNC_END;
+
 	// Xbox directsound doesn't require locking buffers
 	// This Xbox api only exists to match PC
 

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
@@ -27,14 +27,13 @@
 #define LOG_PREFIX CXBXR_MODULE::DSOUND
 
 #include <imgui.h>
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui_internal.h" // For ImVec
 #include "core/common/imgui/ui.hpp"
 
 #include <dsound.h>
 #include "DirectSoundGlobal.hpp"
 #include "DirectSoundInline.hpp" // For GetCurrentPosition, RegionCurrentLocation
-
-#define IMGUI_DEFINE_MATH_OPERATORS
-#include "imgui_internal.h" // For ImVec
 
 Settings::s_audio            g_XBAudio = { 0 };
 std::recursive_mutex         g_DSoundMutex;

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
@@ -29,13 +29,12 @@
 #include <imgui.h>
 #include "core/common/imgui/ui.hpp"
 
-#include <core\kernel\exports\xboxkrnl.h>
 #include <dsound.h>
 #include "DirectSoundGlobal.hpp"
-#include "DirectSoundInline.hpp"
+#include "DirectSoundInline.hpp" // For GetCurrentPosition, RegionCurrentLocation
 
 #define IMGUI_DEFINE_MATH_OPERATORS
-#include "imgui_internal.h"
+#include "imgui_internal.h" // For ImVec
 
 Settings::s_audio            g_XBAudio = { 0 };
 std::recursive_mutex         g_DSoundMutex;

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
@@ -150,11 +150,10 @@ void DSound_DrawBufferVisualization(bool is_focus, bool* p_show, ImGuiWindowFlag
 
 				ImGui::PopID();
 			}
-			ImGui::EndChild();
 		}
-
-		ImGui::End();
+        ImGui::EndChild();
 	}
+    ImGui::End();
 }
 
 void DSound_PrintStats(bool is_focus, ImGuiWindowFlags input_handler, bool m_show_audio_stats)
@@ -252,7 +251,7 @@ void DSound_PrintStats(bool is_focus, ImGuiWindowFlags input_handler, bool m_sho
                     ImGui::Text("Total active DSStream = %u", isActive);
                 }
             }
-            ImGui::End();
         }
+        ImGui::End();
     }
 }

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.cpp
@@ -54,6 +54,8 @@ DWORD                               g_dwXbMemAllocated = 0;
 DWORD                               g_dwFree2DBuffers = 0;
 DWORD                               g_dwFree3DBuffers = 0;
 
+DsBufferStreaming g_dsBufferStreaming;
+
 void DSound_PrintStats(bool is_focus, ImGuiWindowFlags input_handler, bool m_show_audio_stats)
 {
     DSoundMutexGuardLock;

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundGlobal.hpp
@@ -61,6 +61,13 @@ extern DWORD                               g_dwXbMemAllocated;
 extern DWORD                               g_dwFree2DBuffers;
 extern DWORD                               g_dwFree3DBuffers;
 
+struct DsBufferStreaming {
+	DWORD streamInterval = 1;
+	DWORD streamAhead = 50;
+	float tweakCopyOffset = 0;
+};
+extern DsBufferStreaming g_dsBufferStreaming;
+
 // size of DirectSound cache max size
 #define X_DIRECTSOUND_CACHE_MAX 0x800
 

--- a/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
+++ b/src/core/hle/DSOUND/DirectSound/DirectSoundInline.hpp
@@ -569,7 +569,6 @@ static inline void DSoundBufferResizeUpdate(
 static inline void DSoundBufferRegionCurrentLocation(
     xbox::XbHybridDSBuffer*      pHybridThis,
     DWORD                       dwPlayFlags,
-    HRESULT                    &hRet,
     DWORD                      &Xb_dwStartOffset,
     DWORD                      &Xb_dwByteLength)
 {
@@ -608,7 +607,7 @@ static inline void DSoundBufferUpdate(
     DWORD Xb_dwByteLength;
     DWORD Xb_dwStartOffset;
 
-    DSoundBufferRegionCurrentLocation(pHybridThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
+    DSoundBufferRegionCurrentLocation(pHybridThis, dwPlayFlags, Xb_dwStartOffset, Xb_dwByteLength);
 
     DSoundBufferResizeUpdate(pHybridThis, dwPlayFlags, hRet, Xb_dwStartOffset, Xb_dwByteLength);
 }


### PR DESCRIPTION
Unlike in DirectSound on Windows, Xbox titles can write to audio buffers at any time - with no need to call `lock` APIs to notify XDirectSound
We currently patch `lock`/`unlock`, so on `unlock` we can obtain updates to audio buffers.

But since Xbox titles don't _need_ to ever call `unlock`, there are plenty of titles that don't, and we don't know when the audio buffer has been updated.

This can manifest as a lack of audio, or the first part of audio looping repeatedly.

This PR continuously streams chunks of audio data from audio buffers, keeping just ahead of the audio that is currently playing, so audio is kept up to date.

Improvements:
* NBA Live 2005 (music / various sounds)
* Crash Tag Team Racing (Broken audio loops)
* Madagascar (Broken audio loops)
* Outrun 2006 (Performance related to fix by @RadWolfie, related PR #2311)
* Spyro: a Hero's Tail (missing audio)
* PoP: Sands of Time (missing music)
* PoP: Warrior Within (missing audio)
* Sphinx and the Cursed Mummy  (Broken audio loops)
* Buffy: Chaos Bleeds  (Broken audio loops)
* Need for Speed: Hot Pursuit 2 (missing audio)
* 007 Nightfire (missing audio)
* From Russia with Love (missing audio)
* CoD 3 (crash fix?)
* Max Payne 2 (Broken audio loops)
* Just Cause (unable to lock buffer)
* Robotech: Battlecry (broken audio loops)

Regressions:
* ~~Halo (intro is crackly) (intro latency)~~
* ~~DoA3 (doubled up drum beat entering the menu)~~
* Yourself!Fitness (crash)
* ~~Max Payne 2 (crash due to SetCurrentPosition broken)~~
* Probably lots of things