### PR TITLE
Fix hardware model conversions + use respective hardware model based on console type

### DIFF
--- a/src/core/kernel/common/types.h
+++ b/src/core/kernel/common/types.h
@@ -2081,6 +2081,11 @@ typedef enum _XC_VALUE_INDEX
 }
 XC_VALUE_INDEX, *PXC_VALUE_INDEX;
 
+#define XBOX_HW_FLAG_INTERNAL_USB_HUB 0x00000001
+#define XBOX_HW_FLAG_DEVKIT_KERNEL    0x00000002
+#define XBOX_480P_MACROVISION_ENABLED 0x00000004
+#define XBOX_HW_FLAG_ARCADE           0x00000008
+
 // ******************************************************************
 // * XBOX_HARDWARE_INFO
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnlXbox.cpp
+++ b/src/core/kernel/exports/EmuKrnlXbox.cpp
@@ -41,15 +41,19 @@ XBSYSAPI EXPORTNUM(321) xbox::XBOX_KEY_DATA xbox::XboxEEPROMKey = { 0 };
 // ******************************************************************
 // * 0x0142 - XboxHardwareInfo
 // ******************************************************************
+// TODO: The main goal is to completely unset custom init values and have
+//       them set from kernel's initialization end and device classes.
+//       Although, device classes does not really set this value but read
+//       from PCI space for Gpu rev, Mcp rev, and possibility INTERNAL_USB flag.
 XBSYSAPI EXPORTNUM(322) xbox::XBOX_HARDWARE_INFO xbox::XboxHardwareInfo =
 {
 	// TODO: What exactly 0xC0000030 flags are? Might need default to null then set them later properly.
 	// NOTE: Will be set by src/devices/Xbox.cpp and maybe other file(s)...
-	0xC0000030, // Flags: 1=INTERNAL_USB, 2=DEVKIT, 4=MACROVISION, 8=CHIHIRO
-	0xD3, // GpuRevision, byte read from NV2A first register, at 0xFD0000000 - see NV_PMC_BOOT_0
-	0, // NOTE: Will be set by src/devices/Xbox.cpp file.
-	0, // unknown
-	0 // unknown
+	.Flags = 0xC0000030, // Flags: 1=INTERNAL_USB, 2=DEVKIT, 4=MACROVISION, 8=CHIHIRO
+	.GpuRevision = 0xD3, // GpuRevision, byte read from NV2A first register, at 0xFD0000000 - see NV_PMC_BOOT_0
+	.McpRevision = 0, // NOTE: Will be set by src/devices/Xbox.cpp file.
+	.Unknown3 = 0, // unknown
+	.Unknown4 = 0 // unknown
 };
 
 // ******************************************************************

--- a/src/core/kernel/exports/EmuKrnlXbox.cpp
+++ b/src/core/kernel/exports/EmuKrnlXbox.cpp
@@ -43,9 +43,11 @@ XBSYSAPI EXPORTNUM(321) xbox::XBOX_KEY_DATA xbox::XboxEEPROMKey = { 0 };
 // ******************************************************************
 XBSYSAPI EXPORTNUM(322) xbox::XBOX_HARDWARE_INFO xbox::XboxHardwareInfo =
 {
-	0xC0000031, // Flags: 1=INTERNAL_USB, 2=DEVKIT, 4=MACROVISION, 8=CHIHIRO
-	0xA2, // GpuRevision, byte read from NV2A first register, at 0xFD0000000 - see NV_PMC_BOOT_0
-	0xD3, // McpRevision, Retail 1.6 - see https://github.com/JayFoxRox/xqemu-jfr/wiki/MCPX-and-bootloader
+	// TODO: What exactly 0xC0000030 flags are? Might need default to null then set them later properly.
+	// NOTE: Will be set by src/devices/Xbox.cpp and maybe other file(s)...
+	0xC0000030, // Flags: 1=INTERNAL_USB, 2=DEVKIT, 4=MACROVISION, 8=CHIHIRO
+	0xD3, // GpuRevision, byte read from NV2A first register, at 0xFD0000000 - see NV_PMC_BOOT_0
+	0, // NOTE: Will be set by src/devices/Xbox.cpp file.
 	0, // unknown
 	0 // unknown
 };

