### PR TITLE
Improve Xbox Thread Setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ file (GLOB CXBXR_HEADER_EMU
  "${CXBXR_ROOT_DIR}/src/core/kernel/exports/EmuKrnlKe.h"
  "${CXBXR_ROOT_DIR}/src/core/kernel/exports/EmuKrnlKi.h"
  "${CXBXR_ROOT_DIR}/src/core/kernel/exports/EmuKrnlLogging.h"
+ "${CXBXR_ROOT_DIR}/src/core/kernel/exports/EmuKrnlPs.hpp"
  "${CXBXR_ROOT_DIR}/src/core/kernel/init/CxbxKrnl.h"
  "${CXBXR_ROOT_DIR}/src/core/kernel/init/KrnlPatches.hpp"
  "${CXBXR_ROOT_DIR}/src/core/kernel/memory-manager/PhysicalMemory.h"

--- a/src/core/kernel/exports/EmuKrnlKi.h
+++ b/src/core/kernel/exports/EmuKrnlKi.h
@@ -146,6 +146,32 @@ namespace xbox
 		IN PLARGE_INTEGER DueTime,
 		IN OUT PLARGE_INTEGER NewTime
 	);
+
+	// Source: ReactOS
+	void_xt NTAPI KiSuspendNop(
+		IN PKAPC Apc,
+		IN PKNORMAL_ROUTINE* NormalRoutine,
+		IN PVOID* NormalContext,
+		IN PVOID* SystemArgument1,
+		IN PVOID* SystemArgument2
+	);
+
+	// Source: ReactOS
+	void_xt NTAPI KiSuspendThread(
+		IN PVOID NormalContext,
+		IN PVOID SystemArgument1,
+		IN PVOID SystemArgument2
+	);
+
+	void_xt NTAPI KiThreadStartup(void_xt);
+
+	xbox::void_xt KiInitializeContextThread(
+		IN PKTHREAD Thread,
+		IN ulong_xt TlsDataSize,
+		IN PKSYSTEM_ROUTINE SystemRoutine,
+		IN PKSTART_ROUTINE StartRoutine,
+		IN PVOID StartContext
+	);
 };
 
 extern xbox::KPROCESS KiUniqueProcess;

--- a/src/core/kernel/exports/EmuKrnlPs.hpp
+++ b/src/core/kernel/exports/EmuKrnlPs.hpp
@@ -17,38 +17,12 @@
 // *  If not, write to the Free Software Foundation, Inc.,
 // *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
 // *
-// *  (c) 2019 ergo720
-// *
 // *  All rights reserved
 // *
 // ******************************************************************
-
 #pragma once
 
 namespace xbox
 {
-	void_xt NTAPI KeSetSystemTime
-	(
-		IN  PLARGE_INTEGER NewTime,
-		OUT PLARGE_INTEGER OldTime
-	);
-
-	void_xt NTAPI KeInitializeTimer
-	(
-		IN PKTIMER Timer
-	);
-
-	template<bool IsHostThread = false>
-	void_xt KeInitializeThread(
-		IN OUT PKTHREAD Thread,
-		IN PVOID KernelStack,
-		IN ulong_xt KernelStackSize,
-		IN ulong_xt TlsDataSize,
-		IN PKSYSTEM_ROUTINE SystemRoutine,
-		IN PKSTART_ROUTINE StartRoutine,
-		IN PVOID StartContext,
-		IN PKPROCESS Process
-	);
-
-	void_xt KeEmptyQueueApc();
-}
+	void_xt PsInitSystem();
+};

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -50,28 +50,8 @@ namespace NtDll
 #undef RtlFillMemory
 #undef RtlMoveMemory
 #undef RtlZeroMemory
-#undef EXCEPTION_NONCONTINUABLE
-#undef EXCEPTION_UNWINDING
-#undef EXCEPTION_EXIT_UNWIND
-#undef EXCEPTION_STACK_INVALID
-#undef EXCEPTION_NESTED_CALL
-#undef EXCEPTION_TARGET_UNWIND
-#undef EXCEPTION_COLLIDED_UNWIND
-#undef EXCEPTION_UNWIND
 
 #endif // _WIN32
