### PR TITLE
CI: Fix output

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
               exit 1
             fi
           done
-          echo "::set-output name=tag_name::CI-${GITHUB_SHA::7}"
+          echo "tag_name=CI-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
set-output is deprecated: https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/