### PR TITLE
Clear FILE_NO_INTERMEDIATE_BUFFERING in IoCreateFile 

### DIFF
--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -905,7 +905,7 @@ private:
 			return false;
 		}
 
-		assert(HostVertexElementDataType > 0);
+		assert(HostVertexElementDataType < D3DDECLTYPE_UNUSED);
 		assert(HostVertexElementByteSize > 0);
 
 		// Select new stream, if needed

--- a/src/core/kernel/exports/EmuKrnlIo.cpp
+++ b/src/core/kernel/exports/EmuKrnlIo.cpp
@@ -265,6 +265,11 @@ XBSYSAPI EXPORTNUM(66) xbox::ntstatus_xt NTAPI xbox::IoCreateFile
 		DesiredAccess |= SYNCHRONIZE;
 	}
 
+	// Titles can make assumptions about where files are located, but cxbxr can't for end users
+	// Prevent issues with files stored on Windows Storage Spaces (and possibly other "exotic" places)
+	// Test case: JSRF
+	CreateOptions &= (~FILE_NO_INTERMEDIATE_BUFFERING);
+
 	// Force ShareAccess to all 
 	ShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 


### PR DESCRIPTION
Fixes JSRF issue with loading titles from Windows Storage Spaces
Thanks Discord user Jacqyl Frost for gathering data and testing

also fix an assert