### PR TITLE
D3D8LTCG: Add missing patches according to XbSymbolDatabase's symbols found

### DIFF
--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4823,6 +4823,45 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_RunPushBuffer)
 }
 
 // ******************************************************************
+// * patch: D3DDevice_RunPushBuffer_4__LTCG_eax2
+// ******************************************************************
+// Overload for logging
+static void D3DDevice_RunPushBuffer_4__LTCG_eax2
+(
+    xbox::X_D3DPushBuffer       *pPushBuffer,
+	xbox::X_D3DFixup            *pFixup
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(pPushBuffer)
+		LOG_FUNC_ARG(pFixup)
+		LOG_FUNC_END;
+}
+
+// This uses a custom calling convention where parameter is passed in EAX
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_RunPushBuffer_4__LTCG_eax2)
+(
+    X_D3DPushBuffer *pPushBuffer
+)
+{
+	X_D3DFixup* pFixup;
+	__asm {
+		LTCG_PROLOGUE
+		mov  pFixup, eax
+	}
+
+	// Log
+	D3DDevice_RunPushBuffer_4__LTCG_eax2(pPushBuffer, pFixup);
+
+	EmuExecutePushBuffer(pPushBuffer, pFixup);
+
+	__asm {
+		LTCG_EPILOGUE
+		ret  4
+	}
+}
+
+// ******************************************************************
 // * patch: D3DDevice_Clear
 // ******************************************************************
 xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_Clear)

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -4409,9 +4409,9 @@ xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant4)
 // ******************************************************************
 xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline)
 (
-    int_xt         Register,
+    int_xt      Register,
     CONST PVOID pConstantData,
-    dword_xt       ConstantCount
+    dword_xt    ConstantCount
 )
 {
 	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
@@ -4420,6 +4420,42 @@ xbox::void_xt __fastcall xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInli
     // but D3DDevice_SetVertexShaderConstant expects -96..95 range
     // so we adjust before forwarding
 	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - X_D3DSCM_CORRECTION, pConstantData, ConstantCount / 4);
+}
+
+// ******************************************************************
+// * patch: D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3
+// ******************************************************************
+// Overload for logging
+static void D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3()
+{
+	LOG_FORWARD("D3DDevice_SetVertexShaderConstant");
+}
+
+// This uses a custom calling convention where parameter is passed in EBX, EDX, EAX
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3)()
+{
+	int_xt Register;
+	PVOID pConstantData;
+	dword_xt ConstantCount;
+	__asm {
+		LTCG_PROLOGUE
+		mov Register, ebx
+		mov pConstantData, edx
+		mov ConstantCount, eax
+	}
+
+	// Log
+	D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3();
+
+	// The XDK uses a macro to automatically adjust to 0..191 range
+	// but D3DDevice_SetVertexShaderConstant expects -96..95 range
+	// so we adjust before forwarding
+	EMUPATCH(D3DDevice_SetVertexShaderConstant)(Register - X_D3DSCM_CORRECTION, pConstantData, ConstantCount / 4);
+
+	__asm {
+        LTCG_EPILOGUE
+        ret
+    }
 }
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6487,25 +6487,16 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_EnableOverlay_0__LTCG)()
 	CxbxrImpl_EnableOverlay();
 }
 
-// ******************************************************************
-// * patch: D3DDevice_UpdateOverlay
-// ******************************************************************
-xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_UpdateOverlay)
+static void CxbxrImpl_UpdateOverlay
 (
-	X_D3DSurface *pSurface,
-	CONST RECT   *SrcRect,
-	CONST RECT   *DstRect,
-	bool_xt          EnableColorKey,
-	D3DCOLOR      ColorKey
+	xbox::X_D3DSurface *pSurface,
+	CONST RECT         *SrcRect,
+	CONST RECT         *DstRect,
+	xbox::bool_xt       EnableColorKey,
+	D3DCOLOR            ColorKey
 )
 {
-	LOG_FUNC_BEGIN
-		LOG_FUNC_ARG(pSurface)
-		LOG_FUNC_ARG(SrcRect)
-		LOG_FUNC_ARG(DstRect)
-		LOG_FUNC_ARG(EnableColorKey)
-		LOG_FUNC_ARG(ColorKey)
-		LOG_FUNC_END;
+	using namespace xbox;
 
 	// Reset and remember the overlay arguments, so our D3DDevice_Swap patch
 	// can correctly show this overlay surface data.
@@ -6527,6 +6518,76 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_UpdateOverlay)
 		}
 
 		g_OverlaySwap = g_Xbox_SwapData.Swap;