-
-// Exception record flags
-// Source: ReactOS
-// NOTE: don't put these in xboxkrnl.h, they will conflict with the macros provided by Windows
-#define EXCEPTION_NONCONTINUABLE  0x01
-#define EXCEPTION_UNWINDING       0x02
-#define EXCEPTION_EXIT_UNWIND     0x04
-#define EXCEPTION_STACK_INVALID   0x08
-#define EXCEPTION_NESTED_CALL     0x10
-#define EXCEPTION_TARGET_UNWIND   0x20
-#define EXCEPTION_COLLIDED_UNWIND 0x40
-#define EXCEPTION_UNWIND (EXCEPTION_UNWINDING | EXCEPTION_EXIT_UNWIND | EXCEPTION_TARGET_UNWIND | EXCEPTION_COLLIDED_UNWIND)
 
 xbox::dword_xt WINAPI RtlAnsiStringToUnicodeSize(const xbox::STRING *str)
 {
@@ -1503,7 +1483,7 @@ XBSYSAPI EXPORTNUM(303) xbox::void_xt NTAPI xbox::RtlRaiseStatus
 
 	EXCEPTION_RECORD record;
 	record.ExceptionCode = Status;
-	record.ExceptionFlags = EXCEPTION_NONCONTINUABLE;
+	record.ExceptionFlags = X_EXCEPTION_NONCONTINUABLE;
 	record.ExceptionRecord = NULL;
 	record.NumberParameters = 0;
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -113,7 +113,7 @@ std::atomic_bool g_bEnableAllInterrupts = true;
 // Set by the VMManager during initialization. Exported because it's needed in other parts of the emu
 size_t g_SystemMaxMemory = 0;
 
-HANDLE g_CurrentProcessHandle = 0; // Set in CxbxKrnlMain
+HANDLE g_CurrentProcessHandle = 0; // Set in CxbxKrnlEmulate
 
 bool g_CxbxPrintUEM = false;
 ULONG g_CxbxFatalErrorCode = FATAL_ERROR_NONE;
@@ -1016,6 +1016,9 @@ void CxbxKrnlEmulate(unsigned int reserved_systems, blocks_reserved_t blocks_res
 	// and capture any crash from this point and beyond. Useful for capture live crash and generate crash report.
 	g_ExceptionManager = new ExceptionManager();
 
+	// Set current process handle in order for CxbxKrnlShutDown to work properly.
+	g_CurrentProcessHandle = GetCurrentProcess(); // OpenProcess(PROCESS_ALL_ACCESS, FALSE, GetCurrentProcessId());
+
 	// First of all, check if the EmuShared version matches the emu version and abort otherwise
 	char GitVersionEmuShared[GitVersionMaxLength];
 	g_EmuShared->GetGitVersion(GitVersionEmuShared);
@@ -1068,8 +1071,6 @@ void CxbxKrnlEmulate(unsigned int reserved_systems, blocks_reserved_t blocks_res
 
 	int BootFlags;
 	g_EmuShared->GetBootFlags(&BootFlags);
-
-	g_CurrentProcessHandle = GetCurrentProcess(); // OpenProcess(PROCESS_ALL_ACCESS, FALSE, GetCurrentProcessId());
 
 	// Set up the logging variables for the kernel process during initialization.
 	log_sync_config();

--- a/src/core/kernel/support/EmuFS.cpp
+++ b/src/core/kernel/support/EmuFS.cpp
@@ -754,7 +754,7 @@ void EmuGenerateFS(xbox::PETHREAD Ethread, unsigned Host2XbStackBaseReserved, un
 		xbox::addr_xt xTlsData = reinterpret_cast<xbox::addr_xt>(Ethread->Tcb.TlsData);
 		xbox::addr_xt xKernelStack = reinterpret_cast<xbox::addr_xt>(Ethread->Tcb.KernelStack);
 		xbox::dword_xt xKernelStackSize = xStackBase - xKernelStack;
-		assert(xStackBase - xKernelStack <= Host2XbStackSizeReserved);
+		assert(xKernelStackSize <= Host2XbStackSizeReserved);
 		PVOID hKernelStack = reinterpret_cast<PVOID>(Host2XbStackBaseReserved - xKernelStackSize);
 		std::memcpy(hKernelStack, Ethread->Tcb.KernelStack, xKernelStackSize);
 		// Update TlsData address if used

--- a/src/core/kernel/support/EmuFS.h
+++ b/src/core/kernel/support/EmuFS.h
@@ -29,16 +29,20 @@
 #include "common\xbe\Xbe.h"
 #include <windows.h>
 
+// Get Xbox's TIB StackBase address from thread's StackBase.
+xbox::PVOID EmuGetTIBStackBase(xbox::PVOID ThreadStackBase);
+
+// generate stack size reserved for xbox threads to write on.
+// espBaseAddress will return aligned DOWN address, do not rely on return's size for offset usage.
+xbox::dword_xt EmuGenerateStackSize(xbox::addr_xt& espBaseAddress, IN xbox::ulong_xt TlsDataSize);
+
 // initialize fs segment selector emulation
 extern void EmuInitFS();
 
 // generate fs segment selector
 template<bool IsHostThread = false>
-void EmuGenerateFS(Xbe::TLS *pTLS, void *pTLSData, xbox::PETHREAD Ethread);
-// free resources allocated for the thread
-void EmuKeFreeThread(xbox::ntstatus_xt ExitStatus = X_STATUS_ABANDONED);
+void EmuGenerateFS(xbox::PETHREAD Ethread, unsigned XboxThreadStackBaseReserved = 0, unsigned XboxThreadStackSizeReserved = 0);
 // free kpcr allocated for the thread
-template<bool IsHostThread = false>
 void EmuKeFreePcr();
 
 void EmuKeSetPcr(xbox::KPCR *Pcr);
@@ -49,10 +53,5 @@ typedef struct
 	std::vector<uint8_t> data;
 	void* functionPtr;
 }fs_instruction_t;
-
-extern template void EmuGenerateFS<true>(Xbe::TLS *pTLS, void *pTLSData, xbox::PETHREAD Ethread);
-extern template void EmuGenerateFS<false>(Xbe::TLS *pTLS, void *pTLSData, xbox::PETHREAD Ethread);
-extern template void EmuKeFreePcr<true>();
-extern template void EmuKeFreePcr<false>();
 
 #endif


### PR DESCRIPTION
When I started implement `RtlWalkFrameChain` function, I noticed the result return empty. After further investigation, I recently discovered that TlsData reside on the same stack instead of separate memory allocation. With that said, I also found out how we used the xbox's top kernel stack reserved space improperly.

With this pull request fix, I am able to use host's local stack to generate local variable dynamic sized depending on TlsDataSize request and use it for specifically xbox's top kernel stack reserved. Everything else after it are used for cpu instruction requests as normal. And removed the hack method alltogether as well.

I also add `ENABLE_KTHREAD_SWITCHING` macro which works for both method. Except we don't have kthread switching supported.

P.S. `RtlWalkFrameChain` function implemented locally is functional.

---
I had personally verified with DoA 2 and Futurama titles are working as intended.