### PR TITLE
Make the SBC use the cursor mouse mode by default

### DIFF
--- a/src/common/input/Button.cpp
+++ b/src/common/input/Button.cpp
@@ -107,13 +107,8 @@ LRESULT CALLBACK ButtonSbcSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 
 	case WM_RBUTTONDOWN: {
 		Button *button = reinterpret_cast<Button *>(dwRefData);
-		if (wParam & MK_SHIFT) {
-			static_cast<SbcInputWindow *>(button->GetWnd())->SwapMoCursorAxis(button);
-		}
-		else if (!(wParam & ~MK_RBUTTON)) {
-			button->ClearText();
-			static_cast<SbcInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_CLEAR);
-		}
+		button->ClearText();
+		static_cast<SbcInputWindow *>(button->GetWnd())->UpdateProfile(std::string(), BUTTON_CLEAR);
 	}
 	break;
 
@@ -128,7 +123,7 @@ LRESULT CALLBACK ButtonLightgunSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam,
 	{
 	// Remove the window subclass when this window is destroyed
 	case WM_NCDESTROY: {
-		RemoveWindowSubclass(hWnd, ButtonSbcSubclassProc, uIdSubclass);
+		RemoveWindowSubclass(hWnd, ButtonLightgunSubclassProc, uIdSubclass);
 	}
 	break;
 

--- a/src/common/input/EmuDevice.cpp
+++ b/src/common/input/EmuDevice.cpp
@@ -57,7 +57,7 @@ EmuDevice::EmuDevice(int type, HWND hwnd, void *wnd)
 	case to_underlying(XBOX_INPUT_DEVICE::STEEL_BATTALION_CONTROLLER): {
 		for (size_t i = 0; i < ARRAY_SIZE(button_sbc_id); i++) {
 			m_buttons.push_back(new Button(button_sbc_id[i], i, hwnd, wnd));
-			m_buttons.back()->AddTooltip(m_hwnd, m_tooltip_hwnd, tooltip_text_toggle);
+			m_buttons.back()->AddTooltip(m_hwnd, m_tooltip_hwnd, tooltip_text_no_toggle);
 
 			// Install the subclass for the button control
 			SetWindowSubclass(GetDlgItem(hwnd, button_sbc_id[i]), ButtonSbcSubclassProc, 0, reinterpret_cast<DWORD_PTR>(m_buttons[i]));

--- a/src/gui/input/DlgSBControllerConfig.cpp
+++ b/src/gui/input/DlgSBControllerConfig.cpp
@@ -232,7 +232,7 @@ INT_PTR CALLBACK DlgSBControllerConfigProc(HWND hWndDlg, UINT uMsg, WPARAM wPara
 		case IDC_GEAR_UP:
 		case IDC_GEAR_DOWN: {
 			if (HIWORD(wParam) == BN_CLICKED) {
-				g_InputWindow->BindButton(LOWORD(wParam));
+				g_InputWindow->BindButton(LOWORD(wParam), true);
 			}
 		}
 		break;


### PR DESCRIPTION
When bound to a mouse, the aim and sight controls of the SBC works best with the mouse cursor mode, instead of the axis mode. So this makes the cursor mode the default for the SBC, so that users cannot accidentally choose the axis mode and  experience the [re-centering issue](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/2135). Note that existing SBC profiles are unaffected by the change, so users will have either to update it manually or create a new profile.