+	}
+}
+
+// ******************************************************************
+// * patch: D3DDevice_UpdateOverlay
+// ******************************************************************
+xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_UpdateOverlay)
+(
+	X_D3DSurface *pSurface,
+	CONST RECT   *SrcRect,
+	CONST RECT   *DstRect,
+	bool_xt       EnableColorKey,
+	D3DCOLOR      ColorKey
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(pSurface)
+		LOG_FUNC_ARG(SrcRect)
+		LOG_FUNC_ARG(DstRect)
+		LOG_FUNC_ARG(EnableColorKey)
+		LOG_FUNC_ARG(ColorKey)
+		LOG_FUNC_END;
+
+	CxbxrImpl_UpdateOverlay(pSurface, SrcRect, DstRect, EnableColorKey, ColorKey);
+}
+
+// ******************************************************************
+// * patch: D3DDevice_UpdateOverlay_16__LTCG_eax2
+// ******************************************************************
+static void D3DDevice_UpdateOverlay_16__LTCG_eax2
+(
+	xbox::X_D3DSurface *pSurface,
+	CONST RECT         *SrcRect,
+	CONST RECT         *DstRect,
+	xbox::bool_xt       EnableColorKey,
+	D3DCOLOR            ColorKey
+)
+{
+	LOG_FUNC_BEGIN
+		LOG_FUNC_ARG(pSurface)
+		LOG_FUNC_ARG(SrcRect)
+		LOG_FUNC_ARG(DstRect)
+		LOG_FUNC_ARG(EnableColorKey)
+		LOG_FUNC_ARG(ColorKey)
+		LOG_FUNC_END;
+}
+
+// This uses a custom calling convention where parameter is passed in EAX
+__declspec(naked) xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_UpdateOverlay_16__LTCG_eax2)
+(
+	X_D3DSurface *pSurface,
+	CONST RECT   *DstRect,
+	bool_xt       EnableColorKey,
+	D3DCOLOR      ColorKey
+)
+{
+	RECT* SrcRect;
+	__asm {
+		LTCG_PROLOGUE
+		mov  SrcRect, eax
+	}
+
+	// Log
+	D3DDevice_UpdateOverlay_16__LTCG_eax2(pSurface, SrcRect, DstRect, EnableColorKey, ColorKey);
+
+	CxbxrImpl_UpdateOverlay(pSurface, SrcRect, DstRect, EnableColorKey, ColorKey);
+
+	__asm {
+		LTCG_EPILOGUE
+		ret  16
 	}
 }
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.cpp
@@ -6455,6 +6455,15 @@ void UpdateFixedFunctionVertexShaderState()
 	}
 }
 
+static void CxbxrImpl_EnableOverlay()
+{
+	// The Xbox D3DDevice_EnableOverlay call merely resets the active
+	// NV2A overlay state, it doesn't actually enable or disable anything.
+	// Thus, we should just reset our overlay state here too. A title will
+	// show new overlay data via D3DDevice_UpdateOverlay (see below).
+	g_OverlayProxy = {};
+}
+
 // ******************************************************************
 // * patch: D3DDevice_EnableOverlay
 // ******************************************************************
