### PR TITLE
xbe: fix version number formatting

### DIFF
--- a/src/common/xbe/Xbe.cpp
+++ b/src/common/xbe/Xbe.cpp
@@ -825,5 +825,15 @@ XbeType Xbe::GetXbeType()
 	return XbeType::xtRetail;
 }
 
+uint32_t Xbe::GetDiscVersion()
+{
+    return m_Certificate.dwVersion & 0xFF;
+}
+
+uint32_t Xbe::GetPatchVersion()
+{
+    return (m_Certificate.dwVersion & 0xFFFFFF00) >> 8;
+}
+
 template auto Xbe::FindSection<true>(const char *zsSectionName);
 template auto Xbe::FindSection<false>(const char *zsSectionName);

--- a/src/common/xbe/Xbe.h
+++ b/src/common/xbe/Xbe.h
@@ -85,6 +85,9 @@ class Xbe : public Error
 
         XbeType GetXbeType();
 
+        uint32_t GetDiscVersion();
+        uint32_t GetPatchVersion();
+
         // Xbe header
         #include "AlignPrefix1.h"
         struct Header
@@ -157,7 +160,7 @@ class Xbe : public Error
             uint32_t  dwAllowedMedia;                       // 0x009C - allowed media types
             uint32_t  dwGameRegion;                         // 0x00A0 - game region
             uint32_t  dwGameRatings;                        // 0x00A4 - game ratings
-            uint32_t  dwDiskNumber;                         // 0x00A8 - disk number
+            uint32_t  dwDiscNumber;                         // 0x00A8 - disc number
             uint32_t  dwVersion;                            // 0x00AC - version
             uint8_t  bzLanKey[16];                          // 0x00B0 - lan key
             uint8_t  bzSignatureKey[16];                    // 0x00C0 - signature key

--- a/src/common/xbe/XbePrinter.cpp
+++ b/src/common/xbe/XbePrinter.cpp
@@ -58,6 +58,7 @@ std::string DumpInformation(Xbe* Xbe_object)
 }
 
 #define SSTREAM_SET_HEX(stream_name) stream_name << std::setfill('0') << std::uppercase << std::hex;
+#define SSTREAM_SET_DEC(stream_name) stream_name << std::setfill('0') << std::uppercase << std::dec;
 
 std::string FormatTitleId(uint32_t title_id)
 {
@@ -359,8 +360,12 @@ std::string XbePrinter::GenMediaInfo()
     text << "Allowed Media                    : 0x" << std::setw(8) << Xbe_certificate->dwAllowedMedia << " (" << AllowedMediaToString() << ")\n";
     text << "Game Region                      : 0x" << std::setw(8) << Xbe_certificate->dwGameRegion << " (" << Xbe_to_print->GameRegionToString() << ")\n";
     text << "Game Ratings                     : 0x" << std::setw(8) << Xbe_certificate->dwGameRatings << " (" << GameRatingToString() << ")\n";
-    text << "Disk Number                      : 0x" << std::setw(8) << Xbe_certificate->dwDiskNumber << "\n";
-    text << "Version                          : 1." << std::dec << std::setw(2) << Xbe_certificate->dwVersion << "\n";
+    text << "Disc Number                      : 0x" << std::setw(8) << Xbe_certificate->dwDiscNumber << "\n";
+    text << "Version                          : 0x" << std::setw(8) << Xbe_certificate->dwVersion << "\n";
+    SSTREAM_SET_DEC(text);
+    text << "Disc Version                     : " << std::setw(0) << Xbe_to_print->GetDiscVersion() << "\n";
+    text << "Patch Version                    : " << std::setw(0) << Xbe_to_print->GetPatchVersion() << "\n";
+
     return text.str();
 }
 

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1141,7 +1141,10 @@ static void CxbxrLogDumpXbeInfo(Xbe::LibraryVersion* libVersionInfo)
 
 		EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID : %s", FormatTitleId(g_pCertificate->dwTitleId).c_str());
 		EmuLogInit(LOG_LEVEL::INFO, "XBE TitleID (Hex) : 0x%s", titleIdHex.str().c_str());
-		EmuLogInit(LOG_LEVEL::INFO, "XBE Version : 1.%02d", g_pCertificate->dwVersion);
+		if (CxbxKrnl_Xbe != nullptr) {
+			EmuLogInit(LOG_LEVEL::INFO, "XBE Version : %d.%d", CxbxKrnl_Xbe->GetDiscVersion(), CxbxKrnl_Xbe->GetPatchVersion());
+		}
+		EmuLogInit(LOG_LEVEL::INFO, "XBE Version (Hex): %08X", g_pCertificate->dwVersion);
 		EmuLogInit(LOG_LEVEL::INFO, "XBE TitleName : %.40ls", g_pCertificate->wsTitleName);
 		EmuLogInit(LOG_LEVEL::INFO, "XBE Region : %s", CxbxKrnl_Xbe->GameRegionToString());
 	}

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -1852,7 +1852,7 @@ void WndMain::UpdateCaption()
 
 	int i = sprintf(AsciiTitle, "Cxbx-Reloaded %s", CxbxrHashBuild);
 	if (m_Xbe != nullptr) {
-		i += sprintf(AsciiTitle + i, " : %s v1.%02d (%s)", FormatTitleId(m_Xbe->m_Certificate.dwTitleId).c_str(), m_Xbe->m_Certificate.dwVersion, m_Xbe->m_szAsciiTitle);
+		i += sprintf(AsciiTitle + i, " : %s v%d.%d (%s)", FormatTitleId(m_Xbe->m_Certificate.dwTitleId).c_str(), m_Xbe->GetDiscVersion(), m_Xbe->GetPatchVersion(), m_Xbe->m_szAsciiTitle);
 
 		UpdateFpsStatus();
 		UpdateLogStatus();


### PR DESCRIPTION
While working on Insignia, we learned the correct formatting of the Xbe certificate version number field.

It actually consists of two values: a Disc version, and an Update/Patch version.

This PR implements this behaviour and renders version numbers as vX.Y where X is the disc version, and Y is the patch version.