### PR TITLE
Fix RtlTimeFieldsToTime and RtlTimeToTimeFields implements

### DIFF
--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1660,11 +1660,11 @@ XBSYSAPI EXPORTNUM(304) xbox::boolean_xt NTAPI xbox::RtlTimeFieldsToTime
 		month = TimeFields->Month + 1;
 		year = TimeFields->Year;
 	}
-	cleaps = (3 * (year / 100) + 3) / 4;   /* nr of "century leap years"*/
-	day = (36525 * year) / 100 - cleaps + /* year * dayperyr, corrected */
-			(1959 * month) / 64 +         /* months * daypermonth */
-			TimeFields->Day -				/* day of the month */
-			584817;							/* zero that on 1601-01-01 */
+	cleaps = (3 * (year / 100) + 3) / 4;  /* nr of "century leap years"*/
+	day = (36525 * year) / 100 - cleaps + /* year * DayPerYear, corrected */
+	      (1959 * month) / 64 +           /* months * DayPerMonth */
+	      TimeFields->Day -               /* day of the month */
+	      584817;                         /* zero that on 1601-01-01 */
 	/* done */
 
 	/* Convert into Time format */

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1615,11 +1615,6 @@ XBSYSAPI EXPORTNUM(304) xbox::boolean_xt NTAPI xbox::RtlTimeFieldsToTime
 	OUT PLARGE_INTEGER  Time
 )
 {
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(TimeFields)
-		LOG_FUNC_ARG_OUT(Time)
-		LOG_FUNC_END;
-
 	int month, year, cleaps, day;
 
 	/* Verify each TimeFields' variables are within range */
@@ -1674,7 +1669,7 @@ XBSYSAPI EXPORTNUM(304) xbox::boolean_xt NTAPI xbox::RtlTimeFieldsToTime
 	Time->QuadPart = (Time->QuadPart + TimeFields->Second) * 1000;
 	Time->QuadPart = (Time->QuadPart + TimeFields->Millisecond) * TICKSPERMSEC;
 
-	RETURN(TRUE);
+	return TRUE;
 }
 
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1622,19 +1622,29 @@ XBSYSAPI EXPORTNUM(304) xbox::boolean_xt NTAPI xbox::RtlTimeFieldsToTime
 
 	int month, year, cleaps, day;
 
-	/* FIXME: normalize the TIME_FIELDS structure here */
-	/* No, native just returns 0 (error) if the fields are not */
-	if (TimeFields->Millisecond < 0 || TimeFields->Millisecond > 999 ||
-		TimeFields->Second < 0 || TimeFields->Second > 59 ||
-		TimeFields->Minute < 0 || TimeFields->Minute > 59 ||
-		TimeFields->Hour < 0 || TimeFields->Hour > 23 ||
-		TimeFields->Month < 1 || TimeFields->Month > 12 ||
-		TimeFields->Day < 1 ||
-		TimeFields->Day > MonthLengths
-			[TimeFields->Month == 2 || IsLeapYear(TimeFields->Year)]
-			[TimeFields->Month - 1] ||
-		TimeFields->Year < 1601)
+	/* Verify each TimeFields' variables are within range */
+	if (TimeFields->Millisecond < 0 || TimeFields->Millisecond > 999) {
 		return FALSE;
+	}
+	if (TimeFields->Second < 0 || TimeFields->Second > 59) {
+		return FALSE;
+	}
+	if (TimeFields->Minute < 0 || TimeFields->Minute > 59) {
+		return FALSE;
+	}
+	if (TimeFields->Hour < 0 || TimeFields->Hour > 23) {
+		return FALSE;
+	}
+	if (TimeFields->Month < 1 || TimeFields->Month > 12) {
+		return FALSE;
+	}
+	if (TimeFields->Day < 1 ||
+		TimeFields->Day > MonthLengths[IsLeapYear(TimeFields->Year)][TimeFields->Month - 1]) {
+		return FALSE;
+	}
+	if (TimeFields->Year < 1601) {
+		return FALSE;
+	}
 
 	/* now calculate a day count from the date
 	* First start counting years from March. This way the leap days

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -42,7 +42,6 @@ namespace NtDll
 
 #include "core\kernel\init\CxbxKrnl.h" // For CxbxrAbort()
 #include "core\kernel\support\Emu.h" // For EmuLog(LOG_LEVEL::WARNING, )
-#include "EmuKrnlKi.h"
 #include <assert.h>
 
 #ifdef _WIN32
@@ -1662,10 +1661,7 @@ XBSYSAPI EXPORTNUM(304) xbox::boolean_xt NTAPI xbox::RtlTimeFieldsToTime
 		TimeFields->Hour) * MINSPERHOUR +
 		TimeFields->Minute) * SECSPERMIN +
 		TimeFields->Second) * 1000 +
-		TimeFields->Millisecond);
-
-	// This function must return a time expressed in 100ns units (the Windows time interval), so it needs a final multiplication here
-	*Time = RtlExtendedIntegerMultiply(*Time, CLOCK_TIME_INCREMENT);
+		TimeFields->Millisecond) * TICKSPERMSEC;
 
 	RETURN(TRUE);
 }

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1667,11 +1667,12 @@ XBSYSAPI EXPORTNUM(304) xbox::boolean_xt NTAPI xbox::RtlTimeFieldsToTime
 			584817;							/* zero that on 1601-01-01 */
 	/* done */
 
