### PR TITLE
Fix a priority bug in KeQueryBasePriorityThread and KeSetBasePriorityThread

### DIFF
--- a/src/core/kernel/exports/EmuKrnlKe.cpp
+++ b/src/core/kernel/exports/EmuKrnlKe.cpp
@@ -1379,7 +1379,7 @@ XBSYSAPI EXPORTNUM(124) xbox::long_xt NTAPI xbox::KeQueryBasePriorityThread
 	KiLockDispatcherDatabase(&OldIrql);
 
 	// It cannot fail because all thread handles are created by ob
-	const auto& nativeHandle = GetNativeHandle<true>(PspGetCurrentThread()->UniqueThread);
+	const auto& nativeHandle = GetNativeHandle<true>(reinterpret_cast<PETHREAD>(Thread)->UniqueThread);
 	long_xt ret = GetThreadPriority(*nativeHandle);
 
 	KiUnlockDispatcherDatabase(OldIrql);
@@ -1806,7 +1806,7 @@ XBSYSAPI EXPORTNUM(143) xbox::long_xt NTAPI xbox::KeSetBasePriorityThread
 	KiLockDispatcherDatabase(&oldIRQL);
 
 	// It cannot fail because all thread handles are created by ob
-	const auto &nativeHandle = GetNativeHandle<true>(PspGetCurrentThread()->UniqueThread);
+	const auto &nativeHandle = GetNativeHandle<true>(reinterpret_cast<PETHREAD>(Thread)->UniqueThread);
 	LONG ret = GetThreadPriority(*nativeHandle);
 
 	// This would work normally, but it will slow down the emulation, 


### PR DESCRIPTION
The existing implementation is wrongfully setting/querying the priority of the current thread, instead of the specified one. This fixes the deadlock on Metal Slug 3, which can now boot without the speed hack. It also somewhat improves the boot of Halo 2, which sometimes can now reach the title menu without the hack too. @RadWolfie reports that it also fixes the deadlock in GTA 3 and GTA Vice City too.