### PR TITLE
correct mod instruction

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl
+++ b/src/core/hle/D3D8/Direct3D9/CxbxPixelShaderTemplate.hlsl
@@ -117,7 +117,7 @@ R"DELIMITER(
 #ifdef PS_COMBINERCOUNT_MUX_MSB
 	#define FCS_MUX (r0.a >= 0.5) // Check r0.a MSB; Having range upto 1 this should be equal to : (((r0.a * 255) /*mod 256*/) >= 128)
 #else // PS_COMBINERCOUNT_MUX_LSB
-	#define FCS_MUX (((r0.a * 255) mod 2) >= 1) // Check r0.b LSB; Get LSB by converting 1 into 255 (highest 8-bit value) and using modulo 2. TODO : Verify correctness
+	#define FCS_MUX (((r0.a * 255) % 2) >= 1) // Check r0.b LSB; Get LSB by converting 1 into 255 (highest 8-bit value) and using modulo 2. TODO : Verify correctness
 #endif
 
 // PS_FINALCOMBINERSETTING_COMPLEMENT_V1, when defined, applies a modifier to the v1 input when calculating the sum register


### PR DESCRIPTION
not alot to say, correct 'MOD' to %