### PR TITLE
Fix Visual Studio's popup dialog about newline correction

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -3,5 +3,5 @@ root = true
 [*]
 indent_size = 4
 trim_trailing_whitespace = true
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true


### PR DESCRIPTION
Since we enforce to linux's `lf` newline. This update to `.editorconfig` will suppress popup dialog for every time Windows dev edited file content before re-open it.

This pull request is low risk.