@@ -6464,12 +6473,18 @@ xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_EnableOverlay)
 )
 {
 	LOG_FUNC_ONE_ARG(Enable);
-	
-	// The Xbox D3DDevice_EnableOverlay call merely resets the active
-	// NV2A overlay state, it doesn't actually enable or disable anything.
-	// Thus, we should just reset our overlay state here too. A title will
-	// show new overlay data via D3DDevice_UpdateOverlay (see below).
-	g_OverlayProxy = {};
+
+	CxbxrImpl_EnableOverlay();
+}
+
+// ******************************************************************
+// * patch: D3DDevice_EnableOverlay_0__LTCG
+// ******************************************************************
+xbox::void_xt WINAPI xbox::EMUPATCH(D3DDevice_EnableOverlay_0__LTCG)()
+{
+	LOG_FUNC();
+
+	CxbxrImpl_EnableOverlay();
 }
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -737,6 +737,14 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_RunPushBuffer)
 );
 
 // ******************************************************************
+// * patch: D3DDevice_RunPushBuffer_4__LTCG_eax2
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_RunPushBuffer_4__LTCG_eax2)
+(
+    X_D3DPushBuffer *pPushBuffer
+);
+
+// ******************************************************************
 // * patch: D3DDevice_Clear
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_Clear)

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1701,6 +1701,14 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_RunVertexStateShader)
 );
 
 // ******************************************************************
+// * patch: D3DDevice_RunVertexStateShader_4__LTCG_esi2
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_RunVertexStateShader_4__LTCG_esi2)
+(
+    dword_xt Address
+);
+
+// ******************************************************************
 // * patch: D3DDevice_LoadVertexShaderProgram
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_LoadVertexShaderProgram)

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -999,7 +999,18 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_UpdateOverlay)
     X_D3DSurface *pSurface,
     CONST RECT   *SrcRect,
     CONST RECT   *DstRect,
-    bool_xt          EnableColorKey,
+    bool_xt       EnableColorKey,
+    D3DCOLOR      ColorKey
+);
+
+// ******************************************************************
+// * patch: D3DDevice_UpdateOverlay
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_UpdateOverlay_16__LTCG_eax2)
+(
+    X_D3DSurface *pSurface,
+    CONST RECT   *DstRect,
+    bool_xt       EnableColorKey,
     D3DCOLOR      ColorKey
 );
 

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -309,9 +309,18 @@ X_D3DSurface* WINAPI EMUPATCH(D3DDevice_GetBackBuffer2_0__LTCG_eax1)();
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_GetBackBuffer)
 (
-    int_xt                 BackBuffer,
-    D3DBACKBUFFER_TYPE  Type,
-    X_D3DSurface      **ppBackBuffer
+    int_xt             BackBuffer,
+    D3DBACKBUFFER_TYPE Type,
+    X_D3DSurface     **ppBackBuffer
+);
+
+// ******************************************************************
+// * patch: D3DDevice_GetBackBuffer_8__LTCG_eax1
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_GetBackBuffer_8__LTCG_eax1)
+(
+    D3DBACKBUFFER_TYPE Type,
+    X_D3DSurface     **ppBackBuffer
 );
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -987,6 +987,11 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_EnableOverlay)
 );
 
 // ******************************************************************
+// * patch: D3DDevice_EnableOverlay_0__LTCG
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_EnableOverlay_0__LTCG)();
+
+// ******************************************************************
 // * patch: D3DDevice_UpdateOverlay
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_UpdateOverlay)

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1364,6 +1364,11 @@ xbox::void_xt WINAPI EMUPATCH(D3DDevice_MultiplyTransform)
 );
 
 // ******************************************************************
