### PR TITLE
cmake: Raise cmake_minimum_required to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.12)
 
 project(Cxbx-Reloaded)
 

--- a/projects/imgui/CMakeLists.txt
+++ b/projects/imgui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.12)
 project(imgui LANGUAGES CXX)
 # Since imgui doesn't have CMake, we'll make an interface project here.
 

--- a/projects/libtom/crypt/CMakeLists.txt
+++ b/projects/libtom/crypt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.12)
 project(libtomcrypt)
 
 # Suppress extra stuff from generated solution

--- a/projects/libtom/math/CMakeLists.txt
+++ b/projects/libtom/math/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.12)
 project(libtommath)
 
 # Suppress extra stuff from generated solution

--- a/projects/libusb/CMakeLists.txt
+++ b/projects/libusb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.12)
 project(libusb LANGUAGES CXX)
 # Since libusb doesn't have CMake, we'll make an interface project here.
 

--- a/src/CxbxDebugger/CMakeLists.txt
+++ b/src/CxbxDebugger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.12)
 project(cxbxr-debugger LANGUAGES CSharp)
 
 # Output all binary files into one folder


### PR DESCRIPTION
Other parts of the project already have it set to 3.12 so might as well for consistency.