### PR TITLE
Updated libusb submodule to include deadlock fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,8 @@
 	shallow = true
 [submodule "import/libusb"]
 	path = import/libusb
-	url = https://github.com/libusb/libusb
+	url = https://github.com/Cxbx-Reloaded/libusb
+	branch = deadlock_fix
 	shallow = true
 [submodule "import/nv2a_vsh_cpu"]
 	path = import/nv2a_vsh_cpu


### PR DESCRIPTION
I'm currently affected by this [issue](https://github.com/libusb/libusb/issues/1136), which causes cxbxr to freeze every time when opening the input configuration dialog with my controller attached to my system. Since this issue might also affect other cxbxr users, I propose to update the libusb to include [this PR](https://github.com/libusb/libusb/pull/1127) that solves the problem for me. This is a draft because it includes a not yet merged PR in libusb. If this is accepted, then the draft status can be removed and this PR merged.