### PR TITLE
kernel: fix non-ansii file path conversion for reboot process

### DIFF
--- a/src/core/kernel/exports/EmuKrnlHal.cpp
+++ b/src/core/kernel/exports/EmuKrnlHal.cpp
@@ -43,7 +43,6 @@
 #include "common\EmuEEPROM.h" // For EEPROM
 #include "devices\Xbox.h" // For g_SMBus, SMBUS_ADDRESS_SYSTEM_MICRO_CONTROLLER
 #include "devices\SMCDevice.h" // For SMC_COMMAND_SCRATCH
-#include "common/util/strConverter.hpp" // for utf16_to_ascii
 #include "core\kernel\memory-manager\VMManager.h"
 
 #include <algorithm> // for std::replace


### PR DESCRIPTION
Somehow NASCAR Heat 2002 no longer reboot properly. After reviewing the code conversion, I'm determined to drop the current method and use c++17 filesystem's conversion by making request of std::string. Oddly enough, it is willing to do so but needs testing to be sure if this pull request change is enough to handle it.

Please test with titles that does multi-xbe functionality.