### PR TITLE
debugger: mark tool as deprecate

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           submodules: recursive
       - name: Generate CMake files
-        run: cmake -B build -A Win32,version=${{ matrix.sdkver }} -DCMAKE_SYSTEM_VERSION=${{ matrix.winver }}
+        run: cmake -B build -A Win32,version=${{ matrix.sdkver }} -DCMAKE_SYSTEM_VERSION=${{ matrix.winver }} -DBUILD_CXBXR_DEBUGGER=ON
       - name: Build
         run: cmake --build build --config ${{ matrix.configuration }} -j $env:NUMBER_OF_PROCESSORS
       - name: Prepare artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,12 @@ file (GLOB CXBXR_SOURCE_EMU
  "${CXBXR_ROOT_DIR}/src/common/ReserveAddressRanges.cpp"
 )
 
+
+option(BUILD_CXBXR_DEBUGGER "Build cxbxr-debugger tool (with cheat table support)")
+if(BUILD_CXBXR_DEBUGGER)
+ message(DEPRECATION "The Cxbxr-Debugger tool will eventually be removed from the upstream branch.")
+endif()
+
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/cxbx")
 
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/projects/cxbxr-ldr")
@@ -454,7 +460,7 @@ endif()
 
 # Check if generator is Visual Studio then enable Cxbxr-Debugger project.
 # Since C# is currently supported with Visual Studio for now.
-if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
+if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])" AND BUILD_CXBXR_DEBUGGER)
  # Issues with compile (the same with develop branch) and
  # for some reason did not put the files into virtual folder?
  # Might need to put the list in the source folder for workaround fix.

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ Don't open `CMakeLists.txt` from Visual Studio, as it won't generate files in th
 ##### Generate Visual Studio files
 1. If you don't have CMake installed, open `___ Native Tools Command Prompt for VS 20##`.
 2. `cd` to the Cxbx-Reloaded directory.
-3. Run these commands.
-    1. `mkdir build & cd build`
-    2. `cmake .. -G "Visual Studio 17 2022" -A Win32`
-        * VS2022 17.0 or later is required.
+3. Run the following command: `cmake -B build -G "Visual Studio 17 2022" -A Win32` \
+   **NOTES**:
+     * VS2022 17.0 or later is required.
+     * To build the Cxbx-Reloaded Debugger tool, add the variable `-DBUILD_CXBXR_DEBUGGER=ON` to the above command.
+       * _This debugger tool is deprecated and will be eventually removed, please use the Visual Studio debugger instead._
 4. Open `Cxbx-Reloaded.sln` from the `build` directory.
 5. Select the Release configuration, then click Build.
     * Debug builds are **significantly slower, and only for developers**.

--- a/projects/cxbx/CMakeLists.txt
+++ b/projects/cxbx/CMakeLists.txt
@@ -189,7 +189,7 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
 )
 
-if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])")
+if(${CMAKE_GENERATOR} MATCHES "Visual Studio ([^9]|[9][0-9])" AND BUILD_CXBXR_DEBUGGER)
   add_dependencies(cxbx cxbxr-debugger)
 endif()
 

--- a/src/CxbxDebugger/CxbxDebuggerMain.Designer.cs
+++ b/src/CxbxDebugger/CxbxDebuggerMain.Designer.cs
@@ -41,6 +41,7 @@
             this.windowsMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.lblStatusDeprecate = new System.Windows.Forms.ToolStripStatusLabel();
             this.lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
             this.menuStrip.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -132,18 +133,29 @@
             // 
             this.statusStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lblStatusDeprecate,
             this.lblStatus});
+            this.statusStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.VerticalStackWithOverflow;
             this.statusStrip1.Location = new System.Drawing.Point(0, 339);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 9, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(734, 22);
+            this.statusStrip1.Size = new System.Drawing.Size(734, 61);
             this.statusStrip1.TabIndex = 2;
             this.statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStatusDeprecate
+            // 
+            this.lblStatusDeprecate.BackColor = System.Drawing.Color.Yellow;
+            this.lblStatusDeprecate.Name = "lblStatusDeprecate";
+            this.lblStatusDeprecate.Size = new System.Drawing.Size(723, 15);
+            this.lblStatusDeprecate.Spring = true;
+            this.lblStatusDeprecate.Text = "WARNING: cxbxr-debugger will eventually be removed from upstream branch.";
+            this.lblStatusDeprecate.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lblStatus
             // 
             this.lblStatus.Name = "lblStatus";
-            this.lblStatus.Size = new System.Drawing.Size(39, 17);
+            this.lblStatus.Size = new System.Drawing.Size(723, 15);
             this.lblStatus.Text = "Ready";
             // 
             // CxbxDebuggerMain
@@ -180,6 +192,7 @@
         private System.Windows.Forms.ToolStripMenuItem miSuspend;
         private System.Windows.Forms.ToolStripMenuItem miResume;
         private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatusDeprecate;
         private System.Windows.Forms.ToolStripStatusLabel lblStatus;
     }
 }


### PR DESCRIPTION
This pull request changes made were made to replace #2485  pull request to keep minimum changes as possible.

Attempt to launch debugger from Cxbx-Reloaded's context menu already has a pop up window to indicate the developer need to build the debugger in order to use it. Therefore isn't needed to have numerous changes for macro check block statements.

For additional changes compare to #2485 pull request:
- Deprecate message will appear in cmake if include generating debugger tool builder.
- Add BUILD_CXBXR_DEBUGGER to CI workflow since users may be continue to using it. Plus verify the compile process is working as intended without need to manual check ourselves for every future pull request are made.

screenshot of cxbxr-debugger with warning message:
![image](https://github.com/user-attachments/assets/828b7cfe-a21f-4c15-98e4-2b861d071060)


close #2485 