### PR TITLE
fix the build on vs2022 17.9.1

### DIFF
--- a/src/common/util/CxbxUtil.h
+++ b/src/common/util/CxbxUtil.h
@@ -26,6 +26,7 @@
 #ifndef CXBXUTIL_H
 #define CXBXUTIL_H
 
+#include <algorithm>
 #include <stdexcept>
 #include "xbox_types.h"
 #include "Cxbx.h"

--- a/src/gui/DlgAbout.cpp
+++ b/src/gui/DlgAbout.cpp
@@ -64,7 +64,7 @@ INT_PTR CALLBACK DlgAboutProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 			SendMessageW(hWndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
 
 			// Build the Tab Control
-			constexpr size_t text_len = longest_str({ "About", "Contributors", "License" }) + 1;
+			const size_t text_len = longest_str({ "About", "Contributors", "License" }) + 1;
 			char text[text_len];
 			TCITEM tabInfo;
 			memset(&tabInfo, 0, sizeof(tabInfo));


### PR DESCRIPTION
std::max_element is defined in `<algorithm>` so we were missing this required include
the longest_str call in DlgAbout was unable to be determined at compile time so is not suited for constexpr (not sure why this changed?)