+// * patch: D3DDevice_MultiplyTransform_0__LTCG_ebx1_eax2
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_MultiplyTransform_0__LTCG_ebx1_eax2)();
+
+// ******************************************************************
 // * patch: D3DDevice_GetTransform
 // ******************************************************************
 xbox::void_xt WINAPI EMUPATCH(D3DDevice_GetTransform)

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -820,10 +820,21 @@ xbox::void_xt WINAPI EMUPATCH(Lock2DSurface)
 (
     X_D3DPixelContainer *pPixelContainer,
     D3DCUBEMAP_FACES     FaceType,
-    uint_xt                 Level,
+    uint_xt              Level,
     D3DLOCKED_RECT      *pLockedRect,
     RECT                *pRect,
-    dword_xt                Flags
+    dword_xt             Flags
+);
+
+// ******************************************************************
+// * patch: Lock2DSurface_16__LTCG_esi4_eax5
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(Lock2DSurface_16__LTCG_esi4_eax5)
+(
+    X_D3DPixelContainer *pPixelContainer,
+    D3DCUBEMAP_FACES     FaceType,
+    uint_xt              Level,
+    dword_xt             Flags
 );
 
 // ******************************************************************

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -843,10 +843,21 @@ xbox::void_xt WINAPI EMUPATCH(Lock2DSurface_16__LTCG_esi4_eax5)
 xbox::void_xt WINAPI EMUPATCH(Lock3DSurface)
 (
     X_D3DPixelContainer *pPixelContainer,
-    uint_xt				Level,
-	D3DLOCKED_BOX		*pLockedVolume,
-	D3DBOX				*pBox,
-	dword_xt				Flags
+    uint_xt              Level,
+    D3DLOCKED_BOX       *pLockedVolume,
+    D3DBOX              *pBox,
+    dword_xt             Flags
+);
+
+// ******************************************************************
+// * patch: Lock3DSurface_16__LTCG_eax4
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(Lock3DSurface_16__LTCG_eax4)
+(
+    X_D3DPixelContainer *pPixelContainer,
+    uint_xt              Level,
+    D3DLOCKED_BOX       *pLockedVolume,
+    dword_xt             Flags
 );
 
 #if 0 // patch disabled

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -484,6 +484,11 @@ xbox::void_xt __fastcall EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline)
 );
 
 // ******************************************************************
+// * patch: D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3
+// ******************************************************************
+xbox::void_xt WINAPI EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3)();
+
+// ******************************************************************
 // * patch: D3DDevice_SetVertexShaderConstantNotInlineFast
 // ******************************************************************
 xbox::void_xt __fastcall EMUPATCH(D3DDevice_SetVertexShaderConstantNotInlineFast)

--- a/src/core/hle/D3D8/Direct3D9/Direct3D9.h
+++ b/src/core/hle/D3D8/Direct3D9/Direct3D9.h
@@ -1557,6 +1557,14 @@ xbox::hresult_xt WINAPI EMUPATCH(D3DDevice_LightEnable)
 );
 
 // ******************************************************************
+// * patch: D3DDevice_LightEnable_4__LTCG_eax1
+// ******************************************************************
+xbox::hresult_xt WINAPI EMUPATCH(D3DDevice_LightEnable_4__LTCG_eax1)
+(
+    bool_xt bEnable
+);
+
+// ******************************************************************
 // * patch: D3DDevice_Release
 // ******************************************************************
 xbox::ulong_xt WINAPI EMUPATCH(D3DDevice_Release)();

--- a/src/core/hle/D3D8/XbVertexShader.cpp
+++ b/src/core/hle/D3D8/XbVertexShader.cpp
@@ -52,6 +52,8 @@
 #include <bitset>
 #include <filesystem>
 
+#include "nv2a_vsh_emulator.h"
+
 // External symbols :
 extern xbox::X_STREAMINPUT g_Xbox_SetStreamSource[X_VSH_MAX_STREAMS]; // Declared in XbVertexBuffer.cpp
 extern XboxRenderStateConverter XboxRenderStates; // Declared in Direct3D9.cpp
@@ -1624,4 +1626,45 @@ extern void EmuParseVshFunction
 	while (XboxVertexShaderDecoder::VshConvertToIntermediate(pCurToken, pShader)) {
 		pCurToken += X_VSH_INSTRUCTION_SIZE;
 	}
