### PR TITLE
Updated cxbxr projects to use and build with C++20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         configuration: [Release, Debug]
-        vsver: [2022, 2019]
+        vsver: [2022]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Cxbx-Reloaded is an emulator for running Microsoft Xbox (and eventually, Chihiro
 
 ## Prerequisites
 ### Windows
-  * [32-bit (x86) Visual C++ 2019 Redistributable](https://aka.ms/vs/16/release/vc_redist.x86.exe)
+  * [32-bit (x86) Visual C++ 2022 Redistributable](https://aka.ms/vs/17/release/vc_redist.x86.exe)
   * [Npcap *(used for network emulation)*](https://nmap.org/npcap/#download)
     * Make sure to enable winpcap compatibility mode.
   * WinUSB compliant driver
     * *Optional, only needed for USB pass-through of original Xbox and Steel Battalion controllers.*
 
 ### Wine
-**Please use the latest stable release version of Wine. If it does not work for you, then roll back to Wine 5.0.3 which is the last known working version.**
+**Please use the latest stable release version of Wine. If it does not work for you, then roll back to Wine 7.0 which is the last known working version.**
+**There also exists this known [issue](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/2314) which currently prevents savings in some games with the most recent Wine 6.8 and later versions.**
   * Winetricks
     * `vcrun2019`
       * Requires the latest winetricks script.
@@ -83,7 +84,7 @@ Please contact us before you start working on something, so we can make sure you
 Don't open `CMakeLists.txt` from Visual Studio, as it won't generate files in the `build` directory.
 
 ##### Prerequisites
-1. [Visual Studio](https://visualstudio.microsoft.com/downloads/) 2019 or later
+1. [Visual Studio](https://visualstudio.microsoft.com/downloads/) 2022
     * C++ and C# desktop development
     * Windows Universal CRT SDK
     * C++ CMake tools for Windows
@@ -95,11 +96,8 @@ Don't open `CMakeLists.txt` from Visual Studio, as it won't generate files in th
 2. `cd` to the Cxbx-Reloaded directory.
 3. Run these commands.
     1. `mkdir build & cd build`
-    2. `cmake .. -G "generator" -A Win32`
-        * Generators:
-          * `Visual Studio 17 2022`
-          * `Visual Studio 16 2019`
-            * VS2019 16.1 or later is required and has CMake 3.14 bundled.
+    2. `cmake .. -G "Visual Studio 17 2022" -A Win32`
+        * VS2022 17.0 or later is required.
 4. Open `Cxbx-Reloaded.sln` from the `build` directory.
 5. Select the Release configuration, then click Build.
     * Debug builds are **significantly slower, and only for developers**.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Please contact us before you start working on something, so we can make sure you
 Don't open `CMakeLists.txt` from Visual Studio, as it won't generate files in the `build` directory.
 
 ##### Prerequisites
-1. [Visual Studio](https://visualstudio.microsoft.com/downloads/) 2017 or later
+1. [Visual Studio](https://visualstudio.microsoft.com/downloads/) 2019 or later
     * C++ and C# desktop development
     * Windows Universal CRT SDK
     * C++ CMake tools for Windows
@@ -100,7 +100,6 @@ Don't open `CMakeLists.txt` from Visual Studio, as it won't generate files in th
           * `Visual Studio 17 2022`
           * `Visual Studio 16 2019`
             * VS2019 16.1 or later is required and has CMake 3.14 bundled.
-          * `Visual Studio 15 2017`
 4. Open `Cxbx-Reloaded.sln` from the `build` directory.
 5. Select the Release configuration, then click Build.
     * Debug builds are **significantly slower, and only for developers**.

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.12)
 project(cxbx)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Suppress extra stuff from generated solution
 set(CMAKE_SUPPRESS_REGENERATION true)

--- a/projects/cxbxr-emu/CMakeLists.txt
+++ b/projects/cxbxr-emu/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.12)
 project(cxbxr-emu)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Suppress extra stuff from generated solution
 set(CMAKE_SUPPRESS_REGENERATION true)

--- a/projects/cxbxr-ldr/CMakeLists.txt
+++ b/projects/cxbxr-ldr/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.12)
 project(cxbxr-ldr)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Suppress extra stuff from generated solution
 set(CMAKE_SUPPRESS_REGENERATION true)

--- a/src/common/Logging.cpp
+++ b/src/common/Logging.cpp
@@ -396,8 +396,13 @@ inline void output_wchar(std::ostream& os, wchar_t c)
 		default: os << "\\x" << std::setfill('0') << std::setw(4) << std::right << std::hex << std::uppercase << (wint_t)c;
 		}
 	}
-	else
-		os << c;
+	else {
+		const wchar_t *wc = reinterpret_cast<const wchar_t *>(&c);
+		std::string dst(2, '\0');
+		std::mbstate_t ps{};
+		std::wcsrtombs(dst.data(), &wc, 1, &ps);
+		os << dst;
+	}
 }
 
 LOG_SANITIZE_HEADER(hex1, uint8_t)

--- a/src/common/Settings.cpp
+++ b/src/common/Settings.cpp
@@ -1000,7 +1000,7 @@ void Settings::RemoveLegacyConfigs(unsigned int CurrentRevision)
 			std::string current_section = std::string(section_input_port) + std::to_string(port_num);
 			std::string device_name = m_si.GetValue(current_section.c_str(), sect_input_port.device, "");
 
-			if (StrEndsWith(device_name, kb_str)) {
+			if (device_name.ends_with(kb_str)) {
 				device_name += "Mouse";
 				m_si.SetValue(current_section.c_str(), sect_input_port.device, device_name.c_str(), nullptr, true);
 			}

--- a/src/common/input/Button.cpp
+++ b/src/common/input/Button.cpp
@@ -51,16 +51,17 @@ void Button::GetText(char* const text, size_t size) const
 	SendMessage(m_button_hwnd, WM_GETTEXT, size, reinterpret_cast<LPARAM>(text));
 }
 
-void Button::AddTooltip(HWND hwnd, HWND tooltip_hwnd, char *text) const
+void Button::AddTooltip(HWND hwnd, HWND tooltip_hwnd, std::string_view text) const
 {
 	assert((hwnd != NULL) && (tooltip_hwnd != NULL));
 
+	std::string tooltip_text(text);
 	TOOLINFO tool = { 0 };
 	tool.cbSize = sizeof(tool);
 	tool.hwnd = hwnd;
 	tool.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
 	tool.uId = reinterpret_cast<UINT_PTR>(m_button_hwnd);
-	tool.lpszText = text;
+	tool.lpszText = tooltip_text.data();
 	SendMessage(tooltip_hwnd, TTM_ADDTOOL, 0, reinterpret_cast<LPARAM>(&tool));
 }
 

--- a/src/common/input/Button.h
+++ b/src/common/input/Button.h
@@ -51,7 +51,7 @@ public:
 	int GetId() const { return m_id; }
 	int GetIndex() const { return m_index; }
 	void *GetWnd() const { return m_wnd; }
-	void AddTooltip(HWND hwnd, HWND tooltip_hwnd, char *text) const;
+	void AddTooltip(HWND hwnd, HWND tooltip_hwnd, std::string_view text) const;
 
 
 private:

--- a/src/common/input/EmuDevice.cpp
+++ b/src/common/input/EmuDevice.cpp
@@ -31,8 +31,8 @@
 #include "gui/resource/ResCxbx.h"
 
 
-static char *tooltip_text_toggle = "Left-click: start input detection\nRight-click: clear binding\nShift + right-click: toggle mouse input mode";
-static char *tooltip_text_no_toggle = "Left-click: start input detection\nRight-click: clear binding";
+static const char *tooltip_text_toggle = "Left-click: start input detection\nRight-click: clear binding\nShift + right-click: toggle mouse input mode";
+static const char *tooltip_text_no_toggle = "Left-click: start input detection\nRight-click: clear binding";
 
 EmuDevice::EmuDevice(int type, HWND hwnd, void *wnd)
 {

--- a/src/common/input/InputManager.cpp
+++ b/src/common/input/InputManager.cpp
@@ -776,7 +776,7 @@ void InputDeviceManager::RefreshDevices()
 		return Sdl::PopulateOK;
 		});
 	for (auto &dev : m_Devices) {
-		if (StrStartsWith(dev->GetDeviceName(), "KeyboardMouse")) {
+		if (dev->GetDeviceName().starts_with("KeyboardMouse")) {
 			static_cast<DInput::KeyboardMouse *>(dev.get())->SetHwnd(m_hwnd);
 			break;
 		}
@@ -876,7 +876,7 @@ void InputDeviceManager::HotplugHandler(bool is_sdl)
 		std::unique_lock<std::mutex> lck(m_Mtx);
 
 		auto it = std::remove_if(m_Devices.begin(), m_Devices.end(), [](const auto &Device) {
-			if (Device->IsLibusb() || StrStartsWith(Device->GetAPI(), "XInput")) {
+			if (Device->IsLibusb() || Device->GetAPI().starts_with("XInput")) {
 				return true;
 			}
 			return false;

--- a/src/common/input/InputWindow.cpp
+++ b/src/common/input/InputWindow.cpp
@@ -352,11 +352,11 @@ void InputWindow::SwapMoCursorAxis(Button *button)
 	// Axis X- <-> Cursor X-
 	// Axis Y+ <-> Cursor Y-
 	// Axis Y- <-> Cursor Y+
-	if (StrEndsWith(m_host_dev, "KeyboardMouse")) {
+	if (m_host_dev.ends_with("KeyboardMouse")) {
 		assert(button != nullptr);
 		char control_name[HOST_BUTTON_NAME_LENGTH];
 		button->GetText(control_name, sizeof(control_name));
-		if (StrStartsWith(control_name, "Axis")) {
+		if (std::string_view(control_name).starts_with("Axis")) {
 			switch (control_name[5])
 			{
 			case 'X':
@@ -384,7 +384,7 @@ void InputWindow::SwapMoCursorAxis(Button *button)
 			return;
 		}
 
-		if (StrStartsWith(control_name, "Cursor")) {
+		if (std::string_view(control_name).starts_with("Cursor")) {
 			switch (control_name[7])
 			{
 			case 'X':

--- a/src/common/util/CxbxUtil.cpp
+++ b/src/common/util/CxbxUtil.cpp
@@ -280,27 +280,3 @@ std::string StripQuotes(const std::string& str)
 {
 	return StripChars(str, "\"");
 }
-
-// NOTE: with C++20, this can be replaced by simply calling full_str.ends_with()
-bool StrEndsWith(const std::string &full_str, const std::string &substr)
-{
-	if (full_str.length() >= substr.length()) {
-		if (full_str.compare(full_str.length() - substr.length(), substr.length(), substr) == 0) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-// NOTE: with C++20, this can be replaced by simply calling full_str.starts_with()
-bool StrStartsWith(const std::string &full_str, const std::string &substr)
-{
-	if (!full_str.empty()) {
-		if (full_str.rfind(substr, 0) == 0) {
-			return true;
-		}
-	}
-
-	return false;
-}

--- a/src/common/util/CxbxUtil.h
+++ b/src/common/util/CxbxUtil.h
@@ -67,8 +67,6 @@ bool Memory_RW(void* Addr, void* Buf, size_t Num, bool bIsWrite);
 void unix2dos(std::string& string);
 std::string StripSpaces(const std::string& str);
 std::string StripQuotes(const std::string& str);
-bool StrEndsWith(const std::string &full_str, const std::string &substr);
-bool StrStartsWith(const std::string &full_str, const std::string &substr);
 
 // Retrieves the underlying integer value of a scoped enumerator. It allows to avoid using static_cast every time
 template <typename E>
@@ -90,6 +88,19 @@ static uint32_t RoundUp(uint32_t dwValue, uint32_t dwMult)
 		return dwValue;
 
 	return dwValue + dwMult - remainder;
+}
+
+constexpr std::size_t longest_str(const std::vector<std::string_view> &vec)
+{
+	if (!vec.empty()) {
+		return std::max_element(vec.begin(), vec.end(),
+			[](const auto &a, const auto &b) {
+				return a.length() < b.length();
+			})->length();
+	}
+	else {
+		throw std::logic_error("No strings to compare!");
+	}
 }
 
 #endif

--- a/src/common/win32/EmuShared.h
+++ b/src/common/win32/EmuShared.h
@@ -272,7 +272,7 @@ class EmuShared : public Mutex
 		void GetImGuiIniSettings(char value[IMGUI_INI_SIZE_MAX]) {
 			Lock();
 			if (m_imgui_general.ini_size < IMGUI_INI_SIZE_MAX) {
-				value = '\0';
+				value[0] = '\0';
 				return;
 			}
 			strcpy_s(value, IMGUI_INI_SIZE_MAX, m_imgui_general.ini_settings);

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -921,7 +921,7 @@ void *GetDataFromXboxResource(xbox::X_D3DResource *pXboxResource)
 	return (uint8_t*)pData;
 }
 
-typedef struct {
+typedef struct _resource_info_t {
 	IDirect3DResource* pHostResource = nullptr;
 	DWORD dwXboxResourceType = 0;
 	void* pXboxData = xbox::zeroptr;

--- a/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
+++ b/src/core/hle/D3D8/Direct3D9/TextureStates.cpp
@@ -38,7 +38,7 @@
 #include <optional>
 
 typedef struct {
-    char* S;                // String representation.
+    const char* S;          // String representation.
     bool IsSamplerState;    // True if the state maps to a Sampler State instead of Texture Stage
     DWORD PC;               // PC Index
 } TextureStateInfo;

--- a/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
+++ b/src/core/hle/D3D8/Direct3D9/VertexShader.cpp
@@ -79,7 +79,7 @@ void OutputHlsl(std::stringstream& hlsl, VSH_IMD_OUTPUT& dest)
 
 void ParameterHlsl(std::stringstream& hlsl, VSH_IMD_PARAMETER& param, bool IndexesWithA0_X)
 {
-	static char* RegisterName[/*VSH_PARAMETER_TYPE*/] = {
+	static const char* RegisterName[/*VSH_PARAMETER_TYPE*/] = {
 		"?", // PARAM_UNKNOWN = 0,
 		"r", // PARAM_R,          // Temporary (scRatch) registers
 		"v", // PARAM_V,          // Vertex registers

--- a/src/core/hle/D3D8/Direct3D9/VertexShaderSource.h
+++ b/src/core/hle/D3D8/Direct3D9/VertexShaderSource.h
@@ -39,7 +39,7 @@ private:
 	std::mutex cacheMutex;
 	std::map<ShaderKey, LazyVertexShader> cache;
 
-	bool VertexShaderSource::_FindShader(ShaderKey key, LazyVertexShader** ppLazyShader);
+	bool _FindShader(ShaderKey key, LazyVertexShader** ppLazyShader);
 };
 
 extern VertexShaderSource g_VertexShaderSource;

--- a/src/core/hle/D3D8/XbConvert.cpp
+++ b/src/core/hle/D3D8/XbConvert.cpp
@@ -861,7 +861,7 @@ typedef struct _FormatInfo {
 	_ComponentEncoding components;
 	D3DFORMAT pc;
 	_FormatUsage usage;
-	char *warning;
+	const char *warning;
 } FormatInfo;
 
 static const FormatInfo FormatInfos[] = {

--- a/src/core/hle/D3D8/XbConvert.h
+++ b/src/core/hle/D3D8/XbConvert.h
@@ -1805,12 +1805,12 @@ typedef enum _TXBType {
 } TXBType;
 
 typedef struct _RenderStateInfo {
-	char *S;   // String representation.
+	const char *S;   // String representation.
 	WORD V;    // The XDK version since which a render state was introduced (using the 5911 declarations as a base).
 	TXBType T = xt_Unknown; // The Xbox data type. Defaults to xt_Unknown.
 	xbox::NV2AMETHOD M; // The related push buffer method. Not always a 1-to-1 mapping. Needs push-buffer interpretation & conversion code.
 	D3DRENDERSTATETYPE PC = (D3DRENDERSTATETYPE)0; // Map XBox to PC render state
-	char *N;   // XDK notes. Defaults to ''.
+	const char *N;   // XDK notes. Defaults to ''.
 	WORD R; // The XDK version since which a render state was removed
 }
 RenderStateInfo;

--- a/src/core/kernel/exports/EmuKrnl.h
+++ b/src/core/kernel/exports/EmuKrnl.h
@@ -28,6 +28,7 @@
 #include "core\kernel\init\CxbxKrnl.h"
 #include "core\kernel\support\Emu.h"
 #include "core\kernel\support\EmuFS.h"
+#include "EmuKrnlKi.h"
 #include <future>
 
 // CONTAINING_RECORD macro

--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -181,7 +181,7 @@ XBSYSAPI EXPORTNUM(43) xbox::void_xt NTAPI xbox::HalEnableSystemInterrupt
 
 #ifdef _DEBUG_TRACE
 // Source : Xbox Linux
-char *IRQNames[MAX_BUS_INTERRUPT_LEVEL + 1] =
+const char *IRQNames[MAX_BUS_INTERRUPT_LEVEL + 1] =
 {
 	"<unknown>",
 	"USB0", // IRQ 1 USB Controller: nVidia Corporation nForce USB Controller (rev d4) (prog-if 10 [OHCI])
@@ -554,7 +554,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 				}
 			}
 
-			std::string& XbePath = CxbxConvertXboxToHostPath(TitlePath);
+			const std::string& XbePath = CxbxConvertXboxToHostPath(TitlePath);
 
 			// Relaunch Cxbx, to load another Xbe
 			{

--- a/src/core/kernel/exports/EmuKrnlKe.cpp
+++ b/src/core/kernel/exports/EmuKrnlKe.cpp
@@ -78,7 +78,6 @@ namespace NtDll
 #include "core\kernel\init\CxbxKrnl.h" // For CxbxrKrnlAbort
 #include "core\kernel\support\Emu.h" // For EmuLog(LOG_LEVEL::WARNING, )
 #include "EmuKrnl.h" // For InitializeListHead(), etc.
-#include "EmuKrnlKi.h" // For KiRemoveTreeTimer(), KiInsertTreeTimer()
 #include "EmuKrnlKe.h"
 #include "core\kernel\support\EmuFile.h" // For IsEmuHandle(), NtStatusToString()
 #include "core\kernel\support\NativeHandle.h"

--- a/src/core/kernel/exports/EmuKrnlNt.cpp
+++ b/src/core/kernel/exports/EmuKrnlNt.cpp
@@ -1099,7 +1099,7 @@ XBSYSAPI EXPORTNUM(207) xbox::ntstatus_xt NTAPI xbox::NtQueryDirectoryFile
 			// Xbox expects directories to be listed when *.* is passed
 			if (strncmp(FileMask->Buffer, "*.*", FileMask->Length) == 0) {
 				FileMask->Length = 1;
-				FileMask->Buffer = "*";
+				std::strcpy(FileMask->Buffer, "*");
 			}
 
 			mbstowcs(/*Dest=*/wszObjectName, /*Source=*/FileMask->Buffer, /*MaxCount=*/MAX_PATH);

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1699,8 +1699,9 @@ XBSYSAPI EXPORTNUM(308) xbox::ntstatus_xt NTAPI xbox::RtlUnicodeStringToAnsiStri
 		LOG_FUNC_ARG(AllocateDestinationString)
 		LOG_FUNC_END;
 
-	ntstatus_xt ret = X_STATUS_SUCCESS;
+	ntstatus_xt result, ret = X_STATUS_SUCCESS;
 	dword_xt AnsiMaxLength = RtlUnicodeStringToAnsiSize(SourceString);
+	xbox::ulong_xt index = 0;
 
 	DestinationString->Length = (ushort_xt)(AnsiMaxLength - 1);
 	if (AllocateDestinationString) {
@@ -1720,8 +1721,7 @@ XBSYSAPI EXPORTNUM(308) xbox::ntstatus_xt NTAPI xbox::RtlUnicodeStringToAnsiStri
 		DestinationString->Length = DestinationString->MaximumLength - 1;
 	}
 
-	xbox::ulong_xt index = 0;
-	ntstatus_xt result = RtlUnicodeToMultiByteN(DestinationString->Buffer, DestinationString->Length, &index, (PWSTR)SourceString->Buffer, SourceString->Length);
+	result = RtlUnicodeToMultiByteN(DestinationString->Buffer, DestinationString->Length, &index, (PWSTR)SourceString->Buffer, SourceString->Length);
 
 	if (X_NT_SUCCESS(result)) {
 		DestinationString->Buffer[index] = 0;

--- a/src/core/kernel/support/EmuFS.cpp
+++ b/src/core/kernel/support/EmuFS.cpp
@@ -243,7 +243,7 @@ void EmuKeFreeThread(xbox::ntstatus_xt ExitStatus)
 
 	if (GetNativeHandle(eThread->UniqueThread)) {
 		xbox::NtClose(eThread->UniqueThread);
-		eThread->UniqueThread = xbox::zero;
+		eThread->UniqueThread = xbox::zeroptr;
 	}
 
 	EmuKeFreePcr();

--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -1369,7 +1369,7 @@ std::ostream& operator<<(std::ostream& os, const NtDll::NTSTATUS& value)
 */
 
 // TODO : Create (and use) an Xbox version of this too
-CHAR* NtStatusToString(IN NTSTATUS Status)
+const CHAR* NtStatusToString(IN NTSTATUS Status)
 {
 #define _CASE(s) case s: return #s;
 

--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -255,7 +255,7 @@ typedef struct _fatx_volume_metadata {
 	xbox::PVOID buffer;
 } fatx_volume_metadata, *pfatx_volume_metadata;
 
-CHAR* NtStatusToString(IN NTSTATUS Status);
+const CHAR* NtStatusToString(IN NTSTATUS Status);
 
 class io_mu_metadata
 {

--- a/src/core/kernel/support/NativeHandle.cpp
+++ b/src/core/kernel/support/NativeHandle.cpp
@@ -96,7 +96,7 @@ std::optional<HANDLE> GetNativeHandle(xbox::HANDLE xhandle)
 	}
 
 	std::shared_lock<std::shared_mutex> lck(g_MapMtx);
-	auto &it = g_RegisteredHandles.find(xhandle);
+	const auto &it = g_RegisteredHandles.find(xhandle);
 	if (it == g_RegisteredHandles.end()) {
 		return std::nullopt;
 	}

--- a/src/devices/network/NVNetDevice.cpp
+++ b/src/devices/network/NVNetDevice.cpp
@@ -157,7 +157,7 @@ struct RingDesc {
 	uint16_t flags;
 };
 
-char* EmuNVNet_GetRegisterName(xbox::addr_xt addr)
+const char* EmuNVNet_GetRegisterName(xbox::addr_xt addr)
 {
 	switch (addr) {
 	case NvRegIrqStatus:             return "NvRegIrqStatus";
@@ -205,7 +205,7 @@ char* EmuNVNet_GetRegisterName(xbox::addr_xt addr)
 	}
 }
 
-char* EmuNVNet_GetMiiRegisterName(uint8_t reg)
+const char* EmuNVNet_GetMiiRegisterName(uint8_t reg)
 {
 	switch (reg) {
 	case MII_PHYSID1:   return "MII_PHYSID1";

--- a/src/devices/video/nv2a.cpp
+++ b/src/devices/video/nv2a.cpp
@@ -337,7 +337,7 @@ void _check_gl_error(const char *file, int line)
 {
 	while (true) {
 		GLenum err = glGetError();
-		char *error;
+		const char *error;
 		switch (err) {
 		case GL_NO_ERROR: return;
 		case GL_INVALID_ENUM: error = "GL_INVALID_ENUM"; break;

--- a/src/devices/x86/EmuX86.cpp
+++ b/src/devices/x86/EmuX86.cpp
@@ -431,7 +431,7 @@ uint32_t EmuX86_Distorm_read_disp(const _DInst& info)
 	return (uint32_t)info.disp;
 }
 
-typedef struct {
+typedef struct _OperandAddress {
 	xbox::addr_xt addr = 0;
 	bool is_internal_addr = false; // If set, addr points to a CPU context (or Distorm immedate value) member (instead of Xbox memory)
 	int size = 0; // Expressed in bytes, not bits!
@@ -1640,7 +1640,7 @@ const char *Distorm_RegStrings[/*_RegisterType*/] = {
 	"DR0", "DR1", "DR2", "DR3", "UNUSED4", "UNUSED5", "DR6", "DR7",
 };
 
-char *Distorm_OpcodeString(const int opcode)
+const char *Distorm_OpcodeString(const int opcode)
 {
 	// Note : Distorm's GET_MNEMONIC_NAME() doesn't link somehow...
 	switch (opcode) {

--- a/src/gui/DlgAbout.cpp
+++ b/src/gui/DlgAbout.cpp
@@ -55,7 +55,7 @@ INT_PTR CALLBACK DlgAboutProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
     switch(uMsg)
     {
         case WM_INITDIALOG:
-        {
+		{
 			// Set the dialog icon
 			HICON hIcon = (HICON)LoadImageW(
 				GetModuleHandleW(nullptr), MAKEINTRESOURCEW(IDI_CXBX), IMAGE_ICON, 0, 0, LR_DEFAULTCOLOR | LR_DEFAULTSIZE
@@ -64,15 +64,18 @@ INT_PTR CALLBACK DlgAboutProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 			SendMessageW(hWndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
 
 			// Build the Tab Control
+			constexpr size_t text_len = longest_str({ "About", "Contributors", "License" }) + 1;
+			char text[text_len];
 			TCITEM tabInfo;
 			memset(&tabInfo, 0, sizeof(tabInfo));
 			tabInfo.mask = TCIF_TEXT;
-			tabInfo.cchTextMax = 20;
-			tabInfo.pszText = "About";
+			tabInfo.cchTextMax = text_len;
+			tabInfo.pszText = text;
+			std::strcpy(text, "About");
 			SendMessage(GetDlgItem(hWndDlg, IDC_TAB1), TCM_INSERTITEM, 0, (LPARAM)&tabInfo);
-			tabInfo.pszText = "Contributors";
+			std::strcpy(text, "Contributors");
 			SendMessage(GetDlgItem(hWndDlg, IDC_TAB1), TCM_INSERTITEM, 1, (LPARAM)&tabInfo);
-			tabInfo.pszText = "License";
+			std::strcpy(text, "License");
 			SendMessage(GetDlgItem(hWndDlg, IDC_TAB1), TCM_INSERTITEM, 2, (LPARAM)&tabInfo);
 
 			// Get tab pane dimensions

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -783,7 +783,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 						{
 							FILE *logo = fopen(ofn.lpstrFile, "rb");
 
-							char *bmp_err = 0;
+							const char *bmp_err = 0;
 
 							// read bitmap header
 							if (!bmp_err)
@@ -1387,7 +1387,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 }
 
 // suggest a file name
-void WndMain::SuggestFilename(const char *x_orig_filename, char *x_filename, char x_extension[4])
+void WndMain::SuggestFilename(const char *x_orig_filename, char *x_filename, const char x_extension[4])
 {
     if(strrchr(x_orig_filename, '\\') != nullptr)
     {

--- a/src/gui/WndMain.h
+++ b/src/gui/WndMain.h
@@ -82,7 +82,7 @@ class WndMain : public Wnd
         // ******************************************************************
         // * suggest appropriate filename based on input
         // ******************************************************************
-        static void SuggestFilename(const char *x_orig_filename, char *x_filename, char x_extension[4]);
+        static void SuggestFilename(const char *x_orig_filename, char *x_filename, const char x_extension[4]);
 
     private:
 		// ******************************************************************


### PR DESCRIPTION
This allows the cxbxr projects to build successfully with the new C++20 standard, which is required for future work on the xbox pointer type. Since Visual Studio 2017 has practically no support for C++20, it has been removed form the readme instructions. Other than that, this should not cause any visible changes in the games.