### PR TITLE
Fix false positive emulation is either still running or stopped

### DIFF
--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -583,6 +583,7 @@ XBSYSAPI EXPORTNUM(49) xbox::void_xt DECLSPEC_NORETURN NTAPI xbox::HalReturnToFi
 	case ReturnFirmwareFatal:
 	{
 		xbox::HalWriteSMBusValue(SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER, SMC_COMMAND_SCRATCH, 0, SMC_SCRATCH_DISPLAY_FATAL_ERROR);
+		is_reboot = true;
 
 		g_VMManager.SavePersistentMemory();
 

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -2331,29 +2331,25 @@ void WndMain::CrashMonitor(DWORD dwChildProcID)
 
 		HANDLE hProcess = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_INFORMATION, FALSE, dwChildProcID);
 
-	 	// If we do receive valid handle, let's do the next step.
-	 	if (hProcess != NULL) {
+		// If we do receive valid handle, let's do the next step.
+		if (hProcess != NULL) {
 
-	 		WaitForSingleObject(hProcess, INFINITE);
+			WaitForSingleObject(hProcess, INFINITE);
 
-	 		GetExitCodeProcess(hProcess, &dwExitCode);
-	 		CloseHandle(hProcess);
+			GetExitCodeProcess(hProcess, &dwExitCode);
+			CloseHandle(hProcess);
 
-	 		g_EmuShared->GetBootFlags(&iBootFlags);
+			g_EmuShared->GetBootFlags(&iBootFlags);
 
-	 		if (!iBootFlags) {
-	 			if (dwExitCode == EXIT_SUCCESS) {// StopEmulation
-	 				return;
-	 			}
-				// Or else, it's a crash
-	 		}
-	 		else {
-
-	 			// multi-xbe
-	 			// destroy this thread and start a new one
-	 			return;
-	 		}
-	 	}
+			// Check if reboot did occur.
+			if (iBootFlags) {
+				// Destroy this thread and start a new one
+				// since emulation is still running.
+				return;
+			}
+			// Otherwise emulation did stopped or crashed
+			// But need to tell GUI that emulation did end.
+		}
 	}
 
 	// Crash clean up.


### PR DESCRIPTION
When testing recent pull request #2408, we noticed GUI thinks emulation is still running when it's not. I performed another test to be sure reboot is working as intended. Turns out GUI also receive emulation is not running yet it is. So this pull request contain two minor bugfixes to resolve false positive emulation status.