### PR TITLE
Fix pull request 2348 regression

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -5956,7 +5956,7 @@ void CreateHostResource(xbox::X_D3DResource *pResource, DWORD D3DUsage, int iTex
 							pSrc, pxMipWidth, pxMipHeight, dwMipRowPitch, mip2dSize,
 							pDst, dwDstRowPitch, dwDstSlicePitch,
 							pxMipDepth,//used pxMipDepth here because in 3D mip map the 3rd dimension also shrinked to 1/2 at each mip level.
-							iTextureStage)) {
+							g_pXbox_Palette_Data[iTextureStage])) {
 							CxbxrAbort("Unhandled conversion!");
 						}
 					}

--- a/src/core/hle/D3D8/XbConvert.cpp
+++ b/src/core/hle/D3D8/XbConvert.cpp
@@ -1591,8 +1591,6 @@ Direct3D9 states unused :
 	D3DRS_BLENDOPALPHA = 209   // Blending operation for the alpha channel when D3DRS_SEPARATEDESTALPHAENABLE is TRUE
 */
 
-static xbox::PVOID g_pXbox_Palette_Data[xbox::X_D3DTS_STAGECOUNT] = { xbox::zeroptr, xbox::zeroptr, xbox::zeroptr, xbox::zeroptr }; // cached palette pointer
-
 xbox::X_D3DFORMAT GetXboxPixelContainerFormat(const xbox::dword_xt XboxPixelContainer_Format)
 {
 	xbox::X_D3DFORMAT d3d_format = (xbox::X_D3DFORMAT)((XboxPixelContainer_Format & X_D3DFORMAT_FORMAT_MASK) >> X_D3DFORMAT_FORMAT_SHIFT);
@@ -1655,7 +1653,7 @@ bool ConvertD3DTextureToARGBBuffer(
 	int SrcWidth, int SrcHeight, int SrcRowPitch, int SrcSlicePitch,
 	uint8_t* pDst, int DstRowPitch, int DstSlicePitch,
 	unsigned int uiDepth ,
-	int iTextureStage
+	xbox::PVOID pPalleteData
 )
 {
 	const FormatToARGBRow ConvertRowToARGB = EmuXBFormatComponentConverter(X_Format);
@@ -1678,7 +1676,7 @@ bool ConvertD3DTextureToARGBBuffer(
 
 	int AdditionalArgument;
 	if (X_Format == xbox::X_D3DFMT_P8)
-		AdditionalArgument = (int)g_pXbox_Palette_Data[iTextureStage];
+		AdditionalArgument = (int)pPalleteData;
 	else
 		AdditionalArgument = DstRowPitch;
 
@@ -1723,7 +1721,7 @@ uint8_t* ConvertD3DTextureToARGB(
 	xbox::X_D3DPixelContainer* pXboxPixelContainer,
 	uint8_t* pSrc,
 	int* pWidth, int* pHeight,
-	int TextureStage // default = 0
+	xbox::PVOID pPalleteData // default = zeroptr
 )
 {
 	// Avoid allocating pDest when ConvertD3DTextureToARGBBuffer will fail anyway
@@ -1756,7 +1754,7 @@ uint8_t* ConvertD3DTextureToARGB(
 		pSrc, *pWidth, *pHeight, SrcRowPitch, SrcSlicePitch,
 		pDst, DstRowPitch, DstSlicePitch,
 		DstDepth,
-		TextureStage);
+		pPalleteData);
 
 	// NOTE : Caller must take ownership!
 	return pDst;

--- a/src/core/hle/D3D8/XbConvert.h
+++ b/src/core/hle/D3D8/XbConvert.h
@@ -1830,7 +1830,7 @@ extern bool ConvertD3DTextureToARGBBuffer(
 	int SrcWidth, int SrcHeight, int SrcRowPitch, int SrcSlicePitch,
 	uint8_t* pDst, int DstRowPitch, int DstSlicePitch,
 	unsigned int uiDepth = 1,
-	int iTextureStage = 0
+	xbox::PVOID pPalleteData = xbox::zeroptr
 );
 
 extern void CxbxSetPixelContainerHeader
@@ -1849,7 +1849,7 @@ extern uint8_t* ConvertD3DTextureToARGB(
 	xbox::X_D3DPixelContainer* pXboxPixelContainer,
 	uint8_t* pSrc,
 	int* pWidth, int* pHeight,
-	int TextureStage = 0
+	xbox::PVOID pPalleteData = xbox::zeroptr
 );
 
 #endif


### PR DESCRIPTION
Thanks to @NZJenkins and @PatrickvL for the inputs.

We're able to resolve conflict between gui and emu difference for `ConvertD3DTextureToARGBBuffer` function. Turns out we only need to pass down pallete pointer depending on `iTextureStage` index from emulator's end. GUI does not rely on this input for generate xbe's icons.

fixed pull request #2348

----

Titles regression are confirmed back to working state:
- Haunted Mansion
- Fallout - Brotherhood of Steel
- Red Faction 2