### PR TITLE
Fixed wrong type for MmGlobalData kernel export

### DIFF
--- a/src/core/kernel/exports/EmuKrnlMm.cpp
+++ b/src/core/kernel/exports/EmuKrnlMm.cpp
@@ -49,7 +49,7 @@ namespace NtDll
 // ******************************************************************
 // * 0x0066 - MmGlobalData
 // ******************************************************************
-XBSYSAPI EXPORTNUM(102) xbox::PVOID xbox::MmGlobalData[8] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
+XBSYSAPI EXPORTNUM(102) xbox::MMGLOBALDATA xbox::MmGlobalData = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
 // ******************************************************************
 // * 0x00A4 - LaunchDataPage

--- a/src/core/kernel/memory-manager/PhysicalMemory.cpp
+++ b/src/core/kernel/memory-manager/PhysicalMemory.cpp
@@ -45,9 +45,9 @@ inline FreeBlock* ListEntryToFreeBlock(xbox::PLIST_ENTRY pListEntry)
 
 void PhysicalMemory::InitializePageDirectory()
 {
-	PMMPTE pPde;
-	PMMPTE pPde_end;
-	MMPTE TempPte;
+	xbox::PMMPTE pPde;
+	xbox::PMMPTE pPde_end;
+	xbox::MMPTE TempPte;
 
 
 	// Write the pde's of the WC (tiled) memory - no page tables
@@ -76,7 +76,7 @@ void PhysicalMemory::InitializePageDirectory()
 	// TODO: map memory for the file system cache?
 }
 
