### PR TITLE
Implement Thread Stack Readers

### DIFF
--- a/src/common/AddressRanges.h
+++ b/src/common/AddressRanges.h
@@ -146,15 +146,6 @@ inline constexpr uint32_t FLASH_DEVICE4_END  =     (FLASH_DEVICE4_BASE - 1 + FLA
 #define PAGE_SIZE                           (1 << PAGE_SHIFT) // = 0x00001000 = KiB(4)
 #define PAGE_MASK                           (PAGE_SIZE - 1)
 
-// Common page calculations
-#define ROUND_UP_4K(size) (((size) + PAGE_MASK) & (~PAGE_MASK))
-#define ROUND_UP(size, alignment) (((size) + (alignment - 1)) & (~(alignment - 1)))
-#define ROUND_DOWN_4K(size) ((size) & (~PAGE_MASK))
-#define ROUND_DOWN(size, alignment) ((size) & (~(alignment - 1)))
-#define CHECK_ALIGNMENT(size, alignment) (((size) % (alignment)) == 0)
-
-#define PAGE_ALIGN(address)                 ROUND_DOWN_4K(address)
-
 #define LARGE_PAGE_SHIFT                    22 // 2^22 = 4 MiB
 #define LARGE_PAGE_SIZE                     (1 << LARGE_PAGE_SHIFT) // = 0x00400000 = 4 MiB
 #define LARGE_PAGE_MASK                     (LARGE_PAGE_SIZE - 1)
@@ -171,6 +162,19 @@ inline constexpr uint32_t FLASH_DEVICE4_END  =     (FLASH_DEVICE4_BASE - 1 + FLA
 // Memory size per system
 #define XBOX_MEMORY_SIZE                    (MiB(64))
 #define CHIHIRO_MEMORY_SIZE                 (MiB(128))
+
+// Common page calculations
+#define ROUND_UP_4K(size)                   (((size) + PAGE_MASK) & (~PAGE_MASK))
+#define ROUND_UP(size, alignment)           (((size) + (alignment - 1)) & (~(alignment - 1)))
+#define ROUND_DOWN_4K(size)                 ((size) & (~PAGE_MASK))
+#define ROUND_DOWN(size, alignment)         ((size) & (~(alignment - 1)))
+#define CHECK_ALIGNMENT(size, alignment)    (((size) % (alignment)) == 0)
+#define BYTE_OFFSET(Va)                     ((xbox::ulong_xt)((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)))
+#define BYTE_OFFSET_LARGE(Va)               ((xbox::ulong_xt)((xbox::ulong_ptr_xt)(Va) & (LARGE_PAGE_SIZE - 1)))
+#define PAGE_ALIGN(address)                 ROUND_DOWN_4K(address)
+#define PAGE_END(Va)                        (((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)) == 0)
+#define PAGES_SPANNED(Va, Size)             ((xbox::ulong_xt)((((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)) + (Size) + (PAGE_SIZE - 1)) >> PAGE_SHIFT))
+#define PAGES_SPANNED_LARGE(Va, Size)       ((xbox::ulong_xt)((((xbox::ulong_ptr_xt)(Va) & (LARGE_PAGE_SIZE - 1)) + (Size) + (LARGE_PAGE_SIZE - 1)) >> LARGE_PAGE_SHIFT))
 
 // Windows' address space allocation granularity;
 // See https://blogs.msdn.microsoft.com/oldnewthing/20031008-00/?p=42223

--- a/src/common/AddressRanges.h
+++ b/src/common/AddressRanges.h
@@ -145,6 +145,7 @@ inline constexpr uint32_t FLASH_DEVICE4_END  =     (FLASH_DEVICE4_BASE - 1 + FLA
 #define PAGE_SHIFT                          12 // 2^12 = 4 KiB
 #define PAGE_SIZE                           (1 << PAGE_SHIFT) // = 0x00001000 = KiB(4)
 #define PAGE_MASK                           (PAGE_SIZE - 1)
+#define PAGE_ALIGN(address)                 (PVOID) ((ulong_ptr_xt)(address) & ~PAGE_MASK))
 
 #define LARGE_PAGE_SHIFT                    22 // 2^22 = 4 MiB
 #define LARGE_PAGE_SIZE                     (1 << LARGE_PAGE_SHIFT) // = 0x00400000 = 4 MiB

--- a/src/common/AddressRanges.h
+++ b/src/common/AddressRanges.h
@@ -145,7 +145,15 @@ inline constexpr uint32_t FLASH_DEVICE4_END  =     (FLASH_DEVICE4_BASE - 1 + FLA
 #define PAGE_SHIFT                          12 // 2^12 = 4 KiB
 #define PAGE_SIZE                           (1 << PAGE_SHIFT) // = 0x00001000 = KiB(4)
 #define PAGE_MASK                           (PAGE_SIZE - 1)
-#define PAGE_ALIGN(address)                 (PVOID) ((ulong_ptr_xt)(address) & ~PAGE_MASK))
+
+// Common page calculations
+#define ROUND_UP_4K(size) (((size) + PAGE_MASK) & (~PAGE_MASK))
+#define ROUND_UP(size, alignment) (((size) + (alignment - 1)) & (~(alignment - 1)))
+#define ROUND_DOWN_4K(size) ((size) & (~PAGE_MASK))
+#define ROUND_DOWN(size, alignment) ((size) & (~(alignment - 1)))
+#define CHECK_ALIGNMENT(size, alignment) (((size) % (alignment)) == 0)
+
+#define PAGE_ALIGN(address)                 ROUND_DOWN_4K(address)
 
 #define LARGE_PAGE_SHIFT                    22 // 2^22 = 4 MiB
 #define LARGE_PAGE_SIZE                     (1 << LARGE_PAGE_SHIFT) // = 0x00400000 = 4 MiB

--- a/src/common/AddressRanges.h
+++ b/src/common/AddressRanges.h
@@ -169,12 +169,7 @@ inline constexpr uint32_t FLASH_DEVICE4_END  =     (FLASH_DEVICE4_BASE - 1 + FLA
 #define ROUND_DOWN_4K(size)                 ((size) & (~PAGE_MASK))
 #define ROUND_DOWN(size, alignment)         ((size) & (~(alignment - 1)))
 #define CHECK_ALIGNMENT(size, alignment)    (((size) % (alignment)) == 0)
-#define BYTE_OFFSET(Va)                     ((xbox::ulong_xt)((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)))
-#define BYTE_OFFSET_LARGE(Va)               ((xbox::ulong_xt)((xbox::ulong_ptr_xt)(Va) & (LARGE_PAGE_SIZE - 1)))
 #define PAGE_ALIGN(address)                 ROUND_DOWN_4K(address)
-#define PAGE_END(Va)                        (((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)) == 0)
-#define PAGES_SPANNED(Va, Size)             ((xbox::ulong_xt)((((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)) + (Size) + (PAGE_SIZE - 1)) >> PAGE_SHIFT))
-#define PAGES_SPANNED_LARGE(Va, Size)       ((xbox::ulong_xt)((((xbox::ulong_ptr_xt)(Va) & (LARGE_PAGE_SIZE - 1)) + (Size) + (LARGE_PAGE_SIZE - 1)) >> LARGE_PAGE_SHIFT))
 
 // Windows' address space allocation granularity;
 // See https://blogs.msdn.microsoft.com/oldnewthing/20031008-00/?p=42223

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1106,7 +1106,31 @@ XBSYSAPI EXPORTNUM(288) xbox::void_xt NTAPI xbox::RtlGetCallersAddress
 		LOG_FUNC_ARG_OUT(CallersCaller)
 	LOG_FUNC_END;
 
-	LOG_UNIMPLEMENTED();
+	/* Get the tow back trace address */
+	PVOID BackTrace[2];
+	ushort_xt FrameCount = RtlCaptureStackBackTrace(2, 2, &BackTrace[0], zeroptr);
+
+	/* Only if user want it */
+	if (CallersAddress != NULL) {
+		/* only when first frames exist */
+		if (FrameCount >= 1) {
+			*CallersAddress = BackTrace[0];
+		}
+		else {
+			*CallersAddress = zeroptr;
+		}
+	}
+
+	/* Only if user want it */
+	if (CallersCaller != NULL) {
+		/* only when second frames exist */
+		if (FrameCount >= 2) {
+			*CallersCaller = BackTrace[1];
+		}
+		else {
+			*CallersCaller = zeroptr;
+		}
+	}
 }
 
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -268,7 +268,7 @@ XBSYSAPI EXPORTNUM(265) xbox::void_xt NTAPI xbox::RtlCaptureContext
 		mov ebx, [esp + 8]           // ebx = ContextRecord;
 
 		mov [ebx + CONTEXT.Eax], eax // ContextRecord->Eax = eax;
-		mov eax, [esp]				 // eax = original value of ebx
+		mov eax, [esp]               // eax = original value of ebx
 		mov [ebx + CONTEXT.Ebx], eax // ContextRecord->Ebx = original value of ebx
 		mov [ebx + CONTEXT.Ecx], ecx // ContextRecord->Ecx = ecx;
 		mov [ebx + CONTEXT.Edx], edx // ContextRecord->Edx = edx;

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -82,7 +82,7 @@ xbox::boolean_xt RtlpCaptureStackLimits(
 	else {
 		/* We're somewhere else entirely... use EBP for safety */
 		*StackBegin = Ebp;
-		*StackEnd = reinterpret_cast<ulong_ptr_xt>(PAGE_ALIGN((*StackBegin));
+		*StackEnd = PAGE_ALIGN(*StackBegin);
 	}
 
 	/* Return success */

--- a/src/core/kernel/memory-manager/PhysicalMemory.h
+++ b/src/core/kernel/memory-manager/PhysicalMemory.h
@@ -37,8 +37,8 @@
 
 
 /* Global typedefs */
-typedef uintptr_t VAddr;
-typedef uintptr_t PAddr;
+typedef xbox::ulong_ptr_xt VAddr;
+typedef xbox::ulong_ptr_xt PAddr;
 typedef uint32_t u32;
 
 
@@ -123,14 +123,6 @@ typedef enum _MmLayout
 #define CONVERT_CONTIGUOUS_PHYSICAL_TO_PFN(Va) (((Va) & (BYTES_IN_PHYSICAL_MAP - 1)) >> PAGE_SHIFT)
 #define XBOX_PFN_ELEMENT(pfn) (&((PXBOX_PFN)XBOX_PFN_ADDRESS)[pfn])
 #define CHIHIRO_PFN_ELEMENT(pfn) (&((PXBOX_PFN)CHIHIRO_PFN_ADDRESS)[pfn])
-
-
-/* Common page calculations */
-#define PAGES_SPANNED(Va, Size) ((ULONG)((((VAddr)(Va) & (PAGE_SIZE - 1)) + (Size) + (PAGE_SIZE - 1)) >> PAGE_SHIFT))
-#define PAGES_SPANNED_LARGE(Va, Size) ((ULONG)((((VAddr)(Va) & (LARGE_PAGE_SIZE - 1)) + (Size) + (LARGE_PAGE_SIZE - 1)) >> LARGE_PAGE_SHIFT))
-#define BYTE_OFFSET(Va) ((ULONG)((VAddr)(Va) & (PAGE_SIZE - 1)))
-#define BYTE_OFFSET_LARGE(Va) ((ULONG)((VAddr)(Va) & (LARGE_PAGE_SIZE - 1)))
-#define PAGE_END(Va) (((ULONG_PTR)(Va) & (PAGE_SIZE - 1)) == 0)
 
 
 /* These macros check if the supplied address is inside a known range */

--- a/src/core/kernel/memory-manager/PhysicalMemory.h
+++ b/src/core/kernel/memory-manager/PhysicalMemory.h
@@ -126,11 +126,6 @@ typedef enum _MmLayout
 
 
 /* Common page calculations */
-#define ROUND_UP_4K(size) (((size) + PAGE_MASK) & (~PAGE_MASK))
-#define ROUND_UP(size, alignment) (((size) + (alignment - 1)) & (~(alignment - 1)))
-#define ROUND_DOWN_4K(size) ((size) & (~PAGE_MASK))
-#define ROUND_DOWN(size, alignment) ((size) & (~(alignment - 1)))
-#define CHECK_ALIGNMENT(size, alignment) (((size) % (alignment)) == 0)
 #define PAGES_SPANNED(Va, Size) ((ULONG)((((VAddr)(Va) & (PAGE_SIZE - 1)) + (Size) + (PAGE_SIZE - 1)) >> PAGE_SHIFT))
 #define PAGES_SPANNED_LARGE(Va, Size) ((ULONG)((((VAddr)(Va) & (LARGE_PAGE_SIZE - 1)) + (Size) + (LARGE_PAGE_SIZE - 1)) >> LARGE_PAGE_SHIFT))
 #define BYTE_OFFSET(Va) ((ULONG)((VAddr)(Va) & (PAGE_SIZE - 1)))

--- a/src/core/kernel/memory-manager/PhysicalMemory.h
+++ b/src/core/kernel/memory-manager/PhysicalMemory.h
@@ -125,6 +125,14 @@ typedef enum _MmLayout
 #define CHIHIRO_PFN_ELEMENT(pfn) (&((PXBOX_PFN)CHIHIRO_PFN_ADDRESS)[pfn])
 
 
+// Common page calculations
+#define BYTE_OFFSET(Va)                     ((xbox::ulong_xt)((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)))
+#define BYTE_OFFSET_LARGE(Va)               ((xbox::ulong_xt)((xbox::ulong_ptr_xt)(Va) & (LARGE_PAGE_SIZE - 1)))
+#define PAGE_END(Va)                        (((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)) == 0)
+#define PAGES_SPANNED(Va, Size)             ((xbox::ulong_xt)((((xbox::ulong_ptr_xt)(Va) & (PAGE_SIZE - 1)) + (Size) + (PAGE_SIZE - 1)) >> PAGE_SHIFT))
+#define PAGES_SPANNED_LARGE(Va, Size)       ((xbox::ulong_xt)((((xbox::ulong_ptr_xt)(Va) & (LARGE_PAGE_SIZE - 1)) + (Size) + (LARGE_PAGE_SIZE - 1)) >> LARGE_PAGE_SHIFT))
+
+
 /* These macros check if the supplied address is inside a known range */
 #define IS_PHYSICAL_ADDRESS(Va) (((VAddr)(Va) - PHYSICAL_MAP_BASE) <= (PHYSICAL_MAP_END - PHYSICAL_MAP_BASE))
 #define IS_SYSTEM_ADDRESS(Va) (((VAddr)(Va) - SYSTEM_MEMORY_BASE) <= (SYSTEM_MEMORY_END - SYSTEM_MEMORY_BASE))


### PR DESCRIPTION
The following implement are:
- RtlWalkFrameChain
- RtlCaptureStackBackTrace
- RtlGetCallersAddress

which comply with https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite/pull/75 tests.

There shouldn't be any form of regression. However, these implements are a step closer to have xbox's exception handler support.