### PR TITLE
fix DOT_STR_3D/CUBE mode

### DIFF
--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -489,10 +489,6 @@ typedef struct s_CxbxPSDef {
 
 	void AdjustTextureModes(DecodedRegisterCombiner &RC)
 	{
-		if (RC.PSTextureModes[3] == PS_TEXTUREMODES_DOT_STR_3D) {
-			RC.TexModeAdjust = true;
-		}
-
 		// if this flag is set, the texture mode for each texture stage is adjusted as follows:
 		if (RC.TexModeAdjust) {
 			for (int i = 0; i < xbox::X_D3DTS_STAGECOUNT; i++) {
@@ -560,6 +556,14 @@ typedef struct s_CxbxPSDef {
 					EmuLog(LOG_LEVEL::WARNING, "PROJECT2D sampling is used with a cubemap texture - using CUBEMAP sampling instead");
 					RC.PSTextureModes[i] = PS_TEXTUREMODES_CUBEMAP;
 				}
+				// Test-case: MS-033 Crimson Skies (Plane texturing in-game and selection menu)
+				// HACK: use the TexModeAdjust path to downgrade PS_TEXTUREMODES_DOT_STR_3D to PS_TEXTUREMODES_DOT_STR_CUBE for cube textures.
+				if (ActiveTextureTypes[i] == xbox::X_D3DRTYPE_CUBETEXTURE && RC.PSTextureModes[i] == PS_TEXTUREMODES_DOT_STR_3D) {
+					EmuLog(LOG_LEVEL::WARNING, "DOT_STR_3D sampling is used with a cubemap texture - using DOT_STR_CUBE sampling instead");
+					RC.PSTextureModes[i] = PS_TEXTUREMODES_DOT_STR_CUBE;
+				}
+
+				
 			}
 		}
 	}

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -489,6 +489,10 @@ typedef struct s_CxbxPSDef {
 
 	void AdjustTextureModes(DecodedRegisterCombiner &RC)
 	{
+		if (RC.PSTextureModes[3] = PS_TEXTUREMODES_DOT_STR_CUBE) {
+			RC.TexModeAdjust = true;
+		}
+
 		// if this flag is set, the texture mode for each texture stage is adjusted as follows:
 		if (RC.TexModeAdjust) {
 			for (int i = 0; i < xbox::X_D3DTS_STAGECOUNT; i++) {

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -556,14 +556,12 @@ typedef struct s_CxbxPSDef {
 					EmuLog(LOG_LEVEL::WARNING, "PROJECT2D sampling is used with a cubemap texture - using CUBEMAP sampling instead");
 					RC.PSTextureModes[i] = PS_TEXTUREMODES_CUBEMAP;
 				}
+
 				// Test-case: MS-033 Crimson Skies (Plane texturing in-game and selection menu)
-				// HACK: use the TexModeAdjust path to downgrade PS_TEXTUREMODES_DOT_STR_3D to PS_TEXTUREMODES_DOT_STR_CUBE for cube textures.
 				if (ActiveTextureTypes[i] == xbox::X_D3DRTYPE_CUBETEXTURE && RC.PSTextureModes[i] == PS_TEXTUREMODES_DOT_STR_3D) {
 					EmuLog(LOG_LEVEL::WARNING, "DOT_STR_3D sampling is used with a cubemap texture - using DOT_STR_CUBE sampling instead");
 					RC.PSTextureModes[i] = PS_TEXTUREMODES_DOT_STR_CUBE;
 				}
-
-				
 			}
 		}
 	}

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -489,7 +489,7 @@ typedef struct s_CxbxPSDef {
 
 	void AdjustTextureModes(DecodedRegisterCombiner &RC)
 	{
-		if (RC.PSTextureModes[3] = PS_TEXTUREMODES_DOT_STR_CUBE) {
+		if (RC.PSTextureModes[3] == PS_TEXTUREMODES_DOT_STR_3D) {
 			RC.TexModeAdjust = true;
 		}
 


### PR DESCRIPTION
when a cube texture is used and dot_str_3d is the texture mode, it is suppose to be flagged by combiner for change to dot_str_cube.
this is not happening. So I added a check for that mode. 

If PS_TEXTUREMODES_DOT_STR_3D is set and a cube texture is used, the mode is changed to  PS_TEXTUREMODES_DOT_STR_CUBE

 test case:
Crimson skies
the plane is textured with this fix

before:
![image](https://user-images.githubusercontent.com/38597905/179442179-828c5015-313b-451b-9470-6e50f0dfe558.png)

after:
![image](https://user-images.githubusercontent.com/38597905/179402704-1e54a82a-2dac-4a89-8533-562e29777fec.png)

WORLD RACING

master:
![image](https://user-images.githubusercontent.com/38597905/179526745-83eda18f-2831-4543-9496-9cb38610bcb4.png)

PR:
![image](https://user-images.githubusercontent.com/38597905/179526898-d8758855-704e-45a7-8667-338dca331246.png)