-void PhysicalMemory::WritePfn(PFN pfn_start, PFN pfn_end, PMMPTE pPte, PageType BusyType, bool bZero)
+void PhysicalMemory::WritePfn(xbox::PFN pfn_start, xbox::PFN pfn_end, xbox::PMMPTE pPte, xbox::PageType BusyType, bool bZero)
 {
 	XBOX_PFN TempPF;
 
@@ -101,7 +101,7 @@ void PhysicalMemory::WritePfn(PFN pfn_start, PFN pfn_end, PMMPTE pPte, PageType 
 			TempPF.Default = 0;
 			TempPF.Busy.Busy = 1;
 			TempPF.Busy.BusyType = BusyType;
-			if (BusyType != VirtualPageTableType && BusyType != SystemPageTableType) {
+			if (BusyType != xbox::VirtualPageTableType && BusyType != xbox::SystemPageTableType) {
 				TempPF.Busy.PteIndex = GetPteOffset(GetVAddrMappedByPte(pPte));
 			}
 			else { TempPF.PTPageFrame.PtesUsed = 0; } // we are writing a pfn of a PT
@@ -118,13 +118,13 @@ void PhysicalMemory::WritePfn(PFN pfn_start, PFN pfn_end, PMMPTE pPte, PageType 
 	}
 }
 
-void PhysicalMemory::WritePte(PMMPTE pPteStart, PMMPTE pPteEnd, MMPTE Pte, PFN pfn, bool bZero)
+void PhysicalMemory::WritePte(xbox::PMMPTE pPteStart, xbox::PMMPTE pPteEnd, xbox::MMPTE Pte, xbox::PFN pfn, bool bZero)
 {
 	// This function is intended to write pte's, not pde's. To write those, use (De)AllocatePT which will perform
 	// all the necessary housekeeping. Also, the pde's mapping these pte's should have already being commited or else
 	// GetPfnOfPT will assert
 
-	PMMPTE PointerPte = pPteStart;
+	xbox::PMMPTE PointerPte = pPteStart;
 	PXBOX_PFN PTpfn;
 
 	if (bZero)
@@ -163,16 +163,16 @@ void PhysicalMemory::WritePte(PMMPTE pPteStart, PMMPTE pPteEnd, MMPTE Pte, PFN p
 	}
 }
 
-bool PhysicalMemory::RemoveFree(PFN_COUNT NumberOfPages, PFN* result, PFN_COUNT PfnAlignment, PFN start, PFN end)
+bool PhysicalMemory::RemoveFree(xbox::PFN_COUNT NumberOfPages, xbox::PFN* result, xbox::PFN_COUNT PfnAlignment, xbox::PFN start, xbox::PFN end)
 {
 	xbox::PLIST_ENTRY ListEntry;
-	PFN PfnStart;
-	PFN PfnEnd;
-	PFN IntersectionStart;
-	PFN IntersectionEnd;
-	PFN_COUNT PfnCount;
-	PFN_COUNT PfnAlignmentMask;
-	PFN_COUNT PfnAlignmentSubtraction;
+	xbox::PFN PfnStart;
+	xbox::PFN PfnEnd;
+	xbox::PFN IntersectionStart;
+	xbox::PFN IntersectionEnd;
+	xbox::PFN_COUNT PfnCount;
+	xbox::PFN_COUNT PfnAlignmentMask;
+	xbox::PFN_COUNT PfnAlignmentSubtraction;
 
 	// The caller should already guarantee that there are enough free pages available
 	if (NumberOfPages == 0) { result = nullptr; return false; }
@@ -307,10 +307,10 @@ bool PhysicalMemory::RemoveFree(PFN_COUNT NumberOfPages, PFN* result, PFN_COUNT 
 	return false;
 }
 
-void PhysicalMemory::InsertFree(PFN start, PFN end)
+void PhysicalMemory::InsertFree(xbox::PFN start, xbox::PFN end)
 {
 	xbox::PLIST_ENTRY ListEntry;
-	PFN_COUNT size = end - start + 1;
+	xbox::PFN_COUNT size = end - start + 1;
 
 	ListEntry = FreeList.Blink; // search from the top
 
@@ -374,7 +374,7 @@ void PhysicalMemory::InsertFree(PFN start, PFN end)
 	}
 }
 
-bool PhysicalMemory::ConvertXboxToSystemPtePermissions(DWORD perms, PMMPTE pPte)
+bool PhysicalMemory::ConvertXboxToSystemPtePermissions(DWORD perms, xbox::PMMPTE pPte)
 {
 	ULONG Mask = 0;
 
@@ -431,7 +431,7 @@ bool PhysicalMemory::ConvertXboxToSystemPtePermissions(DWORD perms, PMMPTE pPte)
 	return false;
 }
 
-bool PhysicalMemory::ConvertXboxToPtePermissions(DWORD perms, PMMPTE pPte)
+bool PhysicalMemory::ConvertXboxToPtePermissions(DWORD perms, xbox::PMMPTE pPte)
 {
 	ULONG Mask = 0;
 	ULONG LowNibble;
@@ -644,12 +644,12 @@ DWORD PhysicalMemory::ConvertXboxToWinPermissions(DWORD Perms)
 
 bool PhysicalMemory::AllocatePT(size_t Size, VAddr addr)
 {
-	PFN pfn;
-	PMMPTE pPde;
-	MMPTE TempPte;
-	PFN_COUNT PdeNumber = PAGES_SPANNED_LARGE(addr, Size);
-	PFN_COUNT PTtoCommit = 0;
-	PageType BusyType = SystemPageTableType;
+	xbox::PFN pfn;
+	xbox::PMMPTE pPde;
+	xbox::MMPTE TempPte;
+	xbox::PFN_COUNT PdeNumber = PAGES_SPANNED_LARGE(addr, Size);
+	xbox::PFN_COUNT PTtoCommit = 0;
+	xbox::PageType BusyType = xbox::SystemPageTableType;
 	VAddr StartingAddr = addr;
 
 	assert(Size);
@@ -677,7 +677,7 @@ bool PhysicalMemory::AllocatePT(size_t Size, VAddr addr)
 
 		return false;
 	}
-	if (addr <= HIGHEST_USER_ADDRESS) { BusyType = VirtualPageTableType; }
+	if (addr <= HIGHEST_USER_ADDRESS) { BusyType = xbox::VirtualPageTableType; }
 	StartingAddr = addr;
 
 	// Now actually commit the PT's. Note that we won't construct the vma's for the PTs since they are outside of all
@@ -705,9 +705,9 @@ bool PhysicalMemory::AllocatePT(size_t Size, VAddr addr)
 
 void PhysicalMemory::DeallocatePT(size_t Size, VAddr addr)
 {
-	PMMPTE pPde;
+	xbox::PMMPTE pPde;
 	PXBOX_PFN PTpfn;
-	PFN_COUNT PdeNumber = PAGES_SPANNED_LARGE(addr, Size);
+	xbox::PFN_COUNT PdeNumber = PAGES_SPANNED_LARGE(addr, Size);
 	VAddr StartingAddr = addr;
 
 	assert(Size);
@@ -721,14 +721,14 @@ void PhysicalMemory::DeallocatePT(size_t Size, VAddr addr)
 		if (PTpfn->PTPageFrame.PtesUsed == 0)
 		{
 			InsertFree(pPde->Hardware.PFN, pPde->Hardware.PFN);
-			WritePfn(pPde->Hardware.PFN, pPde->Hardware.PFN, pPde, (PageType)PTpfn->PTPageFrame.BusyType, true);
+			WritePfn(pPde->Hardware.PFN, pPde->Hardware.PFN, pPde, (xbox::PageType)PTpfn->PTPageFrame.BusyType, true);
 			WRITE_ZERO_PTE(pPde);
 		}
 		StartingAddr += LARGE_PAGE_SIZE;
 	}
 }
 
-bool PhysicalMemory::IsMappable(PFN_COUNT PagesRequested, bool bRetailRegion, bool bDebugRegion)
+bool PhysicalMemory::IsMappable(xbox::PFN_COUNT PagesRequested, bool bRetailRegion, bool bDebugRegion)
 {
 	bool ret = false;
 	if (bRetailRegion && m_PhysicalPagesAvailable >= PagesRequested) { ret = true; }
@@ -738,12 +738,12 @@ bool PhysicalMemory::IsMappable(PFN_COUNT PagesRequested, bool bRetailRegion, bo
 	return ret;
 }
 
-PXBOX_PFN PhysicalMemory::GetPfnOfPT(PMMPTE pPte)
+PXBOX_PFN PhysicalMemory::GetPfnOfPT(xbox::PMMPTE pPte)
 {
 	PXBOX_PFN PTpfn;
 
 	// GetPteAddress on a pte address will yield the corresponding pde which maps the supplied pte
-	PMMPTE PointerPde = GetPteAddress(pPte);
+	xbox::PMMPTE PointerPde = GetPteAddress(pPte);
 	// PointerPde should have already been written to by AllocatePT
 	assert(PointerPde->Hardware.Valid != 0);
 	if (m_MmLayoutRetail || m_MmLayoutDebug) {
@@ -751,8 +751,8 @@ PXBOX_PFN PhysicalMemory::GetPfnOfPT(PMMPTE pPte)
 	}
 	else { PTpfn = CHIHIRO_PFN_ELEMENT(PointerPde->Hardware.PFN); }
 	assert(PTpfn->PTPageFrame.Busy == 1);
-	assert(PTpfn->PTPageFrame.BusyType == SystemPageTableType ||
-		PTpfn->PTPageFrame.BusyType == VirtualPageTableType);
+	assert(PTpfn->PTPageFrame.BusyType == xbox::SystemPageTableType ||
+		PTpfn->PTPageFrame.BusyType == xbox::VirtualPageTableType);
 
 	return PTpfn;
 }

--- a/src/core/kernel/memory-manager/PhysicalMemory.h
+++ b/src/core/kernel/memory-manager/PhysicalMemory.h
@@ -40,82 +40,35 @@
 typedef uintptr_t VAddr;
 typedef uintptr_t PAddr;
 typedef uint32_t u32;
-typedef unsigned int PFN;
-typedef unsigned int PFN_COUNT;
 
 
 /* An entry of the list tracking the free pages on the system */
 typedef struct _FreeBlock
 {
-	PFN start;                        // starting page of the block
-	PFN_COUNT size;                   // number of pages in the block
+	xbox::PFN start;                        // starting page of the block
+	xbox::PFN_COUNT size;                   // number of pages in the block
 	xbox::LIST_ENTRY ListEntry;
 }FreeBlock, *PFreeBlock;
-
-
-/* The Xbox PTE, modelled around the Intel 386 PTE specification */
-typedef struct _XBOX_PTE
-{
-	ULONG Valid : 1;
-	ULONG Write : 1;
-	ULONG Owner : 1;
-	ULONG WriteThrough : 1;
-	ULONG CacheDisable : 1;
-	ULONG Accessed : 1;
-	ULONG Dirty : 1;
-	ULONG LargePage : 1;
-	ULONG Global : 1;
-	ULONG GuardOrEnd : 1; // software field used for our own purposes
-	ULONG Persist : 1;    // software field used for our own purposes
-	ULONG Unused : 1;     // software field used for our own purposes
-	ULONG PFN : 20;
-} XBOX_PTE, *PXBOX_PTE;
-
-
-/* PTE as used by the memory manager */
-typedef union _MMPTE
-{
-	ULONG Default;
-	XBOX_PTE Hardware;
-}MMPTE, *PMMPTE;
 
 
 /* PFN entry used by the memory manager */
 typedef union _XBOX_PFN
 {
-	ULONG Default;
+	xbox::ulong_xt Default;
 	struct {
-		ULONG LockCount : 16;  // Set to prevent page relocation. Used by MmLockUnlockPhysicalPage and others
-		ULONG Busy : 1;        // If set, PFN is in use
-		ULONG Unused : 1;
-		ULONG PteIndex : 10;   // Offset in the PT that maps the pte (it seems to be needed only for page relocations)
-		ULONG BusyType : 4;    // What the page is used for
+		xbox::ulong_xt LockCount : 16;  // Set to prevent page relocation. Used by MmLockUnlockPhysicalPage and others
+		xbox::ulong_xt Busy : 1;        // If set, PFN is in use
+		xbox::ulong_xt Unused : 1;
+		xbox::ulong_xt PteIndex : 10;   // Offset in the PT that maps the pte (it seems to be needed only for page relocations)
+		xbox::ulong_xt BusyType : 4;    // What the page is used for
 	} Busy;
 	struct {
-		ULONG LockCount : 16;  // Set to prevent page relocation. Used by MmLockUnlockPhysicalPage and others
-		ULONG Busy : 1;        // If set, PFN is in use
-		ULONG PtesUsed : 11;   // Number of used pte's in the PT pointed by the pde
-		ULONG BusyType : 4;    // What the page is used for (must be VirtualPageTableType or SystemPageTableType)
+		xbox::ulong_xt LockCount : 16;  // Set to prevent page relocation. Used by MmLockUnlockPhysicalPage and others
+		xbox::ulong_xt Busy : 1;        // If set, PFN is in use
+		xbox::ulong_xt PtesUsed : 11;   // Number of used pte's in the PT pointed by the pde
+		xbox::ulong_xt BusyType : 4;    // What the page is used for (must be VirtualPageTableType or SystemPageTableType)
 	} PTPageFrame;
 }XBOX_PFN, *PXBOX_PFN;
-
-
-/* enum describing the usage type of the memory pages */
-typedef enum _PageType
-{
-	UnknownType,                   // Used by the PFN database
-	StackType,                     // Used by MmCreateKernelStack
-	VirtualPageTableType,          // Used by the pages holding the PTs that map the user memory (lower 2 GiB)
-	SystemPageTableType,           // Used by the pages holding the PTs that map the system memory
-	PoolType,                      // Used by ExAllocatePoolWithTag
-	VirtualMemoryType,             // Used by NtAllocateVirtualMemory
-	SystemMemoryType,              // Used by MmAllocateSystemMemory
-	ImageType,                     // Used to mark executable memory
-	CacheType,                     // Used by the file cache related functions
-	ContiguousType,                // Used by MmAllocateContiguousMemoryEx and others
-	DebuggerType,                  // xbdm-related
-	COUNTtype                      // The size of the array containing the page usage per type
-}PageType;
 
 
 /* enum describing the memory layouts the memory manager can use */
@@ -155,8 +108,8 @@ typedef enum _MmLayout
 
 
 /* Various macros to manipulate PDE/PTE/PFN */
-#define GetPdeAddress(Va) ((PMMPTE)(((((ULONG)(Va)) >> 22) << 2) + PAGE_DIRECTORY_BASE)) // (Va/4M) * 4 + PDE_BASE
-#define GetPteAddress(Va) ((PMMPTE)(((((ULONG)(Va)) >> 12) << 2) + PAGE_TABLES_BASE))    // (Va/4K) * 4 + PTE_BASE
+#define GetPdeAddress(Va) ((xbox::PMMPTE)(((((ULONG)(Va)) >> 22) << 2) + PAGE_DIRECTORY_BASE)) // (Va/4M) * 4 + PDE_BASE
+#define GetPteAddress(Va) ((xbox::PMMPTE)(((((ULONG)(Va)) >> 12) << 2) + PAGE_TABLES_BASE))    // (Va/4K) * 4 + PTE_BASE
 #define GetVAddrMappedByPte(Pte) ((VAddr)((ULONG_PTR)(Pte) << 10))
 #define GetPteOffset(Va) ((((ULONG)(Va)) << 10) >> 22)
 #define IsPteOnPdeBoundary(Pte) (((ULONG_PTR)(Pte) & (PAGE_SIZE - 1)) == 0)
@@ -201,15 +154,15 @@ class PhysicalMemory
 		// highest pfn available for contiguous allocations
 		PAddr m_MaxContiguousPfn = XBOX_CONTIGUOUS_MEMORY_LIMIT;
 		// amount of free physical pages available for non-debugger usage
-		PFN_COUNT m_PhysicalPagesAvailable = X64M_PHYSICAL_PAGE;
+		xbox::PFN_COUNT m_PhysicalPagesAvailable = X64M_PHYSICAL_PAGE;
 		// amount of free physical pages available for usage by the debugger (devkit only)
-		PFN_COUNT m_DebuggerPagesAvailable = 0;
+		xbox::PFN_COUNT m_DebuggerPagesAvailable = 0;
 		// array containing the number of pages in use per type
-		PFN_COUNT m_PagesByUsage[COUNTtype] = { 0 };
+		xbox::PFN_COUNT m_PagesByUsage[xbox::COUNTtype] = { 0 };
 		// highest page on the system
-		PFN m_HighestPage = XBOX_HIGHEST_PHYSICAL_PAGE;
+		xbox::PFN m_HighestPage = XBOX_HIGHEST_PHYSICAL_PAGE;
 		// first page of the nv2a instance memory
-		PFN m_NV2AInstancePage = XBOX_INSTANCE_PHYSICAL_PAGE;
+		xbox::PFN m_NV2AInstancePage = XBOX_INSTANCE_PHYSICAL_PAGE;
 		// number of allocated bytes for the nv2a instance memory
 		size_t m_NV2AInstanceMemoryBytes = NV2A_INSTANCE_PAGE_COUNT << PAGE_SHIFT;
 		// boolean that indicates that the extra 64 MiB on a devkit can be used for heap/Nt allocations
@@ -227,19 +180,19 @@ class PhysicalMemory
 		// set up the page directory
 		void InitializePageDirectory();
 		// write a contiguous range of pfn's
-		void WritePfn(PFN pfn_start, PFN pfn_end, PMMPTE pPte, PageType BusyType, bool bZero = false);
+		void WritePfn(xbox::PFN pfn_start, xbox::PFN pfn_end, xbox::PMMPTE pPte, xbox::PageType BusyType, bool bZero = false);
 		// write a contiguous range of pte's
-		void WritePte(PMMPTE pPteStart, PMMPTE pPteEnd, MMPTE Pte, PFN pfn, bool bZero = false);
+		void WritePte(xbox::PMMPTE pPteStart, xbox::PMMPTE pPteEnd, xbox::MMPTE Pte, xbox::PFN pfn, bool bZero = false);
 		// retrieves the pfn entry which maps a PT
-		PXBOX_PFN GetPfnOfPT(PMMPTE pPte);
+		PXBOX_PFN GetPfnOfPT(xbox::PMMPTE pPte);
 		// commit a contiguous number of pages
-		bool RemoveFree(PFN_COUNT NumberOfPages, PFN* result, PFN_COUNT PfnAlignment, PFN start, PFN end);
+		bool RemoveFree(xbox::PFN_COUNT NumberOfPages, xbox::PFN* result, xbox::PFN_COUNT PfnAlignment, xbox::PFN start, xbox::PFN end);
 		// release a contiguous number of pages
-		void InsertFree(PFN start, PFN end);
+		void InsertFree(xbox::PFN start, xbox::PFN end);
 		// convert from Xbox to the desired system pte protection (if possible) and return it
-		bool ConvertXboxToSystemPtePermissions(DWORD perms, PMMPTE pPte);
+		bool ConvertXboxToSystemPtePermissions(DWORD perms, xbox::PMMPTE pPte);
 		// convert from Xbox to non-system pte protection (if possible) and return it
-		bool ConvertXboxToPtePermissions(DWORD perms, PMMPTE pPte);
+		bool ConvertXboxToPtePermissions(DWORD perms, xbox::PMMPTE pPte);
 		// convert from pte permissions to the corresponding Xbox protection code
 		DWORD ConvertPteToXboxPermissions(ULONG PteMask);
 		// convert from Xbox to Windows permissions
@@ -251,7 +204,7 @@ class PhysicalMemory
 		// deallocate page tables (if possible)
 		void DeallocatePT(size_t Size, VAddr addr);
 		// checks if enough free pages are available for the allocation (doesn't account for fragmentation)
-		bool IsMappable(PFN_COUNT PagesRequested, bool bRetailRegion, bool bDebugRegion);
+		bool IsMappable(xbox::PFN_COUNT PagesRequested, bool bRetailRegion, bool bDebugRegion);
 };
 
 #endif

--- a/src/core/kernel/memory-manager/PoolManager.cpp
+++ b/src/core/kernel/memory-manager/PoolManager.cpp
@@ -95,7 +95,7 @@ VAddr PoolManager::AllocatePool(size_t Size, uint32_t Tag)
 		Lock();
 
 		PoolDesc->RunningAllocs += 1;
-		Entry = reinterpret_cast<PPOOL_HEADER>(g_VMManager.AllocateSystemMemory(PoolType, XBOX_PAGE_READWRITE, Size, false));
+		Entry = reinterpret_cast<PPOOL_HEADER>(g_VMManager.AllocateSystemMemory(xbox::PoolType, XBOX_PAGE_READWRITE, Size, false));
 
 		if (Entry != nullptr) {
 			NumberOfPages = ROUND_UP_4K(Size) >> PAGE_SHIFT;
@@ -202,7 +202,7 @@ VAddr PoolManager::AllocatePool(size_t Size, uint32_t Tag)
 
 		// The current pool descriptor is exhausted, so we ask the VMManager to allocate a page to create a new one
 
-		Entry = reinterpret_cast<PPOOL_HEADER>(g_VMManager.AllocateSystemMemory(PoolType, XBOX_PAGE_READWRITE, PAGE_SIZE, false));
+		Entry = reinterpret_cast<PPOOL_HEADER>(g_VMManager.AllocateSystemMemory(xbox::PoolType, XBOX_PAGE_READWRITE, PAGE_SIZE, false));
 
 		if (Entry == nullptr) {
 			EmuLog(LOG_LEVEL::WARNING, "AllocatePool returns nullptr");
@@ -245,7 +245,7 @@ void PoolManager::DeallocatePool(VAddr addr)
 
 		PoolDesc->RunningDeAllocs += 1;
 		
-		BigPages = g_VMManager.DeallocateSystemMemory(PoolType, addr, 0);
+		BigPages = g_VMManager.DeallocateSystemMemory(xbox::PoolType, addr, 0);
 
 		PoolDesc->TotalBigPages -= BigPages;
 
@@ -306,7 +306,7 @@ void PoolManager::DeallocatePool(VAddr addr)
 	if (CHECK_ALIGNMENT(reinterpret_cast<VAddr>(Entry), PAGE_SIZE) &&
 		(PAGE_END(reinterpret_cast<PPOOL_BLOCK>(Entry) + Entry->BlockSize) != false)) {
 
-		g_VMManager.DeallocateSystemMemory(PoolType, reinterpret_cast<VAddr>(Entry), 0);
+		g_VMManager.DeallocateSystemMemory(xbox::PoolType, reinterpret_cast<VAddr>(Entry), 0);
 
 		PoolDesc->TotalPages -= 1;
 	}

--- a/src/core/kernel/memory-manager/VMManager.h
+++ b/src/core/kernel/memory-manager/VMManager.h
@@ -103,13 +103,13 @@ class VMManager : public PhysicalMemory
 		// retrieves memory statistics
 		void MemoryStatistics(xbox::PMM_STATISTICS memory_statistics);
 		// allocates memory in the system region
-		VAddr AllocateSystemMemory(PageType BusyType, DWORD Perms, size_t Size, bool bAddGuardPage);
+		VAddr AllocateSystemMemory(xbox::PageType BusyType, DWORD Perms, size_t Size, bool bAddGuardPage);
 		// allocates memory in the contiguous region
 		VAddr AllocateContiguousMemory(size_t Size, PAddr LowestAddress, PAddr HighestAddress, ULONG Alignment, DWORD Perms);
 		// maps device memory in the system region
 		VAddr MapDeviceMemory(PAddr Paddr, size_t Size, DWORD Perms);
 		// deallocates memory in the system region
-		PFN_COUNT DeallocateSystemMemory(PageType BusyType, VAddr addr, size_t Size);
+		xbox::PFN_COUNT DeallocateSystemMemory(xbox::PageType BusyType, VAddr addr, size_t Size);
 		// deallocates memory in the contiguous region
 		void DeallocateContiguousMemory(VAddr addr);
 		// unmaps device memory in the system region
@@ -131,9 +131,9 @@ class VMManager : public PhysicalMemory
 		// make contiguous memory persist across a quick reboot
 		void PersistMemory(VAddr addr, size_t Size, bool bPersist);
 		// debug function to reset a pte or check if it is writable
-		VAddr DbgTestPte(VAddr addr, PMMPTE Pte, bool bWriteCheck);
+		VAddr DbgTestPte(VAddr addr, xbox::PMMPTE Pte, bool bWriteCheck);
 		// retrieves the number of free debugger pages
-		PFN_COUNT QueryNumberOfFreeDebuggerPages();
+		xbox::PFN_COUNT QueryNumberOfFreeDebuggerPages();
 		// xbox implementation of NtAllocateVirtualMemory
 		xbox::ntstatus_xt XbAllocateVirtualMemory(VAddr* addr, ULONG ZeroBits, size_t* Size, DWORD AllocationType, DWORD Protect);
 		// xbox implementation of NtFreeVirtualMemory
@@ -161,7 +161,7 @@ class VMManager : public PhysicalMemory
 		void* m_PersistentMemoryHandle = nullptr;
 
 		// same as AllocateContiguousMemory, but it allows to allocate beyond m_MaxContiguousPfn
-		VAddr AllocateContiguousMemoryInternal(PFN_COUNT NumberOfPages, PFN LowestPfn, PFN HighestPfn, PFN PfnAlignment, DWORD Perms, PageType BusyType = ContiguousType);
+		VAddr AllocateContiguousMemoryInternal(xbox::PFN_COUNT NumberOfPages, xbox::PFN LowestPfn, xbox::PFN HighestPfn, xbox::PFN PfnAlignment, DWORD Perms, xbox::PageType BusyType = xbox::ContiguousType);
 		// set up the system allocations
 		void InitializeSystemAllocations();
 		// initializes a memory region struct
@@ -169,7 +169,7 @@ class VMManager : public PhysicalMemory
 		// clears all memory region structs
 		void DestroyMemoryRegions();
 		// map a memory block with the supplied allocation routine
-		VAddr MapMemoryBlock(MemoryRegionType Type, PFN_COUNT PteNumber, DWORD Permissions, bool b64Blocks, VAddr HighestAddress = 0);
+		VAddr MapMemoryBlock(MemoryRegionType Type, xbox::PFN_COUNT PteNumber, DWORD Permissions, bool b64Blocks, VAddr HighestAddress = 0);
 		// helper function which allocates user memory with VirtualAlloc
 		VAddr MapHostMemory(VAddr StartingAddr, size_t Size, size_t VmaEnd, DWORD Permissions);
 		// constructs a vma


### PR DESCRIPTION
Triggered by this [PR](https://github.com/XboxDev/nxdk/pull/560) in nxdk.