### PR TITLE
Make the wait of KeStallExecutionProcessor more accurate

### DIFF
--- a/src/common/Timer.cpp
+++ b/src/common/Timer.cpp
@@ -69,6 +69,24 @@ void SleepPrecise(std::chrono::steady_clock::time_point targetTime)
 	}
 }
 
+// This is to be used for sub-milliseconds waits, for which Sleep is not suitable because it will wait for at least 1 ms
+void MicrosecondDelay(uint32_t MicroSeconds)
+{
+	LARGE_INTEGER freq;
+	freq.QuadPart = HostQPCFrequency;
+	LARGE_INTEGER CurrentTime, EndingTime;
+	QueryPerformanceCounter(&CurrentTime);
+	CurrentTime.QuadPart *= 1000000000;
+	CurrentTime.QuadPart /= freq.QuadPart;
+	EndingTime.QuadPart = CurrentTime.QuadPart + MicroSeconds * 1000;
+
+	while (CurrentTime.QuadPart < EndingTime.QuadPart) {
+		QueryPerformanceCounter(&CurrentTime);
+		CurrentTime.QuadPart *= 1000000000;
+		CurrentTime.QuadPart /= freq.QuadPart;
+	}
+}
+
 // Virtual clocks will probably become useful once LLE CPU is implemented, but for now we don't need them.
 // See the QEMUClockType QEMU_CLOCK_VIRTUAL of XQEMU for more info.
 #define CLOCK_REALTIME 0

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -68,5 +68,6 @@ void Timer_Shutdown();
 int64_t Timer_GetScaledPerformanceCounter(int64_t Period);
 
 void SleepPrecise(std::chrono::steady_clock::time_point targetTime);
+void MicrosecondDelay(uint32_t MicroSeconds);
 
 #endif

--- a/src/core/kernel/exports/EmuKrnlKe.cpp
+++ b/src/core/kernel/exports/EmuKrnlKe.cpp
@@ -2083,19 +2083,7 @@ XBSYSAPI EXPORTNUM(151) xbox::void_xt NTAPI xbox::KeStallExecutionProcessor
 	// Don't use std::this_thread::sleep_for because it's too inaccurate. Instead, we do this as Microsoft says it should be done
 	// https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-kestallexecutionprocessor, with a busy loop
 
-	::LARGE_INTEGER freq;
-	freq.QuadPart = HostQPCFrequency;
-	::LARGE_INTEGER CurrentTime, EndingTime;
-	QueryPerformanceCounter(&CurrentTime);
-	CurrentTime.QuadPart *= 1000000000;
-	CurrentTime.QuadPart /= freq.QuadPart;
-	EndingTime.QuadPart = CurrentTime.QuadPart + MicroSeconds * 1000;
-
-	while (CurrentTime.QuadPart < EndingTime.QuadPart) {
-		QueryPerformanceCounter(&CurrentTime);
-		CurrentTime.QuadPart *= 1000000000;
-		CurrentTime.QuadPart /= freq.QuadPart;
-	}
+	MicrosecondDelay(MicroSeconds);
 }
 
 // ******************************************************************


### PR DESCRIPTION
Fixes https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/issues/981. This function is called from the dashboard when opening the xbox live menu. Adding some time measuring code to it, shows that we are waiting between 1.2 and 4 ms inside it, while the function only requested waits of 10, 50 and 500us. This PR fixes it by implementing the function with a busy wait, which is how Microsoft says it should be done. With this, I'm measuring average waits of 10.2, 50.3 and 500.1us now.