### PR TITLE
Sync XbSymbolDatabase and extend couple of info output

### DIFF
--- a/src/common/xbe/Xbe.h
+++ b/src/common/xbe/Xbe.h
@@ -81,7 +81,10 @@ class Xbe : public Error
 		void PurgeBadChar(std::string& s, const std::string& illegalChars = "\\/:?\"<>|");
 
         // Convert game region field to string
-        const char *GameRegionToString(uint32_t dwRegionFlags = 0);
+        std::string GameRegionToString(uint32_t dwRegionFlags = 0);
+
+        // Convert version field to string
+        std::string VersionToString();
 
         XbeType GetXbeType();
 

--- a/src/core/hle/Intercept.cpp
+++ b/src/core/hle/Intercept.cpp
@@ -65,6 +65,9 @@ static struct {
 	const char* TitleID = "TitleID";
 	const char* TitleIDHex = "TitleIDHex";
 	const char* Region = "Region";
+	const char* RegionHex = "RegionHex";
+	const char* Version = "Version";
+	const char* VersionHex = "VersionHex";
 } sect_certificate_keys;
 
 static const char* section_libs = "Libs";
@@ -509,7 +512,10 @@ void EmuHLEIntercept(Xbe::Header *pXbeHeader)
 	symbolCacheData.SetValue(section_certificate, sect_certificate_keys.Name, tAsciiTitle);
 	symbolCacheData.SetValue(section_certificate, sect_certificate_keys.TitleID, FormatTitleId(CxbxKrnl_Xbe->m_Certificate.dwTitleId).c_str());
 	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.TitleIDHex, CxbxKrnl_Xbe->m_Certificate.dwTitleId, nullptr, /*UseHex =*/true);
-	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.Region, CxbxKrnl_Xbe->m_Certificate.dwGameRegion, nullptr, /*UseHex =*/true);
+	symbolCacheData.SetValue(section_certificate, sect_certificate_keys.Region, CxbxKrnl_Xbe->GameRegionToString().c_str());
+	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.RegionHex, CxbxKrnl_Xbe->m_Certificate.dwGameRegion, nullptr, /*UseHex =*/true);
+	symbolCacheData.SetValue(section_certificate, sect_certificate_keys.Version, CxbxKrnl_Xbe->VersionToString().c_str());
+	symbolCacheData.SetLongValue(section_certificate, sect_certificate_keys.VersionHex, CxbxKrnl_Xbe->m_Certificate.dwVersion, nullptr, /*UseHex =*/true);
 
 	// Store Library Details
 	for (unsigned int i = 0; i < pXbeHeader->dwLibraryVersions; i++) {

--- a/src/core/kernel/init/CxbxKrnl.cpp
+++ b/src/core/kernel/init/CxbxKrnl.cpp
@@ -1101,7 +1101,10 @@ static void CxbxrLogDumpXbeInfo(Xbe::LibraryVersion* libVersionInfo)
 		}
 		EmuLogInit(LOG_LEVEL::INFO, "XBE Version (Hex): %08X", g_pCertificate->dwVersion);
 		EmuLogInit(LOG_LEVEL::INFO, "XBE TitleName : %.40ls", g_pCertificate->wsTitleName);
-		EmuLogInit(LOG_LEVEL::INFO, "XBE Region : %s", CxbxKrnl_Xbe->GameRegionToString());
+		if (CxbxKrnl_Xbe != nullptr) {
+			EmuLogInit(LOG_LEVEL::INFO, "XBE Region : %s", CxbxKrnl_Xbe->GameRegionToString().c_str());
+		}
+		EmuLogInit(LOG_LEVEL::INFO, "XBE Region (Hex): %08X", g_pCertificate->dwGameRegion);
 	}
 
 	// Dump Xbe library build numbers


### PR DESCRIPTION
The sync of XbSymbolDatabase does not have any impact of existence patches other than possibility missing memory unit support for titles compiled with 5120 build.

I have extended info to the log and verbose to document version and region, including hexadecimal values too, into symbol cache files. Previously, only the title version was output to the console or log file.