### PR TITLE
xdm, xdd, xmd component count fix

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl
@@ -141,15 +141,17 @@ R"DELIMITER(
 	#define FCS_SUM s_ident // otherwise identity mapping. TODO : Confirm correctness
 #endif
 
+#define xdot(s0, s1) dot((s0).rgb, (s1).rgb)
+
 // Xbox supports only one 'pixel shader' opcode, but bit flags tunes it's function;
 // Here, effective all 5 Xbox opcodes, extended with a variable macro {xop_m(m,...)} for destination modifier :
 // Note : Since both d0 AND d1 could be the same output register, calculation of d2 can re-use only one (d0 or d1)
 #define xmma(d0, d1, d2,  s0, s1, s2, s3, m, tmp) tmp = d0 = m(s0 * s1); d1 = m(s2 * s3); d2 =           d1 + tmp // PS_COMBINEROUTPUT_AB_CD_SUM=           0x00L, // 3rd output is AB+CD
 #define xmmc(d0, d1, d2,  s0, s1, s2, s3, m, tmp) tmp = d0 = m(s0 * s1); d1 = m(s2 * s3); d2 = FCS_MUX ? d1 : tmp // PS_COMBINEROUTPUT_AB_CD_MUX=           0x04L, // 3rd output is MUX(AB,CD) based on R0.a
 
-#define xdm(d0, d1,  s0, s1, s2, s3, m) d0 = m(dot(s0 , s1)); d1 = m(    s2 * s3 )                                // PS_COMBINEROUTPUT_AB_DOT_PRODUCT=      0x02L, // RGB only // PS_COMBINEROUTPUT_CD_MULTIPLY=         0x00L,
-#define xdd(d0, d1,  s0, s1, s2, s3, m) d0 = m(dot(s0 , s1)); d1 = m(dot(s2 , s3))                                // PS_COMBINEROUTPUT_CD_DOT_PRODUCT=      0x01L, // RGB only // PS_COMBINEROUTPUT_AB_MULTIPLY=         0x00L, 
-#define xmd(d0, d1,  s0, s1, s2, s3, m) d0 = m(    s0 * s1 ); d1 = m(dot(s2 , s3))                                // PS_COMBINEROUTPUT_AB_DOT_PRODUCT=      0x02L, // RGB only // PS_COMBINEROUTPUT_CD_MULTIPLY=         0x01L,
+#define xdm(d0, d1,  s0, s1, s2, s3, m) d0 = m(xdot(s0 , s1)); d1 = m(     s2 * s3 )                              // PS_COMBINEROUTPUT_AB_DOT_PRODUCT=      0x02L, // RGB only // PS_COMBINEROUTPUT_CD_MULTIPLY=         0x00L,
+#define xdd(d0, d1,  s0, s1, s2, s3, m) d0 = m(xdot(s0 , s1)); d1 = m(xdot(s2 , s3))                              // PS_COMBINEROUTPUT_CD_DOT_PRODUCT=      0x01L, // RGB only // PS_COMBINEROUTPUT_AB_MULTIPLY=         0x00L, 
+#define xmd(d0, d1,  s0, s1, s2, s3, m) d0 = m(     s0 * s1 ); d1 = m(xdot(s2 , s3))                              // PS_COMBINEROUTPUT_AB_DOT_PRODUCT=      0x02L, // RGB only // PS_COMBINEROUTPUT_CD_MULTIPLY=         0x01L,
 
 // After the register combiner stages, there's one (optional) final combiner step, consisting of 4 parts;
 // All the 7 final combiner inputs operate on rgb only and clamp negative input to zero:


### PR DESCRIPTION
all 3 use 3 components but on cxbx they were using 4
discovered by NZJenkins
test case Morrowind water
before 
![image](https://user-images.githubusercontent.com/38597905/186821656-cfb1d1dc-f446-4639-b3c6-37ac120eaecf.png)

after
![image](https://user-images.githubusercontent.com/38597905/186821715-f594d2fa-6b82-486a-9362-01ade17760db.png)
![image](https://user-images.githubusercontent.com/38597905/186824384-32761e45-537d-49ed-a973-72340160a412.png)

water in crimson skies improved
![image](https://user-images.githubusercontent.com/38597905/186825597-ae7dffe2-6c43-4cef-961b-2ae0bde094ef.png)
