### PR TITLE
Dpc recursion fix

### DIFF
--- a/src/core/kernel/exports/EmuKrnlKe.cpp
+++ b/src/core/kernel/exports/EmuKrnlKe.cpp
@@ -1268,7 +1268,7 @@ XBSYSAPI EXPORTNUM(119) xbox::boolean_xt NTAPI xbox::KeInsertQueueDpc
 		InsertTailList(&(g_DpcData.DpcQueue), &(Dpc->DpcListEntry));
 		// TODO : Instead of DpcQueue, add the DPC to KeGetCurrentPrcb()->DpcListHead
 		// Signal the Dpc handling code there's work to do
-		if (g_DpcData.IsDpcActive.test() == false) {
+		if (!IsDpcActive()) {
 			HalRequestSoftwareInterrupt(DISPATCH_LEVEL);
 		}
 		// OpenXbox has this instead:
@@ -1291,11 +1291,12 @@ XBSYSAPI EXPORTNUM(121) xbox::boolean_xt NTAPI xbox::KeIsExecutingDpc
 {
 	LOG_FUNC();
 
-	// This is the correct implementation, but it doesn't work because our Prcb is per-thread instead of being per-processor
 #if 0
+	// This is the correct implementation, but it doesn't work because our Prcb is per-thread instead of being per-processor
 	BOOLEAN ret = (BOOLEAN)KeGetCurrentPrcb()->DpcRoutineActive;
-#endif
+#else
 	BOOLEAN ret = (BOOLEAN)IsDpcActive();
+#endif
 
 	RETURN(ret);
 }

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1205,8 +1205,8 @@ static void CxbxrKrnlInitHacks()
 	Timer_Init();
 	// for unicode conversions
 	setlocale(LC_ALL, "English");
-	// Initialize time-related variables for the kernel and the timers
-	CxbxInitPerformanceCounters();
+	// Initialize DPC global
+	InitDpcData();
 #ifdef _DEBUG
 //	PopupCustom(LOG_LEVEL::INFO, "Attach a Debugger");
 //  Debug child processes using https://marketplace.visualstudio.com/items?itemName=GreggMiskelly.MicrosoftChildProcessDebuggingPowerTool

--- a/src/core/kernel/init/CxbxKrnl.h
+++ b/src/core/kernel/init/CxbxKrnl.h
@@ -155,7 +155,7 @@ void CxbxKrnlPanic();
 /*! empty function */
 void CxbxKrnlNoFunc();
 
-void CxbxInitPerformanceCounters(); // Implemented in EmuKrnlKe.cpp
+void InitDpcData(); // Implemented in EmuKrnlKe.cpp
 
 /*! kernel thunk table */
 extern uint32_t CxbxKrnl_KernelThunkTable[379];

--- a/src/core/kernel/init/CxbxKrnl.h
+++ b/src/core/kernel/init/CxbxKrnl.h
@@ -156,6 +156,7 @@ void CxbxKrnlPanic();
 void CxbxKrnlNoFunc();
 
 void InitDpcData(); // Implemented in EmuKrnlKe.cpp
+bool IsDpcActive();
 
 /*! kernel thunk table */
 extern uint32_t CxbxKrnl_KernelThunkTable[379];


### PR DESCRIPTION
The current implementation can incur in a dpc recursion issue, which happens when the currently executing dpc queues another one, and we call it right away. If this happens too many times, the title will eventually crash with a stack overflow exception sooner or later. This fixes a crash on boot in Halo 2 (when not using the speed hack), which was caused by the previous wrong behavior.