### PR TITLE
Slightly reduce build time

### DIFF
--- a/src/Cxbx.h
+++ b/src/Cxbx.h
@@ -84,6 +84,4 @@ extern volatile bool g_bPrintfOn;
 #define CxbxSetThreadName(Name)
 #endif
 
-#include <filesystem>
-
 #endif

--- a/src/common/FilePaths.cpp
+++ b/src/common/FilePaths.cpp
@@ -25,6 +25,7 @@
 #define LOG_PREFIX CXBXR_MODULE::FILE
 #define LOG_PREFIX_INIT CXBXR_MODULE::INIT
 
+#include <filesystem>
 #include "common/cxbxr.hpp"
 #include "Settings.hpp"
 #include "EmuShared.h"

--- a/src/common/FilePaths.hpp
+++ b/src/common/FilePaths.hpp
@@ -31,6 +31,8 @@ extern std::string g_DataFilePath;
 extern std::string g_DiskBasePath;
 extern std::string g_MuBasePath;
 
+#include <filesystem>
+
 //TODO: Possible move CxbxResolveHostToFullPath inline function someplace else if become useful elsewhere.
 // Let filesystem library clean it up for us, including resolve host's symbolic link path.
 // Since internal kernel do translate to full path than preserved host symoblic link path.

--- a/src/common/Settings.hpp
+++ b/src/common/Settings.hpp
@@ -26,7 +26,6 @@
 // ******************************************************************
 #ifndef SETTINGS_HPP
 #define SETTINGS_HPP
-#include "Cxbx.h"
 
 #include "SimpleIni.h"
 #include "common\input\InputManager.h"

--- a/src/common/cxbxr.hpp
+++ b/src/common/cxbxr.hpp
@@ -24,7 +24,6 @@
 // ******************************************************************
 #pragma once
 
-#include <filesystem>
 #include <string>
 #include <optional>
 

--- a/src/common/input/DInputKeyboardMouse.cpp
+++ b/src/common/input/DInputKeyboardMouse.cpp
@@ -37,6 +37,7 @@
 #include "DInputKeyboardMouse.h"
 #include "InputManager.h"
 #include "core\kernel\support\Emu.h"
+#include <algorithm>
 
 // Unfortunately, sdl doesn't seem to be able to capture keyboard/mouse input from windows it didn't create (we currently use
 // win32 for that). So unless we create sdl windows, we will have to keep dinput around to handle keyboard/mouse input.

--- a/src/common/input/EmuDevice.cpp
+++ b/src/common/input/EmuDevice.cpp
@@ -25,6 +25,7 @@
 // *
 // ******************************************************************
 
+#include <algorithm>
 #include "Button.h"
 #include "InputManager.h"
 #include "layout_xbox_device.h"

--- a/src/common/input/SdlJoystick.cpp
+++ b/src/common/input/SdlJoystick.cpp
@@ -35,6 +35,7 @@
 #define LOG_PREFIX CXBXR_MODULE::SDL
 
 #include <assert.h>
+#include <algorithm>
 #include <thread>
 #include "core\kernel\support\Emu.h"
 #include "SdlJoystick.h"

--- a/src/common/util/CxbxUtil.h
+++ b/src/common/util/CxbxUtil.h
@@ -26,12 +26,14 @@
 #ifndef CXBXUTIL_H
 #define CXBXUTIL_H
 
+#include <stdexcept>
 #include "xbox_types.h"
 #include "Cxbx.h"
 #include <stdint.h>
 #include <assert.h>
 #include <string>
 #include <type_traits>
+#include <vector>
 #include "std_extend.hpp" // for ARRAY_SIZE
 
 /* This is a linux struct for vectored I/O. See readv() and writev() */

--- a/src/core/hle/D3D8/XbPixelShader.cpp
+++ b/src/core/hle/D3D8/XbPixelShader.cpp
@@ -51,6 +51,7 @@
 #include <assert.h> // assert()
 #include <process.h>
 #include <locale.h>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -34,6 +34,7 @@
 
 #include <cmath>
 #include <iomanip> // For std::setfill and std::setw
+#include <filesystem>
 
 #include "core\kernel\init\CxbxKrnl.h"
 #include "core\kernel\support\Emu.h"

--- a/src/core/kernel/support/EmuFile.h
+++ b/src/core/kernel/support/EmuFile.h
@@ -26,6 +26,7 @@
 
 
 #include <core\kernel\exports\xboxkrnl.h>
+#include <filesystem>
 #include "core\kernel\init\CxbxKrnl.h"
 #include <vector>
 #include <cstdio>

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -59,6 +59,7 @@
 #include <io.h>
 #include <shlobj.h>
 
+#include <filesystem>
 #include <sstream> // for std::stringstream
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Building with Visual Studio build insights highlighted time spent processing `filesystem`.
It turns out this is imported in places it's not used - removing them marginally sped up full rebuilds.

Rebuild timing:
before; 01:24.535 minutes
after: 01:07.085 minutes