-	Time->QuadPart = (((((LONGLONG)day * HOURSPERDAY +
-		TimeFields->Hour) * MINSPERHOUR +
-		TimeFields->Minute) * SECSPERMIN +
-		TimeFields->Second) * 1000 +
-		TimeFields->Millisecond) * TICKSPERMSEC;
+	/* Convert into Time format */
+	Time->QuadPart = day * HOURSPERDAY;
+	Time->QuadPart = (Time->QuadPart + TimeFields->Hour) * MINSPERHOUR;
+	Time->QuadPart = (Time->QuadPart + TimeFields->Minute) * SECSPERMIN;
+	Time->QuadPart = (Time->QuadPart + TimeFields->Second) * 1000;
+	Time->QuadPart = (Time->QuadPart + TimeFields->Millisecond) * TICKSPERMSEC;
 
 	RETURN(TRUE);
 }

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1686,11 +1686,6 @@ XBSYSAPI EXPORTNUM(305) xbox::void_xt NTAPI xbox::RtlTimeToTimeFields
 	OUT PTIME_FIELDS    TimeFields
 )
 {
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(Time)
-		LOG_FUNC_ARG_OUT(TimeFields)
-		LOG_FUNC_END;
-
 	LONGLONG Days, cleaps, years, yearday, months;
 
 	/* Extract milliseconds from time and days from milliseconds */

--- a/src/core/kernel/exports/EmuKrnlRtl.cpp
+++ b/src/core/kernel/exports/EmuKrnlRtl.cpp
@@ -1719,7 +1719,7 @@ XBSYSAPI EXPORTNUM(305) xbox::void_xt NTAPI xbox::RtlTimeToTimeFields
 	yearday = Days - (years * DAYSPERNORMALQUADRENNIUM) / 4;
 	months = (64 * yearday) / 1959;
 	/* the result is based on a year starting on March.
-	* To convert take 12 from Januari and Februari and
+	* To convert take 12 from January and February and
 	* increase the year by one. */
 	if (months < 14) {
 		TimeFields->Month = (USHORT)(months - 1);


### PR DESCRIPTION
@ergo720 and I made some extensive tests to RtlTimeFieldsToTime and RtlTimeToTimeFields tests. We discovered there are more faults in Cxbx-Reloaded's kernel implement for these APIs. This pull request resolve the test's failures.

Plus I also clean up the codes to make it look more readable than bunked into single if statement and operations.

Before:
```
Kernel Test Suite
build: 6d76b16
Random seed used is 0
Config File Was Loaded. Only running requested tests.
-----------------------------------------------------
0x0130 - RtlTimeFieldsToTime: Tests Starting
  ERROR(line 112): Expected array time_tests[18].time_expected.QuadPart = 0x0, Got time_tests[18].time_actual.QuadPart = 0x26bffb7ecc000
  ERROR(line 113): Expected array time_tests[18].result_expected = 0x0, Got time_tests[18].result_actual = 0x1
0x0130 - RtlTimeFieldsToTime: One or more tests FAILED
0x0131 - RtlTimeToTimeFields: Tests Starting
  ERROR(line 159): Expected array time_fields_tests[12].expected.Year = 0x28a, Got time_fields_tests[12].actual.Year = 0xffff9416
  ERROR(line 160): Expected array time_fields_tests[12].expected.Month = 0x5, Got time_fields_tests[12].actual.Month = 0xfffffff9
  ERROR(line 161): Expected array time_fields_tests[12].expected.Day = 0xa, Got time_fields_tests[12].actual.Day = 0xfffffff7
  ERROR(line 162): Expected array time_fields_tests[12].expected.Hour = 0x4a6, Got time_fields_tests[12].actual.Hour = 0xfffffffe
  ERROR(line 163): Expected array time_fields_tests[12].expected.Minute = 0xe, Got time_fields_tests[12].actual.Minute = 0xffffffd0
  ERROR(line 164): Expected array time_fields_tests[12].expected.Second = 0x29, Got time_fields_tests[12].actual.Second = 0xfffffffb
  ERROR(line 165): Expected array time_fields_tests[12].expected.Millisecond = 0x333, Got time_fields_tests[12].actual.Millisecond = 0xfffffe23
0x0131 - RtlTimeToTimeFields: One or more tests FAILED
------------------------ End of Tests -----------------------
```

After:
```
Kernel Test Suite
build: 6d76b16
Random seed used is 0
Config File Was Loaded. Only running requested tests.
-----------------------------------------------------
0x0130 - RtlTimeFieldsToTime: Tests Starting
0x0130 - RtlTimeFieldsToTime: All tests PASSED
0x0131 - RtlTimeToTimeFields: Tests Starting
0x0131 - RtlTimeToTimeFields: All tests PASSED
------------------------ End of Tests -----------------------
```