+}
+
+void CxbxrImpl_RunVertexStateShader(DWORD Address, CONST FLOAT *pData)
+{
+	// If pData is assigned, pData[0..3] is pushed towards nv2a transform data registers
+	// then sends the nv2a a command to launch the vertex shader function located at Address
+	if (Address >= NV2A_MAX_TRANSFORM_PROGRAM_LENGTH) {
+		LOG_TEST_CASE("Address out of bounds");
+		return;
+	}
+
+	NV2AState* dev = g_NV2A->GetDeviceState();
+	PGRAPHState* pg = &(dev->pgraph);
+
+	Nv2aVshProgram program = {}; // Note: This nulls program.steps
+	// TODO : Retain program globally and perform nv2a_vsh_parse_program only when
+	//        the address-range we're about to emulate was modified since last parse.
+	// TODO : As a suggestion for this, parse all NV2A_MAX_TRANSFORM_PROGRAM_LENGTH slots,
+	//        and here just point program.steps to global vsh_program_steps[Address].
+	Nv2aVshParseResult result = nv2a_vsh_parse_program(
+		&program, // Note : program.steps will be malloc'ed
+		GetCxbxVertexShaderSlotPtr(Address), // TODO : At some point, use pg->program_data[Address] here instead
+		NV2A_MAX_TRANSFORM_PROGRAM_LENGTH - Address);
+	if (result != NV2AVPR_SUCCESS) {
+		LOG_TEST_CASE("nv2a_vsh_parse_program failed");
+		// TODO : Dump Nv2aVshParseResult as string and program for debugging purposes
+		return;
+	}
+
+	Nv2aVshCPUXVSSExecutionState state_linkage;
+	Nv2aVshExecutionState state = nv2a_vsh_emu_initialize_xss_execution_state(
+		&state_linkage, (float*)pg->vsh_constants); // Note : This wil memset(state_linkage, 0)
+	if (pData != nullptr)
+		//if pData != nullptr, then it contains v0.xyzw, we shall copy the binary content directly.
+		memcpy(state_linkage.input_regs, pData, sizeof(state_linkage.input_regs));
+
+	nv2a_vsh_emu_execute_track_context_writes(&state, &program, pg->vsh_constants_dirty);
+	// Note: Above emulation's primary purpose is to update pg->vsh_constants and pg->vsh_constants_dirty
+	// therefor, nothing else needs to be done here, other than to cleanup
+
+	nv2a_vsh_program_destroy(&program); // Note: program.steps will be free'ed
 }

--- a/src/core/hle/D3D8/XbVertexShader.h
+++ b/src/core/hle/D3D8/XbVertexShader.h
@@ -252,5 +252,6 @@ extern void CxbxImpl_SelectVertexShader(DWORD Handle, DWORD Address);
 extern void CxbxImpl_SetVertexShaderInput(DWORD Handle, UINT StreamCount, xbox::X_STREAMINPUT* pStreamInputs);
 extern void CxbxImpl_SetVertexShaderConstant(INT Register, PVOID pConstantData, DWORD ConstantCount);
 extern void CxbxImpl_DeleteVertexShader(DWORD Handle);
