### PR TITLE
Deprecate the Cxbx-Reloaded Debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cmake-build-*/
 
 #Test files
 src/[Vv]ersion.h
+src/common/CxbxDebugger.h
 *.xbe
 
 # Last known git hash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,14 @@ if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${Cxbx-Reloaded_BINARY_DIR}/bin")
 endif()
 
+set(BUILD_CXBXR_DEBUGGER OFF CACHE BOOL "Build the Cxbx-Reloaded debugger")
+message("BUILD_CXBXR_DEBUGGER=${BUILD_CXBXR_DEBUGGER}")
+
+configure_file(
+ "${CMAKE_SOURCE_DIR}/src/common/CxbxDebugger.h.in" "${CMAKE_SOURCE_DIR}/src/common/CxbxDebugger.h" @ONLY
+ NEWLINE_STYLE LF
+)
+
 set(SUBHOOK_TESTS OFF)
 set(SUBHOOK_INSTALL OFF)
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/import/subhook" EXCLUDE_FROM_ALL)
@@ -454,20 +462,23 @@ endif()
 
 # Check if generator is Visual Studio then enable Cxbxr-Debugger project.
 # Since C# is currently supported with Visual Studio for now.
-if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
- # Issues with compile (the same with develop branch) and
- # for some reason did not put the files into virtual folder?
- # Might need to put the list in the source folder for workaround fix.
- add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/src/CxbxDebugger")
+if(${BUILD_CXBXR_DEBUGGER})
+ if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
+  # Issues with compile (the same with develop branch) and
+  # for some reason did not put the files into virtual folder?
+  # Might need to put the list in the source folder for workaround fix.
 
- set_target_properties(Tests_cs_x86
-  PROPERTIES EXCLUDE_FROM_ALL TRUE
- )
+  add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/src/CxbxDebugger")
 
- # Cxbx-Debugger project with third-party libraries
- set_target_properties(cxbxr-debugger cs_x86 Tests_cs_x86 capstone-shared
-  PROPERTIES FOLDER Cxbx-Reloaded/debugger
- )
+  set_target_properties(Tests_cs_x86
+   PROPERTIES EXCLUDE_FROM_ALL TRUE
+  )
+
+  # Cxbx-Debugger project with third-party libraries
+  set_target_properties(cxbxr-debugger cs_x86 Tests_cs_x86 capstone-shared
+   PROPERTIES FOLDER Cxbx-Reloaded/debugger
+  )
+ endif()
 endif()
 
 install(FILES ${cxbxr_INSTALL_files}

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ Don't open `CMakeLists.txt` from Visual Studio, as it won't generate files in th
 1. If you don't have CMake installed, open `___ Native Tools Command Prompt for VS 20##`.
 2. `cd` to the Cxbx-Reloaded directory.
 3. Run these commands.
-    1. `mkdir build & cd build`
+    1. `mkdir build && cd build`
     2. `cmake .. -G "Visual Studio 17 2022" -A Win32`
         * VS2022 17.0 or later is required.
+        * To build the Cxbx-Reloaded Debugger, add the variable `-DBUILD_CXBXR_DEBUGGER=ON` to the above command.
+          * **NOTE**: _This debugger is deprecated, use the Visual Studio debugger instead._
 4. Open `Cxbx-Reloaded.sln` from the `build` directory.
 5. Select the Release configuration, then click Build.
     * Debug builds are **significantly slower, and only for developers**.

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -189,8 +189,10 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
 )
 
-if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
-  add_dependencies(cxbx cxbxr-debugger)
+if(${BUILD_CXBXR_DEBUGGER})
+ if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
+   add_dependencies(cxbx cxbxr-debugger)
+ endif()
 endif()
 
 add_dependencies(cxbx cxbxr-ldr cxbxr-emu misc-batch)

--- a/src/common/CxbxDebugger.cpp
+++ b/src/common/CxbxDebugger.cpp
@@ -143,7 +143,11 @@ namespace CxbxDebugger
 
 	bool CanReport()
 	{
+#ifdef BUILD_CXBXR_DEBUGGER
 		return Internal::IsAttached();
+#else
+		return false;
+#endif
 	}
 
 	void ReportDebuggerInit(const char* XbeTitle)