--- a/src/devices/SMCDevice.cpp
+++ b/src/devices/SMCDevice.cpp
@@ -91,10 +91,13 @@ uint8_t SMCDevice::ReadByte(uint8_t command)
 		// See https://xboxdevwiki.net/PIC#PIC_version_string
 		switch (m_revision) {
 		case SCMRevision::P01: buffer[1] = "P01"[m_PICVersionStringIndex]; break;
-		case SCMRevision::P2L: buffer[1] = "P05"[m_PICVersionStringIndex]; break; // ??
+		case SCMRevision::P05: buffer[1] = "P05"[m_PICVersionStringIndex]; break;
+		case SCMRevision::P11: buffer[1] = "P11"[m_PICVersionStringIndex]; break;
+		case SCMRevision::P2L: buffer[1] = "P2L"[m_PICVersionStringIndex]; break;
 		case SCMRevision::D01: buffer[1] = "DXB"[m_PICVersionStringIndex]; break;
 		case SCMRevision::D05: buffer[1] = "D05"[m_PICVersionStringIndex]; break; // ??
-		// default: UNREACHABLE(m_revision);
+		case SCMRevision::B11: buffer[1] = "B11"[m_PICVersionStringIndex]; break; // ??
+		default: CxbxrAbort("Unknown PIC revision: %d", m_revision);
 		}
 
 		m_PICVersionStringIndex = (m_PICVersionStringIndex + 1) % 3;

