### PR TITLE
HOTFIX: Fix LibusbDevice's initialization process

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Cxbx-Reloaded is an emulator for running Microsoft Xbox (and eventually, Chihiro
   * [32-bit (x86) Visual C++ 2022 Redistributable](https://aka.ms/vs/17/release/vc_redist.x86.exe)
   * [Npcap *(used for network emulation)*](https://nmap.org/npcap/#download)
     * Make sure to enable winpcap compatibility mode.
-  * WinUSB compliant driver
+  * [WinUSB compliant driver](https://github.com/libusb/libusb/wiki/Windows#Driver_Installation)
     * *Optional, only needed for USB pass-through of original Xbox and Steel Battalion controllers.*
 
 ### Wine

--- a/src/common/input/LibusbDevice.cpp
+++ b/src/common/input/LibusbDevice.cpp
@@ -220,7 +220,7 @@ namespace Libusb
 								}
 							}
 							EmuLog(LOG_LEVEL::INFO, "Out endpoint %s", m_HasEndpointOut ? "present" : "not present");
-							if (int err = libusb_claim_interface(m_hDev, m_IfaceNum) != 0) {
+							if (int err = libusb_claim_interface(m_hDev, m_IfaceNum)) {
 								EmuLog(LOG_LEVEL::INFO, "Rejected device %s because libusb could not claim its interface. The error was: %s",
 									m_Name.c_str(), libusb_strerror(err));
 								m_Type = XBOX_INPUT_DEVICE::DEVICE_INVALID;

--- a/src/common/input/LibusbDevice.cpp
+++ b/src/common/input/LibusbDevice.cpp
@@ -170,7 +170,7 @@ namespace Libusb
 		}
 		else {
 			for (size_t i = 0; i < ARRAY_SIZE(SupportedDevices_VidPid); ++i) {
-				if ((Desc->idVendor = SupportedDevices_VidPid[i][0]) && (Desc->idProduct == SupportedDevices_VidPid[i][1])) {
+				if ((Desc->idVendor == SupportedDevices_VidPid[i][0]) && (Desc->idProduct == SupportedDevices_VidPid[i][1])) {
 					m_Type = XBOX_INPUT_DEVICE::HW_XBOX_CONTROLLER;
 					m_UcType = XINPUT_DEVTYPE_GAMEPAD;
 					m_UcSubType = XINPUT_DEVSUBTYPE_GC_GAMEPAD;


### PR DESCRIPTION
The following fixes should resolve third-party devices conflict:
- whitelist xbox devices didn't compare against user's device. device's vendor get overridden instead.
- Missing check for any error occur after call libusb_open. In case of original xbox device could not be opened. Likely caused by missing WinUSB driver installed and allocated with original xbox device.

fixes #2293

This pull request will resolve any unsupported devices, aka not a real original xbox device, has matching product id from whitelist to not be accepted. This include but not limited to such as DS4 controller.