### PR TITLE
Remove Int32x32To64 from the code

### DIFF
--- a/src/core/kernel/exports/EmuKrnlKi.cpp
+++ b/src/core/kernel/exports/EmuKrnlKi.cpp
@@ -503,7 +503,7 @@ xbox::boolean_xt FASTCALL xbox::KiSignalTimer
 	if (Period)
 	{
 		/* Calculate the interval and insert the timer */
-		Interval.QuadPart = Int32x32To64(Period, -10000);
+		Interval.QuadPart = Period * -10000LL;
 		while (!KiInsertTreeTimer(Timer, Interval));
 	}
 
@@ -618,7 +618,7 @@ xbox::void_xt NTAPI xbox::KiTimerExpiration
 				if (Period)
 				{
 					/* Calculate the interval and insert the timer */
-					Interval.QuadPart = Int32x32To64(Period, -10000);
+					Interval.QuadPart = Period * -10000LL;
 					while (!KiInsertTreeTimer(Timer, Interval));
 				}
 
@@ -810,7 +810,7 @@ xbox::void_xt FASTCALL xbox::KiTimerListExpire
 		if (Period)
 		{
 			/* Calculate the interval and insert the timer */
-			Interval.QuadPart = Int32x32To64(Period, -10000);
+			Interval.QuadPart = Period * -10000LL;
 			while (!KiInsertTreeTimer(Timer, Interval));
 		}
 


### PR DESCRIPTION
A minimal PR that is technically a part of my [Y2038 hunt](https://cookieplmonster.github.io/2022/02/17/year-2038-problem/). In Cxbx-R the usage of `Int32x32To64` didn't lead to anything as severe as a year 2038 problem, but these instances typecasted an `uint32` to `int32` before performing a 64-bit multiplication. With this PR, expansion to `int64_t` is performed directly without shoehorning a sign on the int32 value first.