+extern void CxbxrImpl_RunVertexStateShader(DWORD Address, CONST FLOAT* pData);
 extern void CxbxVertexShaderSetFlags();
 #endif

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -122,6 +122,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_LoadVertexShader_0__LTCG_edx1_eax2", xbox::EMUPATCH(D3DDevice_LoadVertexShader_0__LTCG_edx1_eax2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_LoadVertexShader_4__LTCG_eax1", xbox::EMUPATCH(D3DDevice_LoadVertexShader_4__LTCG_eax1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_MultiplyTransform", xbox::EMUPATCH(D3DDevice_MultiplyTransform), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_MultiplyTransform_0__LTCG_ebx1_eax2", xbox::EMUPATCH(D3DDevice_MultiplyTransform_0__LTCG_ebx1_eax2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_PersistDisplay", xbox::EMUPATCH(D3DDevice_PersistDisplay), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_Present", xbox::EMUPATCH(D3DDevice_Present), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_PrimeVertexCache", xbox::EMUPATCH(D3DDevice_PrimeVertexCache), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -128,6 +128,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_Reset_0__LTCG_edi1", xbox::EMUPATCH(D3DDevice_Reset_0__LTCG_edi1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_Reset_0__LTCG_ebx1", xbox::EMUPATCH(D3DDevice_Reset_0__LTCG_ebx1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_RunPushBuffer", xbox::EMUPATCH(D3DDevice_RunPushBuffer), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_RunPushBuffer_4__LTCG_eax2", xbox::EMUPATCH(D3DDevice_RunPushBuffer_4__LTCG_eax2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_RunVertexStateShader", xbox::EMUPATCH(D3DDevice_RunVertexStateShader), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_RunVertexStateShader_4__LTCG_esi2", xbox::EMUPATCH(D3DDevice_RunVertexStateShader_4__LTCG_esi2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SelectVertexShader", xbox::EMUPATCH(D3DDevice_SelectVertexShader), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -116,6 +116,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_IsBusy", xbox::EMUPATCH(D3DDevice_IsBusy), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_IsFencePending", xbox::EMUPATCH(D3DDevice_IsFencePending), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_LightEnable", xbox::EMUPATCH(D3DDevice_LightEnable), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_LightEnable_4__LTCG_eax1", xbox::EMUPATCH(D3DDevice_LightEnable_4__LTCG_eax1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_LoadVertexShader", xbox::EMUPATCH(D3DDevice_LoadVertexShader), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_LoadVertexShaderProgram", xbox::EMUPATCH(D3DDevice_LoadVertexShaderProgram), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_LoadVertexShader_0__LTCG_ecx1_eax2", xbox::EMUPATCH(D3DDevice_LoadVertexShader_0__LTCG_ecx1_eax2), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -188,6 +188,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant1Fast", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant1Fast), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant4", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant4), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstantNotInline", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstantNotInlineFast", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstantNotInlineFast), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderConstant_8__LTCG_edx3", xbox::EMUPATCH(D3DDevice_SetVertexShaderConstant_8__LTCG_edx3), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SetVertexShaderInput", xbox::EMUPATCH(D3DDevice_SetVertexShaderInput), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -83,6 +83,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_DrawVerticesUP", xbox::EMUPATCH(D3DDevice_DrawVerticesUP), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_DrawVerticesUP_12__LTCG_ebx3", xbox::EMUPATCH(D3DDevice_DrawVerticesUP_12__LTCG_ebx3), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_EnableOverlay", xbox::EMUPATCH(D3DDevice_EnableOverlay), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_EnableOverlay_0__LTCG", xbox::EMUPATCH(D3DDevice_EnableOverlay_0__LTCG), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_End", xbox::EMUPATCH(D3DDevice_End), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_EndPush", xbox::EMUPATCH(D3DDevice_EndPush), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_EndVisibilityTest", xbox::EMUPATCH(D3DDevice_EndVisibilityTest), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -206,6 +206,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("Direct3D_CreateDevice_16__LTCG_eax4_ecx6", xbox::EMUPATCH(Direct3D_CreateDevice_16__LTCG_eax4_ecx6), PATCH_HLE_D3D),
 	PATCH_ENTRY("Direct3D_CreateDevice_4__LTCG_eax1_ecx3", xbox::EMUPATCH(Direct3D_CreateDevice_4__LTCG_eax1_ecx3), PATCH_HLE_D3D),
 	PATCH_ENTRY("Lock2DSurface", xbox::EMUPATCH(Lock2DSurface), PATCH_HLE_D3D),
+	PATCH_ENTRY("Lock2DSurface_16__LTCG_esi4_eax5", xbox::EMUPATCH(Lock2DSurface_16__LTCG_esi4_eax5), PATCH_HLE_D3D),
 	PATCH_ENTRY("Lock3DSurface", xbox::EMUPATCH(Lock3DSurface), PATCH_HLE_D3D),
 
 	// DSOUND

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -208,6 +208,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("Lock2DSurface", xbox::EMUPATCH(Lock2DSurface), PATCH_HLE_D3D),
 	PATCH_ENTRY("Lock2DSurface_16__LTCG_esi4_eax5", xbox::EMUPATCH(Lock2DSurface_16__LTCG_esi4_eax5), PATCH_HLE_D3D),
 	PATCH_ENTRY("Lock3DSurface", xbox::EMUPATCH(Lock3DSurface), PATCH_HLE_D3D),
+	PATCH_ENTRY("Lock3DSurface_16__LTCG_eax4", xbox::EMUPATCH(Lock3DSurface_16__LTCG_eax4), PATCH_HLE_D3D),
 
 	// DSOUND
 	PATCH_ENTRY("CDirectSound3DCalculator_Calculate3D", xbox::EMUPATCH(CDirectSound3DCalculator_Calculate3D), PATCH_HLE_DSOUND),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -90,6 +90,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_EndVisibilityTest_0__LTCG_eax1", xbox::EMUPATCH(D3DDevice_EndVisibilityTest_0__LTCG_eax1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_FlushVertexCache", xbox::EMUPATCH(D3DDevice_FlushVertexCache), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetBackBuffer", xbox::EMUPATCH(D3DDevice_GetBackBuffer), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_GetBackBuffer_8__LTCG_eax1", xbox::EMUPATCH(D3DDevice_GetBackBuffer_8__LTCG_eax1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetBackBuffer2", xbox::EMUPATCH(D3DDevice_GetBackBuffer2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetBackBuffer2_0__LTCG_eax1", xbox::EMUPATCH(D3DDevice_GetBackBuffer2_0__LTCG_eax1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_GetDisplayFieldStatus", xbox::EMUPATCH(D3DDevice_GetDisplayFieldStatus), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -194,6 +194,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_Swap_0__LTCG_eax1", xbox::EMUPATCH(D3DDevice_Swap_0__LTCG_eax1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SwitchTexture", xbox::EMUPATCH(D3DDevice_SwitchTexture), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_UpdateOverlay", xbox::EMUPATCH(D3DDevice_UpdateOverlay), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_UpdateOverlay_16__LTCG_eax2", xbox::EMUPATCH(D3DDevice_UpdateOverlay_16__LTCG_eax2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DResource_BlockUntilNotBusy", xbox::EMUPATCH(D3DResource_BlockUntilNotBusy), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3D_BlockOnTime", xbox::EMUPATCH(D3D_BlockOnTime), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3D_BlockOnTime_4__LTCG_eax1", xbox::EMUPATCH(D3D_BlockOnTime_4__LTCG_eax1), PATCH_HLE_D3D),

--- a/src/core/hle/Patches.cpp
+++ b/src/core/hle/Patches.cpp
@@ -129,6 +129,7 @@ std::map<const std::string, const xbox_patch_t> g_PatchTable = {
 	PATCH_ENTRY("D3DDevice_Reset_0__LTCG_ebx1", xbox::EMUPATCH(D3DDevice_Reset_0__LTCG_ebx1), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_RunPushBuffer", xbox::EMUPATCH(D3DDevice_RunPushBuffer), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_RunVertexStateShader", xbox::EMUPATCH(D3DDevice_RunVertexStateShader), PATCH_HLE_D3D),
+	PATCH_ENTRY("D3DDevice_RunVertexStateShader_4__LTCG_esi2", xbox::EMUPATCH(D3DDevice_RunVertexStateShader_4__LTCG_esi2), PATCH_HLE_D3D),
 	PATCH_ENTRY("D3DDevice_SelectVertexShader", xbox::EMUPATCH(D3DDevice_SelectVertexShader), PATCH_HLE_D3D),
 	//PATCH_ENTRY("D3DDevice_SelectVertexShaderDirect", xbox::EMUPATCH(D3DDevice_SelectVertexShaderDirect), PATCH_HLE_D3D),
 	//PATCH_ENTRY("D3DDevice_SelectVertexShaderDirect_0__LTCG_eax1_ebx2", xbox::EMUPATCH(D3DDevice_SelectVertexShaderDirect_0__LTCG_eax1_ebx2), PATCH_HLE_D3D),


### PR DESCRIPTION
Before approve or merge the pull request, I highly recommended to verify for any LTCG assembly code mistakes. Not all patches could be vetted with mentioned titles due to either did not get called or unable get to the point of title progress into menu or in-game.

<details><summary>List of titles detected that could be used for reverse engineering verification or test in the build.</summary>
<p>

- D3DDevice_GetBackBuffer_8__LTCG_eax1
  - NBA 2K2* (Sega Sports) (Sega Sports) **unable to test**
- D3DDevice_EnableOverlay_0__LTCG (eh std is fine)
  - DOOM 3 Demo **triggered at boot**
  - Pariah **triggered at boot**
- D3DDevice_UpdateOverlay_16__LTCG_eax2
  - DOOM 3 Demo **triggered at start of boot intro**
  - Pariah **triggered at start of boot intro**
- D3DDevice_LightEnable_4__LTCG_eax1
  - DOOM 3 Demo **did not get triggered** (unable to test ingame due to early crash)
  - Enter The Matrix **triggered in mission**
  - NBA 2K2* (Sega Sports) (Sega Sports) **unable to test**
  - NINJA GAIDEN Demo **triggered after start mission**
  - Chessmaster **triggered at boot**
  - Pariah **triggered at start of mission**
- D3DDevice_MultiplyTransform_0__LTCG_ebx1_eax2
  - Enter The Matrix **did not get triggered** (unknown where to test it)
  - NBA 2K2* (Sega Sports) (Sega Sports) **unable to test**
- D3DDevice_RunPushBuffer_4__LTCG_eax2
  - **unable to test**
- D3DDevice_RunVertexStateShader_4__LTCG_esi2
  - Enter The Matrix **did not get triggered** (unknown where to test it)
- D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_eax2_edx3
  - Midtown Madness 3 **triggered at boot**
  - Grand Theft Auto III **triggered at start of in-game**
  - Grand Theft Auto: Vice City **did not get triggered** (unknown where to test it)
  - Halo 2 **did not get triggered**
  - Brothers In Arms* **unable to test** (soft lock at logo and rating display)
  - Earned In Blood* **unable to test** (soft lock at logo and rating display)
  - Pariah **did not get triggered** (unable to test ingame due to no graphic update)
- Lock3DSurface_16__LTCG_eax4
  - Enter The Matrix **did not get triggered** (unknown where to test it)
  - Midtown Madness 3 **triggered later on at boot**
  - NBA 2K2* (Sega Sports) **unable to test**
  - segaGT 2002 **triggered at boot**
- Lock2DSurface_16__LTCG_esi4_eax5 (too many titles to be list)
  - Call of Duty 2: Big Red One **triggered at boot**
  - DOOM 3 Demo (from cache partition) **triggered at boot**
  - Grand Theft Auto III **triggered at boot**
  - Grand Theft Auto: Vice City **did not get triggered** (unknown where to test it)
  - Midtown Madness 3 **triggered at boot**
  - segaGT 2002 **triggered at boot**
  - Xbox Dashboard (5659) **did not get triggered** (unknown where to test it)
  - Xbox Dashboard (5960) **did not get triggered** (unknown where to test it)
  - Chessmaster **triggered at boot**
  - Pariah **triggered at boot**
  - Project: Snowblind* **unable to test**

 \* Marked titles couldn't be tested due to either early crash on boot
</p>
</details>

NOTE: Don't expect any graphic improvements from this pull request, they remain the same.