--- a/src/common/CxbxDebugger.h.in
+++ b/src/common/CxbxDebugger.h.in
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#cmakedefine BUILD_CXBXR_DEBUGGER
+
 namespace CxbxDebugger
 {
 	// Skip exception codes produced by the debugger (workaround for child process debugging)

--- a/src/gui/WndMain.cpp
+++ b/src/gui/WndMain.cpp
@@ -48,6 +48,7 @@
 #include "common/util/cliConfig.hpp"
 #include "common/win32/WineEnv.h"
 #include "common/xbe/XbePrinter.h" // for FormatTitleId
+#include "common/CxbxDebugger.h"
 
 #include "resource/ResCxbx.h"
 #include "CxbxVersion.h"
@@ -558,7 +559,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 					}
 					// fall through
 				}
-
+#ifdef BUILD_CXBXR_DEBUGGER
 				case VK_F9:
 				{
 					// Start emulation with the debugger
@@ -574,7 +575,7 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 					}
 					// fall through
 				}
-
+#endif
                 default:
                 {
                     if(m_hwndChild != NULL)
@@ -1248,14 +1249,14 @@ LRESULT CALLBACK WndMain::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
                     StartEmulation(hwnd);
                 }
                 break;
-
+#ifdef BUILD_CXBXR_DEBUGGER
             case ID_EMULATION_STARTDEBUGGER:
                 if (m_Xbe != nullptr)
                 {
                     StartEmulation(hwnd, debuggerOn);
                 }
                 break;
-
+#endif
             case ID_EMULATION_STOP:
                 StopEmulation();
                 break;
@@ -1748,10 +1749,10 @@ void WndMain::RefreshMenus()
 
             // enable emulation start
             EnableMenuItem(emul_menu, ID_EMULATION_START, MF_BYCOMMAND | MF_WhenXbeLoadedNotRunning);
-
+#ifdef BUILD_CXBXR_DEBUGGER
             // enable emulation with debugging
             EnableMenuItem(emul_menu, ID_EMULATION_STARTDEBUGGER, MF_BYCOMMAND | MF_WhenXbeLoadedNotRunning);
-
+#endif
             // enable emulation stop
             EnableMenuItem(emul_menu, ID_EMULATION_STOP, MF_BYCOMMAND | MF_WhenXbeLoadedAndRunning);
         }

--- a/src/gui/resource/Cxbx.rc
+++ b/src/gui/resource/Cxbx.rc
@@ -1,6 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "ResCxbx.h"
+#include "CxbxDebugger.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -801,7 +802,9 @@ BEGIN
     POPUP "E&mulation",                     65535,MFT_STRING,MFS_ENABLED
     BEGIN
         MENUITEM "&Start\tF5",                  ID_EMULATION_START,MFT_STRING,MFS_ENABLED
+#ifdef BUILD_CXBXR_DEBUGGER
         MENUITEM "Start &Debugger...\tF9",      ID_EMULATION_STARTDEBUGGER,MFT_STRING,MFS_ENABLED
+#endif
         MENUITEM "", -1, MFT_SEPARATOR
         MENUITEM "S&top\tF6",                   ID_EMULATION_STOP,MFT_STRING,MFS_ENABLED
     END


### PR DESCRIPTION
This deprecates the usage of the Cxbx-Reloaded Debugger by disabling it in the code. This is done because it has several drawbacks with no obvious benefits:
1. it's possible to load cheat tables with cheat engine itself, so no need to replicate that here.
2. it's not useful to debug issues in cxbxr itself, and developers are expected to use the debugger of Visual Studio instead (which is more capable too).
3. Its file events can be replaced by the file logging options of cxbxr.
4. It's written in C# instead of C++, and brings in a huge dependency on dotnet and capstone, which are not required by cxbxr.
5. After it was introduced, no one has really maintained it or developed any further.

With that being said, it can still be built by passing the variable `-DBUILD_CXBXR_DEBUGGER=ON` to the cmake build command, if someone still wants it.