### PR TITLE
emufile: fix multi-xbe titles when running through xbox-iso-vfs

### DIFF
--- a/src/core/kernel/support/EmuFile.cpp
+++ b/src/core/kernel/support/EmuFile.cpp
@@ -797,9 +797,10 @@ std::string CxbxConvertXboxToHostPath(const std::string_view XboxDevicePath)
 	// If the rootDirectoryHandle is not null, we have a relative path
 	// We need to prepend the path of the root directory to get a full DOS path
 	if (rootDirectoryHandle != nullptr) {
-		char directoryPathBuffer[MAX_PATH];
-		GetFinalPathNameByHandle(rootDirectoryHandle, directoryPathBuffer, MAX_PATH, VOLUME_NAME_DOS);
-		XbePath = directoryPathBuffer + std::string("\\") + XbePath;
+		WCHAR directoryPathBuffer[MAX_PATH];
+		GetFinalPathNameByHandleW(rootDirectoryHandle, directoryPathBuffer, MAX_PATH, VOLUME_NAME_DOS);
+		std::string directoryPath = utf16_to_ascii(directoryPathBuffer);
+		XbePath = directoryPath + std::string("\\") + XbePath;
 	}
 
 	return XbePath;


### PR DESCRIPTION
Prior to this commit, the relaunch path would become corrupted when running a game mounted with xbox-iso-vfs, leading to crashes.

The cause was using GetFinalPathNameByHandle, which resolves to GetFinalPathNameByHandleA instead of GetFinalPathNameByHandleW.

