### PR TITLE
Fix tls data initialization from cxbxr's emulation threads end

### DIFF
--- a/src/common/Timer.cpp
+++ b/src/common/Timer.cpp
@@ -25,8 +25,6 @@
 // *
 // ******************************************************************
 
-#include <core\kernel\exports\xboxkrnl.h>
-
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -36,6 +34,7 @@
 #include "Timer.h"
 #include "common\util\CxbxUtil.h"
 #include "core\kernel\support\EmuFS.h"
+#include "core/kernel/exports/EmuKrnlPs.hpp"
 #ifdef __linux__
 #include <time.h>
 #endif
@@ -218,7 +217,7 @@ void Timer_Start(TimerObject* Timer, uint64_t Expire_MS)
 	Timer->ExpireTime_MS.store(Expire_MS);
 	if (Timer->IsXboxTimer) {
 		xbox::HANDLE hThread;
-		xbox::PsCreateSystemThread(&hThread, xbox::zeroptr, ClockThread, Timer, FALSE);
+		CxbxrCreateThread(&hThread, xbox::zeroptr, ClockThread, Timer, FALSE);
 	}
 	else {
 		std::thread(ClockThread, Timer).detach();

--- a/src/core/kernel/exports/EmuKrnlPs.hpp
+++ b/src/core/kernel/exports/EmuKrnlPs.hpp
@@ -26,3 +26,12 @@ namespace xbox
 {
 	void_xt PsInitSystem();
 };
+
+xbox::ntstatus_xt NTAPI CxbxrCreateThread
+(
+	OUT xbox::PHANDLE         ThreadHandle,
+	OUT xbox::PHANDLE         ThreadId OPTIONAL,
+	IN  xbox::PKSTART_ROUTINE StartRoutine,
+	IN  xbox::PVOID           StartContext,
+	IN  xbox::boolean_xt      DebuggerThread
+);

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1432,7 +1432,7 @@ static void CxbxrKrnlInitHacks()
 	EmuX86_Init();
 	// Create the interrupt processing thread
 	xbox::HANDLE hThread;
-	xbox::PsCreateSystemThread(&hThread, xbox::zeroptr, CxbxKrnlInterruptThread, xbox::zeroptr, FALSE);
+	CxbxrCreateThread(&hThread, xbox::zeroptr, CxbxKrnlInterruptThread, xbox::zeroptr, FALSE);
 	// Start the kernel clock thread
 	TimerObject* KernelClockThr = Timer_Create(CxbxKrnlClockThread, nullptr, "Kernel clock thread", true);
 	Timer_Start(KernelClockThr, SCALE_MS_IN_NS);


### PR DESCRIPTION
I recently discovered this problem while attempting to run rebased chihiro branch. It turns out couple of our emulated kernel threads caller are using TLS in which we didn't cover it. With this correction, I no longer get any error pop up for this type of problem.

> `PsCreateSystemThread` doesn't use xbe's tls data size. It is hardcoded to 0. Our clock thread do call ExecuteDpcQueue(). Using PsCreateSystemThread isn't viable for our emulated kernel thread implement. So... instead of doing this, we should be using Xapi's CreateThread-like method.