--- a/src/devices/SMCDevice.h
+++ b/src/devices/SMCDevice.h
@@ -93,10 +93,14 @@
 
 typedef enum {
 	// https://xboxdevwiki.net/System_Management_Controller
+	// https://xboxdevwiki.net/Xboxen_Info
 	P01,
+	P05,
+	P11,
 	P2L,
 	D01, // Seen in a debug kit 
 	D05, // Seen in a earlier model chihiro
+	B11,
 } SCMRevision;
 
 class SMCDevice : public SMDevice {

--- a/src/devices/Xbox.cpp
+++ b/src/devices/Xbox.cpp
@@ -25,8 +25,12 @@
 // *
 // ******************************************************************
 
+#define LOG_PREFIX CXBXR_MODULE::XBOX
+
 #include "Xbox.h" // For HardwareModel
 #include "common\xbe\Xbe.h"  // Without this HLEIntercept complains about some undefined xbe variables
+#include "core\kernel\common\xbox.h"
+#include "cxbxr.hpp"
 #include "core\hle\Intercept.hpp"
 
 PCIBus* g_PCIBus;
@@ -41,66 +45,82 @@ USBDevice* g_USB0;
 
 MCPXRevision MCPXRevisionFromHardwareModel(HardwareModel hardwareModel)
 {
-	switch (hardwareModel) {
-	case Revision1_0:
-	case Revision1_1:
-	case Revision1_2:
-	case Revision1_3:
-	case Revision1_4:
-	case Revision1_5:
-	case Revision1_6:
+	// https://xboxdevwiki.net/Xboxen_Info
+	switch (GET_HW_CONSOLE(hardwareModel)) {
+	case Retail:
 		return MCPXRevision::MCPX_X3;
 	case DebugKit:
-		// EmuLog(LOG_LEVEL::WARNING, "Guessing MCPXVersion");
+	case Chihiro:
 		return MCPXRevision::MCPX_X2;
 	default:
-		// UNREACHABLE(hardwareModel);
-		return MCPXRevision::MCPX_X3;
+		CxbxrAbort("MCPXRevisionFromHardwareModel: Unknown conversion for hardware model (0x%02X)", hardwareModel);
 	}
 }
 
 SCMRevision SCMRevisionFromHardwareModel(HardwareModel hardwareModel)
 {
+	// https://xboxdevwiki.net/Xboxen_Info
 	switch (hardwareModel) {
 	case Revision1_0:
-		return SCMRevision::P01; // Our SCM returns PIC version string "P01"
+		return SCMRevision::P01;
 	case Revision1_1:
+		return SCMRevision::P05;
 	case Revision1_2:
 	case Revision1_3:
 	case Revision1_4:
+		return SCMRevision::P11;
 	case Revision1_5:
 	case Revision1_6:
-		// EmuLog(LOG_LEVEL::WARNING, "Guessing SCMRevision");
-		return SCMRevision::P2L; // Assumption; Our SCM returns PIC version string "P05"
-	case DebugKit:
-		return SCMRevision::D01; // Our SCM returns PIC version string "DXB"
-	default:
-		// UNREACHABLE(hardwareModel);
 		return SCMRevision::P2L;
+	case DebugKit:
+		return SCMRevision::D01;
+	case Chihiro_Type1:
+		return SCMRevision::D05;
+	case DebugKit_r1_2:
+	case Chihiro_Type3:
+		return SCMRevision::B11;
+	default:
+		CxbxrAbort("SCMRevisionFromHardwareModel: Unknown conversion for hardware model (0x%02X)", hardwareModel);
 	}
 }
 
 TVEncoder TVEncoderFromHardwareModel(HardwareModel hardwareModel)
 {
-	switch (hardwareModel) {
+	// https://xboxdevwiki.net/Xboxen_Info
+	// LukeUsher : My debug kit and at least most of them (maybe all?)
+	// are equivalent to v1.0 and have Conexant encoders.
+	switch (GET_HW_REVISION(hardwareModel)) {
 	case Revision1_0:
 	case Revision1_1:
 	case Revision1_2:
 	case Revision1_3:
 		return TVEncoder::Conexant;
 	case Revision1_4:
+	case Revision1_5: // Assumption
 		return TVEncoder::Focus;
-	case Revision1_5:
-		return TVEncoder::Focus; // Assumption
 	case Revision1_6:
 		return TVEncoder::XCalibur;
-	case DebugKit:
-		// LukeUsher : My debug kit and at least most of them (maybe all?)
-		// are equivalent to v1.0 and have Conexant encoders.
-		return TVEncoder::Conexant;
-	default: 
-		// UNREACHABLE(hardwareModel);
-		return TVEncoder::Focus;
+	default:
+		CxbxrAbort("TVEncoderFromHardwareModel: Unknown conversion for hardware model (0x%02X)", hardwareModel);
+	}
+}
+
+xbox::uchar_xt MCP_PCIRevisionFromHardwareModel(HardwareModel hardwareModel)
+{
+	// https://xboxdevwiki.net/Xboxen_Info
+	switch (GET_HW_REVISION(hardwareModel)) {
+		case Revision1_0:
+			return 0xB2;
+		case Revision1_1:
+		case Revision1_2:
+		case Revision1_3:
+		case Revision1_4:
+		case Revision1_5: // Assumption
+			return 0xD4;
+		case Revision1_6:
+			return 0xD5;
+		default:
+			CxbxrAbort("MCP_PCIRevisionFromHardwareModel: Unknown conversion for hardware model (0x%02X)", hardwareModel);
 	}
 }
 
@@ -111,16 +131,29 @@ void InitXboxHardware(HardwareModel hardwareModel)
 	SCMRevision smc_revision = SCMRevisionFromHardwareModel(hardwareModel);
 	TVEncoder tv_encoder = TVEncoderFromHardwareModel(hardwareModel);
 
+	// Only Xbox 1.0 has usb daughterboard supplied, later revisions are integrated onto motherboard.
+	if (GET_HW_REVISION(hardwareModel) == HardwareModel::Revision1_0) {
+		xbox::XboxHardwareInfo.Flags |= XBOX_HW_FLAG_INTERNAL_USB_HUB;
+	}
+	// Set the special type of consoles according to xbox kernel designed respectively.
+	if (IS_DEVKIT(hardwareModel)) {
+		xbox::XboxHardwareInfo.Flags |= XBOX_HW_FLAG_DEVKIT_KERNEL;
+	}
+	else if (IS_CHIHIRO(hardwareModel)) {
+		xbox::XboxHardwareInfo.Flags |= XBOX_HW_FLAG_ARCADE;
+	}
+
+	xbox::XboxHardwareInfo.McpRevision = MCP_PCIRevisionFromHardwareModel(hardwareModel);
+
 	// Create busses
 	g_PCIBus = new PCIBus();
 	g_SMBus = new SMBus();
 
 	// Create devices
 	g_MCPX = new MCPXDevice(mcpx_revision);
-															
-	g_SMC = new SMCDevice(smc_revision, g_bIsChihiro ? 6 : 1); // 6 = AV_PACK_STANDARD, 1 = AV_PACK_HDTV. Chihiro doesn't support HDTV!
-															   // SMC uses different AV_PACK values than the Kernel
-															   // See https://xboxdevwiki.net/PIC#The_AV_Pack
+	g_SMC = new SMCDevice(smc_revision, IS_CHIHIRO(hardwareModel) ? 6 : 1); // 6 = AV_PACK_STANDARD, 1 = AV_PACK_HDTV. Chihiro doesn't support HDTV!
+	                                                                        // SMC uses different AV_PACK values than the Kernel
+	                                                                        // See https://xboxdevwiki.net/PIC#The_AV_Pack
 	g_EEPROM = new EEPROMDevice();
 	g_NVNet = new NVNetDevice();
 	g_NV2A = new NV2ADevice();

--- a/src/devices/Xbox.h
+++ b/src/devices/Xbox.h
@@ -54,6 +54,7 @@ typedef enum {
 	Revision1_5,
 	Revision1_6,
 	Retail = 0x00,
+	// We don't need include revison 1.0 to 1.6 here, use above revision range instead.
 	DebugKit = 0x10, // TODO: Since there are 1.0/1.1/1.2 revisions. For now, let's go with 1.2 by default.
 	DebugKit_r1_2 = DebugKit | Revision1_2,
 	Chihiro = 0x20,

--- a/src/devices/Xbox.h
+++ b/src/devices/Xbox.h
@@ -53,8 +53,19 @@ typedef enum {
 	Revision1_4,
 	Revision1_5,
 	Revision1_6,
-	DebugKit
+	Retail = 0x00,
+	DebugKit = 0x10, // TODO: Since there are 1.0/1.1/1.2 revisions. For now, let's go with 1.2 by default.
+	DebugKit_r1_2 = DebugKit | Revision1_2,
+	Chihiro = 0x20,
+	Chihiro_Type1 = Chihiro | Revision1_1,
+	Chihiro_Type3 = Chihiro | Revision1_2, // TODO: Need verify on Chihiro hw, it is currently base on (B11) Debug Kit list.
 } HardwareModel;
+
+#define GET_HW_REVISION(hardwareModel) (hardwareModel & 0x0F)
+#define GET_HW_CONSOLE(hardwareModel) (hardwareModel & 0xF0)
+#define IS_RETAIL(hardwareModel) (GET_HW_CONSOLE(hardwareModel) == Retail)
+#define IS_DEVKIT(hardwareModel) (GET_HW_CONSOLE(hardwareModel) == DebugKit)
+#define IS_CHIHIRO(hardwareModel) (GET_HW_CONSOLE(hardwareModel) == Chihiro)
 
 typedef enum { // TODO : Move to it's own file
 	// https://xboxdevwiki.net/Hardware_Revisions#Video_encoder


### PR DESCRIPTION
When I was writing extended log info based on documentation by the xboxdevwiki community for xbox kernel test suite. I noticed a flaw in hardware model conversion from Cxbx-Reloaded's end. Such as `HardwareModel::Revision1_5` points to `P2L` flag which then return `P05`, aka `Revision 1.1` string incorrectly. So, I corrected the return string to `P2L` as expected. Plus made major update on the conversions function and used respective hardware models based on console type.

I changed the retail revision 1.5 to 1.6 as the last released revision model.

Reference used by: https://xboxdevwiki.net/Xboxen_Info

---
> [!NOTE]
> Not everything is fully implemented to use respective hardware model accuracy. For now, this is the first move to use proper hardware model.